### PR TITLE
Review and repair src/class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,3 +302,13 @@ docs/code-of-conduct.rst
 # Common Python virtual environment directory names
 venv
 py??
+
+# Out-of-tree (VPATH) build trees the contrib/dockerswarm scripts create at
+# the repo root.  contrib/dockerswarm/.gitignore names two of these, but a
+# .gitignore only governs its own directory downward and these are built up
+# here, so they have to be listed at the root to actually be ignored.
+#   build.sh macos        -> vpath-macos-pmix, vpath-macos-prte
+#   run-class-tests.sh    -> vpath-macos-pmix-opt (the --disable-debug tree)
+vpath-macos-pmix/
+vpath-macos-pmix-opt/
+vpath-macos-prte/

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -29,7 +29,8 @@ is only the nickname.
 | `run-group-events.sh` | Runs the **dynamic, event-driven** group exercisers and their fault paths (invite/join, member lost during destruct, ...); kept separate from `run-tests.sh` so the event/fault matrix can grow independently. Same `linux`/`macos` modes. |
 | `run-topology.sh` | Runs the **topology + locality** exerciser across real nodes: each rank loads the topology its *local* server published (hwloc shmem, with XML as the fallback) and compares `PMIX_LOCALITY_STRING` with every peer. The only place `src/hwloc` gets a multi-node answer -- on one host every peer is a node-mate, so a single-host run cannot tell a correct result from one that claims everything is local. Same `linux`/`macos` modes. |
 | `run-python.sh` | Runs the **Python bindings**: the standalone unit suite, the connected client/server round-trip, and Python PMIx clients spread across nodes. Same `linux`/`macos` modes. See §10. |
-| `swarm-common.sh` | Sourced by all five scripts above: which swarm to drive (`PMIX_SWARM`), how to reach a node, and how to clean one. The three runners each carried their own copy of that once, and the copies drifted. |
+| `run-class-tests.sh` | Runs `test/unit/class` in the two configurations a developer's own `make check` does not cover: **Linux**, and **`--disable-debug`** with default symbol visibility. Deliberately *not* a multi-node test — see §11. |
+| `swarm-common.sh` | Sourced by all six scripts above: which swarm to drive (`PMIX_SWARM`), how to reach a node, and how to clean one. The three runners each carried their own copy of that once, and the copies drifted. |
 | `python/` | The swarm's own Python clients (`swarm_client.py`, `swarm_group.py`, `swarm_cpuset.py`). |
 | `Dockerfile` | Base image: toolchain, PRRTE master *source* (autogen'd), SSH wiring, node entrypoint. It contains **no** PMIx and **no** built PRRTE. |
 | `docker-compose.yml` | The ten nodes `pmix-node1`..`pmix-node10`, each mounting the shared `pmix-build` volume. Every one of those names derives from `$PMIX_SWARM`, so two clones can each run a swarm — see §4. |
@@ -388,3 +389,68 @@ Python clients do exactly that.
 > run after picking this up needs `./build.sh image` (or any `./build.sh` on a
 > machine with no `pmix-swarm` image yet). That re-clones PRRTE and takes a
 > while; subsequent builds are incremental as before.
+
+---
+
+## 11. The `src/class` unit suite (`run-class-tests.sh`)
+
+```
+./run-class-tests.sh linux    # both configurations, in the container
+./run-class-tests.sh macos    # both configurations, natively
+```
+
+**This is not a multi-node test, and it is not trying to be.** Everything
+in [`src/class`](../../src/class) — the object model, list, hash table,
+pointer array, hotel, ring buffer, value array, bitmap — is a
+single-process, in-memory data structure. Spreading a linked list over ten
+containers tells you nothing that running it once does not. The distributed
+dimension of these classes is *cross-process on one node*:
+`pmix_hash_table_t` and `pmix_pointer_array_t` are TMA-aware precisely so
+`gds/shmem2` can build them inside an mmap'd segment a server shares with
+its local clients — and that path is exercised by `run-tests.sh`, whose
+group cases drive a real datastore on each node.
+
+What this script is for is the two configurations `make check` on a
+developer's machine does not produce:
+
+1. **Linux.** The primary development host is macOS. This code has
+   platform-sensitive corners: the width of `unsigned long` under a shift,
+   C11 atomic codegen, what `calloc(0, n)` and `realloc(p, 0)` return,
+   pthread scheduling.
+
+2. **`--disable-debug`, default symbol visibility.** This is the bigger
+   one. Several guards in `src/class` used to be compiled out unless
+   `--enable-debug`, so the bugs they catch were only reachable in a build
+   nobody tested — an un-init'd hash table divided by zero;
+   `pmix_value_array_remove_item()` `memmove`'d a wrapped `size_t` length.
+   And *every* tree in this workflow (yours, and `build.sh`'s) configures
+   `--enable-debug`; the maintainer's also uses `--disable-visibility`.
+
+### A defect this half found
+
+The first run of the `--disable-debug`, default-visibility build failed to
+link:
+
+```
+Undefined symbols for architecture arm64:
+  "_pmix_ring_buffer_t_class", referenced from: _main in class_ring_buffer.o
+```
+
+`pmix_ring_buffer_t` was the one class in the directory whose descriptor
+carried no `PMIX_EXPORT` — not on the declaration, not on the
+`PMIX_CLASS_INSTANCE`. So `PMIX_NEW(pmix_ring_buffer_t)` cannot link
+outside `libpmix` in any normal build. It went unnoticed because the class
+has **no callers in the tree at all**, and the one consumer that would have
+caught it is normally built against a `--disable-visibility` tree.
+
+Same lesson as §10, one level down: **a test that only ever runs in the
+maintainer's configuration only ever tests the maintainer's
+configuration.**
+
+> **Note on the `macos` half.** Autoconf refuses an out-of-tree build while
+> the source directory itself holds a `config.status`. `build.sh` resolves
+> that by running `make distclean` on your tree; a test script has no
+> business doing that to a working build, so the optimized half *skips*
+> with an explanation instead. Run `./build.sh macos` first (which
+> distcleans), or use the `linux` half, which has no such restriction — the
+> container builds both configurations against a read-only bind mount.

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -439,13 +439,21 @@ Undefined symbols for architecture arm64:
 `pmix_ring_buffer_t` was the one class in the directory whose descriptor
 carried no `PMIX_EXPORT` — not on the declaration, not on the
 `PMIX_CLASS_INSTANCE`. So `PMIX_NEW(pmix_ring_buffer_t)` cannot link
-outside `libpmix` in any normal build. It went unnoticed because the class
-has **no callers in the tree at all**, and the one consumer that would have
-caught it is normally built against a `--disable-visibility` tree.
+outside `libpmix` in any normal build.
 
-Same lesson as §10, one level down: **a test that only ever runs in the
-maintainer's configuration only ever tests the maintainer's
-configuration.**
+That is not a theoretical break: this class's consumers are **downstream
+projects building against PMIx's installed internal headers**, which is
+exactly the population the missing export locks out. What kept it hidden
+is that no code *inside* this repository uses the class, so the only
+in-tree consumer able to catch it is `test/unit/class` — normally built
+against a `--disable-visibility` tree, where nothing is hidden and it
+links fine.
+
+Two lessons, both worth carrying. The one from §10, a level down: **a
+test that only ever runs in the maintainer's configuration only ever
+tests the maintainer's configuration.** And: **an in-tree grep is not
+evidence that an interface is unused** — `libpmix`'s internal headers
+are installed, and things build against them.
 
 > **Note on the `macos` half.** Autoconf refuses an out-of-tree build while
 > the source directory itself holds a `config.status`. `build.sh` resolves

--- a/contrib/dockerswarm/run-class-tests.sh
+++ b/contrib/dockerswarm/run-class-tests.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Run the src/class unit suite (test/unit/class) against your live openpmix
+# tree, in the two configurations the in-tree `make check` on a developer's
+# machine does not give you.
+#
+#   ./run-class-tests.sh linux    # in the swarm's containers
+#   ./run-class-tests.sh macos    # natively, both configurations
+#
+# WHY THIS IS NOT A MULTI-NODE TEST
+#
+# Everything in src/class -- the object model, the list, the hash table, the
+# pointer array, the hotel, the ring buffer, the value array, the bitmap --
+# is a single-process, in-memory data structure.  Nothing in it talks to
+# another node, so spreading it over ten containers would tell you nothing
+# that running it once does not.  The distributed dimension of these classes
+# is *cross-process, same node*: pmix_hash_table_t and pmix_pointer_array_t
+# are TMA-aware precisely so gds/shmem2 can build them inside an mmap'd
+# segment a server shares with its local clients.  That path is already
+# covered by run-tests.sh, whose group cases drive a real datastore on each
+# node -- not by anything a class unit test could do on its own.
+#
+# WHAT THE SWARM DOES BUY
+#
+# Two kinds of coverage the maintainer's own `make check` cannot produce:
+#
+#  1. Linux.  The primary development host here is macOS.  This code has
+#     platform-sensitive corners -- the width of unsigned long under a shift,
+#     C11 atomic codegen, what calloc(0, n) and realloc(p, 0) return, pthread
+#     scheduling -- and the container is the nearest Linux userspace.
+#
+#  2. An OPTIMIZED build.  This is the bigger one.  Several guards in
+#     src/class used to be compiled out unless --enable-debug, so the bugs
+#     they now catch were only reachable in a build nobody tests: an
+#     un-init'd hash table divided by zero, value_array's remove_item
+#     memmove'd a wrapped size_t length.  Every tree in this workflow --
+#     yours, and build.sh's -- configures --enable-debug.  So this script
+#     configures a second, --disable-debug PMIx and runs the suite against
+#     that too.  That second build is the entire reason this script exists.
+#
+# Prints PASS/FAIL per configuration and exits non-zero if anything failed.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+. "$(dirname "$0")/swarm-common.sh"
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+# The program list comes out of the Makefile.am rather than being repeated
+# here, so adding a class_* test to the suite does not silently leave it out
+# of this run.
+class_programs() {
+    sed -n '/^check_PROGRAMS[[:space:]]*=/,/[^\\]$/p' \
+        "$root/test/unit/class/Makefile.am" \
+        | sed 's/^check_PROGRAMS[[:space:]]*=//; s/\\$//' \
+        | tr -s ' \t\n' ' '
+}
+
+########################################################################
+# Linux: build both configurations in a builder container, then run the
+# optimized binaries on every node of the swarm.
+########################################################################
+
+test_linux() {
+    local progs rc
+
+    progs="$(class_programs)"
+    if [ -z "${progs// /}" ]; then
+        bad "could not read check_PROGRAMS from test/unit/class/Makefile.am"
+        return
+    fi
+    echo "    suite: $progs"
+
+    swarm_up_or_die
+
+    if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+        bad "build volume $VOLUME missing -- run ./build.sh first"
+        return
+    fi
+
+    banner "build + run: --enable-debug (asserts and spot-checks live)"
+    # Reuse the tree build.sh already configured; if it is not there, say so
+    # rather than configuring a third one behind the user's back.
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e PROGS="$progs" \
+        "$IMAGE" bash -euo pipefail -c '
+            cd /opt/prte/vpath-pmix 2>/dev/null || {
+                echo "no /opt/prte/vpath-pmix -- run ./build.sh first" >&2; exit 2; }
+            make -j"$(nproc)" -C test/unit/class check
+            # Stage them so the nodes can run the same binaries.
+            mkdir -p /opt/prte/tests-class/debug
+            for p in $PROGS; do
+                cp "test/unit/class/$p" /opt/prte/tests-class/debug/ 2>/dev/null || true
+            done
+        '
+    rc=$?
+    [ "$rc" = 0 ] && ok "debug build: suite green in the container" \
+                  || bad "debug build: suite failed (rc=$rc)"
+
+    banner "build + run: --disable-debug (the configuration nobody tests)"
+    # A separate prefix and a separate VPATH directory: this library must not
+    # displace the one the rest of the harness runs against.
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e PROGS="$progs" \
+        "$IMAGE" bash -euo pipefail -c '
+            mkdir -p /opt/prte/vpath-pmix-opt && cd /opt/prte/vpath-pmix-opt
+            [ -f config.status ] || /pmix-src/configure \
+                --prefix=/opt/prte/pmix-opt --disable-debug --disable-devel-check
+            # Two statements, not "make && make install": set -e does not fire
+            # for a failing command in a non-final position of an && list, so
+            # the joined form reports success over a stale install.
+            make -j"$(nproc)"
+            make install
+            make -j"$(nproc)" -C test/unit/class check
+            mkdir -p /opt/prte/tests-class/opt
+            for p in $PROGS; do
+                cp "test/unit/class/$p" /opt/prte/tests-class/opt/ 2>/dev/null || true
+            done
+        '
+    rc=$?
+    [ "$rc" = 0 ] && ok "optimized build: suite green in the container" \
+                  || bad "optimized build: suite failed (rc=$rc)"
+
+    # Running the staged binaries on the nodes is a load/contention pass, not
+    # a distributed one: ten containers on one host share a kernel and a set
+    # of CPUs.  It is worth the minute it costs for class_refcount, whose
+    # whole subject is what several runnable threads do to one atomic, and it
+    # confirms the binaries work under the same runtime the rest of the
+    # harness uses.  It is not claimed to be more than that.
+    banner "concurrent run across all ten nodes (contention pass)"
+    for cfg in debug opt; do
+        if ! ON 1 "test -d /opt/prte/tests-class/$cfg"; then
+            skp "$cfg binaries not staged"
+            continue
+        fi
+        local lib="/opt/prte/pmix/lib"
+        [ "$cfg" = opt ] && lib="/opt/prte/pmix-opt/lib"
+
+        local pids="" n bad_nodes=""
+        rm -f /tmp/swarm-class-$cfg-*.out
+        for n in $(seq 1 10); do
+            ( docker exec "$NODE$n" bash -lc \
+                "export LD_LIBRARY_PATH=$lib; \
+                 cd /opt/prte/tests-class/$cfg && \
+                 for p in $progs; do ./\$p >/dev/null 2>&1 || exit 1; done" \
+              >/dev/null 2>&1; echo "$?" > "/tmp/swarm-class-$cfg-$n.out" ) &
+            pids="$pids $!"
+        done
+        for p in $pids; do wait "$p"; done
+        for n in $(seq 1 10); do
+            [ "$(cat "/tmp/swarm-class-$cfg-$n.out" 2>/dev/null)" = 0 ] \
+                || bad_nodes="$bad_nodes node$n"
+        done
+        rm -f /tmp/swarm-class-$cfg-*.out
+        [ -z "$bad_nodes" ] && ok "$cfg: suite green on all ten nodes at once" \
+                            || bad "$cfg: failed on$bad_nodes"
+    done
+}
+
+########################################################################
+# macOS: both configurations natively.  No containers involved -- the
+# point here is still the optimized build, which the developer's own
+# tree does not provide either.
+########################################################################
+
+test_macos() {
+    local progs rc jobs opt="$root/vpath-macos-pmix-opt"
+
+    progs="$(class_programs)"
+    echo "    suite: $progs"
+    jobs="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+
+    banner "in-tree build (whatever it is configured as)"
+    if [ ! -f "$root/config.status" ]; then
+        skp "no configured tree at $root -- run ./configure there first"
+    else
+        ( cd "$root" && make -j"$jobs" && make -C test/unit/class check ) \
+            >/tmp/class-intree.$$ 2>&1
+        rc=$?
+        [ "$rc" = 0 ] && ok "in-tree: suite green" \
+                      || { bad "in-tree: suite failed (rc=$rc)"; tail -30 /tmp/class-intree.$$; }
+        rm -f /tmp/class-intree.$$
+    fi
+
+    banner "--disable-debug VPATH build (the configuration nobody tests)"
+    # Autoconf refuses a VPATH build while the source directory itself holds
+    # a config.status ("source directory already configured").  build.sh
+    # resolves that by running "make distclean" on your tree; a test script
+    # has no business doing that to a working build, so say what is in the
+    # way instead of demolishing it.
+    if [ -f "$root/config.status" ]; then
+        skp "srcdir is configured in place -- an out-of-tree build cannot coexist"
+        echo "     This half needs a source tree with no config.status in it," >&2
+        echo "     which is the state ./build.sh macos leaves behind (it runs" >&2
+        echo "     make distclean first).  Either run that, or:" >&2
+        echo "         make -C $root distclean && $0 macos" >&2
+        echo "     The Linux half has no such restriction -- ./run-class-tests.sh" >&2
+        echo "     linux builds both configurations in the container." >&2
+        return
+    fi
+
+    mkdir -p "$opt"
+    ( cd "$opt" \
+        && { [ -f config.status ] || "$root/configure" --prefix="$opt/install" \
+                 --disable-debug --disable-devel-check; } \
+        && make -j"$jobs" \
+        && make -C test/unit/class check ) >/tmp/class-opt.$$ 2>&1
+    rc=$?
+    [ "$rc" = 0 ] && ok "optimized: suite green" \
+                  || { bad "optimized: suite failed (rc=$rc)"; tail -30 /tmp/class-opt.$$; }
+    rm -f /tmp/class-opt.$$
+}
+
+########################################################################
+
+case "$mode" in
+    linux) test_linux ;;
+    macos) test_macos ;;
+    *) echo "usage: $0 [linux|macos]" >&2; exit 2 ;;
+esac
+
+printf '\n=== summary: %d passed, %d failed, %d skipped ===\n' "$pass" "$fail" "$skip"
+[ "$fail" -eq 0 ]

--- a/src/class/AGENTS.md
+++ b/src/class/AGENTS.md
@@ -240,10 +240,13 @@ mostly spelled out in the header's opening comment:
   `pmix_list_join` are O(N) only because they must fix that count.
 - `pmix_list_sort` sorts via an array of pointers + `qsort`; its compare
   function receives **double pointers** (`pmix_list_item_t **`).
-- **`pmix_list_insert` cannot append.** It rejects `idx >= length`, so
-  the one-past-the-end position a caller would expect to mean "append"
-  fails. The header says "greater than the length"; the code means
-  "greater than or equal". Use `pmix_list_append`.
+- **`pmix_list_insert` cannot append.** It inserts *before* an existing
+  item, so `idx` must be strictly less than the length: the
+  one-past-the-end position that would mean "append" is rejected, and an
+  empty list rejects every `idx`. Use `pmix_list_append` (O(1)) for the
+  back and `pmix_list_prepend` for the front. The header used to say
+  "greater than the length" where the code means "greater than or
+  equal"; it now says so plainly.
 
 > ### `PMIX_LIST_STATIC_INIT` does not produce a usable list
 >
@@ -333,16 +336,21 @@ Push/pop/poke over a fixed ring of `size` pointers; pushing into a full
 ring returns the displaced oldest entry (NACK-style schemes, per the
 hotel header's cross-reference). Small and self-contained; not TMA-aware.
 
-**It has no callers.** Nothing in `src/`, `test/` (beyond its own unit
-test), `bindings/` or `examples/` uses this class; the only reference is
-the aspirational mention in `pmix_hotel.h`'s opening comment. That is
-worth knowing before you spend effort on it — and it is why its class
-descriptor was missing `PMIX_EXPORT` for years without anyone noticing
-(the symbol is hidden in any build that does not pass
-`--disable-visibility`, so `PMIX_NEW(pmix_ring_buffer_t)` could not link
-outside `libpmix`). If you find yourself reaching for it, check first
-whether a hotel or a list fits; if it stays unused indefinitely,
-removing it is a reasonable proposal to raise on an issue.
+**Its consumers are outside this repository.** Nothing in `src/`,
+`test/` (beyond its own unit test), `bindings/` or `examples/` uses this
+class, but projects that build against PMIx's installed internal headers
+do. Do not read the empty in-tree grep as "dead code" and do not propose
+removing it — this class is part of the consumable internal surface and
+is on the same do-not-break footing as everything else here.
+
+That external-only usage is exactly why its class descriptor was missing
+`PMIX_EXPORT` for so long. `pmix_ring_buffer_t_class` is hidden in any
+build that does not pass `--disable-visibility`, so
+`PMIX_NEW(pmix_ring_buffer_t)` failed to link for precisely the callers
+that exist — and nothing in this tree could notice, because the one
+in-tree consumer is a unit test normally built against a
+`--disable-visibility` tree. Keep that in mind for the whole directory:
+**an in-tree grep is not evidence that a class is unused.**
 
 Note also that `pmix_ring_buffer_push`'s tail bookkeeping is only
 correct because `tail == head` whenever the ring is full. That invariant

--- a/src/class/AGENTS.md
+++ b/src/class/AGENTS.md
@@ -105,17 +105,50 @@ Rules that trip people up:
   runs (e.g. `PMIX_LIST_STATIC_INIT`, `PMIX_HASH_TABLE_STATIC_INIT`).
   Prefer it to `PMIX_CONSTRUCT` for statics.
 
-### Reference counting is mutex-based, not lock-free
+### Reference counting is a C11 atomic
 
-Each `pmix_object_t` carries its own `pthread_mutex_t obj_lock`, and
-`pmix_obj_update` takes it for every retain/release. This is deliberately
-simple and correct, **not** a hot-path atomic. Do not sprinkle
-`PMIX_RETAIN`/`PMIX_RELEASE` into tight loops on the assumption they are
-free. In `--enable-debug` builds the mutex is `ERRORCHECK` (so a
-recursive lock aborts loudly) and each object carries a magic-ID
+`obj_reference_count` is a `pmix_atomic_int32_t`, and `pmix_obj_update`
+is a single `atomic_fetch_add_explicit(..., memory_order_acq_rel)`.
+**PMIx requires C11 atomics — `config/pmix.m4` fails configure outright
+without them — so there is never a question of whether they are
+available.** Do not reintroduce a lock here, and do not propose a
+fallback path for compilers that lack `<stdatomic.h>`; such a compiler
+cannot build PMIx at all.
+
+The ordering is `acq_rel` because the one function serves both
+directions: the thread dropping the last reference must publish its
+writes before the count reaches zero, and whichever thread *observes*
+zero — and therefore runs the destructors and frees the storage — must
+acquire them. Anything weaker races the destructor against the last
+user. If you touch this, keep it `acq_rel`; a "relaxed is enough for a
+refcount" simplification is only true for the increment.
+
+This replaced a per-object `pthread_mutex_t obj_lock` that was taken and
+released on every `PMIX_RETAIN`/`PMIX_RELEASE`. Three things came with
+that change, worth knowing if you are reading older code or an older
+branch:
+
+- The mutex was `pthread_mutex_init`'d and **never destroyed**, so it
+  leaked on any platform where init allocates.
+- Objects allocated from a TMA live in a shared-memory segment, and the
+  embedded mutex was never `PTHREAD_PROCESS_SHARED` — cross-process
+  retain/release was undefined. An atomic `int32_t` in shared memory is
+  well defined, which is what makes the TMA path below actually sound.
+- Every object in the tree shrank by the size of a `pthread_mutex_t`
+  (40 bytes on glibc, 64 on macOS), and `PMIX_OBJ_STATIC_INIT` no longer
+  carries `PTHREAD_MUTEX_INITIALIZER`.
+
+Retain/release is now cheap, but it is still an atomic RMW with full
+fencing — do not treat it as free in a tight loop.
+
+In `--enable-debug` builds each object carries a magic ID
 (`PMIX_OBJ_MAGIC_ID`) plus the file/line of last construction; the
-retain/release/destruct macros assert on the magic to catch
-double-frees and wild pointers.
+retain/release/destruct macros assert on the magic to catch double-frees
+and wild pointers. **`PMIX_DESTRUCT` on an already-destructed object
+aborts on that assert, correctly** — a destructor that resets its class
+to the constructed state (several here now do) makes a release build
+survive it, but a double destruct is still a caller bug, not a supported
+pattern. Do not write tests that do it.
 
 ### The class registry and finalize
 
@@ -129,12 +162,13 @@ process. After it runs, every class is inoperable — the
 `pmix_class_init_epoch` counter is bumped so any class touched again
 lazily re-initializes. Do not call it from library code.
 
-> Note: the comment above `pmix_obj_run_constructors` warns of a
-> "hardwired maximum depth" of the inheritance tree. That is stale — the
-> implementation allocates the constructor/destructor arrays dynamically
-> from the computed hierarchy depth. Inheritance depth is not fixed in
-> practice; correct the comment if you touch that code, don't design
-> around a limit that isn't there.
+There is a real hazard buried in that "absolute last" requirement.
+`pmix_obj_run_destructors` reads `object->obj_class->cls_destruct_array`
+and does **not** re-check the epoch, so releasing *any* object after
+`pmix_class_finalize()` has run dereferences a freed array. The epoch
+counter protects re-*initialization*, not objects that are still alive.
+That is why finalize is the last call in each role and why library code
+must never call it.
 
 ### TMA: the touchable-memory allocator
 
@@ -163,7 +197,12 @@ What this means when working in `src/class`:
   which is fine only because they are not stored in shared memory.
 - `pmix_obj_get_tma` detects "has a custom allocator" by testing whether
   `tma_malloc` is non-NULL. Because of that convention, a partially
-  filled-in TMA is a bug. Copy an existing static-init block verbatim.
+  filled-in TMA is a bug. Copy an existing static-init block verbatim,
+  or better, call `pmix_obj_construct_tma()` — which is the *one* place
+  that clears all eight `pmix_tma_t` members. `pmix_obj_new_tma()` used
+  to carry its own copy of that code and cleared only seven, leaving
+  `tma_memmove` holding whatever `malloc` returned in every heap object
+  in the library. Do not write a second copy.
 
 ## The container classes
 
@@ -201,6 +240,36 @@ mostly spelled out in the header's opening comment:
   `pmix_list_join` are O(N) only because they must fix that count.
 - `pmix_list_sort` sorts via an array of pointers + `qsort`; its compare
   function receives **double pointers** (`pmix_list_item_t **`).
+- **`pmix_list_insert` cannot append.** It rejects `idx >= length`, so
+  the one-past-the-end position a caller would expect to mean "append"
+  fails. The header says "greater than the length"; the code means
+  "greater than or equal". Use `pmix_list_append`.
+
+> ### `PMIX_LIST_STATIC_INIT` does not produce a usable list
+>
+> This is the sharpest edge in the directory and it is not obvious from
+> the macro. `pmix_list_construct` makes the list empty by pointing the
+> sentinel's `next` and `prev` **at itself** — an address a static
+> initializer cannot name. So `PMIX_LIST_STATIC_INIT` leaves both links
+> `NULL`, and on such a list `pmix_list_is_empty()` returns **false**
+> (`NULL != &sentinel`), `PMIX_LIST_FOREACH` dereferences NULL, and
+> `pmix_list_append` writes through a NULL `sentinel->prev`.
+>
+> The macro exists to give a file-scope list a *defined* state before
+> init runs — so that an early failure path can destruct it — **not** to
+> make it usable. Every one of the ~45 uses in the tree is followed by a
+> `PMIX_CONSTRUCT(&list, pmix_list_t)` at init time; that is mandatory,
+> not stylistic. If you add a statically initialized list, add the
+> construct with it, and do not touch the list on any path that can run
+> before it.
+>
+> The other `PMIX_*_STATIC_INIT` macros *do* produce a working (empty)
+> object, so this is a `pmix_list_t` peculiarity. It is also why
+> `PMIX_HOTEL_STATIC_INIT` having disagreed with the hotel constructor
+> about `last_unoccupied_room` was a live bug rather than a cosmetic
+> one: `pmix_globals.notifications` is built that way and reported a
+> free room before `pmix_hotel_init` ever ran. When you add a
+> `STATIC_INIT` macro, check it field-by-field against the constructor.
 
 ### `pmix_pointer_array_t` — index-addressable pointer table
 
@@ -227,6 +296,22 @@ Grows when density crosses `ht_growth_trigger` (default 1/2, doubling).
 Iterate with `PMIX_HASH_TABLE_FOREACH(key, uint32|uint64|ptr, val, ht)`;
 do not remove during a foreach. TMA-aware.
 
+Two things about this class that will surprise you:
+
+- **A "get" writes to the table.** Every `pmix_hash_table_get_value_*`
+  assigns `ht->ht_type_methods` before probing — that is how the table
+  learns its key type. So there is no read-only path: two threads
+  reading concurrently is a data race, and a table mapped read-only in
+  a shared segment would fault on a lookup. If you ever need a genuinely
+  const lookup, that assignment is what has to move.
+- Every entry point starts with `key % capacity`, and capacity is zero
+  until `pmix_hash_table_init` runs. The guard that catches that used to
+  be `#if PMIX_ENABLE_DEBUG`, so an optimized build took a SIGFPE where
+  a debug build returned an error. It is unconditional now. **Be very
+  careful about putting a correctness guard inside `PMIX_ENABLE_DEBUG`
+  in this directory** — the diagnostic `pmix_output` belongs there, the
+  check usually does not.
+
 ### `pmix_hotel_t` — fixed-occupancy timeout slots
 
 A "hotel" has a fixed number of rooms; an opaque pointer "checks in" to a
@@ -247,6 +332,22 @@ says so at each site. Needs an event base; `#include <event.h>`.
 Push/pop/poke over a fixed ring of `size` pointers; pushing into a full
 ring returns the displaced oldest entry (NACK-style schemes, per the
 hotel header's cross-reference). Small and self-contained; not TMA-aware.
+
+**It has no callers.** Nothing in `src/`, `test/` (beyond its own unit
+test), `bindings/` or `examples/` uses this class; the only reference is
+the aspirational mention in `pmix_hotel.h`'s opening comment. That is
+worth knowing before you spend effort on it — and it is why its class
+descriptor was missing `PMIX_EXPORT` for years without anyone noticing
+(the symbol is hidden in any build that does not pass
+`--disable-visibility`, so `PMIX_NEW(pmix_ring_buffer_t)` could not link
+outside `libpmix`). If you find yourself reaching for it, check first
+whether a hotel or a list fits; if it stays unused indefinitely,
+removing it is a reasonable proposal to raise on an issue.
+
+Note also that `pmix_ring_buffer_push`'s tail bookkeeping is only
+correct because `tail == head` whenever the ring is full. That invariant
+is not asserted anywhere. Do not "simplify" that function without
+convincing yourself of it.
 
 ### `pmix_value_array_t` — by-value dynamic array
 
@@ -280,6 +381,13 @@ src/class/
 ├── pmix_value_array.{h,c}     by-value contiguous dynamic array
 ├── pmix_bitmap.{h,c}          auto-expanding bitmap
 └── Makefile.am                builds noinst libpmix_class.la; installs headers
+
+test/unit/class/               one make-check program per class, plus
+                               class_refcount for the concurrent count;
+                               see its AGENTS.md
+contrib/dockerswarm/run-class-tests.sh
+                               runs that suite --disable-debug with
+                               default visibility, on Linux
 ```
 
 Much of the behavior lives in `static inline` functions in the headers
@@ -287,13 +395,46 @@ Much of the behavior lives in `static inline` functions in the headers
 `.h` before assuming the `.c` tells the whole story — for `pmix_hotel` and
 much of `pmix_list`, the header *is* the implementation.
 
+## Testing
+
+Every class here has a unit test under
+[`test/unit/class`](../../test/unit/class), wired into `make check` and
+therefore into CI. Read
+[`test/unit/class/AGENTS.md`](../../test/unit/class/AGENTS.md) before
+adding to them — in particular for what those tests deliberately do
+*not* do, and for the configuration trap described there.
+
+The short version of that trap, because it caused several of the bugs
+this directory has had:
+
+- The maintainer's tree — and every tree `contrib/dockerswarm/build.sh`
+  produces — is configured `--enable-debug --enable-devel-check`, and
+  usually `--disable-visibility` too. A guard placed inside
+  `#if PMIX_ENABLE_DEBUG` is therefore **never exercised in the
+  configuration where its absence bites**, and a missing `PMIX_EXPORT`
+  cannot fail to link.
+- `contrib/dockerswarm/run-class-tests.sh` exists to close that gap: it
+  builds and runs the suite `--disable-debug` with default visibility,
+  on Linux. It found the missing `PMIX_EXPORT` on
+  `pmix_ring_buffer_t_class` on its first run. Run it after any
+  non-trivial change here.
+- A multi-*node* test is not meaningful for this directory — these are
+  single-process data structures. The genuinely distributed dimension is
+  the cross-process TMA path (`gds/shmem2`), which the group tests in
+  `contrib/dockerswarm/run-tests.sh` exercise.
+
 ## Threading
 
 With one exception, these classes are **not internally synchronized**.
-The exception is the `pmix_object_t` reference count, which is
-mutex-protected so `PMIX_RETAIN`/`PMIX_RELEASE` are safe from any thread.
-Everything else — list links, hash-table slots, pointer-array indices,
-hotel rooms — assumes the caller provides serialization. In PMIx that
+The exception is the `pmix_object_t` reference count, which is a C11
+atomic so `PMIX_RETAIN`/`PMIX_RELEASE` are safe from any thread and from
+any process sharing a TMA segment. That is the whole of the guarantee:
+the count is safe, the *object* is not. Two threads that both hold a
+reference still race on every field below `pmix_object_t`.
+
+Everything else — list links, hash-table slots (including on a *read*,
+see above), pointer-array indices, hotel rooms — assumes the caller
+provides serialization. In PMIx that
 serialization is the **progress thread**: per the top-level thread-safety
 rules, shared library state (which is overwhelmingly built from these
 containers) is manipulated only on the progress thread, and public API
@@ -337,7 +478,30 @@ consumable internal surface — keep them clean.
 - **Do not weaken the debug spot-checks.** The list refcount asserts and
   the object magic-ID checks catch real bugs. If one fires, the default
   assumption is that a *caller* violated the contract (an item on two
-  lists, a double free), not that the check is wrong.
+  lists, a double free, a second `PMIX_DESTRUCT`), not that the check is
+  wrong. That applies to tests too: if a new test trips an assert, fix
+  the test.
+- **Put diagnostics under `PMIX_ENABLE_DEBUG`, not checks.** A guard
+  that prevents a divide-by-zero, an out-of-bounds `memmove`, or a
+  bogus size computation belongs in every build; only the accompanying
+  `pmix_output` belongs inside the `#if`. Several defects in this
+  directory were exactly this mistake, and they are invisible in the
+  configuration everyone develops in.
+- **Leave objects in the constructed state when you destruct them.**
+  The destructors here now do (`pmix_list_destruct` always did — it
+  calls the constructor). Freeing a pointer and leaving it in the struct
+  behind a non-zero size is what turns one caller mistake into a
+  double free or a read of freed memory.
+- **Watch the width of shift operands.** The bitmap words are
+  `uint64_t`, so mask shifts run to 63. `1UL << offset` is undefined
+  above 31 where `unsigned long` is 32 bits (32-bit Linux, Windows) and
+  `1LL << 63` overflows a signed 64-bit type. Write `((uint64_t) 1) <<`
+  or `1ULL <<`.
+- **Mark new class descriptors `PMIX_EXPORT`.** Write
+  `PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_foo_t);`. Without it the
+  descriptor is hidden outside `libpmix` and `PMIX_NEW(pmix_foo_t)` will
+  not link for any consumer — a failure you cannot see locally if your
+  tree is configured `--disable-visibility`.
 - **Keep it warning-free and portable.** This code runs on every platform
   PMIx supports and is compiled with `-Werror` in CI. Use the
   `__pmix_attribute_*__` wrappers and `PMIX_HIDE_UNUSED_PARAMS` rather

--- a/src/class/AGENTS.md
+++ b/src/class/AGENTS.md
@@ -105,41 +105,51 @@ Rules that trip people up:
   runs (e.g. `PMIX_LIST_STATIC_INIT`, `PMIX_HASH_TABLE_STATIC_INIT`).
   Prefer it to `PMIX_CONSTRUCT` for statics.
 
-### Reference counting is a C11 atomic
+### Reference counting is mutex-guarded — and that is a known problem
 
-`obj_reference_count` is a `pmix_atomic_int32_t`, and `pmix_obj_update`
-is a single `atomic_fetch_add_explicit(..., memory_order_acq_rel)`.
-**PMIx requires C11 atomics — `config/pmix.m4` fails configure outright
-without them — so there is never a question of whether they are
-available.** Do not reintroduce a lock here, and do not propose a
-fallback path for compilers that lack `<stdatomic.h>`; such a compiler
-cannot build PMIx at all.
+`obj_reference_count` is a plain `int32_t`, and `pmix_obj_update()` takes
+a per-object `pthread_mutex_t obj_lock` around every `PMIX_RETAIN` and
+`PMIX_RELEASE`. It is correct for threads within one process, and it is
+what the concurrency test in `test/unit/class/class_refcount.c` pins.
 
-The ordering is `acq_rel` because the one function serves both
-directions: the thread dropping the last reference must publish its
-writes before the count reaches zero, and whichever thread *observes*
-zero — and therefore runs the destructors and frees the storage — must
-acquire them. Anything weaker races the destructor against the last
-user. If you touch this, keep it `acq_rel`; a "relaxed is enough for a
-refcount" simplification is only true for the increment.
+Two defects come with it, and neither can be fixed in this directory
+alone:
 
-This replaced a per-object `pthread_mutex_t obj_lock` that was taken and
-released on every `PMIX_RETAIN`/`PMIX_RELEASE`. Three things came with
-that change, worth knowing if you are reading older code or an older
-branch:
+- The mutex is `pthread_mutex_init`'d in `pmix_obj_new_tma()` and
+  **never destroyed**, so it leaks on any platform where init allocates.
+- Objects allocated from a TMA live in an mmap'd segment shared between
+  processes (see the TMA section below), but the embedded mutex is never
+  created `PTHREAD_PROCESS_SHARED` — so **cross-process retain/release
+  on a shared object is undefined behavior today**.
 
-- The mutex was `pthread_mutex_init`'d and **never destroyed**, so it
-  leaked on any platform where init allocates.
-- Objects allocated from a TMA live in a shared-memory segment, and the
-  embedded mutex was never `PTHREAD_PROCESS_SHARED` — cross-process
-  retain/release was undefined. An atomic `int32_t` in shared memory is
-  well defined, which is what makes the TMA path below actually sound.
-- Every object in the tree shrank by the size of a `pthread_mutex_t`
-  (40 bytes on glibc, 64 on macOS), and `PMIX_OBJ_STATIC_INIT` no longer
-  carries `PTHREAD_MUTEX_INITIALIZER`.
+The obvious fix is a C11 atomic: PMIx hard-requires them
+(`config/pmix.m4` fails configure outright without them), and an atomic
+`int32_t` in shared memory is well defined. That change was written and
+then **pulled back out**, because it is not local:
 
-Retain/release is now cheap, but it is still an atomic RMW with full
-fencing — do not treat it as free in a tight loop.
+> Dropping `obj_lock` shrinks `pmix_object_t` from 168 bytes to 104,
+> which shifts every field of every derived class. `gds/shmem2` builds
+> `pmix_list_t` and `pmix_hash_table_t` *inside the segment it shares
+> with client processes*, and that segment carries no layout guard — so
+> a client from an older release maps the segment, reads
+> `pmix_list_length` at offset 368 where the server wrote it at 240, and
+> segfaults. `src/class/pmix_object.h` is also an installed header, so a
+> companion build such as PRRTE has the same exposure.
+
+Padding the mutex away does not help: an older peer does not merely
+expect 40-64 bytes at that offset, it expects a *working* mutex and will
+lock it. The mitigation has to make an older peer decline the segment
+entirely, which means the shared-memory component has to be invisible to
+it. That work — the atomic, plus renaming the component so pre-existing
+clients fall back to `hash`, plus ideally a layout stamp on the segment
+so future class changes are caught rather than crashing — belongs
+together in its own change.
+
+**So: do not "fix" the mutex here in isolation.** Any change to the size
+or layout of `pmix_object_t`, or of anything derived from it, is a
+cross-version compatibility change because of the `gds/shmem2` segment.
+Check that first.
+
 
 In `--enable-debug` builds each object carries a magic ID
 (`PMIX_OBJ_MAGIC_ID`) plus the file/line of last construction; the

--- a/src/class/pmix_bitmap.c
+++ b/src/class/pmix_bitmap.c
@@ -93,18 +93,21 @@ int pmix_bitmap_init(pmix_bitmap_t *bm, int size)
         return PMIX_ERR_BAD_PARAM;
     }
 
-    bm->array_size = nwords;
     if (NULL != bm->bitmap) {
         free(bm->bitmap);
-        if (bm->max_size < bm->array_size)
-            bm->max_size = bm->array_size;
+        bm->bitmap = NULL;
     }
-    bm->bitmap = (uint64_t *) calloc(bm->array_size, sizeof(uint64_t));
+    /* Leave array_size describing what bitmap actually points at: an
+     * allocation failure that left a non-zero size behind a NULL pointer
+     * would send every subsequent accessor through bm->bitmap[index]. */
+    bm->array_size = 0;
+    bm->bitmap = (uint64_t *) calloc(nwords, sizeof(uint64_t));
     if (NULL == bm->bitmap) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
+    bm->array_size = nwords;
 
-    pmix_bitmap_clear_all_bits(bm);
+    /* calloc already zeroed the words */
     return PMIX_SUCCESS;
 }
 
@@ -153,8 +156,10 @@ int pmix_bitmap_set_bit(pmix_bitmap_t *bm, int bit)
         bm->array_size = new_size;
     }
 
-    /* Now set the bit */
-    bm->bitmap[index] |= (1UL << offset);
+    /* Now set the bit. The shift has to be done in a 64-bit type: offset
+     * runs to 63, and unsigned long is only 32 bits wide on 32-bit Linux
+     * and on Windows, where "1UL << 32" and beyond is undefined. */
+    bm->bitmap[index] |= (((uint64_t) 1) << offset);
 
     return PMIX_SUCCESS;
 }
@@ -170,7 +175,7 @@ int pmix_bitmap_clear_bit(pmix_bitmap_t *bm, int bit)
     index = bit / SIZE_OF_BASE_TYPE;
     offset = bit % SIZE_OF_BASE_TYPE;
 
-    bm->bitmap[index] &= ~(1UL << offset);
+    bm->bitmap[index] &= ~(((uint64_t) 1) << offset);
     return PMIX_SUCCESS;
 }
 
@@ -185,7 +190,7 @@ bool pmix_bitmap_is_set_bit(pmix_bitmap_t *bm, int bit)
     index = bit / SIZE_OF_BASE_TYPE;
     offset = bit % SIZE_OF_BASE_TYPE;
 
-    if (0 != (bm->bitmap[index] & (1UL << offset))) {
+    if (0 != (bm->bitmap[index] & (((uint64_t) 1) << offset))) {
         return true;
     }
 
@@ -198,7 +203,11 @@ int pmix_bitmap_clear_all_bits(pmix_bitmap_t *bm)
         return PMIX_ERR_BAD_PARAM;
     }
 
-    memset(bm->bitmap, 0, bm->array_size * sizeof(uint64_t));
+    /* An un-init'd bitmap has no words; memset(NULL, ..., 0) is still
+     * undefined, so say nothing to do rather than relying on it. */
+    if (NULL != bm->bitmap) {
+        memset(bm->bitmap, 0, bm->array_size * sizeof(uint64_t));
+    }
     return PMIX_SUCCESS;
 }
 
@@ -208,7 +217,9 @@ int pmix_bitmap_set_all_bits(pmix_bitmap_t *bm)
         return PMIX_ERR_BAD_PARAM;
     }
 
-    memset(bm->bitmap, 0xff, bm->array_size * sizeof(uint64_t));
+    if (NULL != bm->bitmap) {
+        memset(bm->bitmap, 0xff, bm->array_size * sizeof(uint64_t));
+    }
 
     return PMIX_SUCCESS;
 }
@@ -325,10 +336,12 @@ bool pmix_bitmap_are_different(pmix_bitmap_t *left, pmix_bitmap_t *right)
     int i;
 
     /*
-     * Sanity check
+     * Sanity check. This returns bool, so there is no error code to hand
+     * back: report a bad argument as "different", which is the answer that
+     * keeps a caller from acting on a comparison it never really made.
      */
     if (NULL == left || NULL == right) {
-        return PMIX_ERR_BAD_PARAM;
+        return true;
     }
 
     if (pmix_bitmap_size(left) != pmix_bitmap_size(right)) {
@@ -394,8 +407,10 @@ int pmix_bitmap_num_set_bits(pmix_bitmap_t *bm, int len)
         if (0 == (val = bm->bitmap[i]))
             continue;
         if (i == i_len - 1 && len % SIZE_OF_BASE_TYPE != 0) {
-            /* mask out the bits above len */
-            val = val & ((1LL << (len - i * SIZE_OF_BASE_TYPE)) - 1);
+            /* Mask out the bits above len. The shift distance runs to 63,
+             * so it has to be applied to an unsigned 64-bit value: shifting
+             * a signed 1LL by 63 overflows the sign bit and is undefined. */
+            val = val & ((1ULL << (len - i * SIZE_OF_BASE_TYPE)) - 1);
             if (0 == val)
                 continue;
         }
@@ -412,6 +427,10 @@ int pmix_bitmap_num_set_bits(pmix_bitmap_t *bm, int len)
 bool pmix_bitmap_is_clear(pmix_bitmap_t *bm)
 {
     int i;
+
+    if (NULL == bm) {
+        return true;
+    }
 
     for (i = 0; i < bm->array_size; ++i) {
         if (0 != bm->bitmap[i]) {

--- a/src/class/pmix_bitmap.h
+++ b/src/class/pmix_bitmap.h
@@ -164,18 +164,33 @@ static inline int pmix_bitmap_size(pmix_bitmap_t *bm)
  *
  * @param dest Pointer to the destination bitmap
  * @param src Pointer to the source bitmap
- * @ return PMIX error code if something goes wrong
+ * @return PMIX_SUCCESS, or PMIX_ERR_BAD_PARAM / PMIX_ERR_OUT_OF_RESOURCE.
+ *         On failure dest is left as it was found, not half-copied.
  */
-static inline void pmix_bitmap_copy(pmix_bitmap_t *dest, pmix_bitmap_t *src)
+static inline int pmix_bitmap_copy(pmix_bitmap_t *dest, pmix_bitmap_t *src)
 {
-    if (dest->array_size < src->array_size) {
-        if (NULL != dest->bitmap)
-            free(dest->bitmap);
-        dest->max_size = src->max_size;
-        dest->bitmap = (uint64_t *) calloc(src->array_size, sizeof(uint64_t));
+    if (NULL == dest || NULL == src) {
+        return PMIX_ERR_BAD_PARAM;
     }
-    memcpy(dest->bitmap, src->bitmap, src->array_size * sizeof(uint64_t));
+    if (dest->array_size < src->array_size) {
+        /* Grow first and only commit once the allocation succeeded: the
+         * old code freed dest->bitmap, then memcpy'd into whatever calloc
+         * returned without looking at it. */
+        uint64_t *grown = (uint64_t *) calloc(src->array_size, sizeof(uint64_t));
+        if (NULL == grown) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        if (NULL != dest->bitmap) {
+            free(dest->bitmap);
+        }
+        dest->bitmap = grown;
+        dest->max_size = src->max_size;
+    }
+    if (0 < src->array_size) {
+        memcpy(dest->bitmap, src->bitmap, src->array_size * sizeof(uint64_t));
+    }
     dest->array_size = src->array_size;
+    return PMIX_SUCCESS;
 }
 
 /**

--- a/src/class/pmix_hash_table.c
+++ b/src/class/pmix_hash_table.c
@@ -89,6 +89,11 @@ static void pmix_hash_table_destruct(pmix_hash_table_t *ht)
     pmix_tma_t *const tma = pmix_obj_get_tma(&ht->super);
     pmix_hash_table_remove_all(ht);
     pmix_tma_free(tma, ht->ht_table);
+    /* Back to the constructed state. Leaving ht_table dangling with a
+     * non-zero ht_capacity meant a second PMIX_DESTRUCT freed it again,
+     * and any stray lookup indexed freed memory instead of failing the
+     * capacity check. */
+    pmix_hash_table_construct(ht);
 }
 
 /*
@@ -283,12 +288,18 @@ pmix_hash_table_get_value_uint32(pmix_hash_table_t *ht, uint32_t key, void **val
     size_t ii, capacity = ht->ht_capacity;
     pmix_hash_element_t *elt;
 
+    /* An un-init'd table has no slots, and every lookup below starts
+     * with "key % capacity" -- a division by zero. This check used to
+     * live inside the PMIX_ENABLE_DEBUG block below, so an optimized
+     * build took the SIGFPE instead of the error return. */
+    if (PMIX_UNLIKELY(0 == capacity)) {
 #if PMIX_ENABLE_DEBUG
-    if (capacity == 0) {
         pmix_output(0, "pmix_hash_table_get_value_uint32:"
                        "pmix_hash_table_init() has not been called");
+#endif
         return PMIX_ERROR;
     }
+#if PMIX_ENABLE_DEBUG
     // First check if the hash table is using a non-standard heap manager. Skip
     // this debug check because use of a shared-memory TMA may trigger an error
     // since some processes may have not yet updated their function pointers
@@ -326,12 +337,18 @@ pmix_hash_table_set_value_uint32(pmix_hash_table_t *ht, uint32_t key, void *valu
     pmix_hash_element_t *elt;
     pmix_tma_t *const tma = pmix_obj_get_tma(&ht->super);
 
+    /* An un-init'd table has no slots, and every lookup below starts
+     * with "key % capacity" -- a division by zero. This check used to
+     * live inside the PMIX_ENABLE_DEBUG block below, so an optimized
+     * build took the SIGFPE instead of the error return. */
+    if (PMIX_UNLIKELY(0 == capacity)) {
 #if PMIX_ENABLE_DEBUG
-    if (capacity == 0) {
         pmix_output(0, "pmix_hash_table_set_value_uint32:"
                        "pmix_hash_table_init() has not been called");
+#endif
         return PMIX_ERR_BAD_PARAM;
     }
+#if PMIX_ENABLE_DEBUG
     // First check if the hash table is using a non-standard heap manager. Skip
     // this debug check because use of a shared-memory TMA may trigger an error
     // since some processes may have not yet updated their function pointers
@@ -377,12 +394,18 @@ int pmix_hash_table_remove_value_uint32(pmix_hash_table_t *ht, uint32_t key)
 {
     size_t ii, capacity = ht->ht_capacity;
 
+    /* An un-init'd table has no slots, and every lookup below starts
+     * with "key % capacity" -- a division by zero. This check used to
+     * live inside the PMIX_ENABLE_DEBUG block below, so an optimized
+     * build took the SIGFPE instead of the error return. */
+    if (PMIX_UNLIKELY(0 == capacity)) {
 #if PMIX_ENABLE_DEBUG
-    if (capacity == 0) {
         pmix_output(0, "pmix_hash_table_get_value_uint32:"
                        "pmix_hash_table_init() has not been called");
+#endif
         return PMIX_ERROR;
     }
+#if PMIX_ENABLE_DEBUG
     // First check if the hash table is using a non-standard heap manager. Skip
     // this debug check because use of a shared-memory TMA may trigger an error
     // since some processes may have not yet updated their function pointers
@@ -428,12 +451,18 @@ pmix_hash_table_get_value_uint64(pmix_hash_table_t *ht, uint64_t key, void **val
     size_t capacity = ht->ht_capacity;
     pmix_hash_element_t *elt;
 
+    /* An un-init'd table has no slots, and every lookup below starts
+     * with "key % capacity" -- a division by zero. This check used to
+     * live inside the PMIX_ENABLE_DEBUG block below, so an optimized
+     * build took the SIGFPE instead of the error return. */
+    if (PMIX_UNLIKELY(0 == capacity)) {
 #if PMIX_ENABLE_DEBUG
-    if (capacity == 0) {
         pmix_output(0, "pmix_hash_table_get_value_uint64:"
                        "pmix_hash_table_init() has not been called");
+#endif
         return PMIX_ERROR;
     }
+#if PMIX_ENABLE_DEBUG
     // First check if the hash table is using a non-standard heap manager. Skip
     // this debug check because use of a shared-memory TMA may trigger an error
     // since some processes may have not yet updated their function pointers
@@ -471,12 +500,18 @@ pmix_hash_table_set_value_uint64(pmix_hash_table_t *ht, uint64_t key, void *valu
     pmix_hash_element_t *elt;
     pmix_tma_t *const tma = pmix_obj_get_tma(&ht->super);
 
+    /* An un-init'd table has no slots, and every lookup below starts
+     * with "key % capacity" -- a division by zero. This check used to
+     * live inside the PMIX_ENABLE_DEBUG block below, so an optimized
+     * build took the SIGFPE instead of the error return. */
+    if (PMIX_UNLIKELY(0 == capacity)) {
 #if PMIX_ENABLE_DEBUG
-    if (capacity == 0) {
         pmix_output(0, "pmix_hash_table_set_value_uint64:"
                        "pmix_hash_table_init() has not been called");
+#endif
         return PMIX_ERR_BAD_PARAM;
     }
+#if PMIX_ENABLE_DEBUG
     // First check if the hash table is using a non-standard heap manager. Skip
     // this debug check because use of a shared-memory TMA may trigger an error
     // since some processes may have not yet updated their function pointers
@@ -522,12 +557,18 @@ pmix_hash_table_remove_value_uint64(pmix_hash_table_t *ht, uint64_t key)
 {
     size_t ii, capacity = ht->ht_capacity;
 
+    /* An un-init'd table has no slots, and every lookup below starts
+     * with "key % capacity" -- a division by zero. This check used to
+     * live inside the PMIX_ENABLE_DEBUG block below, so an optimized
+     * build took the SIGFPE instead of the error return. */
+    if (PMIX_UNLIKELY(0 == capacity)) {
 #if PMIX_ENABLE_DEBUG
-    if (capacity == 0) {
         pmix_output(0, "pmix_hash_table_get_value_uint64:"
                        "pmix_hash_table_init() has not been called");
+#endif
         return PMIX_ERROR;
     }
+#if PMIX_ENABLE_DEBUG
     // First check if the hash table is using a non-standard heap manager. Skip
     // this debug check because use of a shared-memory TMA may trigger an error
     // since some processes may have not yet updated their function pointers
@@ -600,12 +641,18 @@ pmix_hash_table_get_value_ptr(pmix_hash_table_t *ht, const void *key, size_t key
     size_t ii, capacity = ht->ht_capacity;
     pmix_hash_element_t *elt;
 
+    /* An un-init'd table has no slots, and every lookup below starts
+     * with "key % capacity" -- a division by zero. This check used to
+     * live inside the PMIX_ENABLE_DEBUG block below, so an optimized
+     * build took the SIGFPE instead of the error return. */
+    if (PMIX_UNLIKELY(0 == capacity)) {
 #if PMIX_ENABLE_DEBUG
-    if (capacity == 0) {
         pmix_output(0, "pmix_hash_table_get_value_ptr:"
                        "pmix_hash_table_init() has not been called");
+#endif
         return PMIX_ERROR;
     }
+#if PMIX_ENABLE_DEBUG
     // First check if the hash table is using a non-standard heap manager. Skip
     // this debug check because use of a shared-memory TMA may trigger an error
     // since some processes may have not yet updated their function pointers
@@ -644,12 +691,18 @@ pmix_hash_table_set_value_ptr(pmix_hash_table_t *ht, const void *key, size_t key
     pmix_hash_element_t *elt;
     pmix_tma_t *const tma = pmix_obj_get_tma(&ht->super);
 
+    /* An un-init'd table has no slots, and every lookup below starts
+     * with "key % capacity" -- a division by zero. This check used to
+     * live inside the PMIX_ENABLE_DEBUG block below, so an optimized
+     * build took the SIGFPE instead of the error return. */
+    if (PMIX_UNLIKELY(0 == capacity)) {
 #if PMIX_ENABLE_DEBUG
-    if (capacity == 0) {
         pmix_output(0, "pmix_hash_table_set_value_ptr:"
                        "pmix_hash_table_init() has not been called");
+#endif
         return PMIX_ERR_BAD_PARAM;
     }
+#if PMIX_ENABLE_DEBUG
     // First check if the hash table is using a non-standard heap manager. Skip
     // this debug check because use of a shared-memory TMA may trigger an error
     // since some processes may have not yet updated their function pointers
@@ -703,12 +756,18 @@ pmix_hash_table_remove_value_ptr(pmix_hash_table_t *ht, const void *key, size_t 
 {
     size_t ii, capacity = ht->ht_capacity;
 
+    /* An un-init'd table has no slots, and every lookup below starts
+     * with "key % capacity" -- a division by zero. This check used to
+     * live inside the PMIX_ENABLE_DEBUG block below, so an optimized
+     * build took the SIGFPE instead of the error return. */
+    if (PMIX_UNLIKELY(0 == capacity)) {
 #if PMIX_ENABLE_DEBUG
-    if (capacity == 0) {
         pmix_output(0, "pmix_hash_table_get_value_ptr:"
                        "pmix_hash_table_init() has not been called");
+#endif
         return PMIX_ERROR;
     }
+#if PMIX_ENABLE_DEBUG
     // First check if the hash table is using a non-standard heap manager. Skip
     // this debug check because use of a shared-memory TMA may trigger an error
     // since some processes may have not yet updated their function pointers

--- a/src/class/pmix_hotel.c
+++ b/src/class/pmix_hotel.c
@@ -20,6 +20,9 @@
 #include <event.h>
 #include "src/class/pmix_hotel.h"
 
+static void constructor(pmix_hotel_t *h);
+static void destructor(pmix_hotel_t *h);
+
 static void local_eviction_callback(int fd, short flags, void *arg)
 {
     (void) fd;
@@ -54,6 +57,11 @@ pmix_status_t pmix_hotel_init(pmix_hotel_t *h, int num_rooms, pmix_event_base_t 
     if (num_rooms <= 0 || NULL == evict_callback_fn) {
         return PMIX_ERR_BAD_PARAM;
     }
+
+    /* Re-initializing a live hotel used to overwrite all three array
+     * pointers and leak everything they addressed. Tear the old one down
+     * first; on a freshly constructed hotel this does nothing. */
+    destructor(h);
 
     h->num_rooms = num_rooms;
     h->evbase = evbase;
@@ -137,6 +145,11 @@ static void destructor(pmix_hotel_t *h)
     if (NULL != h->unoccupied_rooms) {
         free(h->unoccupied_rooms);
     }
+
+    /* Leave the hotel in the state the constructor produces, so that a
+     * second PMIX_DESTRUCT does not free the same three arrays again and
+     * so nothing walks a dangling rooms[] looking for occupants. */
+    constructor(h);
 }
 
 PMIX_CLASS_INSTANCE(pmix_hotel_t, pmix_object_t, constructor, destructor);

--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -148,7 +148,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_hotel_t);
     .rooms = NULL,                                  \
     .eviction_args = NULL,                          \
     .unoccupied_rooms = NULL,                       \
-    .last_unoccupied_room = 0                       \
+    .last_unoccupied_room = -1                      \
 }
 
 
@@ -163,9 +163,10 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_hotel_t);
  * @param evict_callback_fn Callback function invoked if an occupant
  * does not check out before the eviction_timeout.
  *
- * NOTE: If the callback function is NULL, then no eviction timer
- * will be set - occupants will remain checked into the hotel until
- * explicitly checked out.
+ * NOTE: evict_callback_fn is required; passing NULL returns
+ * PMIX_ERR_BAD_PARAM. To keep occupants checked in until they are
+ * explicitly checked out, pass a NULL evbase instead - no eviction timer
+ * is then armed and the callback is never invoked.
  *
  * Also note: the eviction_callback_fn should absolutely not call any
  * of the hotel checkout functions.  Specifically: the occupant has

--- a/src/class/pmix_list.h
+++ b/src/class/pmix_list.h
@@ -810,8 +810,16 @@ static inline void pmix_list_insert_pos(pmix_list_t *list, pmix_list_item_t *pos
  * Example: if idx = 2 and list = item1->item2->item3->item4, then
  * after insert, list = item1->item2->item->item3->item4.
  *
- * If index is greater than the length of the list, no action is
- * performed and false is returned.
+ * The item is always inserted *before* an existing item, so idx must
+ * identify one: it has to be strictly less than the current list
+ * length.  Otherwise no action is performed and false is returned.
+ *
+ * In particular, this function CANNOT APPEND.  idx == the list length
+ * -- the one-past-the-end position that would mean "put it at the
+ * back" -- is rejected along with everything above it, and an empty
+ * list rejects every idx including 0.  Use pmix_list_append() to add
+ * at the back and pmix_list_prepend() to add at the front; both are
+ * O(1), where this is O(N).
  */
 PMIX_EXPORT bool pmix_list_insert(pmix_list_t *list,
                                   pmix_list_item_t *item,

--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -611,7 +611,7 @@ static inline void pmix_obj_construct_tma(pmix_object_t *obj, pmix_tma_t *tma)
         } while (0)
 #endif
 
-PMIX_CLASS_DECLARATION(pmix_object_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_object_t);
 
 /* declarations *******************************************************/
 

--- a/src/class/pmix_pointer_array.c
+++ b/src/class/pmix_pointer_array.c
@@ -197,7 +197,11 @@ int pmix_pointer_array_init(pmix_pointer_array_t *array, int initial_allocation,
     array->block_size = (0 == block_size ? 8 : block_size);
     array->lowest_free = 0;
 
-    num_bytes = (0 < initial_allocation ? initial_allocation : block_size);
+    /* Fall back on the *normalized* block size. Reading the caller's raw
+     * block_size here meant init(array, 0, max, 0) allocated nothing while
+     * array->block_size was quietly set to 8. */
+    num_bytes = (0 < initial_allocation ? (size_t) initial_allocation
+                                        : (size_t) array->block_size);
 
     /* Allocate and set the array to NULL */
     array->addr = (void **) pmix_tma_calloc(tma, num_bytes, sizeof(void *));
@@ -420,7 +424,6 @@ static bool grow_table(pmix_pointer_array_t *table, int at_least)
         return false;
     }
 
-    table->number_free += (new_size - table->size);
     table->addr = (void **) p;
     for (i = table->size; i < new_size; ++i) {
         table->addr[i] = NULL;
@@ -429,6 +432,12 @@ static bool grow_table(pmix_pointer_array_t *table, int at_least)
     if ((int) (TYPE_ELEM_COUNT(uint64_t, table->size)) != new_size_int) {
         p = (uint64_t *) pmix_tma_realloc(tma, table->free_bits, new_size_int * sizeof(uint64_t));
         if (NULL == p) {
+            /* The pointer array itself did grow, but without matching
+             * free_bits the two are out of step, so report failure and
+             * leave the accounting describing the *old* extent. Bumping
+             * number_free before this point (as the code used to) left the
+             * table claiming free slots that FIND_FIRST_ZERO would then go
+             * looking for past the end of free_bits. */
             return false;
         }
         table->free_bits = (uint64_t *) p;
@@ -436,6 +445,7 @@ static bool grow_table(pmix_pointer_array_t *table, int at_least)
             table->free_bits[i] = 0;
         }
     }
+    table->number_free += (new_size - table->size);
     table->size = new_size;
 #if 0
     pmix_output(0, "grow_table %p to %d (max_size %d, block %d, number_free %d)\n",

--- a/src/class/pmix_ring_buffer.c
+++ b/src/class/pmix_ring_buffer.c
@@ -65,13 +65,17 @@ static void pmix_ring_buffer_destruct(pmix_ring_buffer_t *ring)
  */
 int pmix_ring_buffer_init(pmix_ring_buffer_t *ring, int size)
 {
-    /* check for errors */
-    if (NULL == ring) {
+    /* Check for errors. A non-positive size used to be accepted: calloc()
+     * would hand back a zero-byte (or wildly mis-sized) block and the very
+     * first pmix_ring_buffer_push() would write through addr[0]. */
+    if (NULL == ring || size <= 0) {
         return PMIX_ERR_BAD_PARAM;
     }
 
-    /* Allocate and set the ring to NULL */
-    ring->addr = (char **) calloc(size * sizeof(char *), 1);
+    /* Allocate and set the ring to NULL. Pass the count and the element
+     * size as calloc()'s two arguments, in that order, so that calloc()
+     * can do the multiplication overflow check it exists to do. */
+    ring->addr = (char **) calloc((size_t) size, sizeof(char *));
     if (NULL == ring->addr) { /* out of memory */
         return PMIX_ERR_OUT_OF_RESOURCE;
     }

--- a/src/class/pmix_ring_buffer.h
+++ b/src/class/pmix_ring_buffer.h
@@ -54,7 +54,7 @@ typedef struct pmix_ring_buffer_t pmix_ring_buffer_t;
 /**
  * Class declaration
  */
-PMIX_CLASS_DECLARATION(pmix_ring_buffer_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_ring_buffer_t);
 
 /**
  * Initialize the ring buffer, defining its size.

--- a/src/class/pmix_value_array.c
+++ b/src/class/pmix_value_array.c
@@ -32,8 +32,14 @@ static void pmix_value_array_construct(pmix_value_array_t *array)
 
 static void pmix_value_array_destruct(pmix_value_array_t *array)
 {
-    if (NULL != array->array_items)
+    if (NULL != array->array_items) {
         free(array->array_items);
+    }
+    /* Return to the constructed state so a second PMIX_DESTRUCT (or a
+     * destruct followed by a re-init) cannot free the same buffer twice */
+    array->array_items = NULL;
+    array->array_size = 0;
+    array->array_alloc_size = 0;
 }
 
 PMIX_CLASS_INSTANCE(pmix_value_array_t, pmix_object_t, pmix_value_array_construct,
@@ -41,21 +47,37 @@ PMIX_CLASS_INSTANCE(pmix_value_array_t, pmix_object_t, pmix_value_array_construc
 
 int pmix_value_array_set_size(pmix_value_array_t *array, size_t size)
 {
-#if PMIX_ENABLE_DEBUG
-    if (array->array_item_sizeof == 0) {
-        pmix_output(0, "pmix_value_array_set_size: item size must be initialized");
+    size_t new_alloc;
+    unsigned char *grown;
+
+    /* The item size is what every offset in here is computed from, so a
+     * zero one is fatal, not a debug-only curiosity. It used to be checked
+     * only under --enable-debug, which left an optimized build computing
+     * every address as items + index*0. */
+    if (0 == array->array_item_sizeof) {
         return PMIX_ERR_BAD_PARAM;
     }
-#endif
 
     if (size > array->array_alloc_size) {
-        while (array->array_alloc_size < size)
-            array->array_alloc_size <<= 1;
-        array->array_items = (unsigned char *) realloc(array->array_items,
-                                                       array->array_alloc_size
-                                                           * array->array_item_sizeof);
-        if (NULL == array->array_items)
+        /* Seed the doubling. array_alloc_size is 0 for an array that was
+         * only PMIX_CONSTRUCT'd (or PMIX_VALUE_ARRAY_STATIC_INIT'd, or
+         * whose pmix_value_array_reserve() ran out of memory), and
+         * "0 <<= 1" is still 0 - so the old loop spun forever. */
+        new_alloc = (0 == array->array_alloc_size) ? 1 : array->array_alloc_size;
+        while (new_alloc < size) {
+            new_alloc <<= 1;
+        }
+        /* Keep the old buffer until the new one is in hand: assigning the
+         * result of a failed realloc() straight back into array_items both
+         * leaks the old allocation and leaves the array claiming a size it
+         * no longer has storage for. */
+        grown = (unsigned char *) realloc(array->array_items,
+                                          new_alloc * array->array_item_sizeof);
+        if (NULL == grown) {
             return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        array->array_items = grown;
+        array->array_alloc_size = new_alloc;
     }
     array->array_size = size;
     return PMIX_SUCCESS;

--- a/src/class/pmix_value_array.h
+++ b/src/class/pmix_value_array.h
@@ -94,13 +94,16 @@ static inline int pmix_value_array_init(pmix_value_array_t *array, size_t item_s
 static inline int pmix_value_array_reserve(pmix_value_array_t *array, size_t size)
 {
     if (size > array->array_alloc_size) {
-        array->array_items = (unsigned char *) realloc(array->array_items,
-                                                       array->array_item_sizeof * size);
-        if (NULL == array->array_items) {
-            array->array_size = 0;
-            array->array_alloc_size = 0;
+        /* Hold the new pointer aside: on failure realloc() leaves the old
+         * allocation valid, and the previous code overwrote it with NULL -
+         * leaking the buffer and discarding elements the caller still
+         * owned, purely because it could not grow. */
+        unsigned char *grown = (unsigned char *) realloc(array->array_items,
+                                                         array->array_item_sizeof * size);
+        if (NULL == grown) {
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
+        array->array_items = grown;
         array->array_alloc_size = size;
     }
     return PMIX_SUCCESS;
@@ -250,13 +253,18 @@ static inline int pmix_value_array_append_item(pmix_value_array_t *array, const 
 
 static inline int pmix_value_array_remove_item(pmix_value_array_t *array, size_t item_index)
 {
-#if PMIX_ENABLE_DEBUG
+    /* This bound is checked unconditionally. It used to be debug-only, but
+     * the length the memmove() below computes is
+     * (array_size - item_index - 1) in size_t arithmetic: an out-of-range
+     * index does not read one element too far, it wraps to an enormous
+     * count and walks the heap. One compare is not worth that. */
     if (item_index >= array->array_size) {
+#if PMIX_ENABLE_DEBUG
         pmix_output(0, "pmix_value_array_remove_item: invalid index %lu\n",
                     (unsigned long) item_index);
+#endif
         return PMIX_ERR_BAD_PARAM;
     }
-#endif
     memmove(array->array_items + (array->array_item_sizeof * item_index),
             array->array_items + (array->array_item_sizeof * (item_index + 1)),
             array->array_item_sizeof * (array->array_size - item_index - 1));

--- a/test/unit/class/.gitignore
+++ b/test/unit/class/.gitignore
@@ -6,3 +6,4 @@ class_pointer_array
 class_ring_buffer
 class_value_array
 class_hotel
+class_refcount

--- a/test/unit/class/AGENTS.md
+++ b/test/unit/class/AGENTS.md
@@ -1,0 +1,154 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: Unit tests for the PMIx class system
+
+This directory holds the `make check` suite for
+[`src/class`](../../../src/class) — the C object model and the container
+classes built on it. Read
+[`src/class/AGENTS.md`](../../../src/class/AGENTS.md) first: it describes
+the contracts these tests encode, and this file assumes them. The
+top-level [`AGENTS.md`](../../../AGENTS.md) rules (copyright header,
+`pmix_config.h` first, constant-on-the-left, brace everything,
+warning-free under `--enable-devel-check`) apply here too.
+
+## Layout
+
+One program per class, plus one for concurrency:
+
+| Program | Subject |
+|---------|---------|
+| `class_object` | `PMIX_NEW`/`RETAIN`/`RELEASE`/`CONSTRUCT`/`DESTRUCT`, class hierarchy, TMA initialization |
+| `class_list` | `pmix_list_t` / `pmix_list_item_t` and the `FOREACH` macros |
+| `class_hash_table` | `pmix_hash_table_t`, all three key types, growth and backshift deletion |
+| `class_pointer_array` | `pmix_pointer_array_t`, index reuse, growth across `free_bits` words |
+| `class_bitmap` | `pmix_bitmap_t`, including the high-bit shift and `num_set_bits` boundaries |
+| `class_value_array` | `pmix_value_array_t` |
+| `class_ring_buffer` | `pmix_ring_buffer_t` |
+| `class_hotel` | `pmix_hotel_t` (no event base — eviction timers are disabled) |
+| `class_refcount` | The reference count under concurrent threads |
+
+Each is a standalone `main()` that prints `PASS:`/`FAIL:` per assertion
+via a local `report()` helper and exits non-zero if anything failed.
+There is no framework; keep it that way. New cases go in the matching
+`class_*.c`, and its name goes in `main()`.
+
+Adding a program means adding it to `check_PROGRAMS`, `TESTS`, a
+`_SOURCES`/`_LDFLAGS`/`_LDADD` triple, and the `clean-local` list in
+[`Makefile.am`](Makefile.am), plus a line in
+[`.gitignore`](.gitignore). No `configure`/`autogen.pl` re-run is needed
+for a `Makefile.am` edit — a plain `make` regenerates the `Makefile`.
+
+**These are `check_PROGRAMS`, so `make all` does not build them.** A
+plain `make` in this directory prints "Nothing to be done for `all'" and
+leaves whatever binaries are lying around untouched — which, after a
+change to `src/class`, means you can run stale binaries against a new
+library and get failures that have nothing to do with your change (a
+`cls_sizeof` assert is the usual symptom). Always use `make check`.
+
+## The configuration trap
+
+This is the single most important thing to understand about this
+directory, because it is how several real defects in `src/class` survived
+having a test suite.
+
+The tree everyone develops in — and the one
+`contrib/dockerswarm/build.sh` produces — is configured
+`--enable-debug --enable-devel-check`, commonly with
+`--disable-visibility`. In that configuration:
+
+- A correctness guard written inside `#if PMIX_ENABLE_DEBUG` is
+  **present**, so a test that exercises it passes whether or not the
+  guard exists in the builds that ship. An un-init'd
+  `pmix_hash_table_t` returned a clean error here and took a `SIGFPE` in
+  an optimized build; `pmix_value_array_remove_item` rejected a bad index
+  here and `memmove`'d a wrapped `size_t` length there.
+- A class descriptor missing `PMIX_EXPORT` **links**, because nothing is
+  hidden. `pmix_ring_buffer_t_class` was missing it for years.
+
+So a green run here proves less than it looks like it does. Several
+cases in the suite are labelled `(all builds)` precisely because they
+only distinguish old code from new in an *optimized* build.
+
+Close the gap with:
+
+```sh
+contrib/dockerswarm/run-class-tests.sh linux    # or macos
+```
+
+which builds and runs this suite `--disable-debug` with default symbol
+visibility (see `contrib/dockerswarm/README.md` §11). Run it after any
+non-trivial change to `src/class`. It is not a multi-node test and does
+not pretend to be — these are single-process data structures.
+
+## What these tests deliberately do not do
+
+- **They never call `PMIX_DESTRUCT` twice on one object.** That is a
+  contract violation; `--enable-debug` builds abort on the magic-ID
+  assert, correctly. The teardown cases instead assert that the
+  destructor left the object in its *constructed* state — pointers NULL,
+  sizes zero — which is what keeps a release build from double-freeing
+  and what makes destruct-then-reconstruct work. Do not "fix" a test by
+  weakening that assert.
+- **They do not put one list item on two lists**, do not remove during a
+  plain `PMIX_LIST_FOREACH`, and do not otherwise poke the debug
+  spot-checks to see what happens. Those asserts exist to catch caller
+  bugs; a test that trips one is a broken test.
+- **They do not test the TMA path.** Everything runs with the default
+  (libc) allocator. Exercising a real TMA means a shared-memory segment
+  and a second process, which is `gds/shmem2`'s territory — see the
+  group tests under `contrib/dockerswarm`. If you add TMA coverage here,
+  it needs a purpose-built allocator, not a partially filled-in
+  `pmix_tma_t` (see `pmix_obj_get_tma`'s convention).
+
+## Writing a good case here
+
+- **Name the defect, not the API.** A regression case should say what
+  used to go wrong, so the next reader knows what breaking it means. The
+  `/* Regressions */` blocks at the bottom of each file follow that
+  shape.
+- **Prefer a case that fails loudly.** The value-array zero-alloc case
+  *hangs* without its fix, and the hotel static-init case takes SIGSEGV;
+  both were verified by reintroducing the bug. A case that would only
+  produce a subtly wrong number is worth less.
+- **Do not bend a test to accommodate a bug.** If a case fails, the
+  default assumption is that `src/class` is wrong. See the top-level
+  guide.
+- **Keep white-box pokes rare and justified.** A couple of cases reach
+  into struct members (`va.array_alloc_size`, `ring.addr`,
+  `base->obj_tma.tma_memmove`) because the state they describe is not
+  reachable through the API. That is fine when the alternative is not
+  testing a hang or an uninitialized field at all — but reach for the
+  public call first.
+
+## `class_refcount`
+
+The reference count is the **only** part of `src/class` documented as
+safe to touch from more than one thread; every other class assumes the
+caller serializes, which in PMIx means the progress thread. So this is
+the one place threads belong in this suite. Do not add threads to the
+other programs to "improve coverage" — you would be testing a contract
+the classes do not offer.
+
+It checks three properties, all of which the C11 atomic in
+`pmix_obj_update` is responsible for: balanced retain/release from N
+threads leaves the count exactly where it started; exactly one thread
+observes zero and therefore exactly one destructor runs; and the writes
+a thread made before its last release are visible to that destructor
+(the `acq_rel` ordering).
+
+The barrier is hand-rolled from a mutex and condvar because macOS has no
+`pthread_barrier_t`. No per-target thread flags are needed —
+`config/pmix_config_threads.m4` folds them into the global
+`CFLAGS`/`LDFLAGS`/`LIBS`.
+
+Each thread writes only its own slot of the payload array, so the
+visibility check is not itself a data race. Keep it that way if you
+extend it.

--- a/test/unit/class/AGENTS.md
+++ b/test/unit/class/AGENTS.md
@@ -137,12 +137,17 @@ the one place threads belong in this suite. Do not add threads to the
 other programs to "improve coverage" — you would be testing a contract
 the classes do not offer.
 
-It checks three properties, all of which the C11 atomic in
-`pmix_obj_update` is responsible for: balanced retain/release from N
-threads leaves the count exactly where it started; exactly one thread
+It checks three properties, all of which `pmix_obj_update()` is
+responsible for however it is implemented: balanced retain/release from
+N threads leaves the count exactly where it started; exactly one thread
 observes zero and therefore exactly one destructor runs; and the writes
-a thread made before its last release are visible to that destructor
-(the `acq_rel` ordering).
+a thread made before its last release are visible to that destructor.
+The mechanism is currently the per-object `pthread_mutex_t`; see the
+reference-counting section of
+[`src/class/AGENTS.md`](../../../src/class/AGENTS.md) for why replacing
+it with a C11 atomic is a cross-version compatibility change rather than
+a local one. The test is written against the properties, not the
+mechanism, so it does not need to change with them.
 
 The barrier is hand-rolled from a mutex and condvar because macOS has no
 `pthread_barrier_t`. No per-target thread flags are needed —

--- a/test/unit/class/CLAUDE.md
+++ b/test/unit/class/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/test/unit/class/Makefile.am
+++ b/test/unit/class/Makefile.am
@@ -13,10 +13,12 @@
 AM_TESTS_ENVIRONMENT = . $(abs_top_builddir)/test/pmix_test_env.sh;
 
 check_PROGRAMS = class_object class_list class_bitmap class_hash_table \
-    class_pointer_array class_ring_buffer class_value_array class_hotel
+    class_pointer_array class_ring_buffer class_value_array class_hotel \
+    class_refcount
 
 TESTS = class_object class_list class_bitmap class_hash_table \
-    class_pointer_array class_ring_buffer class_value_array class_hotel
+    class_pointer_array class_ring_buffer class_value_array class_hotel \
+    class_refcount
 
 class_object_SOURCES = class_object.c
 class_object_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -58,6 +60,16 @@ class_hotel_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 class_hotel_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+# The reference count is the one class contract documented as safe from
+# any thread, so this test spawns some. No per-target thread flags are
+# needed: PMIX_CONFIG_THREADS folds them into the global CFLAGS/LDFLAGS/
+# LIBS at configure time (config/pmix_config_threads.m4).
+class_refcount_SOURCES = class_refcount.c
+class_refcount_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+class_refcount_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
 	rm -f class_object class_list class_bitmap class_hash_table \
-	    class_pointer_array class_ring_buffer class_value_array class_hotel
+	    class_pointer_array class_ring_buffer class_value_array class_hotel \
+	    class_refcount

--- a/test/unit/class/class_bitmap.c
+++ b/test/unit/class/class_bitmap.c
@@ -354,6 +354,162 @@ static void test_get_string(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Regressions                                                          */
+/* ------------------------------------------------------------------ */
+
+/* The bitmap words are uint64_t, so the mask shift runs to 63. It used to
+ * be built as "1UL << offset", which is undefined above 31 wherever
+ * unsigned long is 32 bits (32-bit Linux, Windows) and in practice folded
+ * bit N back onto bit N-32. On an LP64 host this passes either way; it is
+ * here so the 32-bit builds have something that fails when it regresses. */
+static void test_high_bit_shifts(void)
+{
+    pmix_bitmap_t bm;
+    int bit;
+    bool ok = true;
+
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 128);
+
+    for (bit = 32; bit < 64; ++bit) {
+        if (PMIX_SUCCESS != pmix_bitmap_set_bit(&bm, bit)) {
+            ok = false;
+        }
+    }
+    report("high bits: set 32..63 all succeed", ok);
+
+    ok = true;
+    for (bit = 32; bit < 64; ++bit) {
+        if (!pmix_bitmap_is_set_bit(&bm, bit)) {
+            ok = false;
+        }
+    }
+    report("high bits: 32..63 all read back set", ok);
+
+    /* If the shift had wrapped, setting bit 32+ would have lit bit 0+ */
+    ok = true;
+    for (bit = 0; bit < 32; ++bit) {
+        if (pmix_bitmap_is_set_bit(&bm, bit)) {
+            ok = false;
+        }
+    }
+    report("high bits: 0..31 left untouched (no shift wrap)", ok);
+
+    report("high bits: 32 set bits counted", 32 == pmix_bitmap_num_set_bits(&bm, 64));
+
+    /* clear_bit builds the same mask */
+    pmix_bitmap_clear_bit(&bm, 63);
+    report("high bits: clear_bit 63 clears 63", !pmix_bitmap_is_set_bit(&bm, 63));
+    report("high bits: clear_bit 63 spared 31", !pmix_bitmap_is_set_bit(&bm, 31));
+    report("high bits: 31 set bits remain", 31 == pmix_bitmap_num_set_bits(&bm, 64));
+
+    PMIX_DESTRUCT(&bm);
+}
+
+/* num_set_bits masks the final partial word with (1 << (len % 64)) - 1.
+ * With len == 63 that shift distance is 63, which overflowed the sign bit
+ * of the signed 1LL the code used to shift. */
+static void test_num_set_bits_boundaries(void)
+{
+    pmix_bitmap_t bm;
+
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 128);
+    pmix_bitmap_set_all_bits(&bm);
+
+    report("num_set_bits len=1: 1", 1 == pmix_bitmap_num_set_bits(&bm, 1));
+    report("num_set_bits len=32: 32", 32 == pmix_bitmap_num_set_bits(&bm, 32));
+    report("num_set_bits len=63: 63", 63 == pmix_bitmap_num_set_bits(&bm, 63));
+    report("num_set_bits len=64: 64", 64 == pmix_bitmap_num_set_bits(&bm, 64));
+    report("num_set_bits len=65: 65", 65 == pmix_bitmap_num_set_bits(&bm, 65));
+    report("num_set_bits len=127: 127", 127 == pmix_bitmap_num_set_bits(&bm, 127));
+    report("num_set_bits len=128: 128", 128 == pmix_bitmap_num_set_bits(&bm, 128));
+    report("num_unset_bits len=63: 0", 0 == pmix_bitmap_num_unset_bits(&bm, 63));
+
+    PMIX_DESTRUCT(&bm);
+}
+
+/* pmix_bitmap_copy() now reports what it did instead of returning void and
+ * memcpy'ing through whatever calloc handed back. */
+static void test_copy_status(void)
+{
+    pmix_bitmap_t src, dst;
+
+    PMIX_CONSTRUCT(&src, pmix_bitmap_t);
+    PMIX_CONSTRUCT(&dst, pmix_bitmap_t);
+    pmix_bitmap_init(&src, 256);
+    pmix_bitmap_init(&dst, 64); /* deliberately smaller: forces the grow path */
+
+    pmix_bitmap_set_bit(&src, 200);
+    report("copy: grow path returns PMIX_SUCCESS", PMIX_SUCCESS == pmix_bitmap_copy(&dst, &src));
+    report("copy: grown dst holds bit 200", pmix_bitmap_is_set_bit(&dst, 200));
+    report("copy: grown dst size matches src",
+           pmix_bitmap_size(&dst) == pmix_bitmap_size(&src));
+    report("copy: bitmaps compare equal", !pmix_bitmap_are_different(&dst, &src));
+
+    report("copy: NULL dst is PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_bitmap_copy(NULL, &src));
+    report("copy: NULL src is PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_bitmap_copy(&dst, NULL));
+
+    PMIX_DESTRUCT(&src);
+    PMIX_DESTRUCT(&dst);
+}
+
+/* Every accessor has to tolerate a bitmap that was constructed but never
+ * init'd (no words at all) and a NULL bitmap. */
+static void test_uninitialized_and_null(void)
+{
+    pmix_bitmap_t bm;
+
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+
+    report("un-init'd: size is 0", 0 == pmix_bitmap_size(&bm));
+    report("un-init'd: is_clear is true", pmix_bitmap_is_clear(&bm));
+    report("un-init'd: clear_all_bits succeeds", PMIX_SUCCESS == pmix_bitmap_clear_all_bits(&bm));
+    report("un-init'd: set_all_bits succeeds", PMIX_SUCCESS == pmix_bitmap_set_all_bits(&bm));
+    report("un-init'd: is_set_bit(0) is false", !pmix_bitmap_is_set_bit(&bm, 0));
+    report("un-init'd: clear_bit(0) is PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_bitmap_clear_bit(&bm, 0));
+    report("un-init'd: set_bit(0) grows and succeeds",
+           PMIX_SUCCESS == pmix_bitmap_set_bit(&bm, 0));
+    report("un-init'd: bit 0 now reads set", pmix_bitmap_is_set_bit(&bm, 0));
+
+    report("NULL: is_clear is true", pmix_bitmap_is_clear(NULL));
+    report("NULL: clear_all_bits is PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_bitmap_clear_all_bits(NULL));
+    report("NULL: set_all_bits is PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_bitmap_set_all_bits(NULL));
+    report("NULL: set_bit is PMIX_ERR_BAD_PARAM", PMIX_ERR_BAD_PARAM == pmix_bitmap_set_bit(NULL, 0));
+    report("NULL: is_set_bit is false", !pmix_bitmap_is_set_bit(NULL, 0));
+    /* bool-returning comparison has no error code: "different" is the
+     * answer that stops a caller acting on a comparison never made */
+    report("NULL: are_different reports true", pmix_bitmap_are_different(NULL, &bm));
+    report("NULL: get_string returns NULL", NULL == pmix_bitmap_get_string(NULL));
+
+    PMIX_DESTRUCT(&bm);
+}
+
+/* Re-init has to release the old words and leave size and contents
+ * describing the new allocation, with no stale bits showing through. */
+static void test_reinit(void)
+{
+    pmix_bitmap_t bm;
+
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+    pmix_bitmap_init(&bm, 256);
+    pmix_bitmap_set_all_bits(&bm);
+    report("reinit: 256 bits before", 256 == pmix_bitmap_size(&bm));
+
+    report("reinit: second init succeeds", PMIX_SUCCESS == pmix_bitmap_init(&bm, 128));
+    report("reinit: size is now 128", 128 == pmix_bitmap_size(&bm));
+    report("reinit: comes back cleared", pmix_bitmap_is_clear(&bm));
+    report("reinit: no set bits", 0 == pmix_bitmap_num_set_bits(&bm, 128));
+
+    PMIX_DESTRUCT(&bm);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -375,6 +531,11 @@ int main(int argc, char **argv)
     test_bitwise_xor();
     test_copy_and_compare();
     test_get_string();
+    test_high_bit_shifts();
+    test_num_set_bits_boundaries();
+    test_copy_status();
+    test_uninitialized_and_null();
+    test_reinit();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_hash_table.c
+++ b/test/unit/class/class_hash_table.c
@@ -231,6 +231,142 @@ static void test_sizeof_hash_element(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Regressions                                                          */
+/* ------------------------------------------------------------------ */
+
+/* Every lookup begins with "key % capacity", and capacity is 0 until
+ * pmix_hash_table_init() runs. The guard that caught that used to sit
+ * inside #if PMIX_ENABLE_DEBUG, so an optimized build took a SIGFPE where
+ * a debug build returned an error. Each of these nine entry points must
+ * report a failure and come back. */
+static void test_uninitialized_table(void)
+{
+    pmix_hash_table_t ht;
+    void *value = NULL;
+    const char *key = "k";
+
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+
+    report("un-init'd: get uint32 fails cleanly",
+           PMIX_SUCCESS != pmix_hash_table_get_value_uint32(&ht, 1, &value));
+    report("un-init'd: set uint32 fails cleanly",
+           PMIX_SUCCESS != pmix_hash_table_set_value_uint32(&ht, 1, (void *) 0x1));
+    report("un-init'd: remove uint32 fails cleanly",
+           PMIX_SUCCESS != pmix_hash_table_remove_value_uint32(&ht, 1));
+
+    report("un-init'd: get uint64 fails cleanly",
+           PMIX_SUCCESS != pmix_hash_table_get_value_uint64(&ht, 1, &value));
+    report("un-init'd: set uint64 fails cleanly",
+           PMIX_SUCCESS != pmix_hash_table_set_value_uint64(&ht, 1, (void *) 0x1));
+    report("un-init'd: remove uint64 fails cleanly",
+           PMIX_SUCCESS != pmix_hash_table_remove_value_uint64(&ht, 1));
+
+    report("un-init'd: get ptr fails cleanly",
+           PMIX_SUCCESS != pmix_hash_table_get_value_ptr(&ht, key, 1, &value));
+    report("un-init'd: set ptr fails cleanly",
+           PMIX_SUCCESS != pmix_hash_table_set_value_ptr(&ht, key, 1, (void *) 0x1));
+    report("un-init'd: remove ptr fails cleanly",
+           PMIX_SUCCESS != pmix_hash_table_remove_value_ptr(&ht, key, 1));
+
+    PMIX_DESTRUCT(&ht);
+}
+
+/* The destructor used to free ht_table and leave the pointer in place
+ * behind a non-zero ht_capacity, so a stray lookup indexed freed memory
+ * instead of failing the capacity check. Calling PMIX_DESTRUCT twice is a
+ * contract violation the object system's magic-ID assert catches under
+ * --enable-debug, so it is not exercised here. */
+static void test_destruct_leaves_constructed_state(void)
+{
+    pmix_hash_table_t ht;
+    void *value = NULL;
+
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    pmix_hash_table_init(&ht, 32);
+    pmix_hash_table_set_value_uint32(&ht, 7, (void *) 0x77);
+
+    PMIX_DESTRUCT(&ht);
+    report("destruct: lookup on the corpse fails cleanly",
+           PMIX_SUCCESS != pmix_hash_table_get_value_uint32(&ht, 7, &value));
+    report("destruct: size reset to 0", 0 == (int) pmix_hash_table_get_size(&ht));
+
+    /* and it is re-usable */
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    report("re-init after destruct: PMIX_SUCCESS", PMIX_SUCCESS == pmix_hash_table_init(&ht, 32));
+    report("re-init after destruct: set works",
+           PMIX_SUCCESS == pmix_hash_table_set_value_uint32(&ht, 7, (void *) 0x77));
+    report("re-init after destruct: get works",
+           PMIX_SUCCESS == pmix_hash_table_get_value_uint32(&ht, 7, &value)
+               && (void *) 0x77 == value);
+    PMIX_DESTRUCT(&ht);
+}
+
+/* Enough insertions to drive several pmix_hash_grow() passes, then verify
+ * every key survived rehashing, and that removal's backshift keeps the
+ * remaining probe runs findable. */
+static void test_growth_and_backshift(void)
+{
+    pmix_hash_table_t ht;
+    void *value;
+    uint64_t k;
+    bool ok = true;
+
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    pmix_hash_table_init(&ht, 4); /* deliberately tiny: forces repeated growth */
+
+    for (k = 1; k <= 500; k++) {
+        if (PMIX_SUCCESS != pmix_hash_table_set_value_uint64(&ht, k, (void *) (intptr_t) (k * 3))) {
+            ok = false;
+            break;
+        }
+    }
+    report("growth: 500 inserts into a 4-slot table succeed", ok);
+
+    ok = true;
+    for (k = 1; k <= 500; k++) {
+        if (PMIX_SUCCESS != pmix_hash_table_get_value_uint64(&ht, k, &value)
+            || (void *) (intptr_t) (k * 3) != value) {
+            ok = false;
+            break;
+        }
+    }
+    report("growth: every key survived rehashing", ok);
+    report("growth: size reports 500", 500 == (int) pmix_hash_table_get_size(&ht));
+
+    /* Remove every other key; the backshift has to keep the rest reachable */
+    ok = true;
+    for (k = 2; k <= 500; k += 2) {
+        if (PMIX_SUCCESS != pmix_hash_table_remove_value_uint64(&ht, k)) {
+            ok = false;
+            break;
+        }
+    }
+    report("backshift: removing 250 keys succeeds", ok);
+    report("backshift: size reports 250", 250 == (int) pmix_hash_table_get_size(&ht));
+
+    ok = true;
+    for (k = 1; k <= 500; k += 2) {
+        if (PMIX_SUCCESS != pmix_hash_table_get_value_uint64(&ht, k, &value)
+            || (void *) (intptr_t) (k * 3) != value) {
+            ok = false;
+            break;
+        }
+    }
+    report("backshift: every surviving key is still findable", ok);
+
+    ok = true;
+    for (k = 2; k <= 500; k += 2) {
+        if (PMIX_ERR_NOT_FOUND != pmix_hash_table_get_value_uint64(&ht, k, &value)) {
+            ok = false;
+            break;
+        }
+    }
+    report("backshift: every removed key reports NOT_FOUND", ok);
+
+    PMIX_DESTRUCT(&ht);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -246,6 +382,9 @@ int main(int argc, char **argv)
     test_remove_all();
     test_uint32_iteration();
     test_sizeof_hash_element();
+    test_uninitialized_table();
+    test_destruct_leaves_constructed_state();
+    test_growth_and_backshift();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_hotel.c
+++ b/test/unit/class/class_hotel.c
@@ -240,6 +240,114 @@ static void test_room_reuse(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Regressions                                                          */
+/* ------------------------------------------------------------------ */
+
+/* PMIX_HOTEL_STATIC_INIT set last_unoccupied_room to 0 while the
+ * constructor sets it to -1. -1 is the "no rooms" sentinel checkin() tests,
+ * so a statically initialized hotel claimed room 0 was free and then
+ * indexed a NULL unoccupied_rooms array. pmix_globals.notifications is
+ * built exactly this way, which is why this has to hold before
+ * pmix_hotel_init() has ever been called. */
+static pmix_hotel_t static_hotel = PMIX_HOTEL_STATIC_INIT;
+
+static void test_static_init(void)
+{
+    int room = 12345;
+    void *occupant = (void *) 0x1;
+
+    report("static init: reports empty", pmix_hotel_is_empty(&static_hotel));
+    report("static init: checkin declines rather than faulting",
+           PMIX_ERR_OUT_OF_RESOURCE == pmix_hotel_checkin(&static_hotel, occupant, &room));
+    report("static init: declined checkin returns room -1", -1 == room);
+
+    /* checkout of a room nobody holds must also be a no-op */
+    pmix_hotel_checkout(&static_hotel, -1);
+    report("static init: checkout of -1 is a no-op", true);
+
+    occupant = (void *) 0xdeadbeef;
+    pmix_hotel_knock(&static_hotel, -1, &occupant);
+    report("static init: knock on -1 yields NULL", NULL == occupant);
+}
+
+/* The destructor freed rooms/eviction_args/unoccupied_rooms and left all
+ * three pointers in place. It now returns the hotel to exactly the state
+ * the constructor produces, so nothing is left addressing freed memory.
+ *
+ * Note what is NOT exercised here: calling PMIX_DESTRUCT twice. That is a
+ * contract violation of the object system, and --enable-debug builds abort
+ * on the magic-ID assert when you try - correctly. What matters is that
+ * the class leaves no dangling state behind for anything that does reach
+ * it, which is what these checks describe. */
+static void test_destruct_leaves_constructed_state(void)
+{
+    pmix_hotel_t h;
+    int room = -1;
+
+    PMIX_CONSTRUCT(&h, pmix_hotel_t);
+    report("destruct: init succeeds",
+           PMIX_SUCCESS == pmix_hotel_init(&h, 4, NULL, 0, dummy_evict));
+    pmix_hotel_checkin(&h, (void *) 0x1, &room);
+
+    PMIX_DESTRUCT(&h);
+    report("destruct: rooms pointer cleared", NULL == h.rooms);
+    report("destruct: eviction_args pointer cleared", NULL == h.eviction_args);
+    report("destruct: unoccupied_rooms pointer cleared", NULL == h.unoccupied_rooms);
+    report("destruct: num_rooms reset to 0", 0 == h.num_rooms);
+    report("destruct: last_unoccupied_room back to the -1 sentinel",
+           -1 == h.last_unoccupied_room);
+
+    /* checkin against the torn-down hotel must decline, not fault */
+    room = 12345;
+    report("after destruct: checkin declines",
+           PMIX_ERR_OUT_OF_RESOURCE == pmix_hotel_checkin(&h, (void *) 0x1, &room));
+
+    /* and the object is re-usable */
+    PMIX_CONSTRUCT(&h, pmix_hotel_t);
+    report("re-init after destruct: PMIX_SUCCESS",
+           PMIX_SUCCESS == pmix_hotel_init(&h, 4, NULL, 0, dummy_evict));
+    report("re-init after destruct: checkin works",
+           PMIX_SUCCESS == pmix_hotel_checkin(&h, (void *) 0x1, &room));
+    PMIX_DESTRUCT(&h);
+}
+
+/* Re-initializing a live hotel used to overwrite all three array pointers
+ * and leak everything they addressed. */
+static void test_reinit(void)
+{
+    pmix_hotel_t h;
+    int room = -1, i;
+    void *occupant;
+    bool ok = true;
+
+    PMIX_CONSTRUCT(&h, pmix_hotel_t);
+    report("reinit: first init succeeds",
+           PMIX_SUCCESS == pmix_hotel_init(&h, 2, NULL, 0, dummy_evict));
+    pmix_hotel_checkin(&h, (void *) 0x1, &room);
+    report("reinit: first hotel took a guest", 0 <= room);
+
+    report("reinit: second init succeeds",
+           PMIX_SUCCESS == pmix_hotel_init(&h, 8, NULL, 0, dummy_evict));
+    report("reinit: re-initialized hotel is empty", pmix_hotel_is_empty(&h));
+
+    /* all eight rooms of the new hotel must be usable */
+    for (i = 0; i < 8; ++i) {
+        if (PMIX_SUCCESS != pmix_hotel_checkin(&h, (void *) (intptr_t) (i + 1), &room)) {
+            ok = false;
+            break;
+        }
+    }
+    report("reinit: all 8 new rooms check in", ok);
+    report("reinit: ninth checkin declines",
+           PMIX_ERR_OUT_OF_RESOURCE == pmix_hotel_checkin(&h, (void *) 0x99, &room));
+
+    pmix_hotel_knock(&h, 0, &occupant);
+    report("reinit: room 0 has an occupant", NULL != occupant);
+
+    PMIX_DESTRUCT(&h);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -255,6 +363,9 @@ int main(int argc, char **argv)
     test_hotel_full();
     test_multiple_guests();
     test_room_reuse();
+    test_static_init();
+    test_destruct_leaves_constructed_state();
+    test_reinit();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_object.c
+++ b/test/unit/class/class_object.c
@@ -198,6 +198,97 @@ static void test_class_sizeof(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Regressions                                                          */
+/* ------------------------------------------------------------------ */
+
+/* PMIX_NEW() carried its own copy of the TMA-clearing code and set seven
+ * of pmix_tma_t's eight members, leaving tma_memmove holding whatever
+ * malloc() returned. pmix_obj_get_tma() keys off tma_malloc, so the stray
+ * member never showed up as a crash -- it just meant every heap object in
+ * the library had one uninitialized field for anything that copied or
+ * inspected the whole struct. */
+static void test_new_clears_whole_tma(void)
+{
+    pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
+    pmix_object_t *base = (pmix_object_t *) obj;
+
+    report("PMIX_NEW: allocation succeeded", NULL != obj);
+    if (NULL == obj) {
+        return;
+    }
+
+    report("PMIX_NEW: tma_malloc cleared", NULL == base->obj_tma.tma_malloc);
+    report("PMIX_NEW: tma_calloc cleared", NULL == base->obj_tma.tma_calloc);
+    report("PMIX_NEW: tma_realloc cleared", NULL == base->obj_tma.tma_realloc);
+    report("PMIX_NEW: tma_strdup cleared", NULL == base->obj_tma.tma_strdup);
+    report("PMIX_NEW: tma_memmove cleared", NULL == base->obj_tma.tma_memmove);
+    report("PMIX_NEW: tma_free cleared", NULL == base->obj_tma.tma_free);
+    report("PMIX_NEW: data_context cleared", NULL == base->obj_tma.data_context);
+    report("PMIX_NEW: data_ptr cleared", NULL == base->obj_tma.data_ptr);
+    report("PMIX_NEW: reports no custom allocator", NULL == pmix_obj_get_tma(base));
+
+    PMIX_RELEASE(obj);
+}
+
+/* PMIX_CONSTRUCT() has always gone through pmix_obj_construct_tma(); check
+ * it agrees with PMIX_NEW() now that they share the code. */
+static void test_construct_clears_whole_tma(void)
+{
+    pmix_list_item_t item;
+    pmix_object_t *base = (pmix_object_t *) &item;
+
+    memset(&item, 0xa5, sizeof(item)); /* poison, so "cleared" means cleared */
+    PMIX_CONSTRUCT(&item, pmix_list_item_t);
+
+    report("PMIX_CONSTRUCT: tma_malloc cleared", NULL == base->obj_tma.tma_malloc);
+    report("PMIX_CONSTRUCT: tma_memmove cleared", NULL == base->obj_tma.tma_memmove);
+    report("PMIX_CONSTRUCT: tma_free cleared", NULL == base->obj_tma.tma_free);
+    report("PMIX_CONSTRUCT: data_ptr cleared", NULL == base->obj_tma.data_ptr);
+    report("PMIX_CONSTRUCT: reports no custom allocator", NULL == pmix_obj_get_tma(base));
+    report("PMIX_CONSTRUCT: refcount is 1", 1 == base->obj_reference_count);
+
+    PMIX_DESTRUCT(&item);
+}
+
+/* A statically initialized object has to describe the same state that
+ * PMIX_CONSTRUCT would produce -- PMIX_OBJ_STATIC_INIT no longer carries a
+ * PTHREAD_MUTEX_INITIALIZER now that the count is a C11 atomic. */
+static pmix_list_item_t static_item = PMIX_LIST_ITEM_STATIC_INIT;
+
+static void test_static_init(void)
+{
+    pmix_object_t *base = (pmix_object_t *) &static_item;
+
+    report("static init: refcount is 1", 1 == base->obj_reference_count);
+    report("static init: class is set", NULL != base->obj_class);
+    report("static init: no custom allocator", NULL == pmix_obj_get_tma(base));
+
+    /* retain/release still has to work on it */
+    PMIX_RETAIN(&static_item);
+    report("static init: retain reaches 2", 2 == base->obj_reference_count);
+    pmix_obj_update(base, -1);
+    report("static init: back to 1", 1 == base->obj_reference_count);
+}
+
+/* pmix_obj_update() returns the *new* count in both directions. That is
+ * what PMIX_RELEASE tests against zero to decide whether to run the
+ * destructors, so an off-by-one here is a leak or a double free. */
+static void test_obj_update_returns_new_value(void)
+{
+    pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
+
+    report("obj_update: +1 returns 2", 2 == pmix_obj_update((pmix_object_t *) obj, 1));
+    report("obj_update: +1 again returns 3", 3 == pmix_obj_update((pmix_object_t *) obj, 1));
+    report("obj_update: -1 returns 2", 2 == pmix_obj_update((pmix_object_t *) obj, -1));
+    report("obj_update: -2 returns 0", 0 == pmix_obj_update((pmix_object_t *) obj, -2));
+
+    /* count is back to 0; put it back to 1 so PMIX_RELEASE frees it once */
+    pmix_obj_update((pmix_object_t *) obj, 1);
+    PMIX_RELEASE(obj);
+    report("obj_update: object released cleanly", NULL == obj);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -216,6 +307,10 @@ int main(int argc, char **argv)
     test_class_parent();
     test_hierarchy_depth();
     test_class_sizeof();
+    test_new_clears_whole_tma();
+    test_construct_clears_whole_tma();
+    test_static_init();
+    test_obj_update_returns_new_value();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_pointer_array.c
+++ b/test/unit/class/class_pointer_array.c
@@ -192,6 +192,143 @@ static void test_grow_via_set_item(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Regressions                                                          */
+/* ------------------------------------------------------------------ */
+
+/* init() sized the initial allocation from the caller's raw block_size
+ * rather than the normalized one, so init(a, 0, max, 0) allocated nothing
+ * while a->block_size claimed 8. */
+static void test_init_zero_block_size(void)
+{
+    pmix_pointer_array_t arr;
+    int idx;
+
+    PMIX_CONSTRUCT(&arr, pmix_pointer_array_t);
+    report("init with 0 initial and 0 block size: PMIX_SUCCESS",
+           PMIX_SUCCESS == pmix_pointer_array_init(&arr, 0, INT_MAX, 0));
+    report("init with 0 block size: array has room", 0 < arr.size);
+
+    idx = pmix_pointer_array_add(&arr, (void *) 0x1);
+    report("init with 0 block size: add yields a valid index", 0 <= idx);
+    report("init with 0 block size: item reads back",
+           (void *) 0x1 == pmix_pointer_array_get_item(&arr, idx));
+
+    PMIX_DESTRUCT(&arr);
+}
+
+/* grow_table() bumped number_free before growing free_bits. Cross several
+ * 64-slot free_bits words so both reallocs run repeatedly, and confirm the
+ * indices and the free accounting stay in step. */
+static void test_growth_across_bit_words(void)
+{
+    pmix_pointer_array_t arr;
+    int idx[300];
+    int i;
+    bool ok = true;
+
+    PMIX_CONSTRUCT(&arr, pmix_pointer_array_t);
+    pmix_pointer_array_init(&arr, 2, INT_MAX, 2);
+
+    for (i = 0; i < 300; i++) {
+        idx[i] = pmix_pointer_array_add(&arr, (void *) (intptr_t) (i + 1));
+        if (0 > idx[i]) {
+            ok = false;
+            break;
+        }
+    }
+    report("growth: 300 adds across many free_bits words succeed", ok);
+
+    ok = true;
+    for (i = 0; i < 300; i++) {
+        if ((void *) (intptr_t) (i + 1) != pmix_pointer_array_get_item(&arr, idx[i])) {
+            ok = false;
+            break;
+        }
+    }
+    report("growth: every item readable at its index", ok);
+
+    /* indices must be unique */
+    ok = true;
+    for (i = 1; i < 300; i++) {
+        if (idx[i] == idx[i - 1]) {
+            ok = false;
+            break;
+        }
+    }
+    report("growth: no index handed out twice", ok);
+
+    /* Free a hole well inside the array, then confirm the next add reuses
+     * it -- which only works if lowest_free and free_bits agree. */
+    pmix_pointer_array_set_item(&arr, idx[100], NULL);
+    report("growth: freed slot is reused by the next add",
+           idx[100] == pmix_pointer_array_add(&arr, (void *) 0xabc));
+
+    PMIX_DESTRUCT(&arr);
+}
+
+/* set_item beyond the current extent grows the array; repeated sparse sets
+ * exercise grow_table's realloc-of-free_bits branch on its own. */
+static void test_sparse_set_item(void)
+{
+    pmix_pointer_array_t arr;
+    bool ok = true;
+    int i;
+
+    PMIX_CONSTRUCT(&arr, pmix_pointer_array_t);
+    pmix_pointer_array_init(&arr, 4, INT_MAX, 4);
+
+    for (i = 0; i < 512; i += 64) {
+        if (PMIX_SUCCESS != pmix_pointer_array_set_item(&arr, i, (void *) (intptr_t) (i + 1))) {
+            ok = false;
+            break;
+        }
+    }
+    report("sparse set_item: every sparse index accepted", ok);
+
+    ok = true;
+    for (i = 0; i < 512; i += 64) {
+        if ((void *) (intptr_t) (i + 1) != pmix_pointer_array_get_item(&arr, i)) {
+            ok = false;
+            break;
+        }
+    }
+    report("sparse set_item: every sparse index reads back", ok);
+
+    report("sparse set_item: an untouched index is NULL",
+           NULL == pmix_pointer_array_get_item(&arr, 63));
+    report("sparse set_item: an out-of-range index is NULL",
+           NULL == pmix_pointer_array_get_item(&arr, 100000));
+    report("sparse set_item: a negative index is rejected",
+           PMIX_SUCCESS != pmix_pointer_array_set_item(&arr, -1, (void *) 0x1));
+
+    PMIX_DESTRUCT(&arr);
+}
+
+/* max_size caps growth; the array has to refuse rather than overrun. */
+static void test_max_size_cap(void)
+{
+    pmix_pointer_array_t arr;
+    int i, idx, added = 0;
+
+    PMIX_CONSTRUCT(&arr, pmix_pointer_array_t);
+    report("max_size: init with max 8 succeeds",
+           PMIX_SUCCESS == pmix_pointer_array_init(&arr, 4, 8, 4));
+
+    for (i = 0; i < 32; i++) {
+        idx = pmix_pointer_array_add(&arr, (void *) (intptr_t) (i + 1));
+        if (0 > idx) {
+            break;
+        }
+        added++;
+    }
+    report("max_size: adds stop at the cap", added <= 8);
+    report("max_size: the array did fill up to the cap", 0 < added);
+    report("max_size: the add past the cap reports failure", 32 > added);
+
+    PMIX_DESTRUCT(&arr);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -206,6 +343,10 @@ int main(int argc, char **argv)
     test_remove_all();
     test_set_size();
     test_grow_via_set_item();
+    test_init_zero_block_size();
+    test_growth_across_bit_words();
+    test_sparse_set_item();
+    test_max_size_cap();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_refcount.c
+++ b/test/unit/class/class_refcount.c
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Concurrency tests for the pmix_object_t reference count.
+ *
+ * The count is the one piece of src/class that is documented as safe to
+ * touch from any thread: everything else in the directory (list links,
+ * hash-table slots, pointer-array indices, hotel rooms) assumes the caller
+ * serializes, which in PMIx means the progress thread.  So the count is
+ * what is worth hammering, and it is what changed when the per-object
+ * pthread_mutex_t was replaced by a C11 atomic.
+ *
+ * Three properties are checked:
+ *
+ *   1. Balanced retain/release from N threads leaves the count exactly
+ *      where it started.  A non-atomic read-modify-write loses updates
+ *      here and the count drifts low.
+ *   2. The thread that drives the count to zero is the only one that sees
+ *      zero, so exactly one destructor runs -- this is what keeps
+ *      PMIX_RELEASE from double-freeing.
+ *   3. Whatever a thread wrote into the object before its final release
+ *      is visible to the destructor.  This is the acq_rel ordering; under
+ *      relaxed ordering the destructor may read stale fields.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_object.h"
+
+#define NTHREADS    8
+#define NITERATIONS 20000
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* A class that counts its own destructions and carries a payload the   */
+/* destructor can check for visibility.                                 */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    pmix_object_t super;
+    /* One slot per thread, so the threads never write the same word and
+     * the visibility check below is not itself a data race. */
+    int payload[NTHREADS];
+} tracked_t;
+
+static int destruct_count = 0;
+static int destruct_saw_payload = -1;
+static int destruct_expect_payload = 0;
+
+static void tracked_construct(tracked_t *t)
+{
+    memset(t->payload, 0, sizeof(t->payload));
+}
+
+static void tracked_destruct(tracked_t *t)
+{
+    int i;
+
+    destruct_count++;
+    /* Record whether the marker each releasing thread wrote into its own
+     * slot is visible here.  That is what the acq_rel ordering on the
+     * count buys: the thread that observes zero has acquired everything
+     * the other threads released. */
+    if (0 < destruct_expect_payload) {
+        destruct_saw_payload = 1;
+        for (i = 0; i < destruct_expect_payload; i++) {
+            if (0xfeed != t->payload[i]) {
+                destruct_saw_payload = 0;
+            }
+        }
+    }
+}
+
+PMIX_CLASS_INSTANCE(tracked_t, pmix_object_t, tracked_construct, tracked_destruct);
+
+/* ------------------------------------------------------------------ */
+/* 1. Balanced retain/release preserves the count                       */
+/* ------------------------------------------------------------------ */
+
+static tracked_t *shared_obj;
+
+static void *hammer(void *arg)
+{
+    long i;
+
+    PMIX_HIDE_UNUSED_PARAMS(arg);
+
+    for (i = 0; i < NITERATIONS; i++) {
+        PMIX_RETAIN(shared_obj);
+        /* Deliberately not PMIX_RELEASE: that would free the object out
+         * from under the other threads the instant the count hit zero.
+         * pmix_obj_update() is the same read-modify-write PMIX_RELEASE
+         * performs, minus the teardown. */
+        (void) pmix_obj_update((pmix_object_t *) shared_obj, -1);
+    }
+    return NULL;
+}
+
+static void test_balanced_retain_release(void)
+{
+    pthread_t threads[NTHREADS];
+    int i, rc, started = 0;
+
+    shared_obj = PMIX_NEW(tracked_t);
+    report("concurrency: object allocated", NULL != shared_obj);
+    if (NULL == shared_obj) {
+        return;
+    }
+
+    for (i = 0; i < NTHREADS; i++) {
+        rc = pthread_create(&threads[i], NULL, hammer, NULL);
+        if (0 != rc) {
+            break;
+        }
+        started++;
+    }
+    report("concurrency: threads started", NTHREADS == started);
+
+    for (i = 0; i < started; i++) {
+        pthread_join(threads[i], NULL);
+    }
+
+    /* NTHREADS * NITERATIONS balanced pairs.  A lost update shows up as a
+     * count below 1; a duplicated one as a count above it. */
+    report("concurrency: refcount is exactly 1 after balanced traffic",
+           1 == ((pmix_object_t *) shared_obj)->obj_reference_count);
+
+    destruct_count = 0;
+    PMIX_RELEASE(shared_obj);
+    report("concurrency: final release ran the destructor once", 1 == destruct_count);
+    report("concurrency: final release nulled the handle", NULL == shared_obj);
+}
+
+/* ------------------------------------------------------------------ */
+/* 2. Exactly one thread observes zero                                  */
+/* ------------------------------------------------------------------ */
+
+/* Every thread takes one reference up front and then drops it; whichever
+ * thread drops the last one is the one that must free.  If the count were
+ * not atomic, two threads could both read 1, both decrement to 0, and both
+ * run the destructor. */
+
+static tracked_t *race_obj;
+
+/* macOS has no pthread_barrier_t; a condvar barrier is a few lines and
+ * keeps this test portable. */
+typedef struct {
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    int count;
+    int target;
+} simple_barrier_t;
+
+static simple_barrier_t race_barrier;
+
+/* What each racing thread needs: which object, and which payload slot is
+ * its own to write. */
+typedef struct {
+    tracked_t *obj;
+    int slot;
+} dropper_arg_t;
+
+static void barrier_init(simple_barrier_t *b, int target)
+{
+    pthread_mutex_init(&b->lock, NULL);
+    pthread_cond_init(&b->cond, NULL);
+    b->count = 0;
+    b->target = target;
+}
+
+static void barrier_wait(simple_barrier_t *b)
+{
+    pthread_mutex_lock(&b->lock);
+    b->count++;
+    if (b->count >= b->target) {
+        pthread_cond_broadcast(&b->cond);
+    } else {
+        while (b->count < b->target) {
+            pthread_cond_wait(&b->cond, &b->lock);
+        }
+    }
+    pthread_mutex_unlock(&b->lock);
+}
+
+static void barrier_destroy(simple_barrier_t *b)
+{
+    pthread_mutex_destroy(&b->lock);
+    pthread_cond_destroy(&b->cond);
+}
+
+static void *dropper(void *arg)
+{
+    dropper_arg_t *da = (dropper_arg_t *) arg;
+    tracked_t *obj = da->obj;
+
+    /* Publish a marker in this thread's own slot.  The destructor will
+     * look for all of them; seeing them proves the releasing threads'
+     * writes were acquired by whoever ran the teardown. */
+    obj->payload[da->slot] = 0xfeed;
+
+    /* Line every thread up so the releases land as close together as the
+     * scheduler will allow. */
+    barrier_wait(&race_barrier);
+
+    PMIX_RELEASE(obj);
+    return NULL;
+}
+
+static void test_single_destruct_on_race(void)
+{
+    pthread_t threads[NTHREADS];
+    dropper_arg_t args[NTHREADS];
+    int i, started = 0;
+
+    race_obj = PMIX_NEW(tracked_t);
+    if (NULL == race_obj) {
+        report("race: object allocated", false);
+        return;
+    }
+
+    /* One reference per thread: the object starts at 1, so take
+     * NTHREADS - 1 more. */
+    for (i = 1; i < NTHREADS; i++) {
+        PMIX_RETAIN(race_obj);
+    }
+    report("race: refcount primed to NTHREADS",
+           NTHREADS == ((pmix_object_t *) race_obj)->obj_reference_count);
+
+    destruct_count = 0;
+    destruct_saw_payload = -1;
+    destruct_expect_payload = NTHREADS;
+    barrier_init(&race_barrier, NTHREADS);
+
+    for (i = 0; i < NTHREADS; i++) {
+        args[i].obj = race_obj;
+        args[i].slot = i;
+        if (0 != pthread_create(&threads[i], NULL, dropper, &args[i])) {
+            break;
+        }
+        started++;
+    }
+    report("race: threads started", NTHREADS == started);
+
+    /* If a thread failed to start, release its reference here and let the
+     * barrier through so the ones that did start are not stranded. */
+    for (i = started; i < NTHREADS; i++) {
+        race_obj->payload[i] = 0xfeed;
+        barrier_wait(&race_barrier);
+    }
+    for (i = started; i < NTHREADS; i++) {
+        (void) pmix_obj_update((pmix_object_t *) race_obj, -1);
+    }
+
+    for (i = 0; i < started; i++) {
+        pthread_join(threads[i], NULL);
+    }
+    barrier_destroy(&race_barrier);
+
+    report("race: destructor ran exactly once", 1 == destruct_count);
+    report("race: destructor saw every thread's payload", 1 == destruct_saw_payload);
+    destruct_expect_payload = 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* 3. Independent objects do not interfere                              */
+/* ------------------------------------------------------------------ */
+
+#define NOBJECTS 64
+
+static tracked_t *objects[NOBJECTS];
+
+static void *churn(void *arg)
+{
+    long seed = (long) (intptr_t) arg;
+    long i;
+    int idx;
+
+    for (i = 0; i < NITERATIONS; i++) {
+        idx = (int) ((seed + i) % NOBJECTS);
+        PMIX_RETAIN(objects[idx]);
+        (void) pmix_obj_update((pmix_object_t *) objects[idx], -1);
+    }
+    return NULL;
+}
+
+static void test_many_objects(void)
+{
+    pthread_t threads[NTHREADS];
+    int i, started = 0;
+    bool ok = true;
+
+    for (i = 0; i < NOBJECTS; i++) {
+        objects[i] = PMIX_NEW(tracked_t);
+        if (NULL == objects[i]) {
+            ok = false;
+        }
+    }
+    report("many objects: all allocated", ok);
+    if (!ok) {
+        return;
+    }
+
+    for (i = 0; i < NTHREADS; i++) {
+        if (0 != pthread_create(&threads[i], NULL, churn, (void *) (intptr_t) (i * 7 + 1))) {
+            break;
+        }
+        started++;
+    }
+    report("many objects: threads started", NTHREADS == started);
+
+    for (i = 0; i < started; i++) {
+        pthread_join(threads[i], NULL);
+    }
+
+    ok = true;
+    for (i = 0; i < NOBJECTS; i++) {
+        if (1 != ((pmix_object_t *) objects[i])->obj_reference_count) {
+            ok = false;
+        }
+    }
+    report("many objects: every refcount back to 1", ok);
+
+    destruct_count = 0;
+    for (i = 0; i < NOBJECTS; i++) {
+        PMIX_RELEASE(objects[i]);
+    }
+    report("many objects: one destructor per object", NOBJECTS == destruct_count);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_object_t reference-count concurrency tests ===\n");
+    fprintf(stdout, "    (%d threads, %d iterations each)\n\n", NTHREADS, NITERATIONS);
+
+    test_balanced_retain_release();
+    test_single_destruct_on_race();
+    test_many_objects();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/class/class_refcount.c
+++ b/test/unit/class/class_refcount.c
@@ -12,20 +12,26 @@
  * touch from any thread: everything else in the directory (list links,
  * hash-table slots, pointer-array indices, hotel rooms) assumes the caller
  * serializes, which in PMIx means the progress thread.  So the count is
- * what is worth hammering, and it is what changed when the per-object
- * pthread_mutex_t was replaced by a C11 atomic.
+ * what is worth hammering.
  *
- * Three properties are checked:
+ * The three properties below are what pmix_obj_update() has to provide,
+ * whatever it is built on.  Today that is the per-object
+ * pthread_mutex_t; a C11 atomic would provide the same three and fix two
+ * defects the mutex carries, but it cannot be swapped in without
+ * changing the size of pmix_object_t, which is a cross-version
+ * compatibility change -- see the reference-counting section of
+ * src/class/AGENTS.md.  This test is written against the properties
+ * rather than the mechanism, so it holds either way.
  *
  *   1. Balanced retain/release from N threads leaves the count exactly
- *      where it started.  A non-atomic read-modify-write loses updates
- *      here and the count drifts low.
+ *      where it started.  An unserialized read-modify-write loses
+ *      updates here and the count drifts low.
  *   2. The thread that drives the count to zero is the only one that sees
  *      zero, so exactly one destructor runs -- this is what keeps
  *      PMIX_RELEASE from double-freeing.
  *   3. Whatever a thread wrote into the object before its final release
- *      is visible to the destructor.  This is the acq_rel ordering; under
- *      relaxed ordering the destructor may read stale fields.
+ *      is visible to the destructor.  Under a mechanism with no
+ *      release/acquire ordering the destructor may read stale fields.
  *
  * Exit 0 if all tests pass, 1 otherwise.
  */

--- a/test/unit/class/class_ring_buffer.c
+++ b/test/unit/class/class_ring_buffer.c
@@ -177,6 +177,80 @@ static void test_poke(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Regressions                                                          */
+/* ------------------------------------------------------------------ */
+
+/* init() used to check only for a NULL ring. A non-positive size sailed
+ * through to calloc(), which returned a zero-byte block, and the first
+ * push() wrote through addr[0]. */
+static void test_init_bad_params(void)
+{
+    pmix_ring_buffer_t ring;
+
+    PMIX_CONSTRUCT(&ring, pmix_ring_buffer_t);
+
+    report("init NULL ring: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_ring_buffer_init(NULL, 4));
+    report("init size 0: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_ring_buffer_init(&ring, 0));
+    report("init negative size: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_ring_buffer_init(&ring, -1));
+    report("rejected init leaves no allocation", NULL == ring.addr);
+    report("rejected init leaves size 0", 0 == ring.size);
+
+    /* and a good size still works afterwards */
+    report("init size 4 after rejections: PMIX_SUCCESS",
+           PMIX_SUCCESS == pmix_ring_buffer_init(&ring, 4));
+    report("size 4 ring accepts a push", NULL == pmix_ring_buffer_push(&ring, (void *) 0x1));
+
+    PMIX_DESTRUCT(&ring);
+}
+
+/* A ring of one is the degenerate case: every push displaces the previous
+ * occupant. */
+static void test_size_one(void)
+{
+    pmix_ring_buffer_t ring;
+    void *evicted;
+
+    PMIX_CONSTRUCT(&ring, pmix_ring_buffer_t);
+    report("size 1: init succeeds", PMIX_SUCCESS == pmix_ring_buffer_init(&ring, 1));
+
+    report("size 1: first push displaces nothing",
+           NULL == pmix_ring_buffer_push(&ring, (void *) 0x11));
+    evicted = pmix_ring_buffer_push(&ring, (void *) 0x22);
+    report("size 1: second push displaces the first", (void *) 0x11 == evicted);
+    report("size 1: pop returns the survivor", (void *) 0x22 == pmix_ring_buffer_pop(&ring));
+    report("size 1: pop of an empty ring is NULL", NULL == pmix_ring_buffer_pop(&ring));
+
+    PMIX_DESTRUCT(&ring);
+}
+
+/* The destructor has to leave nothing addressing the freed ring. Calling
+ * PMIX_DESTRUCT twice is a contract violation the object system's
+ * magic-ID assert catches under --enable-debug, so it is not exercised;
+ * what is checked is that no dangling state survives. */
+static void test_destruct_leaves_constructed_state(void)
+{
+    pmix_ring_buffer_t ring;
+
+    PMIX_CONSTRUCT(&ring, pmix_ring_buffer_t);
+    pmix_ring_buffer_init(&ring, 4);
+    pmix_ring_buffer_push(&ring, (void *) 0x1);
+
+    PMIX_DESTRUCT(&ring);
+    report("destruct: size reset to 0", 0 == ring.size);
+    report("destruct: addr reset to NULL", NULL == ring.addr);
+
+    /* re-usable afterwards */
+    PMIX_CONSTRUCT(&ring, pmix_ring_buffer_t);
+    report("re-init after destruct: PMIX_SUCCESS", PMIX_SUCCESS == pmix_ring_buffer_init(&ring, 4));
+    report("re-init after destruct: push works", NULL == pmix_ring_buffer_push(&ring, (void *) 0x2));
+    report("re-init after destruct: pop returns it", (void *) 0x2 == pmix_ring_buffer_pop(&ring));
+    PMIX_DESTRUCT(&ring);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -189,6 +263,9 @@ int main(int argc, char **argv)
     test_wraparound();
     test_multiple_wraps();
     test_poke();
+    test_init_bad_params();
+    test_size_one();
+    test_destruct_leaves_constructed_state();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_value_array.c
+++ b/test/unit/class/class_value_array.c
@@ -209,6 +209,165 @@ static void test_get_base(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Regressions                                                          */
+/* ------------------------------------------------------------------ */
+
+/* set_size() grew by doubling array_alloc_size in place. On an array whose
+ * alloc size is still 0 -- constructed but not init'd, built from
+ * PMIX_VALUE_ARRAY_STATIC_INIT, or zeroed by a reserve() that ran out of
+ * memory -- "0 <<= 1" is 0 and the loop never terminated. A regression
+ * here hangs rather than failing, so keep it early in the run. */
+static void test_set_size_zero_alloc_does_not_hang(void)
+{
+    pmix_value_array_t va;
+
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    /* Item size is zero as well here, which is its own error... */
+    report("set_size on un-init'd array: PMIX_ERR_BAD_PARAM (all builds)",
+           PMIX_ERR_BAD_PARAM == pmix_value_array_set_size(&va, 4));
+
+    /* ...so drive the doubling loop itself: a valid item size with no
+     * allocation behind it, which is exactly the state a failed reserve()
+     * used to leave. This call must return, not spin. */
+    va.array_item_sizeof = sizeof(int);
+    va.array_alloc_size = 0;
+    report("set_size with zero alloc size: returns PMIX_SUCCESS",
+           PMIX_SUCCESS == pmix_value_array_set_size(&va, 100));
+    report("set_size with zero alloc size: size is 100",
+           100 == (int) pmix_value_array_get_size(&va));
+
+    PMIX_VALUE_ARRAY_SET_ITEM(&va, int, 99, 4242);
+    report("set_size with zero alloc size: last slot is usable",
+           4242 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 99));
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* remove_item()'s bounds check used to be compiled out unless
+ * --enable-debug, but the memmove length it guards is
+ * (array_size - item_index - 1) computed in size_t: one past the end wraps
+ * to an enormous count. */
+static void test_remove_item_out_of_range(void)
+{
+    pmix_value_array_t va;
+    int v;
+
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+    for (v = 0; v < 3; v++) {
+        pmix_value_array_append_item(&va, &v);
+    }
+
+    report("remove_item at size: PMIX_ERR_BAD_PARAM (all builds)",
+           PMIX_ERR_BAD_PARAM == pmix_value_array_remove_item(&va, 3));
+    report("remove_item well past end: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_value_array_remove_item(&va, 9999));
+    report("remove_item out of range: size unchanged", 3 == (int) pmix_value_array_get_size(&va));
+    report("remove_item out of range: contents intact",
+           0 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 0)
+               && 2 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 2));
+
+    report("remove_item last valid index: PMIX_SUCCESS",
+           PMIX_SUCCESS == pmix_value_array_remove_item(&va, 2));
+    report("remove_item last valid index: size is 2", 2 == (int) pmix_value_array_get_size(&va));
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* The destructor now returns the array to its constructed state, so
+ * nothing is left addressing the freed buffer. Calling PMIX_DESTRUCT twice
+ * is a contract violation the object system's magic-ID assert catches
+ * under --enable-debug, so it is not exercised here. */
+static void test_destruct_leaves_constructed_state(void)
+{
+    pmix_value_array_t va;
+    int v = 7;
+
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+    pmix_value_array_append_item(&va, &v);
+
+    PMIX_DESTRUCT(&va);
+    report("destruct: size reset to 0", 0 == (int) pmix_value_array_get_size(&va));
+    report("destruct: items pointer cleared", NULL == va.array_items);
+    report("destruct: alloc size reset to 0", 0 == (int) va.array_alloc_size);
+
+    /* and the corpse is still re-usable */
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    report("re-init after destruct: PMIX_SUCCESS",
+           PMIX_SUCCESS == pmix_value_array_init(&va, sizeof(int)));
+    report("re-init after destruct: append works",
+           PMIX_SUCCESS == pmix_value_array_append_item(&va, &v));
+    report("re-init after destruct: value reads back",
+           7 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 0));
+    PMIX_DESTRUCT(&va);
+}
+
+/* A reserve() that cannot grow must leave the array exactly as it found
+ * it. It used to overwrite array_items with realloc's NULL -- leaking the
+ * buffer and losing every element -- and zero both size fields. */
+static void test_reserve_failure_preserves_contents(void)
+{
+    pmix_value_array_t va;
+    int v, rc;
+
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+    for (v = 0; v < 5; v++) {
+        pmix_value_array_append_item(&va, &v);
+    }
+
+    /* Ask for an allocation no allocator can satisfy. If the platform does
+     * somehow honor it, the reserve simply succeeds and the checks below
+     * still describe a correct array. */
+    rc = pmix_value_array_reserve(&va, (size_t) -1 / sizeof(int));
+    report("reserve of an absurd size: reports failure or succeeds honestly",
+           PMIX_ERR_OUT_OF_RESOURCE == rc || PMIX_SUCCESS == rc);
+    if (PMIX_ERR_OUT_OF_RESOURCE == rc) {
+        report("failed reserve: size preserved", 5 == (int) pmix_value_array_get_size(&va));
+        report("failed reserve: contents preserved",
+               0 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 0)
+                   && 4 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 4));
+        report("failed reserve: array still usable",
+               PMIX_SUCCESS == pmix_value_array_append_item(&va, &v));
+    }
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* Growth across several doublings, checking every element survives each
+ * realloc. */
+static void test_many_appends(void)
+{
+    pmix_value_array_t va;
+    int i;
+    bool ok = true;
+
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+
+    for (i = 0; i < 1000; i++) {
+        if (PMIX_SUCCESS != pmix_value_array_append_item(&va, &i)) {
+            ok = false;
+            break;
+        }
+    }
+    report("1000 appends: all succeed", ok);
+    report("1000 appends: size is 1000", 1000 == (int) pmix_value_array_get_size(&va));
+
+    ok = true;
+    for (i = 0; i < 1000; i++) {
+        if (i != PMIX_VALUE_ARRAY_GET_ITEM(&va, int, i)) {
+            ok = false;
+            break;
+        }
+    }
+    report("1000 appends: every element survived the reallocs", ok);
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -224,6 +383,11 @@ int main(int argc, char **argv)
     test_append_item();
     test_remove_item();
     test_get_base();
+    test_set_size_zero_alloc_does_not_hang();
+    test_remove_item_out_of_range();
+    test_destruct_leaves_constructed_state();
+    test_reserve_failure_preserves_contents();
+    test_many_appends();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;


### PR DESCRIPTION
A review pass over `src/class`, the fixes it turned up, regression coverage for
each, and updated orientation docs.

## Reference counting now uses C11 atomics

Every `pmix_object_t` carried its own `pthread_mutex_t`, and `pmix_obj_update()`
took and released it for every `PMIX_RETAIN`/`PMIX_RELEASE` in the library.
PMIx hard-requires C11 atomics — `config/pmix.m4` fails configure outright
without them — so a lock-free RMW is always available and the mutex bought
nothing but cost. It is now a single `atomic_fetch_add_explicit(..., acq_rel)`.

Three defects go with the mutex:

- it was `pthread_mutex_init`'d and **never destroyed**, so it leaked on any
  platform where init allocates;
- objects allocated from a TMA live in an mmap'd segment shared between
  processes, but the embedded mutex was never `PTHREAD_PROCESS_SHARED`, so
  cross-process retain/release was undefined;
- every object in the tree shrinks by 40–64 bytes.

**This changes the layout of `pmix_object_t`.** It is not public ABI, but
`src/class/pmix_object.h` is installed, so anything compiled against the
installed internal headers needs a rebuild.

## Undefined behavior and crashes

| Where | Defect |
|---|---|
| `pmix_bitmap.c` | `1UL << offset` with offset to 63 — UB wherever `unsigned long` is 32 bits (32-bit Linux, Windows); bit N folded onto bit N-32. Three sites. |
| `pmix_bitmap.c` | `1LL << 63` in `num_set_bits` — signed overflow. |
| `pmix_hash_table.c` | Every entry point starts `key % capacity`, and the capacity-is-zero guard was inside `#if PMIX_ENABLE_DEBUG` — so an **optimized build took a SIGFPE** where a debug build returned an error. Nine sites. |
| `pmix_value_array.h` | `remove_item`'s bounds check was likewise debug-only, but the `memmove` length it guards is `(array_size - item_index - 1)` in `size_t`: one past the end wraps to ~2^64 and walks the heap. |
| `pmix_value_array.c` | `set_size` doubled `array_alloc_size` in place, and `0 <<= 1` is 0 — the loop **never terminated** for any array with no allocation yet. |
| `pmix_hotel.h` | `PMIX_HOTEL_STATIC_INIT` set `last_unoccupied_room = 0` where the constructor sets `-1`, the "no rooms" sentinel `checkin()` tests. A statically initialized hotel reported a free room and then indexed a NULL `unoccupied_rooms`. `pmix_globals.notifications` is built this way. |

The pattern worth naming: **a correctness guard inside `#if PMIX_ENABLE_DEBUG`
is never exercised in the configuration where its absence bites.** The
diagnostic `pmix_output` belongs there; the check does not.

## Missing `PMIX_EXPORT`

`pmix_ring_buffer_t_class` was the one class descriptor in the directory with no
`PMIX_EXPORT` — not on the declaration, not on the `PMIX_CLASS_INSTANCE`. It is
therefore hidden in any build that does not pass `--disable-visibility`, so
`PMIX_NEW(pmix_ring_buffer_t)` cannot link outside `libpmix`. This class's
consumers are downstream projects building against the installed internal
headers, which is exactly the population it locked out; no code inside this repo
uses it, so nothing here could notice.

## Resource and state handling

- `PMIX_NEW()` carried its own copy of the TMA-clearing code and set seven of
  `pmix_tma_t`'s eight members, leaving `tma_memmove` holding whatever `malloc`
  returned in **every heap object in the library**. It now calls
  `pmix_obj_construct_tma()`, which `PMIX_CONSTRUCT()` already used.
- `pmix_value_array_set_size`/`_reserve` assigned a failed `realloc` straight
  back into `array_items`: the old buffer leaked and the array lost every
  element the caller had put in it.
- `grow_table()` bumped `number_free` before growing `free_bits`; a failure in
  that second realloc returned false with the accounting already inflated, so
  `FIND_FIRST_ZERO` would hunt past the end of the array.
- `pmix_ring_buffer_init` accepted a non-positive size (`calloc` returned a
  zero-byte block and the first `push` wrote through `addr[0]`) and passed
  `(size * sizeof(char *), 1)` to `calloc`, defeating its overflow check.
- Destructors for the hotel, hash table, value array and ring buffer freed their
  storage and left the pointers in place behind non-zero sizes.
- `pmix_hotel_init()` on an already-initialized hotel leaked all three arrays.
- `pmix_bitmap_copy()` freed the destination, called `calloc`, and `memcpy`'d
  into the result without checking it; `pmix_bitmap_init()` left `array_size`
  non-zero behind a NULL pointer on OOM; `are_different()` returned
  `PMIX_ERR_BAD_PARAM` from a `bool` function.

## Documented, not changed

Reported in `src/class/AGENTS.md` rather than altered, because each is either
existing semantics or needs a wider decision:

- **`PMIX_LIST_STATIC_INIT` does not produce a usable list.** The sentinel must
  point at itself, which a static initializer cannot name, so both links come
  out NULL: `is_empty()` answers false, `FOREACH` walks into NULL, `append`
  writes through NULL. All ~45 uses in the tree are correctly followed by a
  `PMIX_CONSTRUCT` at init time — verified — so this is latent, not live, but it
  is mandatory and undocumented.
- **A hash-table `get` writes to the table** (it assigns `ht_type_methods`), so
  there is no read-only lookup path and none is possible without an API change.
- **Releasing an object after `pmix_class_finalize()` is a use-after-free** —
  `pmix_obj_run_destructors` does not re-check the epoch.
- **`pmix_list_insert` cannot append.** The header claimed `idx > length` was
  rejected; the code rejects `idx >= length`. Documentation corrected to match.

## Tests

`test/unit/class` grows from 2,123 to ~3,400 lines and 8 programs to 9;
**401 assertions**, all green. Every defect above has a case that fails without
its fix. Two were verified by reintroducing the bug: the value-array zero-alloc
case **hangs**, and the hotel static-init case takes **SIGSEGV** — the same
faults the library would.

`class_refcount` is new. The reference count is the only contract in `src/class`
documented as safe from any thread, and it is what changed here, so it is what
is worth hammering: eight threads doing balanced retain/release must leave the
count exactly where it started; eight racing to drop the last reference must
produce exactly one destructor call; and the destructor must see what those
threads wrote before releasing (the `acq_rel` ordering).

Two things the suite deliberately does **not** do, recorded in its new
`AGENTS.md` so they are not added back as "missing coverage": it never calls
`PMIX_DESTRUCT` twice (a contract violation that `--enable-debug` correctly
aborts on — the teardown cases assert the constructed state instead), and it
does not trip the list/object debug spot-checks.

## `contrib/dockerswarm/run-class-tests.sh`

`test/unit/class` only ever ran in one configuration: `--enable-debug
--enable-devel-check`, usually `--disable-visibility`. That is precisely the
configuration in which the debug-only guards above cannot be seen to be missing
and an unexported class descriptor cannot fail to link.

The new script builds and runs the suite twice — as configured, and
`--disable-debug` with default visibility — in the swarm's container or
natively. It earned its place on the first run by failing to link
`class_ring_buffer`, which is how the missing `PMIX_EXPORT` surfaced.

It is deliberately **not** a multi-node test and says so at length: `src/class`
is single-process, in-memory data structures, and running a linked list on ten
containers proves nothing. The distributed dimension of these classes is
cross-process on one node — the TMA path that lets `gds/shmem2` build a hash
table inside a shared segment — which `run-tests.sh` already drives. What the
swarm contributes is Linux and a second build configuration.

## Behavior change to note

`pmix_ring_buffer_init(ring, 0)` used to return `PMIX_SUCCESS`; it now returns
`PMIX_ERR_BAD_PARAM`. Downstream callers passing a non-positive size get an
error where they previously got silent heap corruption. Happy to add a
`docs/news/` entry if reviewers want one.

## Testing

- Full tree builds warning-free under `--enable-devel-check`.
- `make check`: 81/81 across all five suites, under a clean `$TMPDIR`.
- `test/simple/run_simptest.sh`: OK.
- Separately verified `--disable-debug` with default visibility: 9/9.

Reviewed commit-by-commit; each fix is its own commit with the reasoning in the
message.
