### PR TITLE
Two IOF fixes: relayed deliveries, and output that beats the spawn reply

### DIFF
--- a/docs/man/man3/PMIx_server_IOF_deliver.3.rst
+++ b/docs/man/man3/PMIx_server_IOF_deliver.3.rst
@@ -98,6 +98,19 @@ forwarded data. Unrecognized attributes are ignored.
 * ``PMIX_IOF_XML_OUTPUT`` (bool) |mdash| the output should be formatted in XML.
 * ``PMIX_IOF_OUTPUT_RAW`` (bool) |mdash| deliver the output without buffering it
   into complete lines.
+* ``PMIX_IOF_LOCAL_OUTPUT`` (bool) |mdash| whether this server is to write the
+  payload to its own ``stdout``/``stderr`` and to any output files the source
+  namespace was registered with, in addition to delivering it to registered
+  clients. Absent this attribute the server writes locally exactly as it does
+  for the processes it hosts, which is what a host normally wants. Pass it as
+  ``false`` when the payload is **not this server's to emit** |mdash| a host
+  that relays another server's output here solely because a tool attached here
+  asked for it, for example. Without it the relaying and the hosting server
+  both emit the same bytes, and with an output-file directive in effect that
+  means two servers writing the same file. This governs only the local emit;
+  delivery to registered clients is unaffected, and the attribute reaches them
+  with the rest of the ``info`` array, where it carries no meaning |mdash| a
+  client decides its own local output from its own configuration.
 
 
 CALLBACK FUNCTION

--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -56,6 +56,7 @@
 #define PMIX_CAP_IOF_FILE_PATTERN 9
 #define PMIX_CAP_CLI_ORDER       10
 #define PMIX_CAP_TOOL_FINALIZED  11
+#define PMIX_CAP_IOF_DELIVER_LOCAL 12
 
 
 /*****    DEPRECATED    *****/

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1788,6 +1788,30 @@ static pmix_iof_flags_t spawn_or_global_flags(void)
     return pmix_globals.iof_flags;
 }
 
+/* The stand-in above answers two questions, and both of its answers have to
+ * be used or the second one is silently the process-wide default instead.
+ * HOW to format the output is one; WHETHER to write it at all is the other,
+ * and that is the one that was being dropped.
+ *
+ * A tool that spawned a job with an output-to-file directive is told not to
+ * write that job's output locally - PMIX_IOF_FILE_ONLY, which is the default
+ * for such a spawn, becomes local_output=false on the namespace when the
+ * spawn reply lands. Output that arrives BEFORE that reply finds no namespace
+ * record, so it fell through to pmix_globals.iof_flags.local_output - true
+ * for a tool - and went to the terminal after all. The result was that a
+ * nondeterministic subset of the job's output appeared on a terminal the user
+ * had asked to keep clean: whichever ranks' first chunk beat the reply.
+ */
+static pmix_iof_flags_t stand_in_flags(bool *outputio)
+{
+    pmix_iof_flags_t flags = spawn_or_global_flags();
+
+    if (flags.local_output_given) {
+        *outputio = flags.local_output;
+    }
+    return flags;
+}
+
 pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
                                     pmix_iof_channel_t stream,
                                     const pmix_byte_object_t *bo)
@@ -1885,10 +1909,10 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
             }
             myflags = nptr->iof_flags;
         } else {
-            myflags = spawn_or_global_flags();
+            myflags = stand_in_flags(&outputio);
         }
     } else {
-        myflags = spawn_or_global_flags();
+        myflags = stand_in_flags(&outputio);
     }
 
     if (!outputio) {

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3056,10 +3056,13 @@ static void _iofdeliver(int sd, short args, void *cbdata)
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
     pmix_iof_req_t *req;
     bool found = false;
+    bool outputlocal;
     pmix_iof_cache_t *iof;
     int i;
     size_t n;
-    pmix_status_t rc;
+    /* the local write used to be unconditional and was what first set this;
+     * skipping it must not leave the completion status undefined */
+    pmix_status_t rc = PMIX_SUCCESS;
 
     PMIX_ACQUIRE_OBJECT(cd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
@@ -3070,10 +3073,27 @@ static void _iofdeliver(int sd, short args, void *cbdata)
                         PMIx_IOF_channel_string(cd->channels),
                         (int)cd->bo->size);
 
+    /* The host may be handing us output that is not ours to emit - a runtime
+     * relaying another node's output to us solely because a tool attached
+     * here asked for it is the case this exists for. Writing it out again
+     * here would duplicate whatever the server that owns those processes
+     * already wrote, and with output-to-file directives in play that means
+     * two servers writing the same file. So let the host say so per
+     * delivery, using the same attribute that says it at registration. */
+    outputlocal = true;
+    for (n = 0; n < cd->ninfo; n++) {
+        if (PMIX_CHECK_KEY(&cd->info[n], PMIX_IOF_LOCAL_OUTPUT)) {
+            outputlocal = PMIX_INFO_TRUE(&cd->info[n]);
+            break;
+        }
+    }
+
     /* output it locally if requested */
-    rc = pmix_iof_write_output(cd->procs, cd->channels, cd->bo);
-    if (0 > rc) {
-        goto done;
+    if (outputlocal) {
+        rc = pmix_iof_write_output(cd->procs, cd->channels, cd->bo);
+        if (0 > rc) {
+            goto done;
+        }
     }
 
     /* cycle across our list of IOF requests and see who wants


### PR DESCRIPTION
Two independent IOF fixes. They are unrelated to each other and are
separate commits, so they can be split into two PRs if preferred.

## 1. Let a host say an IOF delivery is not ours to write

`PMIx_server_IOF_deliver` assumes anything the host hands it is this
server's own output to emit: it writes the payload to stdout/err and to
any output files the source namespace was registered with, then forwards
it to the clients that asked for it.

That is wrong for a relay. When a tool attaches to a server other than
the one hosting the processes it is watching, only the tool's server can
deliver to it — so the runtime has to move that output there. The server
it lands on then emits a second copy of bytes the owning server already
wrote, and because every server in such a runtime typically registers the
namespace with the same directives, an output-to-file directive means two
servers writing one file.

`PMIX_IOF_LOCAL_OUTPUT` already exists and this call already accepts an
info array that was being forwarded and nothing else. It is now honored
there:

- absent, the server writes locally exactly as before — no existing
  caller changes behavior;
- given as `false`, the payload is delivered to registered requestors and
  not emitted.

`PMIX_CAP_IOF_DELIVER_LOCAL` lets a host detect the support, and the
attribute is documented on the `PMIx_server_IOF_deliver` man page.

**Measured, not assumed.** With a runtime relaying under this directive,
a node hosting only a tool writes no output files. Flipping the directive
to `true` and rebuilding puts a full duplicate set of the job's
`--output file=` files on that node.

## 2. Use the stand-in spawn flags to decide whether to write

A tool that spawns a job with an output-to-file directive is told not to
write that job's output locally: `PMIX_IOF_FILE_ONLY` is the default for
such a spawn and becomes `local_output=false` on the namespace when the
spawn reply lands. Output arriving *before* that reply finds no namespace
record, so the decision fell through to the process-wide flag — which for
a tool says to write it.

A nondeterministic subset of the job's output therefore landed on a
terminal the user had asked to keep clean: whichever ranks' first chunk
beat the reply, about one rank in two. Which ranks leaked varied run to
run, so a single clean run proved nothing.

`spawn_or_global_flags()` already stashes the right answer for exactly
that window, but it answers two questions and only one was being used —
*how* to format the output, never *whether* to write it. It now answers
both.

Reproducer, against a DVM with ranks on two nodes:

```
prun --output file=/tmp/of/out --host node1:1,node2:1 -n 2 --map-by node hostname
```

Documented behavior is that this prints nothing (`NOCOPY` is the default
qualifier). Before: one of the two ranks printed, 5 runs out of 5. After:
nothing, 5 out of 5, while `--output file=X:copy` still delivers every
rank and the files are still written.

## Testing

Both fixes were exercised end-to-end against a ten-node container runtime
(PRRTE's `contrib/dockerswarm`), building PMIx from this branch: 363 cases
passed, 0 failed, including new cases for both fixes. Each new case was
confirmed to fail with its fix reverted and the tree rebuilt, rather than
assumed to have teeth. `make check` passes and the docs build warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)