### PR TITLE
Review and repair src/client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,7 @@ test/sshot/server
 test/sshot/mytopo.json
 test/sshot/testcoord
 
+test/unit/client_api
 test/unit/compress
 test/unit/preg
 test/unit/bfrops_regex2

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -29,6 +29,7 @@ is only the nickname.
 | `run-group-events.sh` | Runs the **dynamic, event-driven** group exercisers and their fault paths (invite/join, member lost during destruct, ...); kept separate from `run-tests.sh` so the event/fault matrix can grow independently. Same `linux`/`macos` modes. |
 | `run-topology.sh` | Runs the **topology + locality** exerciser across real nodes: each rank loads the topology its *local* server published (hwloc shmem, with XML as the fallback) and compares `PMIX_LOCALITY_STRING` with every peer. The only place `src/hwloc` gets a multi-node answer -- on one host every peer is a node-mate, so a single-host run cannot tell a correct result from one that claims everything is local. Same `linux`/`macos` modes. |
 | `run-python.sh` | Runs the **Python bindings**: the standalone unit suite, the connected client/server round-trip, and Python PMIx clients spread across nodes. Same `linux`/`macos` modes. See §10. |
+| `run-client-tests.sh` | Runs the `src/client` API surface across the swarm, so the ranks sit behind **different** PMIx servers. This is the multi-node case for the client library: everything in `src/client` either answers locally or round-trips to a server, and a singleton exercises none of the second half. See §12. |
 | `run-class-tests.sh` | Runs `test/unit/class` in the two configurations a developer's own `make check` does not cover: **Linux**, and **`--disable-debug`** with default symbol visibility. Deliberately *not* a multi-node test — see §11. |
 | `swarm-common.sh` | Sourced by all six scripts above: which swarm to drive (`PMIX_SWARM`), how to reach a node, and how to clean one. The three runners each carried their own copy of that once, and the copies drifted. |
 | `python/` | The swarm's own Python clients (`swarm_client.py`, `swarm_group.py`, `swarm_cpuset.py`). |
@@ -82,6 +83,7 @@ docker compose up -d       # start pmix-node1 .. pmix-node10
 ./run-group-events.sh linux # dynamic invite/join + group fault paths
 ./run-topology.sh linux    # topology handoff + cross-node locality
 ./run-python.sh linux      # Python bindings: units, round-trip, multi-node
+./run-client-tests.sh linux # src/client APIs across separate PMIx servers
 
 # ---- native macOS (single host) ----
 ./build.sh macos           # native PMIx + PRRTE build under vpath-macos-*
@@ -89,6 +91,7 @@ docker compose up -d       # start pmix-node1 .. pmix-node10
 ./run-group-events.sh macos # single-host dynamic-group smoke
 ./run-topology.sh macos    # single-host topology-handoff smoke
 ./run-python.sh macos      # single-host bindings smoke (most checks SKIP)
+./run-client-tests.sh macos # single-host client smoke (one server, not the point)
 ```
 
 Rebuild after editing PMIx: rerun `./build.sh` (incremental). No image rebuild
@@ -462,3 +465,66 @@ are installed, and things build against them.
 > with an explanation instead. Run `./build.sh macos` first (which
 > distcleans), or use the `linux` half, which has no such restriction — the
 > container builds both configurations against a read-only bind mount.
+
+---
+
+## 12. The `src/client` API suite (`run-client-tests.sh`)
+
+```
+./run-client-tests.sh linux    # across the swarm: several PMIx servers
+./run-client-tests.sh macos    # natively: one server, a smoke pass
+```
+
+**This one *is* a multi-node test, and that is the whole point** — the
+opposite of §11. Almost every function in [`src/client`](../../src/client)
+is an instance of "the request could not be answered locally, so pack a
+command and round-trip to the server". A singleton reaches none of it:
+`PMIx_Fence` and `PMIx_Commit` short-circuit to success, `PMIx_Get` never
+leaves the local datastore, and publish/lookup/spawn/connect all stop at
+the "am I connected?" check. The in-tree
+[`test/unit/client_api.c`](../../test/unit/client_api.c) covers what a
+client can decide by itself; this covers what it cannot.
+
+Spreading the ranks over several nodes matters because **each node runs its
+own `prted`, hence its own PMIx server**. That is what makes these paths
+real rather than loopback:
+
+| Case | What it actually exercises |
+|------|---------------------------|
+| `client` | put/commit/fence/get where the answer lives behind another server |
+| `dmodex` | direct modex: rank 0 delays its commit, so the other ranks' gets sit in the client's pending-request list — the coalescing path, where only the first requester sends and the rest are satisfied from the one reply |
+| `nodeinfo` | the node/app/session realm directives, whose answers differ per node — the densest parser in the directory |
+| `pub` | publish/lookup/unpublish resolving up through the daemons |
+| `resolve` | `PMIx_Resolve_peers` / `PMIx_Resolve_nodes` with something to resolve that is not just "this node" |
+| `dynamic` | `PMIx_Spawn` plus `PMIx_Connect`/`PMIx_Disconnect`, i.e. the multi-nspace job-info exchange in `PMIx_Connect_nb` |
+
+A final wide `dmodex` run (10 ranks over 5 nodes) drives the pending-request
+list deep enough for the coalescing to matter.
+
+### Prerequisite: the clients must link *your* PMIx
+
+The examples are **compiled in a throwaway builder container** and **run in
+the long-lived node containers**. Only the shared volume is guaranteed to be
+the same in both, so the script insists on `/opt/prte/pmix` — what
+`./build.sh` installs — and refuses to fall back to a PMIx baked into the
+image. It also repeats `run-tests.sh`'s "containers are running the current
+image" preflight. Both failures are otherwise invisible: you get a missing
+`pmix_common.h`, or an undefined symbol, and nothing in either message
+mentions containers.
+
+So the full sequence from a cold start is:
+
+```sh
+./build.sh                              # installs your PMIx into the volume
+docker compose up -d --force-recreate   # if the nodes predate the image
+./run-client-tests.sh linux
+```
+
+### macOS mode
+
+`./run-client-tests.sh macos` compiles the same clients against the in-tree
+library and runs them under a single local `prterun`. That still drives the
+connected paths a singleton cannot reach — a real server, real
+`PMIX_PTL_SEND_RECV` round-trips — but with one server it is a regression
+smoke pass, not the multi-server case above. Use it when you have changed
+`src/client` and want a quick answer before spending a swarm run.

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -31,7 +31,7 @@ is only the nickname.
 | `run-python.sh` | Runs the **Python bindings**: the standalone unit suite, the connected client/server round-trip, and Python PMIx clients spread across nodes. Same `linux`/`macos` modes. See §10. |
 | `run-client-tests.sh` | Runs the `src/client` API surface across the swarm, so the ranks sit behind **different** PMIx servers. This is the multi-node case for the client library: everything in `src/client` either answers locally or round-trips to a server, and a singleton exercises none of the second half. See §12. |
 | `run-class-tests.sh` | Runs `test/unit/class` in the two configurations a developer's own `make check` does not cover: **Linux**, and **`--disable-debug`** with default symbol visibility. Deliberately *not* a multi-node test — see §11. |
-| `swarm-common.sh` | Sourced by all six scripts above: which swarm to drive (`PMIX_SWARM`), how to reach a node, and how to clean one. The three runners each carried their own copy of that once, and the copies drifted. |
+| `swarm-common.sh` | Sourced by all seven scripts above: which swarm to drive (`PMIX_SWARM`), how to reach a node, and how to clean one. The three runners each carried their own copy of that once, and the copies drifted. |
 | `python/` | The swarm's own Python clients (`swarm_client.py`, `swarm_group.py`, `swarm_cpuset.py`). |
 | `Dockerfile` | Base image: toolchain, PRRTE master *source* (autogen'd), SSH wiring, node entrypoint. It contains **no** PMIx and **no** built PRRTE. |
 | `docker-compose.yml` | The ten nodes `pmix-node1`..`pmix-node10`, each mounting the shared `pmix-build` volume. Every one of those names derives from `$PMIX_SWARM`, so two clones can each run a swarm — see §4. |

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -172,9 +172,18 @@ build_linux() {
             mkdir -p /opt/prte/tests
             for ex in $BUILD_EXAMPLES; do
                 [ -f "/pmix-src/examples/$ex.c" ] || { echo "   (skip $ex: no source)"; continue; }
+                # -rpath, not just -L: these binaries are launched by prted,
+                # which does NOT give its children a login shell, so the
+                # LD_LIBRARY_PATH that env.sh sets is not in scope for them.
+                # With PMIx installed outside the default loader directories
+                # the result is "libpmix.so.2: cannot open shared object file"
+                # on every rank -- which surfaces as a whole suite of group
+                # tests failing with exit code 127 and nothing pointing at the
+                # link line.  (No apostrophes in here: this block is the body
+                # of a single-quoted bash -c argument.)
                 gcc -O0 -g -o "/opt/prte/tests/$ex" "/pmix-src/examples/$ex.c" \
                     -I/opt/prte/pmix/include -I/pmix-src/examples \
-                    -L/opt/prte/pmix/lib -lpmix \
+                    -L/opt/prte/pmix/lib -lpmix -Wl,-rpath,/opt/prte/pmix/lib \
                 && echo "   built $ex" || echo "   FAILED to build $ex"
             done
 
@@ -260,8 +269,10 @@ build_macos() {
     echo ">>> group example clients -> $root/vpath-macos-prte/install/bin"
     for ex in $BUILD_EXAMPLES; do
         [ -f "$root/examples/$ex.c" ] || continue
+        # see the Linux build above for why this needs -rpath and not just -L
         gcc -O0 -g -o "$root/vpath-macos-prte/install/bin/$ex" "$root/examples/$ex.c" \
             -I"$pfx/include" -I"$root/examples" -L"$pfx/lib" -lpmix \
+            -Wl,-rpath,"$pfx/lib" \
         && echo "   built $ex" || echo "   FAILED to build $ex"
     done
     echo ">>> macOS build complete."

--- a/contrib/dockerswarm/run-client-tests.sh
+++ b/contrib/dockerswarm/run-client-tests.sh
@@ -1,0 +1,307 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Exercise the src/client APIs against real, *separate* PMIx servers.
+#
+#   ./run-client-tests.sh linux    # in the 10-container swarm
+#                                  #   (requires: ./build.sh && docker compose up -d)
+#   ./run-client-tests.sh macos    # single-host subset natively
+#                                  #   (requires: ./build.sh macos)
+#
+# WHY THIS ONE *IS* A MULTI-NODE TEST
+#
+# Unlike run-class-tests.sh, whose subject is single-process data structures,
+# essentially every interesting path in src/client is "the request could not
+# be answered locally, so pack a command and round-trip to the server".  A
+# singleton exercises none of it: PMIx_Fence and PMIx_Commit short-circuit,
+# PMIx_Get never leaves the local datastore, and publish/lookup/spawn/connect
+# all bail out at the "am I connected?" check.  test/unit/client_api.c covers
+# what a client can decide by itself; this covers what it cannot.
+#
+# Spreading the ranks over several nodes matters specifically because each
+# node runs its own prted, hence its own PMIx server.  That is what makes
+# these paths real rather than loopback:
+#
+#   * PMIx_Get for a peer on another node cannot be satisfied from the data
+#     the local server pushed down at init, so it takes the full
+#     pack -> PMIX_PTL_SEND_RECV -> _getnb_cbfunc -> GDS-store -> deliver
+#     path, including the pending-request coalescing that makes several
+#     outstanding gets for one proc share a single request.
+#   * PMIx_Fence with collect-data has to modex across daemons.
+#   * publish/lookup resolves through the daemons up to a common ancestor.
+#   * PMIx_Resolve_peers / PMIx_Resolve_nodes have something to resolve that
+#     is not just "this node".
+#   * PMIx_Spawn plus PMIx_Connect/PMIx_Disconnect exercise the multi-nspace
+#     job-info exchange in PMIx_Connect_nb.
+#
+# The realm-directed gets (node/app/session info) are called out separately
+# because that parser is the densest code in the directory and its answers
+# differ per node -- so getting them right is only observable when the ranks
+# are actually on different nodes.
+#
+# Prints PASS/FAIL per case and a summary; exits non-zero if anything failed.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+# RUN/ON, cleanup_swarm, swarm_up_or_die and the swarm naming (PMIX_SWARM,
+# NODE, IMAGE, VOLUME) all live in swarm-common.sh.
+. "$(dirname "$0")/swarm-common.sh"
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+# The examples this runner drives.  Each is an ordinary PMIx client, so each
+# one is a live test of the client library rather than of the example.
+CLIENT_EXAMPLES="${CLIENT_EXAMPLES:-client dmodex nodeinfo pub resolve dynamic}"
+
+# Per-example launch geometry and the marker that says the client got all the
+# way through.  Ranks are always split across at least two nodes so the data
+# a client asks for lives behind a different server than its own.
+#
+#   * dmodex has rank 0 sleep before committing, so the other ranks' gets
+#     block in the client's pending-request list until the reply arrives --
+#     the coalescing path.  It needs at least two ranks.
+#   * dynamic has rank 0 PMIx_Spawn a child job and then connect to it, so
+#     the allocation must leave slots free for the child.
+#   * every example ends by reporting a successful PMIx_Finalize, which is
+#     also the marker that nothing hung on the way there.
+cl_geom() {
+    HOSTS="node1:2,node2:2"; NP=4
+    WANT='PMIx_Finalize successfully completed'
+    case "$1" in
+        dmodex)
+            HOSTS="node1:2,node2:2"; NP=4 ;;
+        dynamic)
+            HOSTS="node1:4,node2:4"; NP=2 ;;
+        resolve)
+            HOSTS="node1:2,node2:2,node3:2"; NP=6
+            # resolve.c reports through its exit code rather than a banner
+            WANT='' ;;
+    esac
+}
+
+# The PMIx these clients link against must be the one build.sh installed into
+# the shared volume (/opt/prte/pmix), not one baked into an image: the clients
+# are COMPILED in a throwaway builder container and RUN in the long-lived node
+# containers, and only the volume is guaranteed to be the same in both.  An
+# image-local /usr/local install satisfies the compile and then fails at run
+# time -- or, on a swarm whose nodes predate the current image, the reverse.
+# Insisting on the volume keeps that whole class of confusion out.
+PMIX_PREFIX=/opt/prte/pmix
+
+OUT=""
+WANT=""
+RC=0
+# Launch a client through a transient DVM with the geometry cl_geom picks.
+# The program is named by absolute path because prterun ships the resolved
+# path to the other daemons, whose non-login launch environment does not have
+# /opt/prte/tests-client on PATH.  --timeout bounds every launch so a genuine
+# hang surfaces as a failure rather than stalling the suite.
+launch() {
+    local prog="$1"; shift
+    cl_geom "$prog"
+    OUT="$(RUN "prterun --host $HOSTS -np $NP --map-by node --timeout 60 /opt/prte/tests-client/$prog $* 2>&1")"
+    RC=$?
+}
+
+# Judge one launch: a hang is always a failure; otherwise require the marker
+# (when the example has one) and the absence of an error report.
+judge() {
+    local name="$1" what="$2"
+    if echo "$OUT" | grep -qiE 'time limit for job|timed out|DVM timeout'; then
+        bad "$name: HUNG (hit the launch timeout)"
+        return
+    fi
+    if [ -n "$WANT" ] && ! echo "$OUT" | grep -qiE "$WANT"; then
+        bad "$name: no completion (output: $(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+        return
+    fi
+    if [ "$RC" != 0 ]; then
+        bad "$name: exit $RC (output: $(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+        return
+    fi
+    if echo "$OUT" | grep -qiE 'PMIX_ERROR|PMIX_ERR_|connection refused|Segmentation'; then
+        bad "$name: completed but reported an error: $(echo "$OUT" | grep -iE 'PMIX_ERROR|PMIX_ERR_|Segmentation' | head -1)"
+        return
+    fi
+    ok "$name: $what"
+}
+
+########################################################################
+# Linux: the 10-node swarm.  Build the clients in a builder container
+# against the PMIx build.sh installed, then drive them with prterun.
+########################################################################
+
+test_linux() {
+    local ex rc
+
+    swarm_up_or_die
+
+    banner "preflight: install present in shared volume"
+    if RUN 'command -v prterun prte pterm >/dev/null'; then
+        ok "prterun/prte/pterm on PATH"
+    else
+        bad "tools missing -- did ./build.sh run?"; return
+    fi
+
+    if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+        bad "build volume $VOLUME missing -- run ./build.sh first"
+        return
+    fi
+
+    # Same check run-tests.sh makes, and for the same reason: the nodes are
+    # long-lived containers while the install they read is replaced under
+    # them, so a node that predates the current image runs a different PMIx
+    # than the builder container compiles against.  The symptom is a missing
+    # header or an undefined symbol, and nothing in either message mentions
+    # containers.
+    banner "preflight: containers are running the current image"
+    local imgid cimg imgn stalenodes=""
+    imgid=$(docker images --no-trunc --format '{{.ID}}' "$IMAGE" 2>/dev/null | head -1)
+    for imgn in $(seq 1 10); do
+        cimg=$(docker inspect "$NODE$imgn" --format '{{.Image}}' 2>/dev/null)
+        [ "$cimg" = "$imgid" ] || stalenodes="$stalenodes node$imgn"
+    done
+    if [ -z "$stalenodes" ]; then
+        ok "all 10 containers are on the current $IMAGE"
+    else
+        bad "containers predate $IMAGE:$stalenodes"
+        echo "     Recreate them: ${SWARM_ENV}docker compose up -d --force-recreate" >&2
+        echo "     (from contrib/dockerswarm, so the pinned project name applies)" >&2
+        return
+    fi
+
+    banner "preflight: PMIx installed in the shared volume"
+    if ON 1 "test -f $PMIX_PREFIX/include/pmix_common.h"; then
+        ok "PMIx headers/libs under $PMIX_PREFIX"
+    else
+        bad "no $PMIX_PREFIX in the volume -- run ./build.sh first"
+        echo "     These clients must link the PMIx you are reviewing, which is the" >&2
+        echo "     one build.sh installs into the shared volume. A PMIx baked into" >&2
+        echo "     the image is not it." >&2
+        return
+    fi
+
+    banner "build the client examples"
+    # Compiled here rather than relying on build.sh's list, so this runner
+    # stays self-contained: adding an example to CLIENT_EXAMPLES is enough.
+    # -I/pmix-src/examples is needed for examples.h, which every example
+    # includes and which is not part of the install.
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e EXAMPLES="$CLIENT_EXAMPLES" \
+        -e PFX="$PMIX_PREFIX" \
+        "$IMAGE" bash -euo pipefail -c '
+            mkdir -p /opt/prte/tests-client
+            for ex in $EXAMPLES; do
+                gcc -O0 -g -o "/opt/prte/tests-client/$ex" "/pmix-src/examples/$ex.c" \
+                    -I"$PFX/include" -I/pmix-src/examples \
+                    -L"$PFX/lib" -lpmix -Wl,-rpath,"$PFX/lib"
+            done
+        '
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        bad "could not build the client examples (rc=$rc)"
+        return
+    fi
+    ok "built: $CLIENT_EXAMPLES"
+
+    banner "client APIs across separate PMIx servers"
+    for ex in $CLIENT_EXAMPLES; do
+        cleanup_swarm
+        if ! RUN "test -x /opt/prte/tests-client/$ex"; then
+            skp "$ex (not built)"; continue
+        fi
+        launch "$ex"
+        case "$ex" in
+            client)   judge "$ex" "put/commit/fence/get across two servers" ;;
+            dmodex)   judge "$ex" "direct modex get with requests pending" ;;
+            nodeinfo) judge "$ex" "node/app/session realm gets per node" ;;
+            pub)      judge "$ex" "publish/lookup/unpublish across servers" ;;
+            resolve)  judge "$ex" "resolve peers/nodes across three nodes" ;;
+            dynamic)  judge "$ex" "spawn + connect/disconnect across nspaces" ;;
+            *)        judge "$ex" "completed" ;;
+        esac
+        [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] \
+            || bad "$ex: stray prted left behind"
+    done
+
+    # A get whose answer is on another node, issued by many ranks at once, is
+    # the case the pending-request coalescing exists for: only the first
+    # requester sends, the rest are satisfied from the one reply.  Widening
+    # dmodex over more nodes makes that list actually get deep.
+    banner "wide direct-modex (pending-request coalescing under load)"
+    cleanup_swarm
+    if RUN 'test -x /opt/prte/tests-client/dmodex'; then
+        OUT="$(RUN 'prterun --host node1:2,node2:2,node3:2,node4:2,node5:2 -np 10 --map-by node --timeout 90 /opt/prte/tests-client/dmodex 2>&1')"
+        RC=$?
+        WANT='PMIx_Finalize successfully completed'
+        judge "dmodex x10" "10 ranks over 5 servers completed their gets"
+    else
+        skp "dmodex not built"
+    fi
+    cleanup_swarm
+}
+
+########################################################################
+# macOS: natively on this host.  One PMIx server, so this is a
+# smoke/regression pass rather than the multi-server case above -- but it
+# still drives the connected client paths a singleton cannot reach.
+########################################################################
+
+test_macos() {
+    local ex prefix="$root/../build/master" jobs
+
+    jobs="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+    [ -d "$prefix" ] || prefix="/opt/prte/pmix"
+
+    banner "native single-host client pass"
+    if [ ! -x "$prefix/bin/prterun" ] && ! command -v prterun >/dev/null; then
+        skp "no prterun available -- run ./build.sh macos first"
+        return
+    fi
+
+    mac_isolate "$prefix" 2>/dev/null || true
+
+    for ex in $CLIENT_EXAMPLES; do
+        local bin="/tmp/pmix-client-$ex.$$"
+        if ! cc -O0 -g -o "$bin" "$root/examples/$ex.c" \
+                -I"$root/include" -I"$root" \
+                -L"$root/src/.libs" -lpmix -Wl,-rpath,"$root/src/.libs" \
+                >/dev/null 2>&1; then
+            skp "$ex (would not compile against the in-tree library)"
+            continue
+        fi
+        OUT="$(prterun -np 4 --timeout 60 "$bin" 2>&1)"; RC=$?
+        WANT='PMIx_Finalize successfully completed'
+        [ "$ex" = resolve ] && WANT=''
+        judge "$ex" "completed against a single local server"
+        rm -f "$bin"
+    done
+
+    mac_done 2>/dev/null || true
+}
+
+case "$mode" in
+    linux) test_linux ;;
+    macos) test_macos ;;
+    *) echo "usage: $0 [linux|macos]" >&2; exit 2 ;;
+esac
+
+banner "summary"
+printf '  %d passed, %d failed, %d skipped\n\n' "$pass" "$fail" "$skip"
+[ "$fail" = 0 ]

--- a/contrib/dockerswarm/run-client-tests.sh
+++ b/contrib/dockerswarm/run-client-tests.sh
@@ -81,15 +81,25 @@ CLIENT_EXAMPLES="${CLIENT_EXAMPLES:-client dmodex nodeinfo pub resolve dynamic}"
 cl_geom() {
     HOSTS="node1:2,node2:2"; NP=4
     WANT='PMIx_Finalize successfully completed'
+    EXTRA=""
     case "$1" in
         dmodex)
             HOSTS="node1:2,node2:2"; NP=4 ;;
         dynamic)
             HOSTS="node1:4,node2:4"; NP=2 ;;
         resolve)
-            HOSTS="node1:2,node2:2,node3:2"; NP=6
-            # resolve.c reports through its exit code rather than a banner
-            WANT='' ;;
+            # resolve.c PMIx_Spawn's a two-proc child job and then resolves
+            # both namespaces, so the allocation must leave slots free for
+            # the child -- fill it and the spawn blocks to the timeout.
+            # It signals completion with its own "Bye." rather than the
+            # finalize banner the other examples print.
+            HOSTS="node1:4,node2:4,node3:4"; NP=3
+            # ...and it spawns the child by the RELATIVE path "./resolve", so
+            # the job has to run with that directory as its cwd or the launch
+            # fails and the non-spawning ranks wait out the timeout for a
+            # child that never appears.
+            EXTRA="--wdir /opt/prte/tests-client"
+            WANT='Bye\.' ;;
     esac
 }
 
@@ -104,6 +114,7 @@ PMIX_PREFIX=/opt/prte/pmix
 
 OUT=""
 WANT=""
+EXTRA=""
 RC=0
 # Launch a client through a transient DVM with the geometry cl_geom picks.
 # The program is named by absolute path because prterun ships the resolved
@@ -113,7 +124,7 @@ RC=0
 launch() {
     local prog="$1"; shift
     cl_geom "$prog"
-    OUT="$(RUN "prterun --host $HOSTS -np $NP --map-by node --timeout 60 /opt/prte/tests-client/$prog $* 2>&1")"
+    OUT="$(RUN "prterun --host $HOSTS -np $NP --map-by node $EXTRA --timeout 60 /opt/prte/tests-client/$prog $* 2>&1")"
     RC=$?
 }
 
@@ -133,8 +144,15 @@ judge() {
         bad "$name: exit $RC (output: $(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
         return
     fi
-    if echo "$OUT" | grep -qiE 'PMIX_ERROR|PMIX_ERR_|connection refused|Segmentation'; then
-        bad "$name: completed but reported an error: $(echo "$OUT" | grep -iE 'PMIX_ERROR|PMIX_ERR_|Segmentation' | head -1)"
+    # Only a crash, a lost connection, or the example's OWN failure banner
+    # counts. Deliberately NOT "any line mentioning a PMIX_ERR_*": several of
+    # these examples query things the swarm has no provider for -- nodeinfo
+    # asks for PMIX_FABRIC_COORDINATES, and with no fabric plugin loaded
+    # PMIX_ERR_NOT_FOUND is the correct answer, which is why the example
+    # prints it and carries on rather than bailing out. Grepping for the
+    # error name turned that into a spurious failure.
+    if echo "$OUT" | grep -qiE 'Segmentation|core dumped|connection refused|: ERROR!'; then
+        bad "$name: $(echo "$OUT" | grep -iE 'Segmentation|core dumped|connection refused|: ERROR!' | head -1)"
         return
     fi
     ok "$name: $what"

--- a/contrib/dockerswarm/swarm-common.sh
+++ b/contrib/dockerswarm/swarm-common.sh
@@ -10,7 +10,7 @@
 # run-python.sh.
 # SOURCED, never executed:  . "$(dirname "$0")/swarm-common.sh"
 #
-# Two things live here because all four scripts need them to agree.
+# Two things live here because all seven scripts need them to agree.
 #
 # 1. WHICH SWARM.  Every global name this harness claims -- the compose
 #    project, the ten container names, the build volume, and (by way of the

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -182,11 +182,57 @@ finalize, after the progress thread has stopped).
   singleton path.** A process with no server still initializes; callers
   must treat `PMIX_ERR_UNREACH` from init as "up but unconnected," not as
   failure.
+- **`PMIX_RELEASE` dereferences its argument — it is *not* a no-op on
+  `NULL`.** (`pmix_obj_update()` reads the reference count straight off
+  the pointer.) Any caddy field that is only sometimes populated —
+  `cb->lg`, `cb->info`, a tracker's `members` — must be `NULL`-checked
+  before release. This is not a defensive nicety; it is the difference
+  between a working call and a segfault, and it is exactly how
+  `PMIx_Get_nb(NULL, PMIX_PROCID, …)` used to crash.
+- **Anything a caddy hands to the request parser must be initialized
+  first.** `process_request()` both reads and writes through the `val`
+  pointer it is given (`PMIX_GET_STATIC_VALUES` dereferences it to find
+  the caller's storage), so passing an uninitialized local means the
+  parser's own "did they provide storage?" test reads the stack.
+- **Every server round-trip must gate on being connected.** The pattern
+  is `pmix_client_globals.singleton ||
+  !pmix_atomic_check_bool(&pmix_globals.connected)`. A helper that packs a
+  command without that check (`refresh_cache` did) will happily build a
+  message for a peer that was never given a transport.
+- **`PMIX_PTL_SEND_RECV` only fails when the peer is already
+  `finalized`, and in that case it has *not* taken the buffer.** So the
+  send site owns the message on the failure path and must `PMIX_RELEASE`
+  it — but must *not* release it on success, where the transport frees it.
+  Several sites in this directory leaked the message here.
+- **A `PMIX_WAIT_THREAD` after a call that might not have fired its
+  callback is a hang.** `PMIx_Notify_event` and
+  `PMIx_Register_event_handler` invoke the completion callback only when
+  they return `PMIX_SUCCESS`; waiting on the lock unconditionally (as the
+  group invite path did) blocks forever on any error. Guard every wait
+  with `if (PMIX_SUCCESS == rc)`.
 - **A zero-byte recv buffer means the connection was lost.** Every PTL
   recv callback must check `PMIX_BUFFER_IS_EMPTY(buf)` before unpacking.
   Note `PMIX_BUFFER_IS_EMPTY` dereferences its argument — a NULL `buf`
   must be guarded separately (some callbacks do, some do not — be
   consistent when you touch one).
+- **A recv callback that gives up must still complete every waiter.**
+  The pending-request list in `pmix_client_get.c` is shared: the caddy the
+  reply was addressed to is itself on that list, and other gets for the
+  same `nspace:rank` were coalesced behind it. Releasing the caddy and
+  returning (as the status-unpack failure path did) both strands a
+  blocking `PMIx_Get` on a lock nothing will ever wake and frees the
+  object it is still waiting on. Fall into the delivery loop instead.
+- **The `_nb` entry points use `cbfunc == NULL` to mean "the caddy is in
+  `cbdata`".** That is an internal convention of their blocking wrappers
+  (`PMIx_Fabric_register_nb`, `PMIx_Fabric_update_nb`), but these are
+  *public* APIs, so user code can call them with both arguments NULL and
+  reach a `cb = (pmix_cb_t *) cbdata` that yields NULL. Validate the pair
+  up front. Where the API genuinely has no other completion route — as in
+  `PMIx_Compute_distances_nb`, whose reply handler calls the callback
+  unconditionally — reject a NULL `cbfunc` outright.
+- **An out-parameter the caller may hand you as NULL is a crash, not a
+  courtesy.** `PMIx_Get` writes `*val` on both the success and the failure
+  path, so it has to reject `val == NULL` before doing anything else.
 - **Realm directives change where data comes from.** In `PMIx_Get`, the
   `PMIX_NODE_INFO` / `PMIX_APP_INFO` / `PMIX_SESSION_INFO` directives and
   the hostname/nodeid/appnum/sessionid qualifiers redirect the lookup to a
@@ -219,6 +265,114 @@ finalize, after the progress thread has stopped).
   trailing reads (older peers), and never reorder — see the top-level
   "Version Interoperability" rules.
 
+## Testing
+
+There are two tiers, and the split is forced by the architecture: almost
+every function here either answers locally or round-trips to a server, so
+a test with no server can only reach the first half.
+
+**Tier 1 — `test/unit/client_api.c` (in `make check`).** Runs as a
+singleton. Covers what a client decides by itself: the `PMIx_Get`
+shortcuts that `process_request` answers outright, the pointer/static
+value forms, and the parameter validation on `PMIx_Get[_nb]`,
+`PMIx_Compute_distances_nb` and the fabric APIs. Every case in it is a
+regression for a specific defect listed below; several of them segfaulted
+before. See [`test/unit/AGENTS.md`](../../test/unit/AGENTS.md).
+
+**Tier 2 — `contrib/dockerswarm/run-client-tests.sh`.** Drives the
+`examples/` clients through PRRTE across the ten-container swarm, so the
+ranks sit behind *different* PMIx servers. That is the only way to
+exercise the real subject of this directory: a `PMIx_Get` whose answer is
+on another node takes the whole
+pack → `PMIX_PTL_SEND_RECV` → `_getnb_cbfunc` → GDS-store → deliver path,
+including the pending-request coalescing; `PMIx_Fence` has something to
+modex; publish/lookup resolves up through the daemons; `PMIx_Spawn` plus
+`PMIx_Connect` exercise the multi-nspace job-info exchange. Requires
+`./build.sh` first, so the clients link the PMIx you are reviewing rather
+than one baked into the image.
+
+Do not diagnose functional failures against an `--enable-test-build`
+tree — its shimmed `pcompress`/`psec` components are non-functional (see
+the top-level guide).
+
+## Defects found in the July 2026 review
+
+Recorded so the same ground is not re-covered, and because each one names
+a pattern worth checking whenever you touch a sibling function. All are
+fixed on `topic/client-review`; the first three are the ones with
+regression coverage in `test/unit/client_api.c`.
+
+*Crashes:*
+
+- `gcbfn()` released `cb->lg` unconditionally, but the caddy built for a
+  locally-answered request never has one — so **every**
+  `PMIx_Get_nb(NULL, PMIX_PROCID, …)` (and the `PMIX_VERSION_NUMERIC` and
+  `PMIX_RANK` shortcuts) segfaulted.
+- `PMIx_Get_nb` passed an uninitialized `val` to `process_request`, which
+  dereferences it under `PMIX_GET_STATIC_VALUES`.
+- `refresh_cache()` dereferenced the caller's `proc`, which `PMIx_Get`
+  explicitly allows to be NULL, and packed a message with no server to
+  send it to.
+- `PMIx_Get` wrote through `val` without checking it for NULL.
+- `PMIx_Spawn_nb` called `pmix_basename(aptr->cmd)` on the branch where
+  the caller supplied `argv` but no `cmd` — a documented-legal
+  combination, and `pmix_basename(NULL)` returns NULL straight into a
+  `strcmp`.
+- `PMIx_Spawn` copied `cb->pname.nspace` without checking it, which the
+  server-role path leaves NULL when the spawn fails.
+- The fabric `_nb` entry points and `PMIx_Compute_distances_nb`
+  dereferenced a NULL caddy / callback (see the invariant above).
+
+*Hangs and use-after-free:*
+
+- `_getnb_cbfunc()` released the caddy and returned when the status
+  unpack failed, stranding blocked callers on a freed lock.
+- `invite_setup()` waited on a lock unconditionally after
+  `PMIx_Register_event_handler` and after `PMIx_Notify_event`.
+
+*Leaks and lifetime:*
+
+- `PMIX_PTL_SEND_RECV` failure paths leaked the message in `PMIx_Init`,
+  `PMIx_Finalize`, `PMIx_Abort`, `_commitfn`, `get_data`,
+  `refresh_cache`, `fallback_to_next_gds` and both `PMIx_Resolve_*`.
+- `get_data()` left `cb2` undestructed when a GDS fetch failed.
+- `PMIx_Connect_nb` leaked `cb2` on the info-list error paths, and
+  constructed a `pmix_buffer_t pbkt` it never used.
+- `respeer()`/`resnode()` allocated `cb->info` without setting
+  `cb->infocopy`, so the caddy destructor never freed it.
+- `PMIx_Fabric_deregister` freed `fabric->info` but left the pointer
+  dangling, so a second deregister freed it again.
+- `construct_cbfunc()` adopted `darray` from `PMIx_Info_list_convert`
+  without checking the return, handing the tracker an uninitialized
+  pointer for its destructor to free.
+
+*Correctness:*
+
+- `pmix_client_convert_group_procs()` silently dropped a proc whose group
+  rank was past the end of the membership, producing a short participant
+  list that failed much later as `PMIX_ERR_NOT_A_MEMBER` or as a
+  collective that never completed. It now returns `PMIX_ERR_NOT_FOUND`.
+  Its wildcard branch also `continue`d the group loop where it meant to
+  `break`.
+- Several GDS fetches took `pmix_list_remove_first()` without a NULL
+  check on paths where the siblings around them have one.
+
+*Known, left alone (deliberately):*
+
+- `resolve_peers()` sets `proc.rank = PMIX_RANK_WILDCARD` for a pre-v3.2
+  server and then unconditionally resets it to `PMIX_RANK_UNDEF` two
+  lines later, so the legacy branch is dead. `try_fetch()` retries an
+  UNDEF rank as WILDCARD, which is why the path still works. Not changed
+  without a pre-v3.2 server to test against; see the comment in the code.
+- `pmix_client_globals.groups` is read and mutated from both the caller's
+  thread (`PMIx_Group_leave_nb`, `PMIx_Group_destruct_nb`) and the
+  progress thread (`add_group` from `construct_cbfunc`), with no lock.
+  Concurrent multithreaded use of the group APIs is unsafe.
+- `_commitfn()` ignores the server's reply status, so a failed commit is
+  reported to the caller as success.
+- `PMIx_Group_join` declares `results`/`nresults` and never touches them,
+  leaving the caller's pointers uninitialized.
+
 ## Building
 
 `src/client` compiles straight into `libpmix` via `Makefile.include`
@@ -229,9 +383,9 @@ the top-level guide's "Test-building your changes." You do **not** need
 `autogen.pl`/`configure` unless you add or remove a source file (adding
 one to `Makefile.include` then needs a `make`, which regenerates the
 top-level `Makefile`). After a build, smoke-test with `make check` in
-`test/` and `./simptest` in `test/simple/`. Do not diagnose functional
-failures against an `--enable-test-build` tree — its shimmed
-`pcompress`/`psec` components are non-functional (see the top-level guide).
+`test/` and `./simptest` in `test/simple/`, then see
+[Testing](#testing) above for the two tiers that actually cover this
+directory.
 
 ## When modifying code here
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -411,20 +411,36 @@ regression coverage in `test/unit/client_api.c`.
   UNDEF rank as WILDCARD, which is why the path still works. Not changed
   without a pre-v3.2 server to test against; see the comment in the code.
 - **`PMIx_Group_join` completes earlier than its man page says, and so
-  returns no results.** `docs/man/man3/PMIx_Group_join.3.rst` states the
-  call returns "once the group has been completely constructed", with
-  the construct results available in `results`. The implementation
-  completes as soon as the accept/decline notification has been handed to
-  the local event system — much earlier, and carrying no group data.
-  Closing that gap means waiting for the leader's
-  `PMIX_GROUP_CONSTRUCT_COMPLETE`, and **that event is not guaranteed to
-  reach an acceptor at all** — the leader-watch registry comment at the
-  top of `pmix_client_group.c` records that in the common single-server
-  case it often does not arrive before the acceptor finalizes. Waiting
-  on it here would therefore hang the common case rather than fix it.
-  This needs a protocol-level fix (guaranteed delivery of the construct
-  result to every acceptor), not a local one. Until then an application
-  gets the membership and context ID from its own
+  returns no results** — and the invitee-side **leader-failure watch does
+  not fire at all**. Both have one cause, and it is *not* the one the
+  comment above `pmix_group_leader_watches` gives.
+
+  The library observes group lifecycle events by registering an ordinary
+  handler (`setup_leader_watch`). That registration lands in the
+  **multi-code** category, and the chain visits `first` → `single-code` →
+  `multi-code` → `default` → `last`. An application handler registered
+  for a *single* code therefore runs first, and if it returns
+  `PMIX_EVENT_ACTION_COMPLETE` — the normal way to say "handled" — the
+  chain ends and the library's own handler is never reached. Any
+  application that watches `PMIX_GROUP_CONSTRUCT_COMPLETE`, which an
+  invite/join application must, blinds the library to it.
+
+  Demonstrated with `test/unit/run_grpinvite.pl`: every acceptor's
+  application handler receives the event while not one of the library's
+  watches does, in the same process and the same run; flipping only the
+  example's return to `PMIX_EVENT_NO_ACTION_TAKEN` makes all three
+  watches receive it. It is not a delivery problem and not a
+  registration race (reordering the watch ahead of the accept changes
+  nothing).
+
+  So join cannot complete at the documented point until the library can
+  see the construct event. The fix is local, not protocol-level: the
+  pre-chain block in `pmix_invoke_local_event_hdlr()`
+  (`src/event/pmix_event_notification.c`) already maintains
+  `pmix_client_globals.groups` on these same codes, unconditionally and
+  ahead of the chain, and that is where the library's interest belongs.
+  Written up for discussion before implementing. Until then an
+  application takes the membership from its own
   `PMIX_GROUP_CONSTRUCT_COMPLETE` handler.
 
 ## Building

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -156,6 +156,10 @@ and torn down in `PMIx_Finalize`. The load-bearing fields:
   `singleton`, or it will double-free or leak. See the comment blocks in
   `PMIx_Init`/`PMIx_Finalize`. (A prior latent crash traced to exactly
   this conflation.)
+- **`grouplock`** (`pmix_mutex_t`) — guards `groups` (below). The one
+  piece of client state that is genuinely shared between the caller's
+  thread and the progress thread; see the rules under
+  [Invariants](#invariants-and-gotchas).
 - **`pending_requests`** (`pmix_list_t` of `pmix_cb_t`) — outstanding
   `PMIx_Get` requests awaiting a server reply. Multiple gets for the same
   `nspace:rank` are **coalesced**: only the first sends; the rest are
@@ -163,7 +167,9 @@ and torn down in `PMIx_Finalize`. The load-bearing fields:
   `pmix_client_get.c`).
 - **`groups`** (`pmix_list_t` of `pmix_group_t`) — PMIx groups this client
   currently belongs to; consulted by `pmix_client_convert_group_procs` to
-  expand group references in collective calls.
+  expand group references in collective calls. **Always hold `grouplock`
+  across a traversal and across any use of a group's `members`** — unlike
+  `pending_requests`, this list is not confined to the progress thread.
 - **`peers`** (`pmix_pointer_array_t`) — cached peer objects for data ops.
 - **`iof_stdout` / `iof_stderr`** — the two static IOF sinks for forwarded
   output.
@@ -233,6 +239,22 @@ finalize, after the progress thread has stopped).
 - **An out-parameter the caller may hand you as NULL is a crash, not a
   courtesy.** `PMIx_Get` writes `*val` on both the success and the failure
   path, so it has to reject `val == NULL` before doing anything else.
+  Define every OUT parameter *before* the first thing that can fail, so
+  the caller can read it on an error return too.
+- **The groups list is the one piece of client state that is not
+  single-threaded.** `pmix_client_globals.groups` is touched by both the
+  progress thread and the caller's thread, so
+  `pmix_client_globals.grouplock` guards it — the list spine *and* the
+  `members` array of every group on it, because the `PMIX_GROUP_LEFT`
+  handler shifts that array down underneath a reader. Two rules:
+  **(1)** never hold it across anything that waits on the progress
+  thread — a blocking `PMIx_Notify_event`, say — because the handler on
+  the other side wants the same lock; copy out what you need and release
+  it first, as `PMIx_Group_destruct_nb` and `PMIx_Group_leave_nb` do.
+  **(2)** it is a plain, non-recursive mutex, so nothing called while
+  holding it may take it again. Do allocations and anything that can
+  fail before acquiring, so error paths do not have to unwind through
+  it.
 - **Realm directives change where data comes from.** In `PMIx_Get`, the
   `PMIX_NODE_INFO` / `PMIX_APP_INFO` / `PMIX_SESSION_INFO` directives and
   the hostname/nodeid/appnum/sessionid qualifiers redirect the lookup to a
@@ -357,6 +379,30 @@ regression coverage in `test/unit/client_api.c`.
 - Several GDS fetches took `pmix_list_remove_first()` without a NULL
   check on paths where the siblings around them have one.
 
+*Concurrency and API contract (second pass):*
+
+- **`pmix_client_globals.groups` had no lock**, but is not confined to
+  one thread: the progress thread appends to it (`add_group` from
+  `construct_cbfunc`, and the `PMIX_GROUP_CONSTRUCT_COMPLETE` handler in
+  `src/event/pmix_event_notification.c`) and *edits a live membership
+  array in place* (the `PMIX_GROUP_LEFT` handler shifts a departed proc
+  out), while the caller's thread reads and removes from it in
+  `PMIx_Group_leave_nb`, `PMIx_Group_destruct_nb`, and every collective
+  that expands a group reference through
+  `pmix_client_convert_group_procs()`. It is now guarded by
+  `pmix_client_globals.grouplock` — see the rules below.
+- `_commitfn()` ignored the server's reply. The generic `wait_cbfunc` it
+  used discards the buffer, so the status the server returns for
+  `PMIX_COMMIT_CMD` was thrown away and every commit reported success —
+  including one the server rejected, which is exactly the case a caller
+  needs to hear about. It now has its own `commit_cbfunc` that unpacks
+  the reply.
+- `PMIx_Group_join` declared `results`/`nresults` unused, leaving the
+  caller's pointers as whatever was on the stack. Both are now defined
+  before anything can fail, and a NULL for either is honored (the man
+  page documents them as optional). See the known gap below for why they
+  come back empty.
+
 *Known, left alone (deliberately):*
 
 - `resolve_peers()` sets `proc.rank = PMIX_RANK_WILDCARD` for a pre-v3.2
@@ -364,14 +410,22 @@ regression coverage in `test/unit/client_api.c`.
   lines later, so the legacy branch is dead. `try_fetch()` retries an
   UNDEF rank as WILDCARD, which is why the path still works. Not changed
   without a pre-v3.2 server to test against; see the comment in the code.
-- `pmix_client_globals.groups` is read and mutated from both the caller's
-  thread (`PMIx_Group_leave_nb`, `PMIx_Group_destruct_nb`) and the
-  progress thread (`add_group` from `construct_cbfunc`), with no lock.
-  Concurrent multithreaded use of the group APIs is unsafe.
-- `_commitfn()` ignores the server's reply status, so a failed commit is
-  reported to the caller as success.
-- `PMIx_Group_join` declares `results`/`nresults` and never touches them,
-  leaving the caller's pointers uninitialized.
+- **`PMIx_Group_join` completes earlier than its man page says, and so
+  returns no results.** `docs/man/man3/PMIx_Group_join.3.rst` states the
+  call returns "once the group has been completely constructed", with
+  the construct results available in `results`. The implementation
+  completes as soon as the accept/decline notification has been handed to
+  the local event system — much earlier, and carrying no group data.
+  Closing that gap means waiting for the leader's
+  `PMIX_GROUP_CONSTRUCT_COMPLETE`, and **that event is not guaranteed to
+  reach an acceptor at all** — the leader-watch registry comment at the
+  top of `pmix_client_group.c` records that in the common single-server
+  case it often does not arrive before the acceptor finalizes. Waiting
+  on it here would therefore hang the common case rather than fix it.
+  This needs a protocol-level fix (guaranteed delivery of the construct
+  result to every acceptor), not a local one. Until then an application
+  gets the membership and context ID from its own
+  `PMIX_GROUP_CONSTRUCT_COMPLETE` handler.
 
 ## Building
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -415,15 +415,28 @@ regression coverage in `test/unit/client_api.c`.
   not fire at all**. Both have one cause, and it is *not* the one the
   comment above `pmix_group_leader_watches` gives.
 
-  The library observes group lifecycle events by registering an ordinary
-  handler (`setup_leader_watch`). That registration lands in the
-  **multi-code** category, and the chain visits `first` → `single-code` →
-  `multi-code` → `default` → `last`. An application handler registered
-  for a *single* code therefore runs first, and if it returns
-  `PMIX_EVENT_ACTION_COMPLETE` — the normal way to say "handled" — the
-  chain ends and the library's own handler is never reached. Any
-  application that watches `PMIX_GROUP_CONSTRUCT_COMPLETE`, which an
-  invite/join application must, blinds the library to it.
+  The library observes group lifecycle events by registering ordinary
+  handlers. Those registrations land in the **multi-code** category, and
+  the chain visits `first` → `single-code` → `multi-code` → `default` →
+  `last`. An application handler registered for a *single* code therefore
+  runs first, and if it returns `PMIX_EVENT_ACTION_COMPLETE` — the normal
+  way to say "handled" — the chain ends and the library's own handler is
+  never reached. Any application that watches
+  `PMIX_GROUP_CONSTRUCT_COMPLETE`, which an invite/join application must,
+  blinds the library to it.
+
+  **Both multi-code registrations in this file are affected**, and the
+  worse one is not the watch. `invite_setup`'s `invite_handler` is the
+  only thing that counts invitation answers, so a *leader* whose
+  application also watches `PMIX_GROUP_INVITE_ACCEPTED` never resolves
+  its invitation: `PMIx_Group_invite` hangs forever without a
+  `PMIX_TIMEOUT`, and the group never forms. Reproduced by adding such a
+  handler to `examples/group_invite.c`. The three `PMIX_DEBUGGER_RELEASE`
+  registrations (client, server, tool) are in the single-code category and
+  safe — but only because they register inside init and block there, so
+  the application never gets a window to compete. A handler with no
+  ordering directive is *prepended*, so a later application registration
+  would otherwise win.
 
   Demonstrated with `test/unit/run_grpinvite.pl`: every acceptor's
   application handler receives the event while not one of the library's

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -354,6 +354,7 @@ static pmix_status_t fallback_to_next_gds(void)
     PMIX_PTL_SEND_RECV(rc, myserver, req, job_data, (void *) &cb);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(req);
         PMIX_DESTRUCT(&cb);
         return rc;
     }
@@ -891,6 +892,10 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, req, job_data, (void *) &cb);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            /* the transport refused the message without taking it, and the
+             * recv callback will never fire, so unwind both here */
+            PMIX_RELEASE(req);
+            PMIX_DESTRUCT(&cb);
             free(suri);
             return rc;
         }
@@ -1219,7 +1224,9 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, finwait_cbfunc, (void *) &tev);
         if (PMIX_SUCCESS != rc) {
             /* the recv callback will not fire, so cancel the timer and
-             * tear down the lock before we return */
+             * tear down the lock before we return - and reclaim the message
+             * the transport declined to take */
+            PMIX_RELEASE(msg);
             pmix_event_del(&tev.ev);
             PMIX_DESTRUCT_LOCK(&tev.lock);
             return rc;
@@ -1372,6 +1379,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
     PMIX_CONSTRUCT_LOCK(&reglock);
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, bfr, wait_cbfunc, (void *) &reglock);
     if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(bfr);
         PMIX_DESTRUCT_LOCK(&reglock);
         return rc;
     }
@@ -1603,6 +1611,8 @@ static void _commitfn(int sd, short args, void *cbdata)
         cb->pstatus = PMIX_SUCCESS;
         return;
     }
+    /* the send was refused without taking the message */
+    PMIX_RELEASE(msgout);
 
 error:
     cb->pstatus = rc;

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -250,6 +250,44 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     PMIX_WAKEUP_THREAD(lock);
 }
 
+/* Completion of a commit: unlike the generic wait_cbfunc above, this one
+ * reads the reply. The server acks PMIX_COMMIT_CMD with the status of the
+ * store it just performed, and discarding that reported every commit as a
+ * success - including one the server rejected, which is precisely the case
+ * the caller needs to hear about, since the data it thinks it published is
+ * not there. */
+static void commit_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
+                          pmix_buffer_t *buf, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t *) cbdata;
+    pmix_status_t rc, ret;
+    int32_t cnt;
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
+
+    PMIX_ACQUIRE_OBJECT(cb);
+
+    /* a NULL or zero-byte buffer means the connection was lost and this
+     * recv is being completed synthetically */
+    if (NULL == buf || PMIX_BUFFER_IS_EMPTY(buf)) {
+        ret = PMIX_ERR_UNREACH;
+    } else {
+        cnt = 1;
+        PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            ret = rc;
+        }
+    }
+
+    pmix_output_verbose(2, pmix_client_globals.base_output,
+                        "pmix:client commit completed with status %s",
+                        PMIx_Error_string(ret));
+
+    cb->pstatus = ret;
+    PMIX_POST_OBJECT(cb);
+    PMIX_WAKEUP_THREAD(&cb->lock);
+}
+
 /* callback to receive job info */
 static void job_data(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
                      pmix_buffer_t *buf, void *cbdata)
@@ -1605,11 +1643,11 @@ static void _commitfn(int sd, short args, void *cbdata)
 
     /* always send, even if we have nothing to contribute, so the server knows
      * that we contributed whatever we had */
-    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msgout, wait_cbfunc, (void *) &cb->lock);
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msgout, commit_cbfunc, (void *) cb);
     if (PMIX_SUCCESS == rc) {
-        /* we should wait for the callback, so don't
-         * modify the active flag */
-        cb->pstatus = PMIX_SUCCESS;
+        /* wait for the reply - commit_cbfunc sets pstatus from the status
+         * the server returns and wakes the caller, so do not pre-declare
+         * success here */
         return;
     }
     /* the send was refused without taking the message */

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -211,6 +211,7 @@ pmix_client_globals_t pmix_client_globals = {
     .pending_requests = PMIX_LIST_STATIC_INIT,
     .peers = PMIX_POINTER_ARRAY_STATIC_INIT,
     .groups = PMIX_LIST_STATIC_INIT,
+    .grouplock = PMIX_MUTEX_STATIC_INIT,
     .get_output = -1,
     .get_verbose = 0,
     .connect_output = -1,

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -114,7 +114,6 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     pmix_status_t rc;
     pmix_cb_t *cb, cb2;
     pmix_byte_object_t bo;
-    pmix_buffer_t pbkt;
     pmix_info_t xfer;
     pmix_kval_t *kv;
     void *ilist;
@@ -218,7 +217,6 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
     if (PMIX_SUCCESS == rc) {
         ilist = PMIx_Info_list_start();
-        PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
         // start with our procID
         PMIx_Info_list_add(ilist, PMIX_PROCID, &pmix_globals.myid, PMIX_PROC);
         // now add the kvals
@@ -237,6 +235,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
                 PMIx_Info_list_release(ilist);
+                PMIX_DESTRUCT(&cb2);
                 PMIX_PROC_FREE(rgs, nrg);
                 return rc;
             }
@@ -250,6 +249,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
                 PMIx_Info_list_release(ilist);
+                PMIX_DESTRUCT(&cb2);
                 PMIX_PROC_FREE(rgs, nrg);
                 return rc;
             }
@@ -329,6 +329,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(msg);
                     PMIx_Info_list_release(ilist);
+                    PMIX_DESTRUCT(&cb2);
                     PMIX_PROC_FREE(rgs, nrg);
                     return rc;
                 }

--- a/src/client/pmix_client_convert.c
+++ b/src/client/pmix_client_convert.c
@@ -63,6 +63,13 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
 
     PMIX_CONSTRUCT(&cache, pmix_list_t);
 
+    /* The groups list, and the membership arrays hanging off it, can be
+     * changed by the progress thread while we walk them - a construct
+     * completing appends a group, and a PMIX_GROUP_LEFT event shifts a
+     * departed member out of an existing one. Every exit below goes through
+     * "unlock" so the lock is dropped exactly once. */
+    pmix_mutex_lock(&pmix_client_globals.grouplock);
+
     /* cycle thru the procs and check to see if any reference
      * a PMIx group */
     for (n = 0; n < insize; n++) {
@@ -102,23 +109,22 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
                         PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
                         if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
                             /* couldn't get the job size, so have to abort */
-                            PMIX_LIST_DESTRUCT(&cache);
                             PMIX_DESTRUCT(&cb2);
-                            return rc;
+                            goto unlock;
                         }
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
                         if (NULL == kv) {  // should never be NULL
                             /* couldn't retrieve the size, so we have
                              * to abort */
-                            PMIX_LIST_DESTRUCT(&cache);
-                            return PMIX_ERR_NOT_FOUND;
+                            rc = PMIX_ERR_NOT_FOUND;
+                            goto unlock;
                         }
                         rc = PMIx_Value_get_number(kv->value, &jsize, PMIX_UINT32);
                         PMIX_RELEASE(kv);
                         if (PMIX_SUCCESS != rc) {
-                            PMIX_LIST_DESTRUCT(&cache);
-                            return PMIX_ERR_BAD_PARAM;
+                            rc = PMIX_ERR_BAD_PARAM;
+                            goto unlock;
                         }
                         if (cnt + jsize > inprocs[n].rank) {
                             /* the specified rank is within this job */
@@ -161,10 +167,11 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
              * much further downstream (as PMIX_ERR_NOT_A_MEMBER, or as a
              * collective that never completes) with nothing pointing back
              * here. */
-            PMIX_LIST_DESTRUCT(&cache);
-            return PMIX_ERR_NOT_FOUND;
+            rc = PMIX_ERR_NOT_FOUND;
+            goto unlock;
         }
     }
+    pmix_mutex_unlock(&pmix_client_globals.grouplock);
 
     /* we have to return the cached array because
      * we might have replaced some of the entries */
@@ -179,6 +186,11 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
     *outprocs = procs;
     *outsize = sz;
     return PMIX_SUCCESS;
+
+unlock:
+    pmix_mutex_unlock(&pmix_client_globals.grouplock);
+    PMIX_LIST_DESTRUCT(&cache);
+    return rc;
 }
 
 /* Return true if pmix_globals.myid is covered by the resolved procs array.

--- a/src/client/pmix_client_convert.c
+++ b/src/client/pmix_client_convert.c
@@ -54,7 +54,7 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
     pmix_proclist_t *nm;
     pmix_group_t *grp;
     size_t n, i, cnt, sz;
-    bool match;
+    bool match, found;
     uint32_t jsize;
     pmix_status_t rc;
     pmix_kval_t *kv;
@@ -67,6 +67,7 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
      * a PMIx group */
     for (n = 0; n < insize; n++) {
         match = false;
+        found = false;
         PMIX_LIST_FOREACH(grp, &pmix_client_globals.groups, pmix_group_t) {
             if (PMIX_CHECK_NSPACE(grp->grpid, inprocs[n].nspace)) {
                 match = true;
@@ -77,7 +78,8 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
                     for (i=0; i < grp->nmbrs; i++) {
                         append_unique(&cache, &grp->members[i]);
                     }
-                    continue;
+                    found = true;
+                    break;
                 }
 
                 /* if the rank isn't wildcard, then we want a specific
@@ -123,6 +125,7 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
                             PMIX_LOAD_NSPACE(proc.nspace, grp->members[i].nspace);
                             proc.rank = inprocs[n].rank - cnt;
                             append_unique(&cache, &proc);
+                            found = true;
                             break;
                         } else {
                             /* increment the count */
@@ -134,6 +137,7 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
                          * it matches the one they asked for */
                         if (cnt == inprocs[n].rank) {
                             append_unique(&cache, &grp->members[i]);
+                            found = true;
                             break;
                         } else {
                             /* increment the count */
@@ -150,6 +154,15 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
         if (!match) {
             /* xfer the incoming proc across to the cache */
             append_unique(&cache, &inprocs[n]);
+        } else if (!found) {
+            /* the nspace named a group we belong to, but the requested group
+             * rank lies beyond its membership. Say so - dropping the entry
+             * silently produced a short participant list that then failed
+             * much further downstream (as PMIX_ERR_NOT_A_MEMBER, or as a
+             * collective that never completes) with nothing pointing back
+             * here. */
+            PMIX_LIST_DESTRUCT(&cache);
+            return PMIX_ERR_NOT_FOUND;
         }
     }
 

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -215,6 +215,19 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register_nb(pmix_fabric_t *fabric,
         return PMIX_ERR_INIT;
     }
 
+    if (NULL == fabric) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* When no callback is given, the caddy is expected to have been supplied
+     * by the blocking wrapper as cbdata - that is the internal convention
+     * these _nb entry points are built on. A user calling the public API with
+     * both NULL has no way to learn the answer and would leave us
+     * dereferencing a NULL caddy in the recv handler. */
+    if (NULL == cbfunc && NULL == cbdata) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
@@ -337,6 +350,16 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric, pmix_op_c
         return PMIX_ERR_INIT;
     }
 
+    if (NULL == fabric) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* see PMIx_Fabric_register_nb: a NULL cbfunc means "the caddy is in
+     * cbdata", so both cannot be NULL */
+    if (NULL == cbfunc && NULL == cbdata) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* if I am a scheduler server, then I should be able
      * to support this myself */
     if (PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
@@ -451,6 +474,10 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_deregister_nb(pmix_fabric_t *fabric, pmix_
 
     PMIX_HIDE_UNUSED_PARAMS(cbfunc, cbdata);
 
+    if (NULL == fabric) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* if I am a scheduler server, then I should be able
      * to support this myself */
     if (PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
@@ -464,6 +491,11 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_deregister_nb(pmix_fabric_t *fabric, pmix_
     /* otherwise, just remove any storage in it */
     if (NULL != fabric->info) {
         PMIX_INFO_FREE(fabric->info, fabric->ninfo);
+        /* the caller's object outlives this call, so leave it in the same
+         * state PMIx_Fabric_construct would - otherwise a second deregister
+         * (or a destructor) frees the array again */
+        fabric->info = NULL;
+        fabric->ninfo = 0;
     }
 
     return PMIX_OPERATION_SUCCEEDED;

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -73,7 +73,7 @@ static void _value_cbfunc(pmix_status_t status, pmix_value_t *kv, void *cbdata);
 
 static pmix_status_t process_values(pmix_cb_t *cb);
 
-static pmix_status_t refresh_cache(const pmix_proc_t *proc);
+static pmix_status_t refresh_cache(const pmix_proc_t *p);
 
 static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
                                      const pmix_info_t info[], size_t ninfo,
@@ -318,6 +318,11 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
         return PMIX_ERR_INIT;
     }
 
+    /* we have no way to hand back the answer without this */
+    if (NULL == val) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
@@ -338,12 +343,16 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
         return rc;
     }
 
-    /* if we are to refresh the cache, go do that */
+    /* if we are to refresh the cache, go do that. Use the resolved target in
+     * "lg", not the caller's "proc" - the latter is allowed to be NULL (a
+     * globally-unique key in our own nspace), and process_request has already
+     * filled lg->p with the nspace/rank the request actually refers to */
     if (lg->refresh_cache) {
-        rc = refresh_cache(proc);
+        rc = refresh_cache(&lg->p);
         if (PMIX_SUCCESS != rc) {
             // couldn't refresh for some reason
             PMIX_RELEASE(lg);
+            *val = NULL;
             return rc;
         }
     }
@@ -392,7 +401,13 @@ static void gcbfn(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     cb->cbfunc.valuefn(cb->status, cb->value, cb->cbdata);
-    PMIX_RELEASE(cb->lg);
+    /* the caddy does not always carry a logic object - the path that answers
+     * a request entirely from process_request builds a bare caddy purely to
+     * deliver the result. PMIX_RELEASE dereferences its argument, so a
+     * missing "lg" is a segfault, not a no-op */
+    if (NULL != cb->lg) {
+        PMIX_RELEASE(cb->lg);
+    }
     PMIX_RELEASE(cb);
 }
 
@@ -403,7 +418,11 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
     pmix_cb_t *cb;
     pmix_status_t rc;
     pmix_get_logic_t *lg;
-    pmix_value_t *val;
+    /* process_request both reads and writes through this pointer - the
+     * PMIX_GET_STATIC_VALUES check dereferences it before assigning - so it
+     * must start life as a known-NULL "no storage provided" rather than
+     * whatever happened to be on the stack */
+    pmix_value_t *val = NULL;
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
@@ -440,9 +459,10 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
         return rc;
     }
 
-    /* if we are to refresh the cache, go do that */
+    /* if we are to refresh the cache, go do that - see the note in PMIx_Get
+     * on why this uses the resolved lg->p rather than the caller's proc */
     if (lg->refresh_cache) {
-        rc = refresh_cache(proc);
+        rc = refresh_cache(&lg->p);
         if (PMIX_SUCCESS != rc) {
             // couldn't refresh for some reason
             PMIX_RELEASE(lg);
@@ -616,9 +636,13 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        pmix_list_remove_item(&pmix_client_globals.pending_requests, &cb->super);
-        PMIX_RELEASE(cb);
-        return;
+        /* fall into the delivery loop below rather than quietly dropping the
+         * request: every waiter registered against this proc must be told the
+         * request failed. Releasing the caddy here instead both stranded a
+         * blocking PMIx_Get on its lock forever and freed the object it was
+         * still waiting on. */
+        ret = rc;
+        goto done;
     }
 
     if (PMIX_SUCCESS != ret) {
@@ -875,7 +899,6 @@ static void get_data(int sd, short args, void *cbdata)
                     }
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                        PMIX_DESTRUCT(&cb2);
                         if (NULL != kv) {  // will never be NULL
                             lg->hostname = strdup(kv->value->data.string);
                             PMIX_RELEASE(kv);
@@ -883,6 +906,10 @@ static void get_data(int sd, short args, void *cbdata)
                             lg->hostname = strdup("unknown");
                         }
                     }
+                    /* destruct on every outcome - a failed fetch used to leave
+                     * the caddy (and anything the GDS had put on its list)
+                     * behind */
+                    PMIX_DESTRUCT(&cb2);
                 }
                 if (UINT32_MAX == lg->nodeid) {
                     /* try for the nodeid */
@@ -909,6 +936,10 @@ static void get_data(int sd, short args, void *cbdata)
                             cb->status = rc;
                             goto done;
                         }
+                    } else {
+                        /* see the hostname fetch above - the caddy must be
+                         * torn down on the failure path too */
+                        PMIX_DESTRUCT(&cb2);
                     }
                 }
                 // set the rank to undefined since this request is
@@ -1003,6 +1034,10 @@ static void get_data(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
+                        if (NULL == kv) {  // should never happen
+                            cb->status = PMIX_ERR_NOT_FOUND;
+                            goto done;
+                        }
                         rc = PMIx_Value_get_number(kv->value, &lg->appnum, PMIX_UINT32);
                         PMIX_RELEASE(kv);
                         if (PMIX_SUCCESS != rc) {
@@ -1078,6 +1113,10 @@ static void get_data(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
+                        if (NULL == kv) {  // should never happen
+                            cb->status = PMIX_ERR_NOT_FOUND;
+                            goto done;
+                        }
                         rc = PMIx_Value_get_number(kv->value, &lg->sessionid, PMIX_UINT32);
                         PMIX_RELEASE(kv);
                         if (PMIX_SUCCESS != rc) {
@@ -1251,6 +1290,9 @@ doget:
     /* send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, _getnb_cbfunc, (void *) cb);
     if (PMIX_SUCCESS != rc) {
+        /* the transport only refuses a send it never took ownership of, so
+         * the message is still ours to release */
+        PMIX_RELEASE(msg);
         pmix_list_remove_item(&pmix_client_globals.pending_requests, &cb->super);
         cb->status = PMIX_ERROR;
         goto done;
@@ -1342,6 +1384,16 @@ static pmix_status_t refresh_cache(const pmix_proc_t *p)
                         PMIX_NAME_PRINT(&pmix_globals.myid),
                         PMIX_NAME_PRINT(p));
 
+    /* only the server can refresh our cache, so there is nothing to do (and
+     * nothing to pack a message against) if we have no server. Every other
+     * server round-trip in this file gates on this; without it a singleton
+     * asking for PMIX_GET_REFRESH_CACHE packed a message for a peer that was
+     * never given a transport. */
+    if (pmix_client_globals.singleton ||
+        !pmix_atomic_check_bool(&pmix_globals.connected)) {
+        return PMIX_SUCCESS;
+    }
+
     /* pack a quick message to the server asking it
      * to refresh our cache */
     msg = PMIX_NEW(pmix_buffer_t);
@@ -1373,6 +1425,7 @@ static pmix_status_t refresh_cache(const pmix_proc_t *p)
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, refcb, (void *)cb);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
         return rc;
     }

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -562,6 +562,10 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
     pmix_info_t *dinfo = (pmix_info_t *) info;
     size_t ndinfo = ninfo, n;
     bool freeinfo = false, notterm = false;
+    /* snapshot of the group taken under the lock - see below */
+    pmix_proc_t *mbrs = NULL;
+    size_t nmbrs = 0;
+    bool grpnotterm = false;
 
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_destruct_nb called");
@@ -584,7 +588,13 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
         return PMIX_ERR_BAD_PARAM;
     }
 
-    /* find this group */
+    /* Find this group and take a copy of what we need from it. We hold the
+     * lock only for the lookup and the copy: the progress thread can append
+     * to this list, remove from it, and trim a departed proc out of a
+     * group's membership, so neither the list nor grp->members can be
+     * relied on once we let go. Packing from a copy also keeps the lock off
+     * the bfrops path entirely. */
+    pmix_mutex_lock(&pmix_client_globals.grouplock);
     grp = NULL;
     PMIX_LIST_FOREACH(pgrp, &pmix_client_globals.groups, pmix_group_t) {
         if (0 == strcmp(grpid, pgrp->grpid)) {
@@ -593,8 +603,20 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
         }
     }
     if (NULL == grp) {
+        pmix_mutex_unlock(&pmix_client_globals.grouplock);
         return PMIX_ERR_NOT_FOUND;
     }
+    grpnotterm = grp->notterm;
+    nmbrs = grp->nmbrs;
+    if (0 < nmbrs) {
+        PMIX_PROC_CREATE(mbrs, nmbrs);
+        if (NULL == mbrs) {
+            pmix_mutex_unlock(&pmix_client_globals.grouplock);
+            return PMIX_ERR_NOMEM;
+        }
+        memcpy(mbrs, grp->members, nmbrs * sizeof(pmix_proc_t));
+    }
+    pmix_mutex_unlock(&pmix_client_globals.grouplock);
 
     /* the group's failure policy was chosen at construct time; re-apply
      * PMIX_GROUP_NOTIFY_TERMINATION here so the server (which keeps no group
@@ -602,7 +624,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
      * group was constructed with the flag and the caller did not itself provide
      * it, append it to the info we send. A caller that explicitly passes the
      * attribute overrides the remembered policy. */
-    if (grp->notterm) {
+    if (grpnotterm) {
         for (n = 0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_NOTIFY_TERMINATION)) {
                 notterm = true;
@@ -639,12 +661,12 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
     /* pack the membership - the server isn't storing it,
      * so we have to send it so that the server can
      * track when all local procs have participated */
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &grp->nmbrs, 1, PMIX_SIZE);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nmbrs, 1, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto done;
     }
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, grp->members, grp->nmbrs, PMIX_PROC);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, mbrs, nmbrs, PMIX_PROC);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto done;
@@ -686,6 +708,9 @@ done:
     }
     if (freeinfo) {
         PMIX_INFO_FREE(dinfo, ndinfo);
+    }
+    if (NULL != mbrs) {
+        PMIX_PROC_FREE(mbrs, nmbrs);
     }
     return rc;
 }
@@ -1458,6 +1483,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
 {
     pmix_status_t rc;
     pmix_group_tracker_t *cb;
+
     PMIX_HIDE_UNUSED_PARAMS(results, nresults);
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
@@ -1649,7 +1675,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
     pmix_group_t *grpobj, *pgrp;
     pmix_proc_t *range = NULL;
     pmix_data_array_t darray;
-    size_t n, m, nrange;
+    size_t n, m, nrange, nmbrs;
 
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_leave_nb called");
@@ -1672,19 +1698,6 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
         return PMIX_ERR_BAD_PARAM;
     }
 
-    /* find this group in our local list - we can only leave a group
-     * we belong to, and we need its membership to know who to notify */
-    grpobj = NULL;
-    PMIX_LIST_FOREACH(pgrp, &pmix_client_globals.groups, pmix_group_t) {
-        if (0 == strcmp(grp, pgrp->grpid)) {
-            grpobj = pgrp;
-            break;
-        }
-    }
-    if (NULL == grpobj) {
-        return PMIX_ERR_NOT_FOUND;
-    }
-
     cb = PMIX_NEW(pmix_group_tracker_t);
     cb->opcbfunc = cbfunc;
     cb->cbdata = cbdata;
@@ -1701,20 +1714,51 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
         return PMIX_ERR_NOMEM;
     }
 
+    /* Find this group in our local list - we can only leave a group we
+     * belong to, and we need its membership to know who to notify - copy
+     * that membership out, and drop the group, all under the lock. The
+     * progress thread owns this list too, and the PMIX_GROUP_LEFT handler
+     * on that side shifts members out of exactly this array.
+     *
+     * Everything that can fail and everything that can block is kept
+     * outside the lock: the allocations above are already done, and the
+     * notification below must not be issued while holding it - the handler
+     * it drives needs this same lock. */
+    pmix_mutex_lock(&pmix_client_globals.grouplock);
+    grpobj = NULL;
+    PMIX_LIST_FOREACH(pgrp, &pmix_client_globals.groups, pmix_group_t) {
+        if (0 == strcmp(grp, pgrp->grpid)) {
+            grpobj = pgrp;
+            break;
+        }
+    }
+    if (NULL == grpobj) {
+        pmix_mutex_unlock(&pmix_client_globals.grouplock);
+        PMIX_RELEASE(cb);
+        return PMIX_ERR_NOT_FOUND;
+    }
+
     /* the custom range is the membership, excluding ourselves */
-    PMIX_PROC_CREATE(range, grpobj->nmbrs);
+    nmbrs = grpobj->nmbrs;
+    PMIX_PROC_CREATE(range, nmbrs);
     if (NULL == range) {
+        pmix_mutex_unlock(&pmix_client_globals.grouplock);
         PMIX_RELEASE(cb);
         return PMIX_ERR_NOMEM;
     }
     nrange = 0;
-    for (m = 0; m < grpobj->nmbrs; m++) {
+    for (m = 0; m < nmbrs; m++) {
         if (PMIX_CHECK_PROCID(&grpobj->members[m], &pmix_globals.myid)) {
             continue;
         }
         PMIX_XFER_PROCID(&range[nrange], &grpobj->members[m]);
         ++nrange;
     }
+
+    /* we are no longer a member - drop the group from our local list */
+    pmix_list_remove_item(&pmix_client_globals.groups, &grpobj->super);
+    PMIX_RELEASE(grpobj);
+    pmix_mutex_unlock(&pmix_client_globals.grouplock);
 
     n = 0;
     darray.type = PMIX_PROC;
@@ -1734,11 +1778,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
         PMIX_INFO_XFER(&cb->info[n], &info[m]);
         ++n;
     }
-    PMIX_PROC_FREE(range, grpobj->nmbrs);
-
-    /* we are no longer a member - drop the group from our local list */
-    pmix_list_remove_item(&pmix_client_globals.groups, &grpobj->super);
-    PMIX_RELEASE(grpobj);
+    PMIX_PROC_FREE(range, nmbrs);
 
     /* generate the event - the callback fires once it has been locally
      * generated, which is when the operation is complete */
@@ -2005,8 +2045,10 @@ static void destruct_cbfunc(struct pmix_peer_t *pr,
         goto report;
     }
 
-    /* find this group */
+    /* find this group and drop it - the caller's thread reads this list too
+     * (see the grouplock note in pmix_client_ops.h) */
     grp = NULL;
+    pmix_mutex_lock(&pmix_client_globals.grouplock);
     PMIX_LIST_FOREACH(grp, &pmix_client_globals.groups, pmix_group_t) {
         if (0 == strcmp(cb->grpid, grp->grpid)) {
             pmix_list_remove_item(&pmix_client_globals.groups, &grp->super);
@@ -2014,6 +2056,7 @@ static void destruct_cbfunc(struct pmix_peer_t *pr,
             break;
         }
     }
+    pmix_mutex_unlock(&pmix_client_globals.grouplock);
 
     /* a zero-byte buffer indicates that this recv is being
      * completed due to a lost connection */
@@ -2087,12 +2130,18 @@ static pmix_status_t add_group(const char *grpid,
 {
     pmix_group_t *grp;
 
+    /* the caller's thread reads this list, so the lookup and the append have
+     * to be one atomic step - two racing completions would otherwise both
+     * miss and both append */
+    pmix_mutex_lock(&pmix_client_globals.grouplock);
+
     /* the construct completion path registers the group for every caller,
      * while the callback the blocking wrapper installs still does so for
      * the join path - so tolerate being asked twice for the same group
      * rather than leaving a duplicate on the list */
     PMIX_LIST_FOREACH(grp, &pmix_client_globals.groups, pmix_group_t) {
         if (0 == strcmp(grpid, grp->grpid)) {
+            pmix_mutex_unlock(&pmix_client_globals.grouplock);
             return PMIX_SUCCESS;
         }
     }
@@ -2111,6 +2160,7 @@ static pmix_status_t add_group(const char *grpid,
      * re-apply PMIX_GROUP_NOTIFY_TERMINATION on the caller's behalf */
     grp->notterm = notterm;
     pmix_list_append(&pmix_client_globals.groups, &grp->super);
+    pmix_mutex_unlock(&pmix_client_globals.grouplock);
 
     return PMIX_SUCCESS;
 }

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -437,6 +437,12 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* check for bozo input - the group ID names the collective and is
+     * strdup'd onto the tracker below */
+    if (NULL == grp) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* An "add members" or "bootstrap" construct does not list all
      * participants in the procs array - the remaining members are
      * supplied separately (via PMIX_GROUP_ADD_MEMBERS) or join later,
@@ -910,10 +916,16 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
     PMIX_INFO_LOAD(&myinfo[1], PMIX_EVENT_HDLR_PREPEND, NULL, PMIX_BOOL);
     ncodes = sizeof(codes) / sizeof(pmix_status_t);
     PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
-    PMIx_Register_event_handler(codes, ncodes, myinfo, 2, invite_handler, regcbfunc, &lock);
-    PMIX_WAIT_THREAD(&lock.lock);
-    rc = lock.status;
-    cb->ref = lock.ref;
+    rc = PMIx_Register_event_handler(codes, ncodes, myinfo, 2,
+                                     invite_handler, regcbfunc, &lock);
+    /* only wait if the registration was actually accepted - regcbfunc is the
+     * only thing that ever wakes this lock, and it does not fire when the
+     * call itself failed */
+    if (PMIX_SUCCESS == rc) {
+        PMIX_WAIT_THREAD(&lock.lock);
+        rc = lock.status;
+        cb->ref = lock.ref;
+    }
     PMIX_DESTRUCT(&lock);
     PMIX_INFO_DESTRUCT(&myinfo[0]);
     PMIX_INFO_DESTRUCT(&myinfo[1]);
@@ -963,8 +975,13 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
     PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
     rc = PMIx_Notify_event(PMIX_GROUP_INVITED, &pmix_globals.myid, PMIX_RANGE_CUSTOM,
                            cb->info, cb->ninfo, op_cbfunc, (void *) &lock);
-    PMIX_WAIT_THREAD(&lock.lock);
-    rc = lock.status;
+    /* as with the registration above, op_cbfunc is the only thing that wakes
+     * this lock and it does not run when the notify call itself failed -
+     * waiting unconditionally hung the caller on an error */
+    if (PMIX_SUCCESS == rc) {
+        PMIX_WAIT_THREAD(&lock.lock);
+        rc = lock.status;
+    }
     PMIX_DESTRUCT(&lock);
     if (PMIX_SUCCESS != rc) {
         return rc;
@@ -1935,9 +1952,13 @@ report:
             goto done;
         }
     }
-    PMIx_Info_list_convert(ilist, &darray);
-    cb->info = (pmix_info_t*)darray.array;
-    cb->ninfo = darray.size;
+    /* on failure darray is left untouched, so adopting it unchecked handed
+     * the tracker an uninitialized pointer that its destructor then freed */
+    rc = PMIx_Info_list_convert(ilist, &darray);
+    if (PMIX_SUCCESS == rc) {
+        cb->info = (pmix_info_t*)darray.array;
+        cb->ninfo = darray.size;
+    }
     PMIx_Info_list_release(ilist);
 
     /* record the group locally now that its construction has succeeded.

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -155,12 +155,25 @@ PMIX_CLASS_INSTANCE(pmix_group_tracker_t, pmix_list_item_t, gtcon, gtdes);
 
 /* Registry of active leader-watch trackers. Each acceptor of a group
  * invitation registers a persistent event handler (see setup_leader_watch)
- * that must live until the group construct completes. The construct-complete
- * (or construct-abort) event that would trigger teardown is not guaranteed to
- * reach the acceptor before it finalizes - in practice, for the common
- * single-server case, it often does not. Rather than leak the tracker (and its
- * registered handler) in that case, we record each active watch here and
- * release any survivors at finalize. Access is confined to the progress thread
+ * that must live until the group construct completes. That teardown event
+ * frequently never reaches the handler - but NOT because it fails to arrive.
+ * It arrives at the process reliably; the library just cannot see it. This
+ * watch is a multi-code handler, and the event chain runs single-code
+ * handlers first, so an application handler for PMIX_GROUP_CONSTRUCT_COMPLETE
+ * that returns PMIX_EVENT_ACTION_COMPLETE - the normal way to say "handled" -
+ * ends the chain before this handler is reached. An invite/join application
+ * has to register for that code, so this is the common case, not the corner
+ * one. (Demonstrated with test/unit/run_grpinvite.pl: the application handler
+ * fires on every acceptor while none of these watches do; changing only the
+ * example's return value to PMIX_EVENT_NO_ACTION_TAKEN makes them all fire.
+ * It is not a registration race either - moving this registration ahead of
+ * the acceptance notification changes nothing.) The real fix is to observe
+ * these codes from the pre-chain block in pmix_invoke_local_event_hdlr(),
+ * which already maintains pmix_client_globals.groups on the same events and
+ * cannot be pre-empted; that is a separate change, under discussion.
+ *
+ * Meanwhile, rather than leak the tracker (and its registered handler), we
+ * record each active watch here and release any survivors at finalize. Access is confined to the progress thread
  * (watches are added in watch_regcb and removed in watch_teardown, both of
  * which run there) and to finalize after the progress thread has stopped, so
  * no lock is required - the same discipline used for pending_requests. The

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -949,7 +949,19 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
         }
     }
 
-    /* register an event handler specifically to respond to accept responses */
+    /* Register an event handler specifically to respond to accept responses.
+     *
+     * WARNING - this handler can be silently pre-empted, and when it is, this
+     * invitation never resolves. invite_handler() is the only thing that
+     * counts answers and calls invite_wake(), but it lands in the multi-code
+     * handler category, and the event chain runs single-code handlers first.
+     * An application that registers its own handler for
+     * PMIX_GROUP_INVITE_ACCEPTED - to log who joined, say - and returns
+     * PMIX_EVENT_ACTION_COMPLETE from it ends the chain before we are
+     * reached, and PMIx_Group_invite blocks forever unless the caller
+     * supplied a PMIX_TIMEOUT. Same exposure as the leader watch below, but
+     * a hang rather than a missed teardown. See the note there for the
+     * demonstration and the intended fix. */
     PMIX_INFO_LOAD(&myinfo[0], PMIX_EVENT_RETURN_OBJECT, cb, PMIX_POINTER);
     PMIX_INFO_LOAD(&myinfo[1], PMIX_EVENT_HDLR_PREPEND, NULL, PMIX_BOOL);
     ncodes = sizeof(codes) / sizeof(pmix_status_t);

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -1484,7 +1484,29 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
     pmix_status_t rc;
     pmix_group_tracker_t *cb;
 
-    PMIX_HIDE_UNUSED_PARAMS(results, nresults);
+    /* Set the default response before anything can fail. These are OUT
+     * parameters the caller is entitled to read on return, and both are
+     * documented as optional, so honor a NULL for either.
+     *
+     * NOTE: they are always returned empty today. The man page says this
+     * call returns "once the group has been completely constructed", with
+     * the construct results available here - but the implementation
+     * completes as soon as the accept/decline notification has been handed
+     * to the local event system, which is much earlier and carries no group
+     * data. Completing at the documented point would mean waiting for the
+     * leader's PMIX_GROUP_CONSTRUCT_COMPLETE, and that event is not
+     * guaranteed to reach an acceptor at all (see the leader-watch registry
+     * near the top of this file) - so waiting for it here would hang the
+     * common case rather than fix it. The gap is recorded in
+     * src/client/AGENTS.md; closing it is a protocol change, not a local
+     * one. Until then the group results reach the application through its
+     * PMIX_GROUP_CONSTRUCT_COMPLETE handler. */
+    if (NULL != results) {
+        *results = NULL;
+    }
+    if (NULL != nresults) {
+        *nresults = 0;
+    }
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
@@ -1513,6 +1535,16 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
     /* wait for the group construction to complete */
     PMIX_WAIT_THREAD(&cb->lock);
     rc = cb->status;
+    /* hand over anything the completion collected. Nothing does today, per
+     * the note above, but the transfer belongs here rather than being
+     * grafted on later - and it keeps this wrapper structurally identical
+     * to PMIx_Group_construct. */
+    if (PMIX_SUCCESS == rc && NULL != results && NULL != nresults) {
+        *results = cb->results;
+        *nresults = cb->nresults;
+        cb->results = NULL;
+        cb->nresults = 0;
+    }
     PMIX_RELEASE(cb);
 
     pmix_output_verbose(2, pmix_client_globals.group_output,
@@ -1816,7 +1848,13 @@ static void op_cbfunc_rel(pmix_status_t status, void *cbdata)
 
     cb->status = status;
     if (NULL != cb->cbfunc) {
-        cb->cbfunc(status, cb->info, cb->ninfo, cb->cbdata, relfn, cb);
+        /* Report no results, not cb->info: the info on this tracker is the
+         * custom range we used to aim the accept/decline notification at the
+         * leader. That is our own event plumbing, and handing it back as the
+         * "results" of the join would present a PMIX_EVENT_CUSTOM_RANGE to
+         * the caller as if it were group data. There genuinely are no
+         * results at this point - see PMIx_Group_join. */
+        cb->cbfunc(status, NULL, 0, cb->cbdata, relfn, cb);
     } else {
         PMIX_RELEASE(cb);
     }

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -29,6 +29,21 @@ typedef struct {
     pmix_list_t pending_requests; // list of pmix_cb_t pending data requests
     pmix_pointer_array_t peers;   // array of pmix_peer_t cached for data ops
     pmix_list_t groups;           // list of groups this client is part of
+    /* Guards "groups" - both the list spine and the membership arrays of the
+     * pmix_group_t objects on it. Unlike pending_requests, this list is not
+     * confined to the progress thread: it is appended and edited there (when
+     * a construct completes, and when a PMIX_GROUP_LEFT event trims a
+     * departed member out of an existing group), but it is read and removed
+     * from on the caller's thread by PMIx_Group_leave_nb,
+     * PMIx_Group_destruct_nb, and every collective that expands a group
+     * reference through pmix_client_convert_group_procs(). Hold this across
+     * any traversal, and across any use of a group's members - the
+     * GROUP_LEFT path shifts that array down underneath a reader.
+     *
+     * Never hold it across a call that waits on the progress thread (a
+     * blocking PMIx_Notify_event, say): the handler on the other side may
+     * need this same lock. Copy out what you need and release it first. */
+    pmix_mutex_t grouplock;
     // verbosity for client get operations
     int get_output;
     int get_verbose;

--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -173,6 +173,12 @@ static void resolve_peers(int sd, short args, void *cbdata)
      * with a key equal to the nodename */
     if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) &&
         PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 100)) {
+        /* NOTE: pre-v3.2 servers filed this under the wildcard rank keyed by
+         * the node name, but the reset below puts the rank back to UNDEF for
+         * both branches, so this assignment has no effect. try_fetch() retries
+         * an UNDEF rank as WILDCARD, which is why the legacy path still
+         * resolves; the dead store is left as-is rather than "fixed" blind,
+         * since no pre-v3.2 server is available to test the difference. */
         proc.rank = PMIX_RANK_WILDCARD;
         key = cd->nodename;
         ninfo = 1;
@@ -358,6 +364,9 @@ static void respeer(pmix_status_t status, pmix_info_t info[], size_t ninfo, void
     if (PMIX_SUCCESS == status) {
         cb->ninfo = ninfo;
         PMIX_INFO_CREATE(cb->info, ninfo);
+        /* this is our copy, so mark it as such - otherwise the caddy
+         * destructor leaves the whole array behind */
+        cb->infocopy = true;
         for (n=0; n < ninfo; n++) {
             PMIX_INFO_XFER(&cb->info[n], &info[n]);
         }
@@ -439,9 +448,11 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
                     } else {
                         *procs = (pmix_proc_t*)val->data.darray->array;
                         *nprocs = val->data.darray->size;
-                        // protect the returned data
-                        cb.info = NULL;
-                        cb.ninfo = 0;
+                        /* detach just the proc array we are handing back, so
+                         * destructing the caddy still reclaims the info array
+                         * and the data-array wrapper around it */
+                        val->data.darray->array = NULL;
+                        val->data.darray->size = 0;
                         PMIX_DESTRUCT(&cb);
                         return rc;
                     }
@@ -518,6 +529,8 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
     cd = PMIX_NEW(pmix_resolve_caddy_t);
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_peers_cbfunc, (void *) cd);
     if (PMIX_SUCCESS != rc) {
+        /* a refused send never took the message, so it is still ours */
+        PMIX_RELEASE(msg);
         PMIX_RELEASE(cd);
         return rc;
     }
@@ -687,6 +700,8 @@ static void resnode(pmix_status_t status, pmix_info_t info[], size_t ninfo, void
     if (PMIX_SUCCESS == status) {
         cb->ninfo = ninfo;
         PMIX_INFO_CREATE(cb->info, ninfo);
+        /* our copy - see respeer() above */
+        cb->infocopy = true;
         for (n=0; n < ninfo; n++) {
             PMIX_INFO_XFER(&cb->info[n], &info[n]);
         }
@@ -752,7 +767,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
                 // string return should be in first info
                 if (0 < cb.ninfo) {
                     val = &cb.info[0].value;
-                    if (PMIX_STRING != val->type) {
+                    if (PMIX_STRING != val->type || NULL == val->data.string) {
                         PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
                     } else {
                         *nodelist = strdup(val->data.string);
@@ -821,6 +836,8 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
     cd = PMIX_NEW(pmix_resolve_caddy_t);
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_node_cbfunc, (void *) cd);
     if (PMIX_SUCCESS != rc) {
+        /* a refused send never took the message, so it is still ours */
+        PMIX_RELEASE(msg);
         PMIX_RELEASE(cd);
         return rc;
     }

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -126,7 +126,9 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
         /* note: the call may have returned PMIX_OPERATION_SUCCEEDED thus indicating
          * that the spawn was atomically completed */
         if (PMIX_OPERATION_SUCCEEDED == rc) {
-            PMIX_LOAD_NSPACE(nspace, cb->pname.nspace);
+            if (NULL != cb->pname.nspace) {
+                PMIX_LOAD_NSPACE(nspace, cb->pname.nspace);
+            }
             rc = PMIX_SUCCESS;
         }
         PMIX_RELEASE(cb);
@@ -136,7 +138,9 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
     /* wait for the result */
     PMIX_WAIT_THREAD(&cb->lock);
     rc = cb->status;
-    if (NULL != nspace) {
+    /* a failed spawn reports no namespace, so leave the caller's (already
+     * zeroed) buffer empty rather than copying from a NULL */
+    if (NULL != cb->pname.nspace) {
         pmix_strncpy(nspace, cb->pname.nspace, PMIX_MAX_NSLEN);
     }
     PMIX_RELEASE(cb);
@@ -320,7 +324,11 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
             fcd->apps[n].argv[1] = NULL;
         } else {
             fcd->apps[n].argv = PMIx_Argv_copy(aptr->argv);
-            tmp = pmix_basename(aptr->cmd);
+            /* take the basename from our own copy of the cmd, not from
+             * aptr->cmd: the caller is allowed to supply argv without a cmd
+             * (we filled it in from argv[0] above), and pmix_basename(NULL)
+             * returns NULL, which the strcmp below would then dereference */
+            tmp = pmix_basename(fcd->apps[n].cmd);
             t2 = pmix_basename(aptr->argv[0]);
             if (0 != strcmp(tmp, t2)) {
                 // assume that the user may have put the argv

--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -258,6 +258,12 @@ pmix_status_t PMIx_Compute_distances_nb(pmix_topology_t *tp, pmix_cpuset_t *cp,
         return PMIX_ERR_INIT;
     }
 
+    /* the server-reply path (direcv) has no completion route other than this
+     * callback, so a NULL one is not something we can honor */
+    if (NULL == cbfunc) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
     }

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -807,6 +807,9 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
             }
         }
         if (NULL != members && NULL != grpid) {
+            /* the caller's thread reads this list - see the grouplock note
+             * in src/client/pmix_client_ops.h */
+            pmix_mutex_lock(&pmix_client_globals.grouplock);
             // see if we already know this group
             grp = NULL;
             PMIX_LIST_FOREACH(gp, &pmix_client_globals.groups, pmix_group_t) {
@@ -826,6 +829,7 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
                 grp->ctxid = ctxid;
                 pmix_list_append(&pmix_client_globals.groups, &grp->super);
             }
+            pmix_mutex_unlock(&pmix_client_globals.grouplock);
         }
     }
 
@@ -842,6 +846,10 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
             }
         }
         if (NULL != grpid && NULL != affected) {
+            /* this shifts a live membership array down underneath anything
+             * reading it from the caller's thread (a collective expanding a
+             * group reference, say), so it has to be held */
+            pmix_mutex_lock(&pmix_client_globals.grouplock);
             PMIX_LIST_FOREACH(gp, &pmix_client_globals.groups, pmix_group_t) {
                 if (0 != strcmp(grpid, gp->grpid)) {
                     continue;
@@ -858,6 +866,7 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
                 }
                 break;
             }
+            pmix_mutex_unlock(&pmix_client_globals.grouplock);
         }
     }
 

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -1,0 +1,133 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The PMIx unit test suite
+
+This directory is the top level of PMIx's `make check` unit suite. The
+top-level [`AGENTS.md`](../../AGENTS.md) rules (copyright header,
+`pmix_config.h` first, constant-on-the-left, brace everything,
+warning-free under `--enable-devel-check`) apply here too, and its
+"Never bend a test to accommodate a bug" rule applies with particular
+force: nearly every program here exists because a specific defect got
+past review, and weakening one hides exactly the regression it was
+written to catch.
+
+Two subdirectories carry their own suites and their own guidance:
+
+- [`class/`](class/) — the `src/class` object model and containers. See
+  [`class/AGENTS.md`](class/AGENTS.md); it documents a build-configuration
+  trap that let several real defects survive having a test suite.
+- [`util/`](util/) — the `src/util` helpers.
+
+## What lives here
+
+Each program is a standalone `main()` linked against
+`$(top_builddir)/src/libpmix.la`. There is no test framework, and there
+should not be one: each prints its own pass/fail lines and exits non-zero
+if anything failed. That keeps a failing test readable in a CI log
+without cross-referencing a harness.
+
+They fall into three groups.
+
+**Self-contained library tests** — no server, no launcher, no network.
+These run anywhere and are the bulk of the suite: `compress`, `preg`,
+`bfrops_regex2`, `bfrops_alloc_inherit`, `info_support`, `iof_pattern`,
+`hwloc_datatype`, `tracker_match`, `trk_complete`, `collective_status`,
+`collect_job_info`, `progress_threads`, `pmix_log`.
+
+**Singleton client tests** — call the real public API in a process that
+comes up with no server. `client_cycle` (init/finalize cycling),
+`tool_cycle`, `singleton_register`, `rndz_stale`, `event_chain`,
+`gds_fallback`, `client_api`.
+
+**Perl-driven server tests** — `run_*.pl`, generated from `.pl.in` by
+`configure`, which start a `test/simple` server and drive real clients
+against it. The `run_grp*.pl` family covers group construct/invite/
+destruct including the failure and timeout cases.
+
+### `client_api` — the `src/client` regression test
+
+[`client_api.c`](client_api.c) is the singleton-side regression suite for
+[`src/client`](../../src/client). Every case in it corresponds to a
+defect found in the July 2026 review of that directory (see
+[`src/client/AGENTS.md`](../../src/client/AGENTS.md) for the full list),
+and several of them segfaulted before being fixed:
+
+- `PMIx_Get_nb` for a request the library answers itself — `PMIX_PROCID`,
+  `PMIX_VERSION_NUMERIC`, `PMIX_RANK` — which built a caddy with no "get
+  logic" object and then released that field unconditionally.
+- `PMIx_Get_nb` under `PMIX_GET_STATIC_VALUES`, which read an
+  uninitialized pointer.
+- `PMIx_Get` under `PMIX_GET_REFRESH_CACHE` with the NULL `proc` the API
+  explicitly permits.
+- Parameter validation on `PMIx_Get`, `PMIx_Get_nb`,
+  `PMIx_Compute_distances_nb`, and the fabric APIs.
+- `PMIx_Fabric_deregister` twice in a row, which used to free the info
+  array a second time.
+
+**What it cannot cover, and why.** A singleton has no server, so every
+path that round-trips — which is most of `src/client` — short-circuits
+before it starts. `PMIx_Fence` and `PMIx_Commit` return success without
+sending; `PMIx_Get` never leaves the local datastore;
+publish/lookup/spawn/connect all stop at the "am I connected?" check.
+That half of the directory is covered by
+`contrib/dockerswarm/run-client-tests.sh`, which puts the ranks behind
+different PMIx servers. Do not try to grow `client_api.c` into it: a
+test that needs a server belongs in the swarm suite or in a `run_*.pl`
+against `test/simple`.
+
+## Running
+
+```sh
+make check          # from this directory, or from test/
+```
+
+`make check` runs against the components in the **build tree**, so it
+needs no prior `make install`: each test sources the generated
+`test/pmix_test_env.sh` by way of `AM_TESTS_ENVIRONMENT`, which supplies
+the component search path.
+
+**These are `check_PROGRAMS`, so `make all` does not build them.** A
+plain `make` here prints "Nothing to be done for `all'" and leaves stale
+binaries in place — so after changing library source you can run
+yesterday's binary against today's library and get a failure that has
+nothing to do with your change. Always use `make check`.
+
+**A stale `$TMPDIR` fails the server-based tests for environmental
+reasons.** If the whole `run_*.pl` family fails at once, rerun under
+`TMPDIR=$(mktemp -d) make check` before investigating; see the top-level
+guide's "Building and Testing".
+
+**Do not run this suite against an `--enable-test-build` tree.** Its
+shimmed `pcompress`/`psec` components are non-functional by design, so
+`preg` and `compress` will fail for reasons that are not defects.
+
+## Adding a test
+
+1. Write `foo.c` with the standard copyright header and a `main()` that
+   returns non-zero on failure.
+2. Add `foo` to both `check_PROGRAMS` and `TESTS` in
+   [`Makefile.am`](Makefile.am), plus a `foo_SOURCES` / `foo_LDFLAGS` /
+   `foo_LDADD` triple matching its neighbours.
+3. Add `test/unit/foo` to the top-level [`.gitignore`](../../.gitignore)
+   — the build products here are ignored from the root, not from a local
+   `.gitignore` (unlike `class/`, which has its own).
+4. Run `make check`. A `Makefile.am` edit needs only a plain `make`; no
+   `autogen.pl`/`configure` re-run.
+
+Note that `PMIX_HIDE_UNUSED_PARAMS` and the other
+`__pmix_attribute_*__` wrappers are **not** available to these programs —
+they are gated on `PMIX_BUILDING` in `pmix_config_bottom.h`, which is not
+set here. Use a plain `(void) arg;` cast instead.
+
+A test that needs a server is a different animal: add it to
+`test/simple` with a `run_foo.pl.in` driver (and to `noinst_SCRIPTS`,
+`EXTRA_DIST`, `TESTS`, and `.gitignore`), or to the dockerswarm suite
+under [`contrib/dockerswarm`](../../contrib/dockerswarm).

--- a/test/unit/CLAUDE.md
+++ b/test/unit/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -32,9 +32,15 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+check_PROGRAMS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
 
-TESTS = compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+TESTS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+
+client_api_SOURCES = \
+        client_api.c
+client_api_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+client_api_LDADD = \
+    $(top_builddir)/src/libpmix.la
 
 compress_SOURCES =  \
         compress.c

--- a/test/unit/client_api.c
+++ b/test/unit/client_api.c
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression coverage for defects found reviewing src/client.
+ *
+ * Every case here is a client-side API call that a well-behaved (or merely
+ * careless) application can make, and that used to segfault, hang, or
+ * silently corrupt the caller's data. They all run as a singleton - no
+ * server, no launcher - so the whole file is safe under "make check". That
+ * restricts what can be covered to the paths a client resolves locally or
+ * rejects up front, which is precisely where these defects lived:
+ *
+ *   1. PMIx_Get_nb for a request the library answers itself (PMIX_PROCID,
+ *      PMIX_VERSION_NUMERIC, or PMIX_RANK) built a bare caddy carrying no
+ *      "get logic" object and then unconditionally PMIX_RELEASE'd that
+ *      field. PMIX_RELEASE dereferences its argument, so this was a NULL
+ *      dereference on the very first such call.
+ *
+ *   2. PMIx_Get_nb passed its uninitialized "val" pointer into the request
+ *      parser, which dereferences it when PMIX_GET_STATIC_VALUES is set.
+ *      The parser's own "did the caller provide storage?" test therefore
+ *      read whatever was on the stack instead of seeing NULL.
+ *
+ *   3. PMIX_GET_REFRESH_CACHE dereferenced the caller's proc pointer, which
+ *      PMIx_Get explicitly allows to be NULL (a key that is globally unique
+ *      within our own namespace). It also packed a message for a server
+ *      that a singleton does not have.
+ *
+ *   4. PMIx_Get with a NULL "val" wrote through it rather than rejecting
+ *      the call.
+ *
+ *   5. PMIx_Compute_distances_nb accepted a NULL callback, then the server
+ *      reply handler invoked it unconditionally.
+ *
+ *   6. PMIx_Fabric_register_nb / PMIx_Fabric_update_nb treat a NULL cbfunc
+ *      as "the caddy is in cbdata" - an internal convention of their
+ *      blocking wrappers. Called from user code with both NULL, they
+ *      dereferenced a NULL caddy.
+ *
+ *   7. PMIx_Fabric_deregister freed the fabric's info array but left the
+ *      pointer dangling, so a second deregister freed it again.
+ *
+ * The locally-satisfied gets are also repeated enough times that a caddy
+ * leak or a reference-count error shows up as growth or a crash rather
+ * than passing quietly.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define REPEAT 200
+
+static int nfail = 0;
+
+static volatile int cbcount = 0;
+static pmix_status_t cbstatus = PMIX_SUCCESS;
+static int cbhadvalue = 0;
+
+static void check(int ok, const char *what)
+{
+    if (ok) {
+        fprintf(stdout, "  ok    : %s\n", what);
+    } else {
+        fprintf(stdout, "  FAILED: %s\n", what);
+        nfail++;
+    }
+}
+
+static void valuecb(pmix_status_t status, pmix_value_t *kv, void *cbdata)
+{
+    (void) cbdata;
+    cbstatus = status;
+    cbhadvalue = (NULL != kv);
+    cbcount++;
+}
+
+/* Spin the caller until the callback has fired. The library delivers a
+ * locally-satisfied get by way of the progress thread, so it does not
+ * complete inside the PMIx_Get_nb call itself. */
+static int wait_for_cb(int target)
+{
+    int spins;
+
+    for (spins = 0; spins < 2000; spins++) {
+        if (cbcount >= target) {
+            return 1;
+        }
+        usleep(1000);
+    }
+    return 0;
+}
+
+static void test_local_get_nb(void)
+{
+    pmix_status_t rc;
+    int i;
+
+    fprintf(stdout, "\n-- PMIx_Get_nb, request satisfied locally --\n");
+
+    /* PMIX_PROCID with a NULL proc: answered outright by the request
+     * parser, which is the path that dereferenced a NULL logic object */
+    cbcount = 0;
+    rc = PMIx_Get_nb(NULL, PMIX_PROCID, NULL, 0, valuecb, NULL);
+    check(PMIX_SUCCESS == rc, "PMIx_Get_nb(NULL, PMIX_PROCID) accepted");
+    check(wait_for_cb(1), "PMIx_Get_nb(PMIX_PROCID) callback fired");
+    check(PMIX_SUCCESS == cbstatus, "PMIx_Get_nb(PMIX_PROCID) reported success");
+    check(cbhadvalue, "PMIx_Get_nb(PMIX_PROCID) delivered a value");
+
+    /* PMIX_VERSION_NUMERIC: the same shortcut, reached with a non-NULL proc */
+    cbcount = 0;
+    rc = PMIx_Get_nb(NULL, PMIX_VERSION_NUMERIC, NULL, 0, valuecb, NULL);
+    check(PMIX_SUCCESS == rc, "PMIx_Get_nb(PMIX_VERSION_NUMERIC) accepted");
+    check(wait_for_cb(1), "PMIx_Get_nb(PMIX_VERSION_NUMERIC) callback fired");
+    check(PMIX_SUCCESS == cbstatus, "PMIx_Get_nb(PMIX_VERSION_NUMERIC) reported success");
+
+    /* repeat, so a caddy leak or refcount slip has room to show itself */
+    cbcount = 0;
+    for (i = 0; i < REPEAT; i++) {
+        rc = PMIx_Get_nb(NULL, PMIX_PROCID, NULL, 0, valuecb, NULL);
+        if (PMIX_SUCCESS != rc) {
+            break;
+        }
+    }
+    check(PMIX_SUCCESS == rc, "repeated PMIx_Get_nb(PMIX_PROCID) all accepted");
+    check(wait_for_cb(REPEAT), "repeated PMIx_Get_nb callbacks all fired");
+}
+
+static void test_get_nb_static_values(void)
+{
+    pmix_info_t info;
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- PMIx_Get_nb with PMIX_GET_STATIC_VALUES --\n");
+
+    /* PMIx_Get_nb has no way to receive caller-provided storage, so this
+     * must be rejected. It must reach that conclusion by inspecting a
+     * known-NULL pointer, not an uninitialized one. */
+    PMIX_INFO_LOAD(&info, PMIX_GET_STATIC_VALUES, NULL, PMIX_BOOL);
+    rc = PMIx_Get_nb(NULL, PMIX_PROCID, &info, 1, valuecb, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc,
+          "PMIx_Get_nb(PMIX_GET_STATIC_VALUES) returns PMIX_ERR_BAD_PARAM");
+    PMIX_INFO_DESTRUCT(&info);
+}
+
+static void test_get_refresh_cache(void)
+{
+    pmix_info_t info;
+    pmix_value_t *val = NULL;
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- PMIx_Get with PMIX_GET_REFRESH_CACHE --\n");
+
+    /* a NULL proc is legal: it means "this key is unique within my own
+     * namespace". The refresh path used to dereference it regardless. */
+    PMIX_INFO_LOAD(&info, PMIX_GET_REFRESH_CACHE, NULL, PMIX_BOOL);
+    rc = PMIx_Get(NULL, "client.api.absent.key", &info, 1, &val);
+    check(PMIX_SUCCESS != rc, "PMIx_Get(NULL proc, refresh, absent key) fails cleanly");
+    check(NULL == val, "PMIx_Get failure leaves the caller's value NULL");
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* and the same with an explicit proc, which must behave identically */
+    val = NULL;
+    PMIX_INFO_LOAD(&info, PMIX_GET_REFRESH_CACHE, NULL, PMIX_BOOL);
+    rc = PMIx_Get(NULL, PMIX_PROCID, &info, 1, &val);
+    check(PMIX_SUCCESS == rc, "PMIx_Get(PMIX_PROCID, refresh) succeeds");
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+    }
+    PMIX_INFO_DESTRUCT(&info);
+}
+
+static void test_get_bad_params(void)
+{
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- PMIx_Get parameter validation --\n");
+
+    /* nowhere to put the answer */
+    rc = PMIx_Get(NULL, PMIX_PROCID, NULL, 0, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Get(val=NULL) returns PMIX_ERR_BAD_PARAM");
+
+    /* both proc and key NULL is explicitly unsupported */
+    {
+        pmix_value_t *val = NULL;
+        rc = PMIx_Get(NULL, NULL, NULL, 0, &val);
+        check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Get(proc=NULL,key=NULL) returns PMIX_ERR_BAD_PARAM");
+    }
+
+    /* PMIx_Get_nb has no callback to report through */
+    rc = PMIx_Get_nb(NULL, PMIX_PROCID, NULL, 0, NULL, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Get_nb(cbfunc=NULL) returns PMIX_ERR_BAD_PARAM");
+}
+
+static void test_get_pointer_and_static(void)
+{
+    pmix_info_t info;
+    pmix_value_t *val;
+    pmix_value_t storage;
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- PMIx_Get pointer/static value forms --\n");
+
+    /* PMIX_GET_POINTER_VALUES hands back a pointer into library state; the
+     * caller must not release it */
+    val = NULL;
+    PMIX_INFO_LOAD(&info, PMIX_GET_POINTER_VALUES, NULL, PMIX_BOOL);
+    rc = PMIx_Get(NULL, PMIX_PROCID, &info, 1, &val);
+    check(PMIX_SUCCESS == rc, "PMIx_Get(PMIX_GET_POINTER_VALUES) succeeds");
+    check(NULL != val && PMIX_PROC == val->type, "pointer form returns a PMIX_PROC value");
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* PMIX_GET_STATIC_VALUES fills storage the caller supplied */
+    PMIX_VALUE_CONSTRUCT(&storage);
+    val = &storage;
+    PMIX_INFO_LOAD(&info, PMIX_GET_STATIC_VALUES, NULL, PMIX_BOOL);
+    rc = PMIx_Get(NULL, PMIX_PROCID, &info, 1, &val);
+    check(PMIX_SUCCESS == rc, "PMIx_Get(PMIX_GET_STATIC_VALUES) succeeds");
+    check(val == &storage, "static form left the caller's storage in place");
+    check(PMIX_PROC == storage.type, "static form filled in a PMIX_PROC value");
+    PMIX_INFO_DESTRUCT(&info);
+    PMIX_VALUE_DESTRUCT(&storage);
+}
+
+static void test_compute_distances(void)
+{
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- PMIx_Compute_distances_nb parameter validation --\n");
+
+    /* the server-reply handler has no completion route other than the
+     * callback, so a NULL one has to be refused rather than accepted and
+     * then invoked */
+    rc = PMIx_Compute_distances_nb(NULL, NULL, NULL, 0, NULL, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc,
+          "PMIx_Compute_distances_nb(cbfunc=NULL) returns PMIX_ERR_BAD_PARAM");
+}
+
+static void test_fabric(void)
+{
+    pmix_fabric_t fabric;
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- fabric API parameter validation and teardown --\n");
+
+    PMIx_Fabric_construct(&fabric);
+
+    /* NULL fabric */
+    rc = PMIx_Fabric_register_nb(NULL, NULL, 0, NULL, (void *) &fabric);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Fabric_register_nb(fabric=NULL) rejected");
+    rc = PMIx_Fabric_update_nb(NULL, NULL, (void *) &fabric);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Fabric_update_nb(fabric=NULL) rejected");
+    rc = PMIx_Fabric_deregister_nb(NULL, NULL, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Fabric_deregister_nb(fabric=NULL) rejected");
+
+    /* a NULL cbfunc means "the caddy is in cbdata"; with both NULL there is
+     * no caddy at all, and the recv handler would dereference it */
+    rc = PMIx_Fabric_register_nb(&fabric, NULL, 0, NULL, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Fabric_register_nb(NULL, NULL) rejected");
+    rc = PMIx_Fabric_update_nb(&fabric, NULL, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Fabric_update_nb(NULL, NULL) rejected");
+
+    /* stand in for a fabric that had been registered, then deregister it
+     * twice: the second call must not free the array again */
+    PMIX_INFO_CREATE(fabric.info, 2);
+    fabric.ninfo = 2;
+    PMIX_INFO_LOAD(&fabric.info[0], PMIX_HOSTNAME, "somehost", PMIX_STRING);
+    PMIX_INFO_LOAD(&fabric.info[1], PMIX_FABRIC_INDEX, &fabric.index, PMIX_SIZE);
+
+    rc = PMIx_Fabric_deregister(&fabric);
+    check(PMIX_SUCCESS == rc, "PMIx_Fabric_deregister succeeds");
+    check(NULL == fabric.info && 0 == fabric.ninfo,
+          "PMIx_Fabric_deregister leaves no dangling info pointer");
+
+    rc = PMIx_Fabric_deregister(&fabric);
+    check(PMIX_SUCCESS == rc, "second PMIx_Fabric_deregister is a safe no-op");
+}
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc;
+    pmix_status_t rc;
+    (void) argc;
+    (void) argv;
+
+    /* force the singleton path - nothing to connect to, so each API call
+     * either resolves locally or is rejected up front */
+    unsetenv("PMIX_NAMESPACE");
+    unsetenv("PMIX_RANK");
+    unsetenv("PMIX_SERVER_URI");
+    unsetenv("PMIX_SERVER_URI2");
+    unsetenv("PMIX_SERVER_URI3");
+    unsetenv("PMIX_SERVER_URI21");
+    unsetenv("PMIX_SERVER_URI41");
+    unsetenv("PMIX_SERVER_URI51");
+
+    fprintf(stdout, "\n=== src/client API regression test ===\n");
+
+    /* a singleton reports PMIX_ERR_UNREACH from init - it is fully
+     * initialized, it just has no server */
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_UNREACH != rc) {
+        fprintf(stderr, "PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    test_local_get_nb();
+    test_get_nb_static_values();
+    test_get_refresh_cache();
+    test_get_bad_params();
+    test_get_pointer_and_static();
+    test_compute_distances();
+    test_fabric();
+
+    rc = PMIx_Finalize(NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Finalize failed: %s\n", PMIx_Error_string(rc));
+        nfail++;
+    }
+
+    if (0 == nfail) {
+        fprintf(stdout, "\nsrc/client API regression test: PASS\n\n");
+    } else {
+        fprintf(stdout, "\nsrc/client API regression test: FAIL (%d)\n\n", nfail);
+    }
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/client_api.c
+++ b/test/unit/client_api.c
@@ -58,8 +58,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <pthread.h>
 
 #define REPEAT 200
+
+/* concurrency smoke: threads x gets, all driving the group-list lock */
+#define NTHREADS 8
+#define NGETS    400
 
 static int nfail = 0;
 
@@ -246,6 +251,57 @@ static void test_compute_distances(void)
           "PMIx_Compute_distances_nb(cbfunc=NULL) returns PMIX_ERR_BAD_PARAM");
 }
 
+/* Hammer the paths that take the group-list lock. PMIx_Get with an explicit
+ * namespace runs the caller's thread through
+ * pmix_client_convert_group_procs(), which walks the group list under that
+ * lock - so this is a direct test that the lock is released on every exit.
+ * A missed unlock hangs here on the second acquisition rather than
+ * corrupting something subtly later. The list is empty in a singleton, so
+ * this proves the locking discipline, not the group logic itself. */
+static void *get_hammer(void *arg)
+{
+    pmix_proc_t proc;
+    pmix_value_t *val;
+    long which = (long) (intptr_t) arg;
+    int i;
+
+    PMIX_LOAD_PROCID(&proc, "some.other.nspace", (pmix_rank_t) which);
+    for (i = 0; i < NGETS; i++) {
+        val = NULL;
+        /* expected to fail - we only care that it returns */
+        (void) PMIx_Get(&proc, "client.api.absent.key", NULL, 0, &val);
+        if (NULL != val) {
+            PMIX_VALUE_RELEASE(val);
+        }
+    }
+    return NULL;
+}
+
+static void test_group_lock_concurrency(void)
+{
+    pthread_t tid[NTHREADS];
+    long n;
+    int rc;
+
+    fprintf(stdout, "\n-- group-list lock under concurrent callers --\n");
+
+    for (n = 0; n < NTHREADS; n++) {
+        rc = pthread_create(&tid[n], NULL, get_hammer, (void *) (intptr_t) n);
+        if (0 != rc) {
+            check(0, "pthread_create");
+            /* join whatever we did start before giving up */
+            while (0 < n--) {
+                pthread_join(tid[n], NULL);
+            }
+            return;
+        }
+    }
+    for (n = 0; n < NTHREADS; n++) {
+        pthread_join(tid[n], NULL);
+    }
+    check(1, "8 threads x 400 gets through the group-list lock completed");
+}
+
 static void test_fabric(void)
 {
     pmix_fabric_t fabric;
@@ -321,6 +377,7 @@ int main(int argc, char **argv)
     test_get_pointer_and_static();
     test_compute_distances();
     test_fabric();
+    test_group_lock_concurrency();
 
     rc = PMIx_Finalize(NULL, 0);
     if (PMIX_SUCCESS != rc) {

--- a/test/unit/client_api.c
+++ b/test/unit/client_api.c
@@ -251,6 +251,36 @@ static void test_compute_distances(void)
           "PMIx_Compute_distances_nb(cbfunc=NULL) returns PMIX_ERR_BAD_PARAM");
 }
 
+static void test_group_join_outparams(void)
+{
+    pmix_info_t *results;
+    size_t nresults;
+    pmix_proc_t leader;
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- PMIx_Group_join out-parameters --\n");
+
+    /* Poison them: they are OUT parameters the caller reads on return, and
+     * this call used to declare them unused, so whatever was on the stack
+     * was what the caller got back. A singleton cannot actually join
+     * anything, which is the point - the defaults must be established
+     * before the call can fail for any reason. */
+    results = (pmix_info_t *) (uintptr_t) 0xdeadbeef;
+    nresults = 12345;
+    PMIX_LOAD_PROCID(&leader, "no.such.nspace", 0);
+
+    rc = PMIx_Group_join("nosuchgroup", &leader, PMIX_GROUP_ACCEPT, NULL, 0,
+                         &results, &nresults);
+    check(PMIX_SUCCESS != rc, "PMIx_Group_join fails cleanly with no server");
+    check(NULL == results, "PMIx_Group_join defined *results on the failure path");
+    check(0 == nresults, "PMIx_Group_join defined *nresults on the failure path");
+
+    /* both are documented as optional, so a caller that does not want the
+     * values must be able to say so */
+    rc = PMIx_Group_join("nosuchgroup", &leader, PMIX_GROUP_ACCEPT, NULL, 0, NULL, NULL);
+    check(PMIX_SUCCESS != rc, "PMIx_Group_join accepts NULL results/nresults");
+}
+
 /* Hammer the paths that take the group-list lock. PMIx_Get with an explicit
  * namespace runs the caller's thread through
  * pmix_client_convert_group_procs(), which walks the group list under that
@@ -377,6 +407,7 @@ int main(int argc, char **argv)
     test_get_pointer_and_static();
     test_compute_distances();
     test_fabric();
+    test_group_join_outparams();
     test_group_lock_concurrency();
 
     rc = PMIx_Finalize(NULL, 0);


### PR DESCRIPTION
A review of `src/client`, in the same shape as #4058 was for `src/class`:
read the directory, fix what it turns up, add regression coverage for the
fixable parts, and write down what was learned.

> Rebased onto master now that #4058 has merged, so this is self-contained:
> thirteen commits, all `src/client` work.

## What was found

**Three reproducible segfaults**, each confirmed by reverting the fix and
re-crashing:

* `PMIx_Get_nb(NULL, PMIX_PROCID, ...)` — and the `PMIX_VERSION_NUMERIC` and
  `PMIX_RANK` shortcuts. Any request the library answers itself built a
  caddy with no "get logic" object and then released that field
  unconditionally. `PMIX_RELEASE` dereferences its argument.
* `PMIx_Get_nb` under `PMIX_GET_STATIC_VALUES` — the uninitialized `val`
  pointer was passed into the request parser, which dereferences it, so the
  parser's own "did the caller provide storage?" test read the stack.
* `PMIx_Get` under `PMIX_GET_REFRESH_CACHE` with the NULL `proc` the API
  explicitly permits.

**Six more crashes** on paths a singleton cannot reach: `PMIx_Get(val=NULL)`;
`PMIx_Spawn_nb` calling `pmix_basename(NULL)` on the documented-legal
argv-without-cmd branch; `PMIx_Spawn` copying a NULL nspace; the fabric `_nb`
pair and `PMIx_Compute_distances_nb` dereferencing a NULL caddy or callback;
`PMIx_Group_construct_nb` strdup'ing a NULL group ID.

**Two liveness bugs.** `_getnb_cbfunc()` released the caddy and returned when
the status unpack failed — that caddy is on the pending-request list with
other gets coalesced behind it, so this both stranded a blocking `PMIx_Get`
on a lock nothing would wake *and* freed the object it was waiting on.
`invite_setup()` waited on a lock unconditionally after two calls that only
fire their completion callback on success.

**Twelve leaks and lifetime errors** — message buffers on every
`PMIX_PTL_SEND_RECV` failure path, undestructed caddies, a missing
`infocopy`, a dangling `fabric->info` that double-freed on a second
deregister, an unchecked `PMIx_Info_list_convert` handing a destructor an
uninitialized pointer.

**Correctness.** `pmix_client_convert_group_procs()` silently dropped a proc
whose group rank was past the end of the membership, producing a short
participant list that failed much later as `PMIX_ERR_NOT_A_MEMBER` or as a
collective that never completed, with nothing pointing back at the
conversion.

**A second pass** covering three things the first pass recorded but did not
fix:

* **`pmix_client_globals.groups` had no lock**, but is not confined to one
  thread. The progress thread appends to it and — via the `PMIX_GROUP_LEFT`
  handler — shifts a departed proc out of a live membership array *in
  place*, while the caller's thread walks and removes from it in
  `PMIx_Group_leave_nb`, `PMIx_Group_destruct_nb`, and every collective that
  expands a group reference. Now guarded by `grouplock`, held off the
  progress-thread-waiting paths and off the bfrops path by snapshotting.
* **`PMIx_Commit` swallowed the server's status.** It used the generic
  `wait_cbfunc`, which discards the buffer, and declared success when the
  *send* was accepted. A commit the server rejected returned
  `PMIX_SUCCESS` — the one case the caller most needs to hear about.
* **`PMIx_Group_join` left `results`/`nresults` uninitialized.**

## What is *not* fixed here

`PMIx_Group_join` still returns empty results, which contradicts its man
page. Investigating why turned into **#4059**: the library has no way to
observe an event the application cannot suppress, so it cannot reliably see
the construct-complete event it would need. That issue also documents an
unbounded hang in `PMIx_Group_invite` from the same cause. Both are recorded
in the code and in `src/client/AGENTS.md` rather than papered over.

An earlier comment in `pmix_client_group.c` attributed the leader-watch
failure to the event "not being guaranteed to reach the acceptor". That is
wrong and is corrected here — the event arrives reliably; the library just
cannot see it. Leaving the old explanation in place would have sent the next
reader after a protocol problem that does not exist.

## Testing

* **`test/unit/client_api.c`** (new, in `make check`) — every case is a
  regression for a specific defect above. Runs as a singleton, so it needs
  no server or launcher. Includes an 8-thread hammer over the group-list
  lock, which hangs on a missed unlock.
* **`contrib/dockerswarm/run-client-tests.sh`** (new) — the multi-node half.
  Almost everything in `src/client` round-trips to a server, and a singleton
  reaches none of it, so this drives the `examples/` clients across the
  swarm with the ranks behind *different* PMIx servers: cross-server get,
  direct modex with requests pending, the realm-directed gets, publish/
  lookup, resolve, and spawn + connect across namespaces.
* `test/unit/AGENTS.md` (new) — the unit suite had no guidance of its own.

Verified: `make check` 35/35 unit + 15/15 server-driven, `simptest` clean,
zero warnings under `--enable-devel-check`. On a ten-container swarm:
12/12 group construction, 8/8 group events, 11/11 the new client suite.

## Drive-by

`contrib/dockerswarm/build.sh` linked the staged example clients with `-L`
but no `-Wl,-rpath`. That worked only while PMIx happened to be installed
somewhere the loader searches by default; once `build.sh` began installing
to `/opt/prte/pmix`, every rank of every group test died with
`libpmix.so.2: cannot open shared object file`. `LD_LIBRARY_PATH` in
`env.sh` does cover it, but `prted` does not give its children a login
shell. What the suite reported was nine tests failing with exit code 127 and
nothing pointing at a link line. Landed as its own commit.
