### PR TITLE
Review src/class: repair the container classes, fix the class-init lock, and export what consumers link

### DIFF
--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -410,8 +410,23 @@ containers tells you nothing that running it once does not. The distributed
 dimension of these classes is *cross-process on one node*:
 `pmix_hash_table_t` and `pmix_pointer_array_t` are TMA-aware precisely so
 `gds/shmem3` can build them inside an mmap'd segment a server shares with
-its local clients — and that path is exercised by `run-tests.sh`, whose
-group cases drive a real datastore on each node.
+its local clients.
+
+That cross-process dimension is covered directly by
+`test/unit/class/class_tma_shared`, which this script picks up
+automatically (the program list is read out of `Makefile.am`). It builds
+those containers, and an object several processes retain and release at
+once, inside a real `MAP_SHARED` segment, and verifies from a second
+process that the storage and the reference count are genuinely shared —
+the two claims `src/class/AGENTS.md` makes about the TMA path. It is also
+the one member of the suite for which the ten-node contention pass below
+is more than a load test. What it does *not* model is segment negotiation
+and attach between **unrelated** processes: its second process comes from
+`fork()`, so the segment lands at the same address and the embedded
+`pmix_tma_t`'s function pointers stay valid. Real `gds/shmem3` peers do
+neither, which is why `pmix_hash_table.c` skips its key-type assert for
+TMA tables. That half stays with `run-tests.sh`, whose group cases drive a
+real datastore on each node.
 
 What this script is for is the two configurations `make check` on a
 developer's machine does not produce:

--- a/contrib/dockerswarm/run-class-tests.sh
+++ b/contrib/dockerswarm/run-class-tests.sh
@@ -23,9 +23,19 @@
 # that running it once does not.  The distributed dimension of these classes
 # is *cross-process, same node*: pmix_hash_table_t and pmix_pointer_array_t
 # are TMA-aware precisely so gds/shmem3 can build them inside an mmap'd
-# segment a server shares with its local clients.  That path is already
-# covered by run-tests.sh, whose group cases drive a real datastore on each
-# node -- not by anything a class unit test could do on its own.
+# segment a server shares with its local clients.
+#
+# That dimension is now tested directly.  test/unit/class/class_tma_shared
+# builds those containers, and an object whose reference count several
+# processes hammer at once, inside a real MAP_SHARED segment, and checks
+# from a second process that the storage and the count are genuinely
+# shared.  It comes along automatically in the run below (the program list
+# is read out of Makefile.am), and being multi-process it is the one member
+# of the suite for which the ten-node contention pass below is more than a
+# load test.  What it does NOT cover is segment negotiation and attach
+# between *unrelated* processes -- its second process comes from fork().
+# That remains gds/shmem3's, exercised by run-tests.sh's group cases
+# driving a real datastore on each node.
 #
 # WHAT THE SWARM DOES BUY
 #

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,54 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Repaired a set of init, teardown and argument-checking defects in the
+   src/class container classes. pmix_hash_table_construct() left ht_label
+   uninitialized, and that field is read and printed by src/util/pmix_hash.c
+   behind only a NULL test, so every table that does not set its own label
+   carried garbage there. The base class descriptor carried NULL
+   constructor and destructor arrays, so PMIX_DESTRUCT on a statically
+   initialized object that had not yet been constructed dereferenced NULL.
+   The ring buffer's destructor left head and tail behind a freed array, so
+   a pop after destruct followed them; its init never set them, so
+   re-initializing a used ring returned one still claiming the old
+   occupancy. Two failed-realloc paths (pmix_bitmap_set_bit,
+   pmix_value_array_init) leaked the old block and left a NULL pointer
+   behind a non-zero size. Two guards - the NULL check in
+   pmix_bitmap_num_set_bits, and a negative-index assert in
+   pmix_pointer_array_test_and_set_item - were absent from every build
+   that ships, the first because it sat inside PMIX_ENABLE_DEBUG and the
+   second because configure adds -DNDEBUG whenever --enable-debug is off.
+   pmix_list_insert accepted a negative index and inserted anyway,
+   pmix_hash_table_init2 used its two ratios without validating them, and
+   pmix_next_poweroftwo shifted a signed int by 31 and by 32
+ - Made the double-checked lock behind lazy class initialization correct.
+   Every PMIX_NEW and PMIX_CONSTRUCT tests whether a class is initialized
+   without taking the class mutex, and both that flag and the epoch were
+   plain int, so a thread could observe the new epoch with nothing
+   ordering it against the constructor array the initializing thread had
+   just built. Both are C11 atomics now, published with a release store
+   after the arrays are written and read with an acquire. This does not
+   change the size of pmix_class_t, so consumers that declare their own
+   classes are unaffected. ThreadSanitizer reports seven data races in
+   pmix_class_initialize against the old code and none against the new
+ - Removed two dead members of the object model: pmix_tma_t's tma_memmove
+   and pmix_list_item_t's item_free. Both were written and never read, and
+   there was no helper through which tma_memmove could even be called.
+   Both live in structures gds/shmem3 builds inside the segment it shares
+   with its local clients, so dropping them moves every field below - a
+   cross-version change, made now while the gds/shmem2 to gds/shmem3
+   rename earlier in this cycle still covers it, since that rename has not
+   yet appeared in a release. pmix_object_t shrinks from 104 to 96 bytes
+   and pmix_list_t from 248 to 232 (measured --enable-debug)
+ - Gave a default-visibility descriptor to every class declared in an
+   installed header. Without it a consumer can include the header but
+   cannot link PMIX_NEW or PMIX_CONSTRUCT on the class, and the failure is
+   invisible in a tree configured --disable-visibility - which is how
+   these are usually built. PRRTE has no object system of its own and uses
+   this one directly, and one of the descriptors it needs
+   (pmix_mca_base_var_file_value_t) was hidden; test/unit could not link
+   at all against a default-visibility build. Classes declared only in
+   headers that are not installed remain hidden
  - Renamed the gds/shmem2 component to gds/shmem3. The component shares
    memory layout rather than a wire format - the server builds the job's
    data structures inside a segment its local clients map and read in

--- a/src/class/AGENTS.md
+++ b/src/class/AGENTS.md
@@ -101,9 +101,47 @@ Rules that trip people up:
 - **Never call `pmix_obj_run_constructors`/`_destructors` or
   `pmix_obj_new_tma` directly** — always go through the macros.
 - Every class provides a **`PMIX_*_STATIC_INIT`** macro for
-  file-scope/stack objects that must be usable before any constructor
-  runs (e.g. `PMIX_LIST_STATIC_INIT`, `PMIX_HASH_TABLE_STATIC_INIT`).
-  Prefer it to `PMIX_CONSTRUCT` for statics.
+  file-scope/stack objects that need a defined state before any
+  constructor runs (e.g. `PMIX_LIST_STATIC_INIT`,
+  `PMIX_HASH_TABLE_STATIC_INIT`). Read the box below before relying on
+  one: they are **not** a substitute for `PMIX_CONSTRUCT`, and for
+  `pmix_list_t` the statically initialized object is not even usable.
+
+> ### A `PMIX_*_STATIC_INIT` object is tagged with the *base* class
+>
+> Every one of these macros expands to
+> `PMIX_OBJ_STATIC_INIT(pmix_object_t)`, which sets `obj_class` to
+> `&pmix_object_t_class` — **not** to the derived class's descriptor. Two
+> consequences, neither obvious from the macro:
+>
+> - `PMIX_DESTRUCT` on such an object does **not** run the derived
+>   destructor. It runs `pmix_object_t`'s (empty) chain. For a statically
+>   initialized object that is the right answer — it owns nothing yet —
+>   but it means a STATIC_INIT is not interchangeable with a construct.
+> - `pmix_object_t_class` is pre-marked initialized, so
+>   `pmix_class_initialize` never runs for it and never builds its
+>   constructor/destructor arrays. Those arrays used to be `NULL`, and
+>   both `pmix_obj_run_constructors` and `_destructors` walk them with
+>   `while (NULL != *array)` — so `PMIX_DESTRUCT` (or a `PMIX_RELEASE`
+>   reaching zero) on a never-constructed STATIC_INIT object
+>   **dereferenced NULL and took SIGSEGV**. They are now empty,
+>   terminated arrays and it is a correct no-op. Do not set them back to
+>   `NULL`; `test/unit/class/class_object.c` pins this.
+>
+> The invariant to hold onto: a STATIC_INIT gives the object a *defined*
+> state, and the matching `PMIX_CONSTRUCT` at init time is what makes it
+> a live instance of its own class. Every in-tree use does both.
+
+**When you add a `STATIC_INIT` macro, diff it against the constructor
+field by field.** This has been wrong four separate times —
+`PMIX_HOTEL_STATIC_INIT` disagreed about `last_unoccupied_room` (a live
+bug: `pmix_globals.notifications` reported a free room before
+`pmix_hotel_init` ran), `PMIX_POINTER_ARRAY_STATIC_INIT` had `max_size`
+and `block_size` at 0 against the constructor's `INT_MAX` and 8 (a
+divide-by-zero in `grow_table`), and `PMIX_LIST_ITEM_STATIC_INIT` had
+`item_free` at 0 against the constructor's 1 (that field has since been
+deleted as dead). Each class's unit test now compares the two structs
+member by member; keep that up for new ones.
 
 ### Reference counting is a C11 atomic
 
@@ -163,6 +201,28 @@ and it needs the shared-memory component renamed in the same commit
 series.** This applies to *any* class here, not just the base — a field
 added to `pmix_list_t` has exactly the same effect.
 
+Two dead fields were deleted on top of the `shmem3` rename, before it
+shipped, which moved the layout again (measured `--enable-debug`,
+arm64):
+
+| | before | after |
+|---|---|---|
+| `pmix_tma_t` | 64 | 56 |
+| `pmix_object_t` | 104 | 96 |
+| `pmix_list_item_t` | 136 | 128 |
+| `pmix_list_t` | 248 | 232 |
+| `pmix_list_length` offset | 240 | 224 |
+
+**No further rename was needed, and the reason is worth understanding
+rather than copying.** The `shmem2` → `shmem3` rename in this same
+development cycle had not appeared in any release — every release branch
+(`v5.0`, `v6.0`, `v6.1`) still shipped `shmem2`, and no tag contained the
+rename. One rename covers every layout change made before the new name
+ships, because what protects an old peer is not recognising the *name*.
+Check that before assuming you get a free ride: `git tag --contains` the
+rename commit and look at what the release branches actually carry. Once
+`shmem3` is released, the next layout change needs `shmem4`.
+
 
 In `--enable-debug` builds each object carries a magic ID
 (`PMIX_OBJ_MAGIC_ID`) plus the file/line of last construction; the
@@ -177,7 +237,33 @@ pattern. Do not write tests that do it.
 
 `pmix_class_initialize` records every initialized class's allocated
 descriptor arrays in a global `classes[]` table (guarded by a private
-`class_mutex`). `pmix_class_finalize()` frees them all. It is called
+`class_mutex`). `pmix_class_finalize()` frees them all.
+
+**Lazy class init is a double-checked lock, and the fast path is
+unlocked.** Every `PMIX_NEW`/`PMIX_CONSTRUCT` tests
+`PMIX_CLASS_IS_INITIALIZED(cls)` *without* taking `class_mutex`, and only
+calls `pmix_class_initialize` when the class looks stale. That makes the
+ordering rules load-bearing:
+
+- `cls_initialized` and `pmix_class_init_epoch` are
+  `pmix_atomic_int32_t`, not `int`.
+- `pmix_class_initialize` publishes with a **release** store, and it does
+  so **last** — after `cls_depth`, `cls_construct_array`,
+  `cls_destruct_array` and their contents are all written.
+- `PMIX_CLASS_IS_INITIALIZED` **acquires**. Unlocking the mutex is not
+  enough to order this, because the reader never takes the mutex.
+
+These were plain `int` accesses, which is the textbook broken
+double-checked lock: a thread could observe the new epoch and then call
+through a `cls_construct_array` it had no ordering against. ThreadSanitizer
+reports seven data races inside `pmix_class_initialize` against the old
+code and none against the current code; `class_refcount`'s
+"class init race" case is what drives it (see
+[`test/unit/class/AGENTS.md`](../../test/unit/class/AGENTS.md)). Note this
+did **not** change `sizeof(pmix_class_t)` — a lock-free `_Atomic int32_t`
+matches `int` in size and alignment — so external consumers with their own
+`PMIX_CLASS_INSTANCE` are unaffected. If you touch this, keep the
+release/acquire pair and keep the publish last. It is called
 exactly once per role, as the **absolute last** thing before exit
 (`src/server/pmix_server.c`, `src/client/pmix_client.c`,
 `src/tool/pmix_tool.c`), purely so valgrind/purify report a clean
@@ -222,10 +308,20 @@ What this means when working in `src/class`:
   `tma_malloc` is non-NULL. Because of that convention, a partially
   filled-in TMA is a bug. Copy an existing static-init block verbatim,
   or better, call `pmix_obj_construct_tma()` — which is the *one* place
-  that clears all eight `pmix_tma_t` members. `pmix_obj_new_tma()` used
-  to carry its own copy of that code and cleared only seven, leaving
-  `tma_memmove` holding whatever `malloc` returned in every heap object
-  in the library. Do not write a second copy.
+  that clears every `pmix_tma_t` member. `pmix_obj_new_tma()` used to
+  carry its own copy of that code and cleared one member fewer, leaving a
+  stray function pointer holding whatever `malloc` returned in every heap
+  object in the library. Do not write a second copy.
+- **`pmix_tma_t` has seven members and a TMA must fill in all of them.**
+  It briefly had an eighth, `tma_memmove`, which was declared, cleared in
+  three places, asserted clear by the unit test — and never assigned or
+  called anywhere. There was no `pmix_tma_memmove()` helper beside the
+  other five, so nothing could reach it; `gds/shmem3` filled in the other
+  five and skipped it. It has been deleted (see the layout note above for
+  why that was affordable). If you ever want it back, add the
+  `pmix_tma_*` inline and wire up every TMA implementation in the same
+  change — a member nothing sets is a member that reads as garbage the
+  moment someone starts calling it.
 
 ## The container classes
 
@@ -263,6 +359,16 @@ mostly spelled out in the header's opening comment:
   `pmix_list_join` are O(N) only because they must fix that count.
 - `pmix_list_sort` sorts via an array of pointers + `qsort`; its compare
   function receives **double pointers** (`pmix_list_item_t **`).
+- **`pmix_list_insert` rejects a negative index.** It used to check only
+  the upper bound, so a computed index that went negative fell through
+  the walk (which ran zero times) and landed the item at position 1,
+  returning `true`.
+- `pmix_list_item_t` briefly carried an `item_free` field that the
+  constructor set and nothing ever read. It has been deleted along with
+  `tma_memmove` (see the layout note above). If you find yourself wanting
+  a per-item flag, note that the debug-only `pmix_list_item_refcount` /
+  `pmix_list_item_belong_to` pair already answers "is this item on a
+  list", and adding a field here is a layout change.
 - **`pmix_list_insert` cannot append.** It inserts *before* an existing
   item, so `idx` must be strictly less than the length: the
   one-past-the-end position that would mean "append" is rejected, and an
@@ -322,7 +428,25 @@ Grows when density crosses `ht_growth_trigger` (default 1/2, doubling).
 Iterate with `PMIX_HASH_TABLE_FOREACH(key, uint32|uint64|ptr, val, ht)`;
 do not remove during a foreach. TMA-aware.
 
-Two things about this class that will surprise you:
+`ht_label` is a debugging label the table itself never sets and never
+reads — but `src/util/pmix_hash.c` prints it at four sites as
+`(NULL == table->ht_label) ? "UNKNOWN" : table->ht_label`. That NULL test
+is the only thing between `%s` and a wild pointer, and the constructor
+used to skip the field entirely: `PMIX_NEW` mallocs without zeroing, so
+every table that does not set its own label (`gds/shmem3`'s, the mca
+base's) carried garbage there. The constructor now clears it. If you add
+a member to this struct, add it to the constructor in the same edit —
+that is the whole defence.
+
+`pmix_hash_table_init2` is a `PMIX_EXPORT` entry point taking two ratios,
+and it now validates them. A zero `density_numer` divided by zero on its
+first line and a zero `growth_denom` did the same inside
+`pmix_hash_grow`; less loudly, a growth factor that does not grow, or a
+density of 1/1 or looser, lets the table fill completely — and since
+every get/set/remove probes with an unbounded `for (;; ii += 1)`, a full
+table is an infinite loop rather than an error.
+
+Two more things about this class that will surprise you:
 
 - **A "get" writes to the table.** Every `pmix_hash_table_get_value_*`
   assigns `ht->ht_type_methods` before probing — that is how the table
@@ -380,6 +504,17 @@ correct because `tail == head` whenever the ring is full. That invariant
 is not asserted anywhere. Do not "simplify" that function without
 convincing yourself of it.
 
+`tail == -1` is this class's "nothing has been pushed yet" flag, and it is
+the field the teardown and re-init paths kept forgetting: the destructor
+freed `addr` and zeroed `size` but left `head`/`tail` alone, so
+`pmix_ring_buffer_pop` on a destructed ring took its "something is on the
+ring" branch and dereferenced the NULL `addr` the destructor had just
+installed; and `pmix_ring_buffer_init` never set them at all, so
+re-initializing a used ring both leaked the old storage and handed back a
+"fresh" ring still claiming the old one's occupancy. Both now reset the
+pair, and `PMIX_RING_BUFFER_STATIC_INIT` (added alongside) spells `tail`
+as `-1` rather than the `0` a plain zero-initializer would give.
+
 ### `pmix_value_array_t` — by-value dynamic array
 
 A growable array that stores elements **by value** (contiguous
@@ -387,7 +522,12 @@ A growable array that stores elements **by value** (contiguous
 `pmix_value_array_init(&a, sizeof(elem))`. Get/set by index (auto-growing
 on set), append, remove-with-shift. `PMIX_VALUE_ARRAY_GET_ITEM` /
 `_SET_ITEM` / `_GET_BASE` are unchecked, fast, typed macros — the caller
-owns bounds-checking. Not TMA-aware.
+owns bounds-checking. Not TMA-aware. `pmix_value_array_init` rejects a
+zero `item_sizeof` (every address in the class is
+`index * array_item_sizeof`, so a zero collapses the array onto one
+slot), and holds the grown buffer aside rather than assigning a failed
+`realloc` back over the live one — the correction `reserve` and
+`set_size` already carried.
 
 ### `pmix_bitmap_t` — auto-expanding bit array
 
@@ -397,6 +537,18 @@ A bitmap over `uint64_t` words. `set_bit` auto-expands the array to fit
 rather than expanding. Provides find-first-unset-and-set, whole-bitmap
 and/or/xor, population counts, copy, compare, and a `_get_string`
 debugging dump. Not TMA-aware.
+
+`max_size` is a public *bit* count on the way in and a **word** count once
+stored (`pmix_bitmap_set_max_size` converts); the constructor and
+`PMIX_BITMAP_STATIC_INIT` both leave it at `INT_MAX`, i.e. uncapped. Two
+things here were the directory's standing anti-patterns in miniature:
+`pmix_bitmap_set_bit`'s growth path assigned a failed `realloc` straight
+back into `bm->bitmap`, leaking the old block and leaving a NULL pointer
+behind a non-zero `array_size` for every later accessor to index (the same
+correction `pmix_bitmap_init` and `pmix_bitmap_copy` had already had); and
+`pmix_bitmap_num_set_bits`'s NULL/negative-length guard sat inside
+`#if PMIX_ENABLE_DEBUG`, so an optimized library read `bm->array_size`
+off a NULL pointer. Both are unconditional now.
 
 ## Directory layout
 
@@ -414,8 +566,9 @@ src/class/
 └── Makefile.am                builds noinst libpmix_class.la; installs headers
 
 test/unit/class/               one make-check program per class, plus
-                               class_refcount for the concurrent count;
-                               see its AGENTS.md
+                               class_refcount for the concurrent count and
+                               class_tma_shared for the cross-process TMA
+                               path; see its AGENTS.md
 contrib/dockerswarm/run-class-tests.sh
                                runs that suite --disable-debug with
                                default visibility, on Linux
@@ -451,15 +604,25 @@ this directory has had:
   non-trivial change here.
 - A multi-*node* test is not meaningful for this directory — these are
   single-process data structures. The genuinely distributed dimension is
-  the cross-process TMA path (`gds/shmem3`), which the group tests in
-  `contrib/dockerswarm/run-tests.sh` exercise.
+  the cross-process TMA path, and that now has a direct test:
+  `test/unit/class/class_tma_shared` builds a `pmix_hash_table_t`, a
+  `pmix_pointer_array_t` and a reference-counted object inside a real
+  `MAP_SHARED` segment and checks from a second process that the storage
+  and the count are genuinely shared. It is in `make check` and, being
+  multi-process, is the one member of the suite the swarm's ten-node
+  contention pass says something about. It stops short of segment
+  negotiation and attach between *unrelated* processes — its second
+  process comes from `fork()` — which stays with `gds/shmem3` and the
+  group tests in `contrib/dockerswarm/run-tests.sh`.
 
 ## Threading
 
 With one exception, these classes are **not internally synchronized**.
 The exception is the `pmix_object_t` reference count, which is a C11
 atomic so `PMIX_RETAIN`/`PMIX_RELEASE` are safe from any thread and from
-any process sharing a TMA segment. That is the whole of the guarantee:
+any process sharing a TMA segment (`class_refcount` and
+`class_tma_shared` pin those two halves respectively). That is the whole
+of the guarantee:
 the count is safe, the *object* is not. Two threads that both hold a
 reference still race on every field below `pmix_object_t`.
 
@@ -518,6 +681,17 @@ consumable internal surface — keep them clean.
   `pmix_output` belongs inside the `#if`. Several defects in this
   directory were exactly this mistake, and they are invisible in the
   configuration everyone develops in.
+- **A bare `assert()` is a debug-only check too.** `config/pmix.m4` adds
+  `-DNDEBUG` to `CFLAGS` whenever `--enable-debug` is off, so every
+  `assert` in this directory compiles to nothing in every build that
+  ships. That is fine for a spot-check on an invariant the code
+  establishes itself; it is not fine as the only thing standing between a
+  caller's argument and an out-of-bounds write.
+  `pmix_pointer_array_test_and_set_item` guarded its index with
+  `assert(index >= 0)` alone, so a negative index wrote below the start
+  of `addr` in exactly the builds that matter — while its sibling
+  `pmix_pointer_array_set_item` had always rejected it outright. If the
+  check is about *caller input*, write an `if` and return an error.
 - **Leave objects in the constructed state when you destruct them.**
   The destructors here now do (`pmix_list_destruct` always did — it
   calls the constructor). Freeing a pointer and leaving it in the struct
@@ -533,6 +707,65 @@ consumable internal surface — keep them clean.
   descriptor is hidden outside `libpmix` and `PMIX_NEW(pmix_foo_t)` will
   not link for any consumer — a failure you cannot see locally if your
   tree is configured `--disable-visibility`.
+
+  **The rule, stated as a boundary:** every class declared in an
+  **installed** header must have an exported descriptor. An installed
+  header *is* the consumable surface — `PRRTE` has no object system of
+  its own and drives PMIx's directly (hundreds of `PMIX_NEW` sites, plus
+  its own classes declared with `PMIX_CLASS_DECLARATION`) — so a class
+  you can `#include` but not link is simply broken as shipped. Classes in
+  headers that are *not* installed should stay hidden; exporting those
+  only grows the dynamic symbol table and wrongly advertises them as
+  consumable. The exception is a class an in-tree `test/unit` program
+  needs, since those link against `libpmix` from outside it too
+  (`pmix_gds_base_active_module_t` is the one such case today).
+
+  **Two places can do the exporting, and that is why this is hard to
+  audit.** Either the declaration in the header:
+
+  ```c
+  PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_foo_t);   /* pmix_foo.h */
+  ```
+
+  or the definition in the `.c`:
+
+  ```c
+  PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_foo_t, ...); /* pmix_foo.c */
+  ```
+
+  Either one gives the symbol default visibility, so **grepping the
+  headers overcounts what is actually broken** — of 59 bare declarations
+  in installed headers, only 31 were genuinely hidden; the rest were
+  exported at the definition site. Prefer the declaration form (it is
+  what the header promises the reader), but when you want the truth, ask
+  the library rather than the source:
+
+  ```sh
+  nm -m src/.libs/libpmix.dylib | grep '_class$' | grep non-external   # macOS
+  readelf -sW src/.libs/libpmix.so | grep '_class$' | grep LOCAL       # Linux
+  ```
+
+  Do that against a tree configured **without** `--disable-visibility`,
+  or every symbol looks fine.
+
+  **And determine "installed" from the install tree, not from the
+  `Makefile.am`s.** Headers reach `$(pmixincludedir)` through several
+  variables and conditional blocks, and a hand-rolled parse of the
+  `headers =` lists undercounts badly — it missed 36 of the 115 headers
+  PMIx actually installs, including `src/server/pmix_server_ops.h`,
+  `src/event/pmix_event.h` and every framework `base/base.h`. Just
+  `make install` to a scratch prefix and look:
+
+  ```sh
+  find $PREFIX/include/pmix -name '*.h' | sed "s|$PREFIX/include/pmix/||"
+  ```
+
+  As of this sweep, 134 class descriptors are defined in `libpmix`, 103
+  are exported, and the 31 that remain hidden are correctly hidden: 27
+  are private to a single `.c` (no header declaration at all) and 4 are
+  `gds/hash` component internals (`pmix_session_t`, `pmix_job_t`,
+  `pmix_apptrkr_t`, `pmix_nodeinfo_t`) whose header is not installed. No
+  class declared in an installed header is hidden.
 - **Keep it warning-free and portable.** This code runs on every platform
   PMIx supports and is compiled with `-Werror` in CI. Use the
   `__pmix_attribute_*__` wrappers and `PMIX_HIDE_UNUSED_PARAMS` rather

--- a/src/class/pmix_bitmap.c
+++ b/src/class/pmix_bitmap.c
@@ -143,11 +143,18 @@ int pmix_bitmap_set_bit(pmix_bitmap_t *bm, int bit)
             new_size = bm->max_size;
 
         /* New size is just a multiple of the original size to fit in
-         the index. */
-        bm->bitmap = (uint64_t *) realloc(bm->bitmap, new_size * sizeof(uint64_t));
-        if (NULL == bm->bitmap) {
+         the index. Hold the grown pointer aside until it is in hand:
+         assigning a failed realloc() straight back into bm->bitmap both
+         leaks the old allocation and leaves a NULL pointer behind a
+         non-zero array_size, so every later is_set_bit/clear_bit/
+         num_set_bits indexed NULL instead of reporting the failure. The
+         same correction was already made in pmix_bitmap_init() and
+         pmix_bitmap_copy(); this path was missed. */
+        uint64_t *grown = (uint64_t *) realloc(bm->bitmap, new_size * sizeof(uint64_t));
+        if (NULL == grown) {
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
+        bm->bitmap = grown;
 
         /* zero out the new elements */
         memset(&bm->bitmap[bm->array_size], 0, (new_size - bm->array_size) * sizeof(uint64_t));
@@ -388,6 +395,11 @@ char *pmix_bitmap_get_string(pmix_bitmap_t *bitmap)
 
 int pmix_bitmap_num_unset_bits(pmix_bitmap_t *bm, int len)
 {
+    /* Answer for a bad argument the same way num_set_bits() does, rather
+     * than reporting "len bits are unset" for a bitmap that does not exist. */
+    if ((len < 0) || NULL == bm) {
+        return 0;
+    }
     return (len - pmix_bitmap_num_set_bits(bm, len));
 }
 
@@ -395,13 +407,18 @@ int pmix_bitmap_num_set_bits(pmix_bitmap_t *bm, int len)
 {
     int i, cnt = 0;
     uint64_t val;
-    int i_len = len / SIZE_OF_BASE_TYPE + (len % SIZE_OF_BASE_TYPE == 0 ? 0 : 1);
+    int i_len;
 
-#if PMIX_ENABLE_DEBUG
+    /* This guard used to sit inside "#if PMIX_ENABLE_DEBUG", so the only
+     * builds that had it were the ones nobody ships: an optimized library
+     * read bm->array_size straight off a NULL bm. Every other entry point
+     * in this file rejects a NULL bitmap unconditionally. Only the
+     * diagnostic belongs behind the debug switch, never the check. */
     if ((len < 0) || NULL == bm) {
         return 0;
     }
-#endif
+
+    i_len = len / SIZE_OF_BASE_TYPE + (len % SIZE_OF_BASE_TYPE == 0 ? 0 : 1);
 
     for (i = 0; i < i_len && i < bm->array_size; ++i) {
         if (0 == (val = bm->bitmap[i]))

--- a/src/class/pmix_bitmap.h
+++ b/src/class/pmix_bitmap.h
@@ -44,6 +44,7 @@
 
 #include "src/include/pmix_config.h"
 
+#include <limits.h>
 #include <string.h>
 
 #include "src/class/pmix_object.h"
@@ -54,12 +55,28 @@ struct pmix_bitmap_t {
     pmix_object_t super; /**< Subclass of pmix_object_t */
     uint64_t *bitmap;    /**< The actual bitmap array of characters */
     int array_size;      /**< The actual array size that maintains the bitmap */
-    int max_size;        /**< The maximum size that this bitmap may grow (optional) */
+    int max_size;        /**< The maximum size that this bitmap may grow (optional),
+                              held internally as a count of 64-bit words, not
+                              of bits -- see pmix_bitmap_set_max_size() */
 };
 
 typedef struct pmix_bitmap_t pmix_bitmap_t;
 
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_bitmap_t);
+
+/* Static initializer, matching pmix_bitmap_construct() field for field.
+ * max_size is INT_MAX (i.e. effectively uncapped) because that is what the
+ * constructor sets; a zero there would reject every subsequent
+ * pmix_bitmap_init() and pmix_bitmap_set_bit(). This yields a usable but
+ * empty bitmap -- set_bit() will grow it from nothing, so an explicit
+ * pmix_bitmap_init() is optional rather than mandatory. */
+#define PMIX_BITMAP_STATIC_INIT                     \
+{                                                   \
+    .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
+    .bitmap = NULL,                                 \
+    .array_size = 0,                                \
+    .max_size = INT_MAX                             \
+}
 
 /**
  * Set the maximum size of the bitmap.

--- a/src/class/pmix_hash_table.c
+++ b/src/class/pmix_hash_table.c
@@ -77,6 +77,14 @@ PMIX_CLASS_INSTANCE(pmix_hash_table_t, pmix_object_t, pmix_hash_table_construct,
 
 static void pmix_hash_table_construct(pmix_hash_table_t *ht)
 {
+    /* ht_label is a real, read field, not decoration: src/util/pmix_hash.c
+     * prints it as "(NULL == table->ht_label) ? "UNKNOWN" : table->ht_label"
+     * at several verbosity-gated sites. Leaving it out of the constructor
+     * meant every table that does not set one carried whatever malloc()
+     * returned -- PMIX_NEW does not zero its allocation -- so that NULL test
+     * passed on garbage and the %s dereferenced a wild pointer. gds/shmem3
+     * and the mca base tables are all built this way. */
+    ht->ht_label = NULL;
     ht->ht_table = NULL;
     ht->ht_capacity = ht->ht_size = ht->ht_growth_trigger = 0;
     ht->ht_density_numer = ht->ht_density_denom = 0;
@@ -113,8 +121,30 @@ pmix_hash_table_init2(pmix_hash_table_t *ht, size_t estimated_max_size, int dens
                       int density_denom, int growth_numer, int growth_denom)
 {
     pmix_tma_t *const tma = pmix_obj_get_tma(&ht->super);
-    size_t est_capacity = estimated_max_size * density_denom / density_numer;
-    size_t capacity = pmix_hash_round_capacity_up(est_capacity);
+    size_t est_capacity, capacity;
+
+    /* Validate the two ratios before dividing by either denominator. This
+     * is a PMIX_EXPORT entry point ("this could be the new init if people
+     * wanted a more general API"), so it has to survive its arguments:
+     *
+     *  - a zero density_numer divides by zero right below;
+     *  - a zero growth_denom divides by zero in pmix_hash_grow();
+     *  - a growth factor that does not actually grow (numer <= denom) leaves
+     *    pmix_hash_grow() returning a table no larger than the one it
+     *    replaced, so the table eventually fills completely and the
+     *    unbounded linear probe in every get/set/remove spins forever.
+     *  - a density of 1/1 or worse lets the table fill before the growth
+     *    trigger ever fires, with the same result.
+     */
+    if (0 >= density_numer || 0 >= density_denom || density_numer >= density_denom) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (0 >= growth_numer || 0 >= growth_denom || growth_numer <= growth_denom) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    est_capacity = estimated_max_size * density_denom / density_numer;
+    capacity = pmix_hash_round_capacity_up(est_capacity);
     ht->ht_table = (pmix_hash_element_t *)pmix_tma_calloc(tma, capacity, sizeof(pmix_hash_element_t));
     if (PMIX_UNLIKELY(NULL == ht->ht_table)) {
         return PMIX_ERR_OUT_OF_RESOURCE;

--- a/src/class/pmix_hash_table.h
+++ b/src/class/pmix_hash_table.h
@@ -366,26 +366,44 @@ pmix_hash_table_sizeof_hash_element(void);
  *
  * @returns The next power of two
  *
- * WARNING: *NO* error checking is performed.  This is meant to be a
- * fast inline function.
+ * WARNING: minimal error checking is performed.  This is meant to be a
+ * fast inline function.  A negative value, or one whose answer will not
+ * fit in a positive int, yields 0 -- there is no representable result.
  * Using __builtin_clz (count-leading-zeros) uses 4 cycles instead of 77
  * compared to the loop-version (on Intel Nehalem -- with icc-12.1.0 -O2).
+ *
+ * Note that both arms compute this in *unsigned* arithmetic. The shift
+ * distance reaches 31 for the largest inputs, and "1 << 31" on a signed
+ * int overflows into the sign bit, which is undefined; so did the
+ * __builtin_clz arm's shift by 32 for a negative value, whose leading-zero
+ * count is 0.
  */
 static inline int pmix_next_poweroftwo(int value)
 {
-    int power2;
+    unsigned int power2;
+
+    if (PMIX_UNLIKELY(0 >= value)) {
+        /* 0 has no set bits to round up past; a negative value has no
+         * power-of-two successor representable in an int. */
+        return (0 == value) ? 1 : 0;
+    }
+    if (PMIX_UNLIKELY(value >= (int) (1u << 30))) {
+        /* This function returns the power of two strictly *above* its
+         * argument, so 1<<30 already wants 1<<31 -- not a positive int. */
+        return 0;
+    }
 
 #if PMIX_C_HAVE_BUILTIN_CLZ
-    if (PMIX_UNLIKELY(0 == value)) {
-        return 1;
-    }
-    power2 = 1 << (8 * sizeof(int) - __builtin_clz(value));
+    power2 = 1u << (8 * sizeof(int) - (unsigned int) __builtin_clz((unsigned int) value));
 #else
-    for (power2 = 1; value > 0; value >>= 1, power2 <<= 1) /* empty */
-        ;
+    {
+        unsigned int v = (unsigned int) value;
+        for (power2 = 1u; 0 != v; v >>= 1, power2 <<= 1) /* empty */
+            ;
+    }
 #endif
 
-    return power2;
+    return (int) power2;
 }
 
 /**

--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -197,8 +197,9 @@ PMIX_EXPORT pmix_status_t pmix_hotel_init(pmix_hotel_t *hotel, int num_rooms,
  *
  * @return PMIX_SUCCESS if the occupant is successfully checked in,
  * and the room parameter will contain a valid value.
- * @return PMIX_ERR_TEMP_OUT_OF_RESOURCE is the hotel is full.  Try
- * again later.
+ * @return PMIX_ERR_OUT_OF_RESOURCE if the hotel is full (room_num is set
+ * to -1).  Try again later.  Note that this is a transient condition, not
+ * an allocation failure -- rooms free up as occupants check out.
  */
 static inline pmix_status_t pmix_hotel_checkin(pmix_hotel_t *hotel, void *occupant, int *room_num)
 {

--- a/src/class/pmix_list.c
+++ b/src/class/pmix_list.c
@@ -106,7 +106,11 @@ bool pmix_list_insert(pmix_list_t *list, pmix_list_item_t *item, long long idx)
     int i;
     volatile pmix_list_item_t *ptr, *next;
 
-    if (idx >= (long long) list->pmix_list_length) {
+    /* idx has to name an existing item to insert before. A negative one used
+     * to slip past the upper-bound test alone: the walk below then ran zero
+     * times, the item landed at position 1 (or into an empty list), and the
+     * call reported success. */
+    if (idx < 0 || idx >= (long long) list->pmix_list_length) {
         return false;
     }
 

--- a/src/class/pmix_list.c
+++ b/src/class/pmix_list.c
@@ -49,7 +49,6 @@ PMIX_CLASS_INSTANCE(pmix_list_t, pmix_object_t, pmix_list_construct, pmix_list_d
 static void pmix_list_item_construct(pmix_list_item_t *item)
 {
     item->pmix_list_next = item->pmix_list_prev = NULL;
-    item->item_free = 1;
 #if PMIX_ENABLE_DEBUG
     item->pmix_list_item_refcount = 0;
     item->pmix_list_item_belong_to = NULL;

--- a/src/class/pmix_list.h
+++ b/src/class/pmix_list.h
@@ -105,7 +105,6 @@ struct pmix_list_item_t {
     /**< Pointer to next list item */
     volatile struct pmix_list_item_t *pmix_list_prev;
     /**< Pointer to previous list item */
-    int32_t item_free;
 
 #if PMIX_ENABLE_DEBUG
     /** Atomic reference count for debugging */
@@ -119,13 +118,14 @@ struct pmix_list_item_t {
  */
 typedef struct pmix_list_item_t pmix_list_item_t;
 
-/* static initializer for pmix_list_t */
+/* static initializer for pmix_list_item_t.
+ *
+ * Keep this in step with pmix_list_item_construct(), field for field. */
 #define PMIX_LIST_ITEM_STATIC_INIT                      \
     {                                                   \
         .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
         .pmix_list_next = NULL,                         \
-        .pmix_list_prev = NULL,                         \
-        .item_free = 0                                  \
+        .pmix_list_prev = NULL                          \
     }
 
 /**

--- a/src/class/pmix_object.c
+++ b/src/class/pmix_object.c
@@ -36,20 +36,48 @@
 #include "src/class/pmix_object.h"
 
 /*
+ * Empty (NULL-terminated) constructor and destructor arrays for the base
+ * class.
+ *
+ * These have to be real, terminated arrays rather than NULL. Because
+ * pmix_object_t_class is pre-marked initialized, pmix_class_initialize()
+ * never runs for it and never fills these in -- so whatever is here is
+ * what pmix_obj_run_constructors()/_destructors() will walk, and both walk
+ * with "while (NULL != *array)". A NULL array meant they dereferenced NULL
+ * instead of finding an immediate end marker.
+ *
+ * That is reachable: every PMIX_*_STATIC_INIT macro expands to
+ * PMIX_OBJ_STATIC_INIT(pmix_object_t), which tags the object with *this*
+ * descriptor rather than the derived one. So PMIX_DESTRUCT (or a
+ * PMIX_RELEASE that reaches zero) on a statically initialized object that
+ * has not yet been PMIX_CONSTRUCT'ed segfaulted -- precisely the "give a
+ * file-scope object a defined state so an early failure path can tear it
+ * down" case those macros exist for. With an empty array it is the correct
+ * no-op: a statically initialized object owns nothing to release.
+ *
+ * Note this does not make PMIX_DESTRUCT run the *derived* destructor for
+ * such an object -- obj_class still says pmix_object_t. Once the object
+ * has been PMIX_CONSTRUCT'ed the class descriptor is the real one and the
+ * full destructor chain runs as usual.
+ */
+static pmix_construct_t pmix_object_t_construct_array[] = {NULL};
+static pmix_destruct_t pmix_object_t_destruct_array[] = {NULL};
+
+/*
  * Instantiation of class descriptor for the base class.  This is
  * special, since be mark it as already initialized, with no parent
  * and no constructor or destructor.
  */
 PMIX_EXPORT pmix_class_t pmix_object_t_class = {
-    "pmix_object_t",      /* name */
-    NULL,                 /* parent class */
-    NULL,                 /* constructor */
-    NULL,                 /* destructor */
-    1,                    /* initialized  -- this class is preinitialized */
-    0,                    /* class hierarchy depth */
-    NULL,                 /* array of constructors */
-    NULL,                 /* array of destructors */
-    sizeof(pmix_object_t) /* size of the pmix object */
+    "pmix_object_t",                /* name */
+    NULL,                           /* parent class */
+    NULL,                           /* constructor */
+    NULL,                           /* destructor */
+    1,                              /* initialized  -- this class is preinitialized */
+    0,                              /* class hierarchy depth */
+    pmix_object_t_construct_array,  /* array of constructors (empty) */
+    pmix_object_t_destruct_array,   /* array of destructors (empty) */
+    sizeof(pmix_object_t)           /* size of the pmix object */
 };
 
 int pmix_class_init_epoch = 1;

--- a/src/class/pmix_object.c
+++ b/src/class/pmix_object.c
@@ -80,7 +80,7 @@ PMIX_EXPORT pmix_class_t pmix_object_t_class = {
     sizeof(pmix_object_t)           /* size of the pmix object */
 };
 
-int pmix_class_init_epoch = 1;
+pmix_atomic_int32_t pmix_class_init_epoch = 1;
 
 /*
  * Local variables
@@ -115,9 +115,12 @@ void pmix_class_initialize(pmix_class_t *cls)
 
     /* If another thread initializing this same class came in at
        roughly the same time, it may have gotten the lock and
-       initialized.  So check again. */
+       initialized.  So check again.  Relaxed is enough here: we hold the
+       mutex, so the winner's release store already happened-before this
+       point by way of the lock. */
 
-    if (pmix_class_init_epoch == cls->cls_initialized) {
+    if (atomic_load_explicit(&cls->cls_initialized, memory_order_relaxed)
+        == atomic_load_explicit(&pmix_class_init_epoch, memory_order_relaxed)) {
         pthread_mutex_unlock(&class_mutex);
         return;
     }
@@ -175,7 +178,16 @@ void pmix_class_initialize(pmix_class_t *cls)
     }
     *cls_destruct_array = NULL; /* end marker for the destructors */
 
-    cls->cls_initialized = pmix_class_init_epoch;
+    /* Publish LAST, and with release semantics.  This is the store the
+       unlocked PMIX_CLASS_IS_INITIALIZED() fast path acquires: every write
+       above -- cls_depth, cls_construct_array, cls_destruct_array and the
+       entries in them -- must be visible to any thread that observes this
+       epoch, or that thread calls through a half-built array.  Unlocking
+       the mutex below is not sufficient: the fast-path reader never takes
+       it. */
+    atomic_store_explicit(&cls->cls_initialized,
+                          atomic_load_explicit(&pmix_class_init_epoch, memory_order_relaxed),
+                          memory_order_release);
     save_class(cls);
 
     /* All done */
@@ -189,12 +201,18 @@ void pmix_class_initialize(pmix_class_t *cls)
 int pmix_class_finalize(void)
 {
     int i;
+    int32_t epoch;
 
-    if (INT_MAX == pmix_class_init_epoch) {
-        pmix_class_init_epoch = 1;
+    /* Documented as the absolute last call in a role, so there is no
+       contention to order against here -- but the fast path reads this
+       without the mutex, so the update is still an atomic store. */
+    epoch = atomic_load_explicit(&pmix_class_init_epoch, memory_order_relaxed);
+    if (INT_MAX == epoch) {
+        epoch = 1;
     } else {
-        pmix_class_init_epoch++;
+        epoch++;
     }
+    atomic_store_explicit(&pmix_class_init_epoch, epoch, memory_order_relaxed);
 
     if (NULL != classes) {
         for (i = 0; i < num_classes; ++i) {

--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -298,7 +298,19 @@ struct pmix_class_t {
     pmix_class_t *cls_parent;       /**< parent class descriptor */
     pmix_construct_t cls_construct; /**< class constructor */
     pmix_destruct_t cls_destruct;   /**< class destructor */
-    int cls_initialized;            /**< is class initialized */
+    /**
+     * Is this class initialized, and for which epoch.
+     *
+     * Atomic because this is the flag of a double-checked lock: every
+     * PMIX_NEW/PMIX_CONSTRUCT reads it *without* the class mutex to decide
+     * whether pmix_class_initialize() needs to run at all. That fast-path
+     * read has to synchronize-with the initializing thread's write, or a
+     * reader can observe the updated epoch while still seeing a stale
+     * cls_construct_array and then call through it. Always read it with
+     * PMIX_CLASS_IS_INITIALIZED() (acquire) and write it only in
+     * pmix_class_initialize() (release).
+     */
+    pmix_atomic_int32_t cls_initialized;
     int cls_depth;                  /**< depth of class hierarchy tree */
     pmix_construct_t *cls_construct_array;
     /**< array of parent class constructors */
@@ -307,7 +319,26 @@ struct pmix_class_t {
     size_t cls_sizeof; /**< size of an object instance */
 };
 
-PMIX_EXPORT extern int pmix_class_init_epoch;
+/**
+ * Bumped by pmix_class_finalize() so every class lazily re-initializes.
+ * Atomic for the same reason cls_initialized is: it is read on the
+ * unlocked fast path below.
+ */
+PMIX_EXPORT extern pmix_atomic_int32_t pmix_class_init_epoch;
+
+/**
+ * The fast-path test behind the double-checked lock: has this class been
+ * initialized for the current epoch?
+ *
+ * The acquire on cls_initialized pairs with the release store at the end
+ * of pmix_class_initialize(), so a thread that sees "yes" is guaranteed to
+ * see the constructor/destructor arrays that thread built. The epoch load
+ * can be relaxed -- it is only ever changed by pmix_class_finalize(),
+ * which is documented as the absolute last call in a role.
+ */
+#define PMIX_CLASS_IS_INITIALIZED(cls)                                          \
+    (atomic_load_explicit(&(cls)->cls_initialized, memory_order_acquire)        \
+     == atomic_load_explicit(&pmix_class_init_epoch, memory_order_relaxed))
 
 /**
  * For static initializations of OBJects.
@@ -562,7 +593,7 @@ static inline void pmix_obj_construct_tma(pmix_object_t *obj, pmix_tma_t *tma)
 #define PMIX_CONSTRUCT_INTERNAL_TMA(object, type, t)               \
     do {                                                           \
         PMIX_SET_MAGIC_ID((object), PMIX_OBJ_MAGIC_ID);            \
-        if (pmix_class_init_epoch != (type)->cls_initialized) {    \
+        if (!PMIX_CLASS_IS_INITIALIZED(type)) {                    \
             pmix_class_initialize((type));                         \
         }                                                          \
         ((pmix_object_t *) (object))->obj_class = (type);          \
@@ -697,7 +728,7 @@ static inline pmix_object_t *pmix_obj_new_tma(pmix_class_t *cls, pmix_tma_t *tma
 
     object = (pmix_object_t *) pmix_tma_malloc(tma, cls->cls_sizeof);
 
-    if (pmix_class_init_epoch != cls->cls_initialized) {
+    if (!PMIX_CLASS_IS_INITIALIZED(cls)) {
         pmix_class_initialize(cls);
     }
     if (NULL != object) {

--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -225,12 +225,6 @@ typedef struct pmix_tma {
      */
     /** Pointer to the TMA's strdup() function. */
     char *(*tma_strdup)(struct pmix_tma *, const char *s);
-    /**
-     * A memmove()-like function that copies the provided contents to an
-     * appropriate location in the memory area maintained by the allocator.
-     * Like memmove(), it returns a pointer to the content's destination.
-     */
-    void *(*tma_memmove)(struct pmix_tma *tma, const void *src, size_t n);
     /** Pointer to the TMA's free() function. */
     void (*tma_free)(struct pmix_tma *, void *);
     /** Points to a user-defined TMA context. */
@@ -356,7 +350,6 @@ PMIX_EXPORT extern pmix_atomic_int32_t pmix_class_init_epoch;
                 .tma_calloc = NULL,                 \
                 .tma_realloc = NULL,                \
                 .tma_strdup = NULL,                 \
-                .tma_memmove = NULL,                \
                 .tma_free = NULL,                   \
                 .data_context = NULL,               \
                 .data_ptr = NULL                    \
@@ -374,7 +367,6 @@ PMIX_EXPORT extern pmix_atomic_int32_t pmix_class_init_epoch;
                 .tma_calloc = NULL,                 \
                 .tma_realloc = NULL,                \
                 .tma_strdup = NULL,                 \
-                .tma_memmove = NULL,                \
                 .tma_free = NULL,                   \
                 .data_context = NULL,               \
                 .data_ptr = NULL                    \
@@ -581,7 +573,6 @@ static inline void pmix_obj_construct_tma(pmix_object_t *obj, pmix_tma_t *tma)
         obj->obj_tma.tma_calloc = NULL;
         obj->obj_tma.tma_realloc = NULL;
         obj->obj_tma.tma_strdup = NULL;
-        obj->obj_tma.tma_memmove = NULL;
         obj->obj_tma.tma_free = NULL;
         obj->obj_tma.data_context = NULL;
         obj->obj_tma.data_ptr = NULL;

--- a/src/class/pmix_pointer_array.c
+++ b/src/class/pmix_pointer_array.c
@@ -343,7 +343,15 @@ int pmix_pointer_array_set_item(pmix_pointer_array_t *table, int index, void *va
 bool pmix_pointer_array_test_and_set_item(pmix_pointer_array_t *table, int index, void *value)
 {
     assert(table != NULL);
-    assert(index >= 0);
+
+    /* A bare assert() is not a guard here: configure adds -DNDEBUG whenever
+     * --enable-debug is off (config/pmix.m4), so in every build that ships
+     * this compiled away and a negative index wrote through table->addr
+     * below the start of the allocation. The sibling
+     * pmix_pointer_array_set_item() has always rejected it outright. */
+    if (PMIX_UNLIKELY(0 > index)) {
+        return false;
+    }
 
 #if 0
     pmix_output(0,"pmix_pointer_array_test_and_set_item: IN:  "

--- a/src/class/pmix_pointer_array.h
+++ b/src/class/pmix_pointer_array.h
@@ -33,6 +33,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include <limits.h>
+
 #include "src/class/pmix_object.h"
 #include "src/include/pmix_prefetch.h"
 
@@ -63,14 +65,21 @@ struct pmix_pointer_array_t {
     void **addr;
 };
 
+/* Keep this in step with pmix_pointer_array_construct(), field for field.
+ * max_size and block_size used to be zero here where the constructor sets
+ * INT_MAX and 8, so a statically initialized array that reached
+ * pmix_pointer_array_add() before pmix_pointer_array_init() divided by a
+ * zero block_size in grow_table() and took SIGFPE. Every in-tree use of
+ * this macro is followed by an init that overwrites both -- which is what
+ * kept that latent -- but the macro must still describe a usable object. */
 #define PMIX_POINTER_ARRAY_STATIC_INIT              \
 {                                                   \
     .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
     .lowest_free = 0,                               \
     .number_free = 0,                               \
     .size = 0,                                      \
-    .max_size = 0,                                  \
-    .block_size = 0,                                \
+    .max_size = INT_MAX,                            \
+    .block_size = 8,                                \
     .free_bits = NULL,                              \
     .addr = NULL                                    \
 }

--- a/src/class/pmix_ring_buffer.c
+++ b/src/class/pmix_ring_buffer.c
@@ -57,6 +57,12 @@ static void pmix_ring_buffer_destruct(pmix_ring_buffer_t *ring)
         ring->addr = NULL;
     }
 
+    /* Return to the constructed state, head and tail included. Clearing
+     * only addr and size left tail holding a live index over a NULL addr,
+     * so pmix_ring_buffer_pop() on a destructed ring took its "something is
+     * on the ring" branch and dereferenced addr[tail]. */
+    ring->head = 0;
+    ring->tail = -1;
     ring->size = 0;
 }
 
@@ -72,6 +78,15 @@ int pmix_ring_buffer_init(pmix_ring_buffer_t *ring, int size)
         return PMIX_ERR_BAD_PARAM;
     }
 
+    /* Re-initializing a ring that has been used before leaked its old
+     * storage and, worse, kept the old head/tail, so the fresh ring started
+     * out claiming entries that were not in it. */
+    if (NULL != ring->addr) {
+        free(ring->addr);
+        ring->addr = NULL;
+    }
+    ring->size = 0;
+
     /* Allocate and set the ring to NULL. Pass the count and the element
      * size as calloc()'s two arguments, in that order, so that calloc()
      * can do the multiplication overflow check it exists to do. */
@@ -80,6 +95,9 @@ int pmix_ring_buffer_init(pmix_ring_buffer_t *ring, int size)
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
     ring->size = size;
+    /* An empty ring: nothing has been pushed, so there is no oldest entry. */
+    ring->head = 0;
+    ring->tail = -1;
 
     return PMIX_SUCCESS;
 }

--- a/src/class/pmix_ring_buffer.h
+++ b/src/class/pmix_ring_buffer.h
@@ -56,6 +56,21 @@ typedef struct pmix_ring_buffer_t pmix_ring_buffer_t;
  */
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_ring_buffer_t);
 
+/* Static initializer, matching pmix_ring_buffer_construct() field for
+ * field. Note that tail is -1, not 0: -1 is how this class spells "nothing
+ * has been pushed yet", and a zero there would make pop() return addr[0]
+ * off a NULL ring. Unlike PMIX_LIST_STATIC_INIT this does produce a usable
+ * (empty) object, but pmix_ring_buffer_init() is still required before any
+ * push -- there is no storage until then. */
+#define PMIX_RING_BUFFER_STATIC_INIT                \
+{                                                   \
+    .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
+    .head = 0,                                      \
+    .tail = -1,                                     \
+    .size = 0,                                      \
+    .addr = NULL                                    \
+}
+
 /**
  * Initialize the ring buffer, defining its size.
  *

--- a/src/class/pmix_value_array.h
+++ b/src/class/pmix_value_array.h
@@ -75,12 +75,29 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_value_array_t);
 
 static inline int pmix_value_array_init(pmix_value_array_t *array, size_t item_sizeof)
 {
+    unsigned char *grown;
+
+    /* Every offset in this class is computed from the item size, so a zero
+     * one makes the array silently degenerate: each element lands at the
+     * same address and remove_item memmoves nothing. */
+    if (0 == item_sizeof) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* Hold the new pointer aside. Assigning a failed realloc() straight into
+     * array_items leaks whatever the array already owned and leaves a NULL
+     * buffer behind the item size and alloc size this call just committed --
+     * the same defect already corrected in pmix_value_array_reserve() and
+     * pmix_value_array_set_size(), missed here. */
+    grown = (unsigned char *) realloc(array->array_items, item_sizeof);
+    if (NULL == grown) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    array->array_items = grown;
     array->array_item_sizeof = item_sizeof;
     array->array_alloc_size = 1;
     array->array_size = 0;
-    array->array_items = (unsigned char *) realloc(array->array_items,
-                                                   item_sizeof * array->array_alloc_size);
-    return (NULL != array->array_items) ? PMIX_SUCCESS : PMIX_ERR_OUT_OF_RESOURCE;
+    return PMIX_SUCCESS;
 }
 
 /**

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -95,7 +95,7 @@ typedef struct {
     pmix_status_t *codes;
     size_t ncodes;
 } pmix_event_hdlr_t;
-PMIX_CLASS_DECLARATION(pmix_event_hdlr_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_event_hdlr_t);
 
 #define PMIX_EVENT_HDLR_STATIC_INIT         \
 {                                           \
@@ -123,7 +123,7 @@ typedef struct {
     size_t nregs;
     void *peer; // (pmix_peer_t *)
 } pmix_active_code_t;
-PMIX_CLASS_DECLARATION(pmix_active_code_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_active_code_t);
 
 /* define an object for housing the different lists of events
  * we have registered so we can easily scan them in precedent
@@ -138,7 +138,7 @@ typedef struct {
     pmix_list_t multi_events;
     pmix_list_t default_events;
 } pmix_events_t;
-PMIX_CLASS_DECLARATION(pmix_events_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_events_t);
 
 #define PMIX_EVENTS_STATIC_INIT                     \
 {                                                   \
@@ -193,7 +193,7 @@ typedef struct pmix_event_chain_t {
     pmix_op_cbfunc_t final_cbfunc;
     void *final_cbdata;
 } pmix_event_chain_t;
-PMIX_CLASS_DECLARATION(pmix_event_chain_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_event_chain_t);
 
 typedef struct {
     pmix_object_t super;
@@ -217,7 +217,7 @@ typedef struct {
     pmix_hdlr_reg_cbfunc_t evregcbfn;
     void *cbdata;
 } pmix_rshift_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_rshift_caddy_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_rshift_caddy_t);
 
 /* prepare a chain for processing by cycling across provided
  * info structs and translating those supported by the event

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -98,7 +98,7 @@ typedef struct {
     pmix_list_item_t super;
     pmix_name_t *pname;
 } pmix_namelist_t;
-PMIX_CLASS_DECLARATION(pmix_namelist_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_namelist_t);
 
 /* define structs for holding entries in the
  * show-help matrix */
@@ -204,7 +204,7 @@ typedef struct {
     char *source;
     void *object;
 } pmix_topo_obj_t;
-PMIX_CLASS_DECLARATION(pmix_topo_obj_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_topo_obj_t);
 
 /* define a command type for communicating to the
  * pmix server */
@@ -299,7 +299,7 @@ typedef struct {
     pmix_list_item_t super;
     char *path;
 } pmix_cleanup_file_t;
-PMIX_CLASS_DECLARATION(pmix_cleanup_file_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_cleanup_file_t);
 
 typedef struct {
     pmix_list_item_t super;
@@ -307,7 +307,7 @@ typedef struct {
     bool recurse;
     bool leave_topdir;
 } pmix_cleanup_dir_t;
-PMIX_CLASS_DECLARATION(pmix_cleanup_dir_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_cleanup_dir_t);
 
 /* define a struct to hold booleans controlling the
  * format/contents of the output */
@@ -381,7 +381,7 @@ typedef struct {
     pmix_iof_flags_t iof_flags;   // output formatting flags
     pmix_list_t sinks;   // IOF write events for output to files or directories
 } pmix_namespace_t;
-PMIX_CLASS_DECLARATION(pmix_namespace_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_namespace_t);
 
 /* define a caddy for quickly creating a list of pmix_namespace_t
  * objects for local, dedicated purposes */
@@ -389,20 +389,20 @@ typedef struct {
     pmix_list_item_t super;
     pmix_namespace_t *ns;
 } pmix_nspace_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_nspace_caddy_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_nspace_caddy_t);
 
 typedef struct {
     pmix_list_item_t super;
     pmix_namespace_t *ns;
     pmix_list_t envars;
 } pmix_nspace_env_cache_t;
-PMIX_CLASS_DECLARATION(pmix_nspace_env_cache_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_nspace_env_cache_t);
 
 typedef struct {
     pmix_list_item_t super;
     pmix_envar_t envar;
 } pmix_envar_list_item_t;
-PMIX_CLASS_DECLARATION(pmix_envar_list_item_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_envar_list_item_t);
 
 
 typedef struct pmix_rank_info_t {
@@ -418,7 +418,7 @@ typedef struct pmix_rank_info_t {
     int proc_cnt;        // #clones of this rank we know about
     void *server_object; // pointer to rank-specific object provided by server
 } pmix_rank_info_t;
-PMIX_CLASS_DECLARATION(pmix_rank_info_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_rank_info_t);
 
 /* define a very simple caddy for dealing with pmix_info_t
  * and pmix_query_t objects when transferring portions of arrays */
@@ -427,25 +427,25 @@ typedef struct {
     pmix_info_t *info;
     size_t ninfo;
 } pmix_info_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_info_caddy_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_info_caddy_t);
 
 typedef struct {
     pmix_list_item_t super;
     pmix_info_t info;
 } pmix_infolist_t;
-PMIX_CLASS_DECLARATION(pmix_infolist_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_infolist_t);
 
 typedef struct {
     pmix_list_item_t super;
     pmix_query_t query;
 } pmix_querylist_t;
-PMIX_CLASS_DECLARATION(pmix_querylist_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_querylist_t);
 
 typedef struct {
     pmix_list_item_t super;
     pmix_proc_t proc;
 } pmix_proclist_t;
-PMIX_CLASS_DECLARATION(pmix_proclist_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_proclist_t);
 
 /* object for tracking peers - each peer can have multiple
  * connections. This can occur if the initial app executes
@@ -480,13 +480,13 @@ typedef struct pmix_peer_t {
     uint32_t dyn_tags_current; // current tag for sendrecvs to this peer
     uint32_t dyn_tags_end; // upper limit of valid tags for sendrecvs to this peer
 } pmix_peer_t;
-PMIX_CLASS_DECLARATION(pmix_peer_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_peer_t);
 
 typedef struct {
     pmix_list_item_t super;
     pmix_peer_t *peer;
 } pmix_peerlist_t;
-PMIX_CLASS_DECLARATION(pmix_peerlist_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_peerlist_t);
 
 typedef struct {
     pmix_object_t super;
@@ -495,7 +495,7 @@ typedef struct {
     bool active;
     void *payload;
 } pmix_timer_t;
-PMIX_CLASS_DECLARATION(pmix_timer_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_timer_t);
 
 /* tracker for IOF requests */
 typedef struct {
@@ -516,7 +516,7 @@ typedef struct {
     pmix_hdlr_reg_cbfunc_t regcbfunc;
     void *cbdata;
 } pmix_iof_req_t;
-PMIX_CLASS_DECLARATION(pmix_iof_req_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_req_t);
 
 /* caddy for query requests */
 typedef struct {
@@ -544,7 +544,7 @@ typedef struct {
     pmix_validation_cbfunc_t validcbfunc;
     void *cbdata;
 } pmix_query_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_query_caddy_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_query_caddy_t);
 
 typedef struct {
     pmix_list_item_t super;
@@ -558,14 +558,14 @@ typedef struct {
      * requested and re-attach it to the destruct request. */
     bool notterm;
 } pmix_group_t;
-PMIX_CLASS_DECLARATION(pmix_group_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_group_t);
 
 typedef struct {
     pmix_list_item_t super;
     pmix_proc_t proc;
     pmix_byte_object_t blob;  // packed blob of info provided by this proc
 } pmix_grpinfo_t;
-PMIX_CLASS_DECLARATION(pmix_grpinfo_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_grpinfo_t);
 
 /* define a tracker for collective operations
  * - instanced in pmix_server_ops.c */
@@ -603,7 +603,7 @@ typedef struct {
     pmix_info_cbfunc_t info_cbfunc;
     void *cbdata;
 } pmix_server_trkr_t;
-PMIX_CLASS_DECLARATION(pmix_server_trkr_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_server_trkr_t);
 
 /* define an object for moving a send
  * request into the server's event base and
@@ -621,7 +621,7 @@ typedef struct {
     pmix_query_t *query;
     char *key;
 } pmix_server_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_server_caddy_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_server_caddy_t);
 
 /****    THREAD-RELATED    ****/
 /* define a caddy for thread-shifting operations */
@@ -669,7 +669,7 @@ typedef struct {
     void *relcbdata;
     size_t ref;
 } pmix_shift_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_shift_caddy_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_shift_caddy_t);
 
 typedef struct {
     pmix_object_t super;
@@ -692,7 +692,7 @@ typedef struct {
     bool appdirective;
     uint32_t appnum;
 } pmix_get_logic_t;
-PMIX_CLASS_DECLARATION(pmix_get_logic_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_get_logic_t);
 
 /* struct for tracking ops */
 typedef struct {
@@ -737,7 +737,7 @@ typedef struct {
     pmix_fabric_t *fabric;
     pmix_topology_t *topo;
 } pmix_cb_t;
-PMIX_CLASS_DECLARATION(pmix_cb_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_cb_t);
 
 #define PMIX_THREADSHIFT(r, c)                                                      \
     do {                                                                            \
@@ -800,7 +800,7 @@ typedef struct {
     pmix_op_cbfunc_t cbfunc;
     void *cbdata;
 } pmix_notify_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_notify_caddy_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_notify_caddy_t);
 
 typedef struct {
     pmix_object_t super;
@@ -809,7 +809,7 @@ typedef struct {
     /** Stores the next ID. */
     uint32_t next_id;
 } pmix_keyindex_t;
-PMIX_CLASS_DECLARATION(pmix_keyindex_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_keyindex_t);
 
 #define PMIX_KEYINDEX_STATIC_INIT                 \
 {                                                 \

--- a/src/mca/base/pmix_mca_base_alias.h
+++ b/src/mca/base/pmix_mca_base_alias.h
@@ -35,7 +35,7 @@ struct pmix_mca_base_alias_item_t {
 
 typedef struct pmix_mca_base_alias_item_t pmix_mca_base_alias_item_t;
 
-PMIX_CLASS_DECLARATION(pmix_mca_base_alias_item_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_alias_item_t);
 
 struct pmix_mca_base_alias_t {
     pmix_object_t super;
@@ -45,7 +45,7 @@ struct pmix_mca_base_alias_t {
 
 typedef struct pmix_mca_base_alias_t pmix_mca_base_alias_t;
 
-PMIX_CLASS_DECLARATION(pmix_mca_base_alias_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_alias_t);
 
 /**
  * @brief Create a alias for a component name.

--- a/src/mca/base/pmix_mca_base_var_enum.h
+++ b/src/mca/base/pmix_mca_base_var_enum.h
@@ -188,7 +188,7 @@ typedef struct pmix_mca_base_var_enum_flag_t pmix_mca_base_var_enum_flag_t;
 /**
  * Object declaration for pmix_mca_base_var_enum_t
  */
-PMIX_CLASS_DECLARATION(pmix_mca_base_var_enum_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_var_enum_t);
 
 /**
  * Create a new default enumerator

--- a/src/mca/base/pmix_mca_base_vari.h
+++ b/src/mca/base/pmix_mca_base_vari.h
@@ -95,7 +95,7 @@ typedef struct pmix_mca_base_var_file_value_t pmix_mca_base_var_file_value_t;
 /**
  * Object declaration for pmix_mca_base_var_file_value_t
  */
-PMIX_CLASS_DECLARATION(pmix_mca_base_var_file_value_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_var_file_value_t);
 
 /**
  * \internal

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -66,7 +66,7 @@ struct pmix_bfrops_base_active_module_t {
     pmix_bfrops_base_component_t *component;
 };
 typedef struct pmix_bfrops_base_active_module_t pmix_bfrops_base_active_module_t;
-PMIX_CLASS_DECLARATION(pmix_bfrops_base_active_module_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_bfrops_base_active_module_t);
 
 /* framework globals */
 struct pmix_bfrops_globals_t {

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -68,7 +68,7 @@ struct pmix_gds_base_active_module_t {
     pmix_gds_base_component_t *component;
 };
 typedef struct pmix_gds_base_active_module_t pmix_gds_base_active_module_t;
-PMIX_CLASS_DECLARATION(pmix_gds_base_active_module_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_gds_base_active_module_t);
 
 /* framework globals */
 struct pmix_gds_globals_t {

--- a/src/mca/plog/base/base.h
+++ b/src/mca/plog/base/base.h
@@ -68,7 +68,7 @@ struct pmix_plog_base_active_module_t {
     pmix_plog_base_component_t *component;
 };
 typedef struct pmix_plog_base_active_module_t pmix_plog_base_active_module_t;
-PMIX_CLASS_DECLARATION(pmix_plog_base_active_module_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_plog_base_active_module_t);
 
 /* framework globals */
 struct pmix_plog_globals_t {

--- a/src/mca/preg/base/base.h
+++ b/src/mca/preg/base/base.h
@@ -64,7 +64,7 @@ struct pmix_preg_base_active_module_t {
     pmix_mca_base_component_t *component;
 };
 typedef struct pmix_preg_base_active_module_t pmix_preg_base_active_module_t;
-PMIX_CLASS_DECLARATION(pmix_preg_base_active_module_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_preg_base_active_module_t);
 
 /* framework globals */
 struct pmix_preg_globals_t {

--- a/src/mca/psec/base/base.h
+++ b/src/mca/psec/base/base.h
@@ -64,7 +64,7 @@ struct pmix_psec_base_active_module_t {
     pmix_psec_base_component_t *component;
 };
 typedef struct pmix_psec_base_active_module_t pmix_psec_base_active_module_t;
-PMIX_CLASS_DECLARATION(pmix_psec_base_active_module_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_psec_base_active_module_t);
 
 /* framework globals */
 struct pmix_psec_globals_t {

--- a/src/mca/psensor/base/base.h
+++ b/src/mca/psensor/base/base.h
@@ -47,7 +47,7 @@ typedef struct {
     pmix_psensor_base_module_t *module;
     int priority;
 } pmix_psensor_active_module_t;
-PMIX_CLASS_DECLARATION(pmix_psensor_active_module_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_psensor_active_module_t);
 
 PMIX_EXPORT extern pmix_psensor_base_t pmix_psensor_base;
 

--- a/src/mca/pstat/base/base.h
+++ b/src/mca/pstat/base/base.h
@@ -154,7 +154,7 @@ typedef struct {
 	pmix_ndstats_t ndstats;
     pmix_cb_t *cb;
 } pmix_pstat_op_t;
-PMIX_CLASS_DECLARATION(pmix_pstat_op_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pstat_op_t);
 
 // p - pmix_pstat_op_t*
 // s - time in seconds

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -119,7 +119,7 @@ typedef struct {
     char *uri;
     char *version;
 } pmix_connection_t;
-PMIX_CLASS_DECLARATION(pmix_connection_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_connection_t);
 
 /* API stubs */
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_notification_cbfunc(pmix_ptl_cbfunc_t cbfunc);

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -244,7 +244,7 @@ typedef struct {
     char *sdptr;
     size_t sdbytes;
 } pmix_ptl_send_t;
-PMIX_CLASS_DECLARATION(pmix_ptl_send_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_ptl_send_t);
 
 /* structure for recving a message */
 typedef struct {
@@ -258,7 +258,7 @@ typedef struct {
     char *rdptr;
     size_t rdbytes;
 } pmix_ptl_recv_t;
-PMIX_CLASS_DECLARATION(pmix_ptl_recv_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_ptl_recv_t);
 
 /* structure for tracking posted recvs */
 typedef struct {
@@ -269,7 +269,7 @@ typedef struct {
     pmix_ptl_cbfunc_t cbfunc;
     void *cbdata;
 } pmix_ptl_posted_recv_t;
-PMIX_CLASS_DECLARATION(pmix_ptl_posted_recv_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_ptl_posted_recv_t);
 
 /* struct for posting send/recv request */
 typedef struct {
@@ -282,7 +282,7 @@ typedef struct {
     pmix_ptl_cbfunc_t cbfunc;
     void *cbdata;
 } pmix_ptl_sr_t;
-PMIX_CLASS_DECLARATION(pmix_ptl_sr_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_ptl_sr_t);
 
 typedef struct {
     pmix_object_t super;
@@ -292,7 +292,7 @@ typedef struct {
     pmix_buffer_t *buf;
     pmix_ptl_tag_t tag;
 } pmix_ptl_queue_t;
-PMIX_CLASS_DECLARATION(pmix_ptl_queue_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_ptl_queue_t);
 
 /* define listener protocol types */
 typedef uint16_t pmix_listener_protocol_t;
@@ -327,7 +327,7 @@ typedef struct {
     gid_t gid;
     pmix_proc_type_t proc_type;
 } pmix_pending_connection_t;
-PMIX_CLASS_DECLARATION(pmix_pending_connection_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pending_connection_t);
 
 /* listener objects */
 typedef struct pmix_listener_t {
@@ -345,7 +345,7 @@ typedef struct pmix_listener_t {
     uint32_t mode;
     pmix_ptl_pending_cbfunc_t cbfunc;
 } pmix_listener_t;
-PMIX_CLASS_DECLARATION(pmix_listener_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_listener_t);
 
 #define PMIX_LISTENER_STATIC_INIT           \
 {                                           \

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -38,7 +38,7 @@ typedef struct {
     pmix_event_t ev;
     pmix_server_trkr_t *trk;
 } pmix_trkr_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_trkr_caddy_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_trkr_caddy_t);
 
 typedef struct {
     pmix_object_t super;
@@ -80,7 +80,7 @@ typedef struct {
     pmix_spawn_cbfunc_t spcbfunc;
     void *cbdata;
 } pmix_setup_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_setup_caddy_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_setup_caddy_t);
 
 /* define a callback function returning inventory */
 typedef void (*pmix_inventory_cbfunc_t)(pmix_status_t status, pmix_list_t *inventory, void *cbdata);
@@ -101,13 +101,13 @@ typedef struct {
     pmix_op_cbfunc_t opcbfunc;
     void *cbdata;
 } pmix_inventory_rollup_t;
-PMIX_CLASS_DECLARATION(pmix_inventory_rollup_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_inventory_rollup_t);
 
 typedef struct {
     pmix_list_item_t super;
     pmix_setup_caddy_t *cd;
 } pmix_dmdx_remote_t;
-PMIX_CLASS_DECLARATION(pmix_dmdx_remote_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_dmdx_remote_t);
 
 typedef struct {
     pmix_list_item_t super;
@@ -117,7 +117,7 @@ typedef struct {
     pmix_info_t *info;    // array of info structs for this request
     size_t ninfo;         // number of info structs
 } pmix_dmdx_local_t;
-PMIX_CLASS_DECLARATION(pmix_dmdx_local_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_dmdx_local_t);
 
 typedef struct {
     pmix_list_item_t super;
@@ -128,7 +128,7 @@ typedef struct {
     pmix_modex_cbfunc_t cbfunc; // cbfunc to be executed when data is available
     void *cbdata;
 } pmix_dmdx_request_t;
-PMIX_CLASS_DECLARATION(pmix_dmdx_request_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_dmdx_request_t);
 
 /* event/error registration book keeping */
 typedef struct {
@@ -138,7 +138,7 @@ typedef struct {
     pmix_proc_t *affected;
     size_t naffected;
 } pmix_peer_events_info_t;
-PMIX_CLASS_DECLARATION(pmix_peer_events_info_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_peer_events_info_t);
 
 typedef struct {
     pmix_list_item_t super;
@@ -150,7 +150,7 @@ typedef struct {
     /* true if we have asked our host to forward this code to us */
     bool active;
 } pmix_regevents_info_t;
-PMIX_CLASS_DECLARATION(pmix_regevents_info_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_regevents_info_t);
 
 typedef struct {
     pmix_list_item_t super;
@@ -158,7 +158,7 @@ typedef struct {
     pmix_rank_t rank;
     size_t idx;
 } pmix_group_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_group_caddy_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_group_caddy_t);
 
 typedef struct {
     pmix_list_item_t super;
@@ -168,7 +168,7 @@ typedef struct {
     pmix_info_t *info;
     size_t ninfo;
 } pmix_iof_cache_t;
-PMIX_CLASS_DECLARATION(pmix_iof_cache_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_cache_t);
 
 typedef struct {
     pmix_list_item_t super;
@@ -176,7 +176,7 @@ typedef struct {
     pmix_proc_t *members;
     size_t nmembers;
 } pmix_pset_t;
-PMIX_CLASS_DECLARATION(pmix_pset_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pset_t);
 
 typedef struct {
     bool module_set;    // pmix_host_server has been set

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -75,7 +75,7 @@ typedef struct {
     int nseq;       // number of entries in seq
     int firstseq;   // position at which this option first appeared
 } pmix_cli_item_t;
-PMIX_CLASS_DECLARATION(pmix_cli_item_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_cli_item_t);
 
 typedef struct {
     pmix_object_t super;
@@ -83,7 +83,7 @@ typedef struct {
     char **tail;  // remainder of argv
     int nseq;  // number of occurrences recorded so far
 } pmix_cli_result_t;
-PMIX_CLASS_DECLARATION(pmix_cli_result_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_cli_result_t);
 
 #define PMIX_CLI_RESULT_STATIC_INIT                 \
 {                                                   \

--- a/test/unit/class/.gitignore
+++ b/test/unit/class/.gitignore
@@ -7,3 +7,4 @@ class_ring_buffer
 class_value_array
 class_hotel
 class_refcount
+class_tma_shared

--- a/test/unit/class/AGENTS.md
+++ b/test/unit/class/AGENTS.md
@@ -21,7 +21,8 @@ warning-free under `--enable-devel-check`) apply here too.
 
 ## Layout
 
-One program per class, plus one for concurrency:
+One program per class, plus two for concurrency — one across threads and
+one across processes:
 
 | Program | Subject |
 |---------|---------|
@@ -34,6 +35,7 @@ One program per class, plus one for concurrency:
 | `class_ring_buffer` | `pmix_ring_buffer_t` |
 | `class_hotel` | `pmix_hotel_t` (no event base — eviction timers are disabled) |
 | `class_refcount` | The reference count under concurrent threads |
+| `class_tma_shared` | The object model and the TMA-aware containers across a **process** boundary, in a shared `mmap` segment |
 
 Each is a standalone `main()` that prints `PASS:`/`FAIL:` per assertion
 via a local `report()` helper and exits non-zero if anything failed.
@@ -71,7 +73,14 @@ The tree everyone develops in — and the one
   an optimized build; `pmix_value_array_remove_item` rejected a bad index
   here and `memmove`'d a wrapped `size_t` length there.
 - A class descriptor missing `PMIX_EXPORT` **links**, because nothing is
-  hidden. `pmix_ring_buffer_t_class` was missing it for years.
+  hidden. `pmix_ring_buffer_t_class` was missing it for years, and
+  `pmix_server_trkr_t` / `pmix_server_caddy_t` / the `gds` active-module
+  class kept `test/unit` from linking at all on a default-visibility
+  tree — which nobody noticed, because nobody builds one. If you add a
+  test that names a library class, build it once without
+  `--disable-visibility` before you trust it. See the export rule in
+  [`src/class/AGENTS.md`](../../../src/class/AGENTS.md), including why
+  grepping the headers for `PMIX_EXPORT` gives the wrong answer.
 
 So a green run here proves less than it looks like it does. Several
 cases in the suite are labelled `(all builds)` precisely because they
@@ -85,8 +94,18 @@ contrib/dockerswarm/run-class-tests.sh linux    # or macos
 
 which builds and runs this suite `--disable-debug` with default symbol
 visibility (see `contrib/dockerswarm/README.md` §11). Run it after any
-non-trivial change to `src/class`. It is not a multi-node test and does
-not pretend to be — these are single-process data structures.
+non-trivial change to `src/class`. It reads the program list out of
+[`Makefile.am`](Makefile.am), so a new `class_*` test is picked up without
+touching the script. It is not a multi-node test and does not pretend to
+be — with the single exception of `class_tma_shared`, these are
+single-process data structures.
+
+A third gap worth knowing about: **a bare `assert()` is debug-only here
+too.** `config/pmix.m4` adds `-DNDEBUG` whenever `--enable-debug` is off,
+so asserts vanish in every shipping build exactly as a
+`#if PMIX_ENABLE_DEBUG` block does. A case that only proves "the assert
+fires" proves nothing about the library users get; write it against the
+return value instead.
 
 ## What these tests deliberately do not do
 
@@ -101,12 +120,13 @@ not pretend to be — these are single-process data structures.
   plain `PMIX_LIST_FOREACH`, and do not otherwise poke the debug
   spot-checks to see what happens. Those asserts exist to catch caller
   bugs; a test that trips one is a broken test.
-- **They do not test the TMA path.** Everything runs with the default
-  (libc) allocator. Exercising a real TMA means a shared-memory segment
-  and a second process, which is `gds/shmem3`'s territory — see the
-  group tests under `contrib/dockerswarm`. If you add TMA coverage here,
-  it needs a purpose-built allocator, not a partially filled-in
-  `pmix_tma_t` (see `pmix_obj_get_tma`'s convention).
+- **The per-class programs do not test the TMA path.** They all run with
+  the default (libc) allocator; TMA coverage lives in `class_tma_shared`
+  and nowhere else. Do not sprinkle a TMA through the others — a
+  half-hearted one is worse than none, because `pmix_obj_get_tma()`
+  decides "this object has a custom allocator" by testing `tma_malloc`
+  alone, so a partially filled-in `pmix_tma_t` reads as valid and then
+  calls through a NULL member.
 
 ## Writing a good case here
 
@@ -118,15 +138,59 @@ not pretend to be — these are single-process data structures.
   *hangs* without its fix, and the hotel static-init case takes SIGSEGV;
   both were verified by reintroducing the bug. A case that would only
   produce a subtly wrong number is worth less.
+- **Verify it by reintroducing the defect.** That is the standard here,
+  not a nicety: revert the fix, build (in the *optimized* configuration
+  if the guard was ever debug-gated), and confirm the case fails. Four of
+  the current regression cases crash outright when their fix is backed
+  out — `class_object`'s STATIC_INIT destruct, `class_bitmap`'s NULL
+  count, `class_pointer_array`'s negative index, `class_ring_buffer`'s
+  pop-after-destruct — which is how you know they are load-bearing.
 - **Do not bend a test to accommodate a bug.** If a case fails, the
   default assumption is that `src/class` is wrong. See the top-level
   guide.
 - **Keep white-box pokes rare and justified.** A couple of cases reach
   into struct members (`va.array_alloc_size`, `ring.addr`,
-  `base->obj_tma.tma_memmove`) because the state they describe is not
+  `base->obj_tma.tma_malloc`) because the state they describe is not
   reachable through the API. That is fine when the alternative is not
   testing a hang or an uninitialized field at all — but reach for the
   public call first.
+
+## `class_tma_shared`
+
+This is the only cross-**process** program in the suite, and the only one
+that exercises a TMA. It exists because two claims in
+[`src/class/AGENTS.md`](../../../src/class/AGENTS.md) were load-bearing
+and untested: that the C11 reference count is well defined for processes
+sharing a TMA segment (the `pthread_mutex_t` it replaced was never
+`PTHREAD_PROCESS_SHARED`, so this was undefined), and that
+`pmix_hash_table_t` and `pmix_pointer_array_t` allocate through
+`pmix_obj_get_tma()` rather than libc so a second process can read what
+the first built.
+
+It mmaps a `MAP_SHARED` segment, lays a bump allocator over it with every
+`pmix_tma_t` member filled in, builds the containers and an object
+inside it, and forks. Children read the containers back; one child writes
+and the parent reads the result; and six children hammer retain/release on
+one object and drop one net reference each, after which the parent checks
+that exactly its own reference survives.
+
+Two things to preserve if you extend it:
+
+- **The start barrier is not decoration.** Without it the children tend to
+  run one after another and a deliberately broken (non-atomic) count
+  survives by luck; with it, reintroducing a non-atomic `pmix_obj_update`
+  fails the case on every run. Verified both ways.
+- **Only one process mutates a container at a time.** These classes are
+  not internally synchronized and are not meant to be. The subject is
+  whether the *storage* is shared, not whether concurrent mutation is
+  safe — it is not.
+
+What it deliberately does not model: segment negotiation and attach
+between unrelated processes. Its second process comes from `fork()`, so
+the segment lands at the same address and the function pointers inside the
+embedded `pmix_tma_t` stay valid. Real `gds/shmem3` peers get neither —
+which is exactly why `pmix_hash_table.c` skips its key-type assert for TMA
+tables. That half belongs to `gds/shmem3` and the swarm group tests.
 
 ## `class_refcount`
 
@@ -145,6 +209,31 @@ a thread made before its last release are visible to that destructor
 (the `acq_rel` ordering). The test is written against the properties
 rather than the mechanism, so it does not need to change if the
 mechanism does.
+
+It carries one more case that is not about the refcount at all: **"class
+init race"**, which puts N threads on the first-ever use of a
+never-instantiated class so they all race into `pmix_class_initialize`.
+Lazy class init is a double-checked lock whose fast path is unlocked (see
+[`src/class/AGENTS.md`](../../../src/class/AGENTS.md)), and nothing else
+in this suite ever has two threads in it at once.
+
+**Be honest about what that case proves on its own: very little.** It
+cannot reliably fail on x86-64 or arm64 even with the release/acquire
+pair removed, because both give the plain load enough ordering in
+practice. Its value is that it creates the concurrency for a race
+detector to find. The real signal is ThreadSanitizer:
+
+```sh
+./configure --enable-debug CC=clang \
+    CFLAGS="-fsanitize=thread -g -O1" LDFLAGS="-fsanitize=thread"
+make && make -C test/unit/class class_refcount
+./test/unit/class/class_refcount
+```
+
+Against the plain-`int` version of `cls_initialized` that reports seven
+data races inside `pmix_class_initialize` and aborts; against the current
+code it reports none. If you change anything about class initialization,
+that is the check to run — not this program's exit status.
 
 The barrier is hand-rolled from a mutex and condvar because macOS has no
 `pthread_barrier_t`. No per-target thread flags are needed —

--- a/test/unit/class/Makefile.am
+++ b/test/unit/class/Makefile.am
@@ -14,11 +14,11 @@ AM_TESTS_ENVIRONMENT = . $(abs_top_builddir)/test/pmix_test_env.sh;
 
 check_PROGRAMS = class_object class_list class_bitmap class_hash_table \
     class_pointer_array class_ring_buffer class_value_array class_hotel \
-    class_refcount
+    class_refcount class_tma_shared
 
 TESTS = class_object class_list class_bitmap class_hash_table \
     class_pointer_array class_ring_buffer class_value_array class_hotel \
-    class_refcount
+    class_refcount class_tma_shared
 
 class_object_SOURCES = class_object.c
 class_object_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -69,7 +69,15 @@ class_refcount_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 class_refcount_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+# The one cross-process program in the suite: it exercises the object model
+# and the TMA-aware containers inside a shared mmap'd segment, from a second
+# process. That is the only genuinely distributed dimension src/class has.
+class_tma_shared_SOURCES = class_tma_shared.c
+class_tma_shared_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+class_tma_shared_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
 	rm -f class_object class_list class_bitmap class_hash_table \
 	    class_pointer_array class_ring_buffer class_value_array class_hotel \
-	    class_refcount
+	    class_refcount class_tma_shared

--- a/test/unit/class/class_bitmap.c
+++ b/test/unit/class/class_bitmap.c
@@ -511,6 +511,67 @@ static void test_reinit(void)
 
 /* ------------------------------------------------------------------ */
 
+/* The NULL/negative-length guard in pmix_bitmap_num_set_bits() used to sit
+ * inside "#if PMIX_ENABLE_DEBUG", so the only builds that had it were the
+ * ones nobody ships: an optimized library read bm->array_size straight off
+ * the NULL pointer. pmix_bitmap_num_unset_bits() inherited it, and worse,
+ * answered "len bits are unset" for a bitmap that does not exist.
+ *
+ * (all builds -- in a debug build the old code returned 0 too, so this
+ * case only distinguishes old from new when compiled --disable-debug) */
+static void test_count_bits_null_guard(void)
+{
+    report("num_set_bits(NULL): returns 0 rather than faulting",
+           0 == pmix_bitmap_num_set_bits(NULL, 64));
+    report("num_unset_bits(NULL): returns 0, not len",
+           0 == pmix_bitmap_num_unset_bits(NULL, 64));
+    report("num_set_bits(NULL, 0): returns 0", 0 == pmix_bitmap_num_set_bits(NULL, 0));
+
+    {
+        pmix_bitmap_t bm;
+        PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+        pmix_bitmap_init(&bm, 64);
+        pmix_bitmap_set_bit(&bm, 0);
+        report("num_set_bits(bm, negative len): returns 0",
+               0 == pmix_bitmap_num_set_bits(&bm, -1));
+        report("num_unset_bits(bm, negative len): returns 0",
+               0 == pmix_bitmap_num_unset_bits(&bm, -1));
+        PMIX_DESTRUCT(&bm);
+    }
+}
+
+/* pmix_bitmap_t was one of two classes with no PMIX_*_STATIC_INIT. The
+ * value of having one is that it agrees with the constructor: max_size in
+ * particular is INT_MAX there, and a zero would have made the resulting
+ * bitmap reject every init() and every set_bit(). */
+static void test_static_init_matches_constructor(void)
+{
+    pmix_bitmap_t stat = PMIX_BITMAP_STATIC_INIT;
+    pmix_bitmap_t ctor;
+    int pos = -1;
+
+    PMIX_CONSTRUCT(&ctor, pmix_bitmap_t);
+
+    report("static init: bitmap matches the constructor", stat.bitmap == ctor.bitmap);
+    report("static init: array_size matches the constructor",
+           stat.array_size == ctor.array_size);
+    report("static init: max_size matches the constructor", stat.max_size == ctor.max_size);
+
+    /* reads on the empty bitmap answer rather than faulting */
+    report("static init: is_set_bit(0) is false", !pmix_bitmap_is_set_bit(&stat, 0));
+    report("static init: is_clear is true", pmix_bitmap_is_clear(&stat));
+    report("static init: size is 0", 0 == pmix_bitmap_size(&stat));
+
+    /* and it is usable: set_bit auto-expands from nothing */
+    report("static init: set_bit(5) succeeds", PMIX_SUCCESS == pmix_bitmap_set_bit(&stat, 5));
+    report("static init: bit 5 reads back set", pmix_bitmap_is_set_bit(&stat, 5));
+    report("static init: find_and_set finds bit 0",
+           PMIX_SUCCESS == pmix_bitmap_find_and_set_first_unset_bit(&stat, &pos) && 0 == pos);
+
+    PMIX_DESTRUCT(&stat);
+    PMIX_DESTRUCT(&ctor);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -536,6 +597,8 @@ int main(int argc, char **argv)
     test_copy_status();
     test_uninitialized_and_null();
     test_reinit();
+    test_count_bits_null_guard();
+    test_static_init_matches_constructor();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_hash_table.c
+++ b/test/unit/class/class_hash_table.c
@@ -16,6 +16,7 @@
 #include "src/include/pmix_config.h"
 #include "src/include/pmix_globals.h"
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -368,6 +369,103 @@ static void test_growth_and_backshift(void)
 
 /* ------------------------------------------------------------------ */
 
+/* pmix_hash_table_construct() initialized every member except ht_label.
+ * That is not a decorative field: src/util/pmix_hash.c prints it at four
+ * sites as "(NULL == table->ht_label) ? "UNKNOWN" : table->ht_label", so
+ * the NULL test is what stands between %s and a wild pointer. PMIX_NEW
+ * mallocs without zeroing, and PMIX_CONSTRUCT initializes in place, so
+ * every table that does not set its own label -- gds/shmem3's and the mca
+ * base's among them -- carried garbage there.
+ *
+ * (all builds -- there was never an assert on this) */
+static void test_construct_initializes_label(void)
+{
+    pmix_hash_table_t *heap;
+    pmix_hash_table_t stack;
+    pmix_hash_table_t stat = PMIX_HASH_TABLE_STATIC_INIT;
+
+    /* The heap case is the one that had garbage: PMIX_NEW does not zero. */
+    heap = PMIX_NEW(pmix_hash_table_t);
+    report("PMIX_NEW: allocation succeeded", NULL != heap);
+    if (NULL != heap) {
+        report("PMIX_NEW: ht_label is NULL, not garbage", NULL == heap->ht_label);
+        PMIX_RELEASE(heap);
+    }
+
+    PMIX_CONSTRUCT(&stack, pmix_hash_table_t);
+    report("PMIX_CONSTRUCT: ht_label is NULL", NULL == stack.ht_label);
+    report("static init: ht_label matches the constructor",
+           stat.ht_label == stack.ht_label);
+    PMIX_DESTRUCT(&stack);
+}
+
+/* pmix_hash_table_init2() is a PMIX_EXPORT entry point that took two
+ * ratios and used them without looking. A zero density_numer divided by
+ * zero on its first line; a zero growth_denom did the same inside
+ * pmix_hash_grow(). Worse silently: a growth factor that does not grow, or
+ * a density of 1/1 or looser, lets the table fill completely -- and every
+ * get/set/remove probes with an unbounded "for (;; ii += 1)" loop, so a
+ * full table is an infinite loop, not an error. */
+static void test_init2_rejects_bad_ratios(void)
+{
+    pmix_hash_table_t ht;
+
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+
+    report("init2 density_numer 0: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_hash_table_init2(&ht, 16, 0, 2, 2, 1));
+    report("init2 density_denom 0: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_hash_table_init2(&ht, 16, 1, 0, 2, 1));
+    report("init2 density 1/1 (table can fill): PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_hash_table_init2(&ht, 16, 1, 1, 2, 1));
+    report("init2 growth_denom 0: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_hash_table_init2(&ht, 16, 1, 2, 2, 0));
+    report("init2 growth 1/1 (does not grow): PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_hash_table_init2(&ht, 16, 1, 2, 1, 1));
+    report("init2 negative growth_numer: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_hash_table_init2(&ht, 16, 1, 2, -2, 1));
+
+    report("rejected init2 left the table un-init'd", 0 == ht.ht_capacity);
+    report("rejected init2 left no allocation", NULL == ht.ht_table);
+
+    /* the sane ratios still work, and so does the default init */
+    report("init2 with 1/2 and 3/2: PMIX_SUCCESS",
+           PMIX_SUCCESS == pmix_hash_table_init2(&ht, 16, 1, 2, 3, 2));
+    report("accepted init2: capacity is non-zero", 0 < ht.ht_capacity);
+    PMIX_DESTRUCT(&ht);
+
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    report("plain init still works", PMIX_SUCCESS == pmix_hash_table_init(&ht, 16));
+    PMIX_DESTRUCT(&ht);
+}
+
+/* pmix_next_poweroftwo() computed "1 << (32 - clz(value))" in *signed*
+ * arithmetic. For any value at or above 0x40000000 that shift lands on bit
+ * 31 of an int -- signed overflow, undefined; for a negative value clz is
+ * 0 and the shift distance is 32, also undefined. The two arms disagreed
+ * on negatives as well. It is computed unsigned now, and inputs with no
+ * representable answer say so with 0 rather than inventing one. */
+static void test_next_poweroftwo(void)
+{
+    report("next_poweroftwo(0) is 1", 1 == pmix_next_poweroftwo(0));
+    report("next_poweroftwo(1) is 2", 2 == pmix_next_poweroftwo(1));
+    report("next_poweroftwo(3) is 4", 4 == pmix_next_poweroftwo(3));
+    report("next_poweroftwo(8) is 16", 16 == pmix_next_poweroftwo(8));
+    report("next_poweroftwo(1000) is 1024", 1024 == pmix_next_poweroftwo(1000));
+
+    /* the boundary that used to be undefined */
+    report("next_poweroftwo(1<<29) is 1<<30",
+           (1 << 30) == pmix_next_poweroftwo(1 << 29));
+    report("next_poweroftwo(1<<30) has no positive answer -> 0",
+           0 == pmix_next_poweroftwo(1 << 30));
+    report("next_poweroftwo(INT_MAX) has no positive answer -> 0",
+           0 == pmix_next_poweroftwo(INT_MAX));
+
+    /* negatives are answered, not shifted by 32 */
+    report("next_poweroftwo(-1) is 0", 0 == pmix_next_poweroftwo(-1));
+    report("next_poweroftwo(INT_MIN) is 0", 0 == pmix_next_poweroftwo(INT_MIN));
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -385,6 +483,9 @@ int main(int argc, char **argv)
     test_uninitialized_table();
     test_destruct_leaves_constructed_state();
     test_growth_and_backshift();
+    test_construct_initializes_label();
+    test_init2_rejects_bad_ratios();
+    test_next_poweroftwo();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_list.c
+++ b/test/unit/class/class_list.c
@@ -346,6 +346,89 @@ static void test_list_release(void)
 
 /* ------------------------------------------------------------------ */
 
+/* pmix_list_insert() checked only the upper bound. A negative idx sailed
+ * past "idx >= length", failed the "0 == idx" prepend test, and fell into
+ * the walk -- whose "for (i = 0; i < idx - 1; i++)" ran zero times. The
+ * item was spliced in after element 0 and the call returned true, so a
+ * caller passing a computed index that went negative silently got a list
+ * in an order it never asked for. */
+static void test_insert_negative_index(void)
+{
+    pmix_list_t list;
+    int_item_t *victim;
+    bool ok;
+
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(10));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(20));
+    pmix_list_append(&list, (pmix_list_item_t *) make_item(30));
+
+    victim = make_item(99);
+    ok = pmix_list_insert(&list, (pmix_list_item_t *) victim, -1);
+    report("insert at -1: rejected", !ok);
+    report("insert at -1: length unchanged", 3 == pmix_list_get_size(&list));
+
+    if (!ok) {
+        /* rejected, so we still own it */
+        PMIX_RELEASE(victim);
+    }
+
+    victim = make_item(98);
+    ok = pmix_list_insert(&list, (pmix_list_item_t *) victim, -100);
+    report("insert at -100: rejected", !ok);
+    report("insert at -100: length unchanged", 3 == pmix_list_get_size(&list));
+    if (!ok) {
+        PMIX_RELEASE(victim);
+    }
+
+    /* the list is still in the order we built it */
+    {
+        int_item_t *it;
+        int expect[3] = {10, 20, 30};
+        int i = 0, good = 1;
+        PMIX_LIST_FOREACH (it, &list, int_item_t) {
+            if (i > 2 || it->value != expect[i]) {
+                good = 0;
+                break;
+            }
+            i++;
+        }
+        report("insert at negative idx: order untouched", good && 3 == i);
+    }
+
+    /* an empty list rejects every index, negative ones included */
+    PMIX_LIST_DESTRUCT(&list);
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+    victim = make_item(1);
+    ok = pmix_list_insert(&list, (pmix_list_item_t *) victim, -1);
+    report("insert at -1 into an empty list: rejected", !ok);
+    report("insert at -1 into an empty list: still empty", pmix_list_is_empty(&list));
+    if (!ok) {
+        PMIX_RELEASE(victim);
+    }
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+/* PMIX_LIST_ITEM_STATIC_INIT disagreed with pmix_list_item_construct()
+ * about item_free -- 0 against 1. That field has since been deleted (it was
+ * read nowhere), but a STATIC_INIT that drifts from its constructor is the
+ * shape of bug PMIX_HOTEL_STATIC_INIT's last_unoccupied_room actually was,
+ * so the two are still compared field for field here. */
+static void test_item_static_init_matches_constructor(void)
+{
+    pmix_list_item_t stat = PMIX_LIST_ITEM_STATIC_INIT;
+    pmix_list_item_t ctor;
+
+    PMIX_CONSTRUCT(&ctor, pmix_list_item_t);
+
+    report("item static init: pmix_list_next matches the constructor",
+           stat.pmix_list_next == ctor.pmix_list_next);
+    report("item static init: pmix_list_prev matches the constructor",
+           stat.pmix_list_prev == ctor.pmix_list_prev);
+
+    PMIX_DESTRUCT(&ctor);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -364,6 +447,8 @@ int main(int argc, char **argv)
     test_sort();
     test_join();
     test_list_release();
+    test_insert_negative_index();
+    test_item_static_init_matches_constructor();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_object.c
+++ b/test/unit/class/class_object.c
@@ -201,12 +201,15 @@ static void test_class_sizeof(void)
 /* Regressions                                                          */
 /* ------------------------------------------------------------------ */
 
-/* PMIX_NEW() carried its own copy of the TMA-clearing code and set seven
- * of pmix_tma_t's eight members, leaving tma_memmove holding whatever
- * malloc() returned. pmix_obj_get_tma() keys off tma_malloc, so the stray
- * member never showed up as a crash -- it just meant every heap object in
- * the library had one uninitialized field for anything that copied or
- * inspected the whole struct. */
+/* PMIX_NEW() carried its own copy of the TMA-clearing code and cleared one
+ * fewer member than pmix_obj_construct_tma() did, leaving a stray
+ * uninitialized function pointer in every heap object in the library.
+ * pmix_obj_get_tma() keys off tma_malloc alone, so it never showed up as a
+ * crash -- it just meant anything copying or inspecting the whole struct
+ * read garbage. The offending member (tma_memmove) has since been deleted
+ * as dead weight, but the invariant it broke is the one that matters:
+ * PMIX_NEW and PMIX_CONSTRUCT must leave *every* pmix_tma_t member
+ * cleared, and both must do it through the one shared helper. */
 static void test_new_clears_whole_tma(void)
 {
     pmix_list_item_t *obj = PMIX_NEW(pmix_list_item_t);
@@ -221,7 +224,6 @@ static void test_new_clears_whole_tma(void)
     report("PMIX_NEW: tma_calloc cleared", NULL == base->obj_tma.tma_calloc);
     report("PMIX_NEW: tma_realloc cleared", NULL == base->obj_tma.tma_realloc);
     report("PMIX_NEW: tma_strdup cleared", NULL == base->obj_tma.tma_strdup);
-    report("PMIX_NEW: tma_memmove cleared", NULL == base->obj_tma.tma_memmove);
     report("PMIX_NEW: tma_free cleared", NULL == base->obj_tma.tma_free);
     report("PMIX_NEW: data_context cleared", NULL == base->obj_tma.data_context);
     report("PMIX_NEW: data_ptr cleared", NULL == base->obj_tma.data_ptr);
@@ -241,7 +243,6 @@ static void test_construct_clears_whole_tma(void)
     PMIX_CONSTRUCT(&item, pmix_list_item_t);
 
     report("PMIX_CONSTRUCT: tma_malloc cleared", NULL == base->obj_tma.tma_malloc);
-    report("PMIX_CONSTRUCT: tma_memmove cleared", NULL == base->obj_tma.tma_memmove);
     report("PMIX_CONSTRUCT: tma_free cleared", NULL == base->obj_tma.tma_free);
     report("PMIX_CONSTRUCT: data_ptr cleared", NULL == base->obj_tma.data_ptr);
     report("PMIX_CONSTRUCT: reports no custom allocator", NULL == pmix_obj_get_tma(base));

--- a/test/unit/class/class_object.c
+++ b/test/unit/class/class_object.c
@@ -10,9 +10,9 @@
  *   PMIX_NEW, PMIX_RETAIN, PMIX_RELEASE, PMIX_CONSTRUCT, PMIX_DESTRUCT,
  *   reference counting, and class hierarchy.
  *
- * pmix_object_t is a pure base class and cannot be instantiated directly
- * (its cls_construct_array is pre-set to NULL).  All tests use
- * pmix_list_item_t, the simplest derived class, as a concrete subject.
+ * pmix_object_t is a pure base class with no constructor or destructor of
+ * its own, so most tests use pmix_list_item_t, the simplest derived class,
+ * as a concrete subject.
  *
  * Exit 0 if all tests pass, 1 otherwise.
  */
@@ -291,6 +291,43 @@ static void test_obj_update_returns_new_value(void)
 
 /* ------------------------------------------------------------------ */
 
+/* Every PMIX_*_STATIC_INIT expands to PMIX_OBJ_STATIC_INIT(pmix_object_t),
+ * which tags the object with the *base* class descriptor rather than the
+ * derived one. That descriptor is pre-marked initialized, so
+ * pmix_class_initialize() never runs for it and never builds its
+ * constructor/destructor arrays -- they stayed NULL, and
+ * pmix_obj_run_destructors() walks its array with "while (NULL != *p)".
+ *
+ * So PMIX_DESTRUCT on a statically initialized object that had not yet
+ * been PMIX_CONSTRUCT'ed dereferenced NULL and took SIGSEGV: exactly the
+ * "defined state, so an early failure path can tear it down" case those
+ * macros exist for. The base class now carries empty, terminated arrays,
+ * making it the correct no-op.
+ *
+ * (all builds -- this is a NULL dereference, not an assert) */
+static void test_destruct_of_static_init_object(void)
+{
+    /* Deliberately NOT PMIX_CONSTRUCT'ed: that is the whole point. */
+    pmix_list_t sl = PMIX_LIST_STATIC_INIT;
+    pmix_object_t so = PMIX_OBJ_STATIC_INIT(pmix_object_t);
+
+    report("base class carries a non-NULL constructor array",
+           NULL != pmix_object_t_class.cls_construct_array);
+    report("base class carries a non-NULL destructor array",
+           NULL != pmix_object_t_class.cls_destruct_array);
+    report("base class constructor array is empty (immediate end marker)",
+           NULL == *pmix_object_t_class.cls_construct_array);
+    report("base class destructor array is empty (immediate end marker)",
+           NULL == *pmix_object_t_class.cls_destruct_array);
+
+    /* The payoff: neither of these used to return. */
+    PMIX_DESTRUCT(&sl);
+    report("PMIX_DESTRUCT of a never-constructed STATIC_INIT list survives", true);
+
+    PMIX_DESTRUCT(&so);
+    report("PMIX_DESTRUCT of a never-constructed static pmix_object_t survives", true);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -312,6 +349,7 @@ int main(int argc, char **argv)
     test_construct_clears_whole_tma();
     test_static_init();
     test_obj_update_returns_new_value();
+    test_destruct_of_static_init_object();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_pointer_array.c
+++ b/test/unit/class/class_pointer_array.c
@@ -330,6 +330,85 @@ static void test_max_size_cap(void)
 
 /* ------------------------------------------------------------------ */
 
+/* pmix_pointer_array_test_and_set_item() guarded its index with a bare
+ * assert(index >= 0). That is not a guard in any build that ships:
+ * configure adds -DNDEBUG whenever --enable-debug is off
+ * (config/pmix.m4), so the check vanished and a negative index wrote
+ * through table->addr below the start of the allocation -- and then ran
+ * SET_BIT on it, corrupting free_bits too. Its sibling
+ * pmix_pointer_array_set_item() has always rejected negatives outright.
+ *
+ * (all builds -- in a debug build the old code aborted on the assert
+ * rather than returning false, so this only distinguishes old from new
+ * when compiled --disable-debug) */
+static void test_test_and_set_negative_index(void)
+{
+    pmix_pointer_array_t arr;
+    int before_free, before_size;
+
+    PMIX_CONSTRUCT(&arr, pmix_pointer_array_t);
+    pmix_pointer_array_init(&arr, 8, 64, 8);
+    pmix_pointer_array_add(&arr, (void *) 0x1);
+
+    before_free = arr.number_free;
+    before_size = arr.size;
+
+    report("test_and_set at -1: returns false",
+           !pmix_pointer_array_test_and_set_item(&arr, -1, (void *) 0xbad));
+    report("test_and_set at -1: number_free untouched", before_free == arr.number_free);
+    report("test_and_set at -1: size untouched", before_size == arr.size);
+
+    report("test_and_set at INT_MIN-ish: returns false",
+           !pmix_pointer_array_test_and_set_item(&arr, -1000000, (void *) 0xbad));
+    report("test_and_set: rejected calls left the array usable",
+           (void *) 0x1 == pmix_pointer_array_get_item(&arr, 0));
+
+    /* a valid index still works */
+    report("test_and_set at 3: succeeds",
+           pmix_pointer_array_test_and_set_item(&arr, 3, (void *) 0x3));
+    report("test_and_set at 3: reads back",
+           (void *) 0x3 == pmix_pointer_array_get_item(&arr, 3));
+
+    PMIX_DESTRUCT(&arr);
+}
+
+/* PMIX_POINTER_ARRAY_STATIC_INIT set max_size and block_size to 0 where
+ * the constructor sets INT_MAX and 8. grow_table() divides by block_size,
+ * so an array that reached pmix_pointer_array_add() on a static
+ * initializer -- without the pmix_pointer_array_init() that every in-tree
+ * use happens to perform first -- took SIGFPE.
+ *
+ * (all builds -- an integer divide by zero, not an assert) */
+static void test_static_init_matches_constructor(void)
+{
+    pmix_pointer_array_t stat = PMIX_POINTER_ARRAY_STATIC_INIT;
+    pmix_pointer_array_t ctor;
+    int idx;
+
+    PMIX_CONSTRUCT(&ctor, pmix_pointer_array_t);
+
+    report("static init: lowest_free matches the constructor",
+           stat.lowest_free == ctor.lowest_free);
+    report("static init: number_free matches the constructor",
+           stat.number_free == ctor.number_free);
+    report("static init: size matches the constructor", stat.size == ctor.size);
+    report("static init: max_size matches the constructor", stat.max_size == ctor.max_size);
+    report("static init: block_size matches the constructor",
+           stat.block_size == ctor.block_size);
+    report("static init: free_bits matches the constructor", stat.free_bits == ctor.free_bits);
+    report("static init: addr matches the constructor", stat.addr == ctor.addr);
+
+    /* The payoff: add() on a never-init'd array grows from nothing rather
+     * than dividing by a zero block size. */
+    idx = pmix_pointer_array_add(&stat, (void *) 0x55);
+    report("static init: add without init returns a valid index", 0 <= idx);
+    report("static init: the pointer reads back",
+           (void *) 0x55 == pmix_pointer_array_get_item(&stat, idx));
+
+    PMIX_DESTRUCT(&stat);
+    PMIX_DESTRUCT(&ctor);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -347,6 +426,8 @@ int main(int argc, char **argv)
     test_growth_across_bit_words();
     test_sparse_set_item();
     test_max_size_cap();
+    test_test_and_set_negative_index();
+    test_static_init_matches_constructor();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_refcount.c
+++ b/test/unit/class/class_refcount.c
@@ -358,6 +358,131 @@ static void test_many_objects(void)
 
 /* ------------------------------------------------------------------ */
 
+/* ------------------------------------------------------------------ */
+/* 4. Concurrent lazy class initialization (the double-checked lock)    */
+/* ------------------------------------------------------------------ */
+
+/* pmix_class_initialize() is reached through a double-checked lock: every
+ * PMIX_NEW/PMIX_CONSTRUCT reads cls->cls_initialized *without* the class
+ * mutex, and only takes it when the class looks uninitialized. The flag
+ * write used to be a plain int store, so a thread that observed the new
+ * epoch had nothing ordering it against the cls_construct_array the
+ * initializing thread had just built -- the textbook broken DCL. It is now
+ * a release store paired with the acquire in PMIX_CLASS_IS_INITIALIZED().
+ *
+ * A caveat worth stating plainly: this case cannot reliably *fail* on
+ * x86-64 or arm64 even with the ordering removed, because both give the
+ * plain load enough ordering in practice. Its job is to put concurrent
+ * first-use of a class under a race detector at all -- nothing else in the
+ * suite does, so before this there was no thread ever exercising
+ * pmix_class_initialize() concurrently. Run it under
+ * "-fsanitize=thread" to get the real signal. */
+
+#define NRACE_CLASSES 8
+
+typedef struct {
+    pmix_object_t super;
+    int stamp;
+} lazy_t;
+
+static void lazy_construct(lazy_t *l)
+{
+    l->stamp = 0x5A5A;
+}
+
+PMIX_CLASS_INSTANCE(lazy_t, pmix_object_t, lazy_construct, NULL);
+
+/* Deeper hierarchies mean longer constructor arrays, so more of the array
+ * build is exposed to a reader that jumped the gun. */
+typedef struct {
+    lazy_t super;
+    int stamp2;
+} lazy2_t;
+
+static void lazy2_construct(lazy2_t *l)
+{
+    l->stamp2 = 0xA5A5;
+}
+
+PMIX_CLASS_INSTANCE(lazy2_t, lazy_t, lazy2_construct, NULL);
+
+static simple_barrier_t init_barrier;
+static int init_ok[NTHREADS];
+
+static void *first_use(void *arg)
+{
+    int slot = (int) (intptr_t) arg;
+    int ok = 1;
+    int i;
+
+    /* Every thread arrives at the very first use of these classes at the
+     * same moment, so they all see cls_initialized as stale and race into
+     * pmix_class_initialize(). */
+    barrier_wait(&init_barrier);
+
+    for (i = 0; i < NRACE_CLASSES; i++) {
+        lazy2_t *o = PMIX_NEW(lazy2_t);
+        if (NULL == o) {
+            ok = 0;
+            break;
+        }
+        /* Both constructors must have run, in parent-first order. If a
+         * thread called through a half-built constructor array, one of
+         * these stamps is missing. */
+        if (0x5A5A != o->super.stamp || 0xA5A5 != o->stamp2) {
+            ok = 0;
+        }
+        if (((pmix_object_t *) o)->obj_class->cls_depth < 3) {
+            ok = 0;
+        }
+        PMIX_RELEASE(o);
+    }
+    init_ok[slot] = ok;
+    return NULL;
+}
+
+static void test_concurrent_class_initialization(void)
+{
+    pthread_t threads[NTHREADS];
+    int i, started = 0;
+    bool all = true;
+
+    for (i = 0; i < NTHREADS; i++) {
+        init_ok[i] = 0;
+    }
+    barrier_init(&init_barrier, NTHREADS);
+
+    for (i = 0; i < NTHREADS; i++) {
+        if (0 != pthread_create(&threads[i], NULL, first_use, (void *) (intptr_t) i)) {
+            break;
+        }
+        started++;
+    }
+    report("class init race: threads started", NTHREADS == started);
+
+    /* Let the barrier through if some thread never started. */
+    for (i = started; i < NTHREADS; i++) {
+        barrier_wait(&init_barrier);
+    }
+    for (i = 0; i < started; i++) {
+        pthread_join(threads[i], NULL);
+    }
+    barrier_destroy(&init_barrier);
+
+    for (i = 0; i < started; i++) {
+        if (!init_ok[i]) {
+            all = false;
+        }
+    }
+    report("class init race: every thread got fully constructed objects", all);
+
+    /* And the class really is initialized once, for this epoch. */
+    report("class init race: class reports initialized",
+           PMIX_CLASS_IS_INITIALIZED(PMIX_CLASS(lazy2_t)));
+    report("class init race: hierarchy depth is 3 (lazy2 -> lazy -> object)",
+           3 == PMIX_CLASS(lazy2_t)->cls_depth);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -368,6 +493,7 @@ int main(int argc, char **argv)
     test_balanced_retain_release();
     test_single_destruct_on_race();
     test_many_objects();
+    test_concurrent_class_initialization();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_ring_buffer.c
+++ b/test/unit/class/class_ring_buffer.c
@@ -250,6 +250,95 @@ static void test_destruct_leaves_constructed_state(void)
     PMIX_DESTRUCT(&ring);
 }
 
+/* The destructor freed addr and zeroed size but left head and tail where
+ * the last push put them. tail is this class's "is anything on the ring"
+ * flag, so a destructed ring still answered "yes" and pop() dereferenced
+ * addr[tail] -- through the NULL the destructor had just installed.
+ *
+ * (all builds -- there is no assert on this path in either configuration) */
+static void test_destruct_resets_head_and_tail(void)
+{
+    pmix_ring_buffer_t ring;
+
+    PMIX_CONSTRUCT(&ring, pmix_ring_buffer_t);
+    pmix_ring_buffer_init(&ring, 4);
+    pmix_ring_buffer_push(&ring, (void *) 0xa1);
+    pmix_ring_buffer_push(&ring, (void *) 0xa2);
+
+    PMIX_DESTRUCT(&ring);
+    report("destruct: head back to 0", 0 == ring.head);
+    report("destruct: tail back to -1 (ring reads as empty)", -1 == ring.tail);
+
+    /* The payoff: this used to segfault rather than return NULL. */
+    report("pop on a destructed ring returns NULL", NULL == pmix_ring_buffer_pop(&ring));
+    report("poke on a destructed ring returns NULL", NULL == pmix_ring_buffer_poke(&ring, 0));
+}
+
+/* pmix_ring_buffer_init() never touched head or tail, so re-initializing a
+ * ring that had been used before leaked the old storage and handed back a
+ * "fresh" ring that still claimed the previous one's occupancy: the first
+ * pop() returned a slot that had never been written.
+ *
+ * Note that this deliberately does *not* re-CONSTRUCT between the two
+ * inits -- re-constructing resets head/tail and hides the defect, which is
+ * why the neighbouring teardown case does not catch it. */
+static void test_reinit_without_reconstruct(void)
+{
+    pmix_ring_buffer_t ring;
+    void *out;
+
+    PMIX_CONSTRUCT(&ring, pmix_ring_buffer_t);
+
+    pmix_ring_buffer_init(&ring, 4);
+    pmix_ring_buffer_push(&ring, (void *) 0xb1);
+    pmix_ring_buffer_push(&ring, (void *) 0xb2);
+    pmix_ring_buffer_push(&ring, (void *) 0xb3);
+
+    report("re-init over a used ring: PMIX_SUCCESS",
+           PMIX_SUCCESS == pmix_ring_buffer_init(&ring, 4));
+    report("re-init: head back to 0", 0 == ring.head);
+    report("re-init: tail back to -1", -1 == ring.tail);
+
+    out = pmix_ring_buffer_pop(&ring);
+    report("re-init: the ring really is empty", NULL == out);
+
+    /* and it behaves normally from there */
+    report("re-init: push then pop round-trips",
+           NULL == pmix_ring_buffer_push(&ring, (void *) 0xb9));
+    report("re-init: pop returns what was pushed", (void *) 0xb9 == pmix_ring_buffer_pop(&ring));
+
+    PMIX_DESTRUCT(&ring);
+}
+
+/* Every other class here carries a PMIX_*_STATIC_INIT; this one did not.
+ * The value of the macro is entirely in agreeing with the constructor --
+ * in particular tail must be -1, not the 0 a plain zero-initializer gives,
+ * or the "empty" ring reports an occupant. */
+static void test_static_init_matches_constructor(void)
+{
+    pmix_ring_buffer_t stat = PMIX_RING_BUFFER_STATIC_INIT;
+    pmix_ring_buffer_t ctor;
+
+    PMIX_CONSTRUCT(&ctor, pmix_ring_buffer_t);
+
+    report("static init: head matches the constructor", stat.head == ctor.head);
+    report("static init: tail matches the constructor", stat.tail == ctor.tail);
+    report("static init: size matches the constructor", stat.size == ctor.size);
+    report("static init: addr matches the constructor", stat.addr == ctor.addr);
+
+    /* usable without a construct: reads answer "empty" rather than faulting */
+    report("static init: pop returns NULL", NULL == pmix_ring_buffer_pop(&stat));
+    report("static init: poke returns NULL", NULL == pmix_ring_buffer_poke(&stat, 0));
+
+    /* and init makes it a working ring */
+    report("static init: init succeeds", PMIX_SUCCESS == pmix_ring_buffer_init(&stat, 2));
+    report("static init: push works", NULL == pmix_ring_buffer_push(&stat, (void *) 0xc1));
+    report("static init: pop returns it", (void *) 0xc1 == pmix_ring_buffer_pop(&stat));
+
+    PMIX_DESTRUCT(&stat);
+    PMIX_DESTRUCT(&ctor);
+}
+
 /* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
@@ -266,6 +355,9 @@ int main(int argc, char **argv)
     test_init_bad_params();
     test_size_one();
     test_destruct_leaves_constructed_state();
+    test_destruct_resets_head_and_tail();
+    test_reinit_without_reconstruct();
+    test_static_init_matches_constructor();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_tma_shared.c
+++ b/test/unit/class/class_tma_shared.c
@@ -1,0 +1,548 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Cross-process tests for the TMA path: the src/class object model and the
+ * TMA-aware containers built inside a shared-memory segment and used from
+ * more than one process.
+ *
+ * WHY THIS TEST EXISTS
+ *
+ * Everything else under test/unit/class is single-process, because
+ * everything in src/class is a single-process data structure. The one
+ * exception is the TMA: pmix_object_t embeds an allocator, and when it is
+ * set the object and everything it allocates live in a caller-provided
+ * arena -- which is how gds/shmem3 places PMIx objects into an mmap'd
+ * segment that a server shares with its local clients. Two claims in
+ * src/class/AGENTS.md rest on that path and were asserted rather than
+ * tested:
+ *
+ *   1. The reference count is a C11 atomic specifically so that
+ *      PMIX_RETAIN/PMIX_RELEASE are well defined "from any process sharing
+ *      a TMA segment". The per-object pthread_mutex_t it replaced was
+ *      never PTHREAD_PROCESS_SHARED, so this was undefined before.
+ *
+ *   2. pmix_hash_table_t and pmix_pointer_array_t allocate through
+ *      pmix_obj_get_tma() rather than libc precisely so a second process
+ *      can read what the first one built.
+ *
+ * WHAT THIS DOES AND DOES NOT MODEL
+ *
+ * The second process here comes from fork() over a MAP_SHARED mapping, so
+ * the segment lands at the same address in both and the function pointers
+ * inside the embedded pmix_tma_t stay valid. Real gds/shmem3 peers are
+ * unrelated processes that map the segment at a negotiated fixed address
+ * and whose method pointers are *not* comparable -- which is why
+ * pmix_hash_table.c skips its key-type assert for TMA tables. So this
+ * covers the memory model and the container layout across a process
+ * boundary; it does not cover segment negotiation or attach. That belongs
+ * to gds/shmem3 and the swarm group tests.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <stdatomic.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "src/class/pmix_hash_table.h"
+#include "src/class/pmix_object.h"
+#include "src/class/pmix_pointer_array.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* A minimal bump allocator over an mmap'd segment.                     */
+/*                                                                      */
+/* The cursor lives *inside* the segment, reached through the TMA's     */
+/* data_ptr, so an allocation made by either process is seen by both -- */
+/* the same arrangement gds/shmem3 uses. Every allocation carries a     */
+/* size header so realloc() can copy the right number of bytes; the     */
+/* real component keeps a registry for that, which is more than this    */
+/* needs.                                                              */
+/*                                                                      */
+/* Note that every pmix_tma_t member is filled in. A partially           */
+/* initialized TMA is a bug: pmix_obj_get_tma() decides "this object     */
+/* has a custom allocator" by testing tma_malloc alone.                  */
+/* ------------------------------------------------------------------ */
+
+#define SEG_SIZE   (4 * 1024 * 1024)
+#define ALIGNMENT  16
+
+typedef struct {
+    /* Bump cursor: an offset, not a pointer, so it is meaningful to any
+     * process regardless of where the segment landed. */
+    size_t cursor;
+    size_t capacity;
+} arena_hdr_t;
+
+/* Base of the mapping in this process. With fork() it is the same value
+ * in both, but keeping the cursor as an offset means nothing here depends
+ * on that. */
+static unsigned char *seg_base = NULL;
+
+static void *arena_alloc(pmix_tma_t *tma, size_t size)
+{
+    arena_hdr_t *hdr = (arena_hdr_t *) tma->data_context;
+    size_t need, off;
+    unsigned char *p;
+
+    if (0 == size) {
+        return NULL;
+    }
+    /* header + payload, rounded up to ALIGNMENT */
+    need = (sizeof(size_t) + size + ALIGNMENT - 1) & ~((size_t) ALIGNMENT - 1);
+    if (hdr->cursor + need > hdr->capacity) {
+        return NULL;
+    }
+    off = hdr->cursor;
+    hdr->cursor += need;
+
+    p = seg_base + off;
+    memcpy(p, &size, sizeof(size_t));
+    return p + sizeof(size_t);
+}
+
+static size_t arena_size_of(void *ptr)
+{
+    size_t size;
+    memcpy(&size, (unsigned char *) ptr - sizeof(size_t), sizeof(size_t));
+    return size;
+}
+
+static void *tma_shared_malloc(pmix_tma_t *tma, size_t size)
+{
+    return arena_alloc(tma, size);
+}
+
+static void *tma_shared_calloc(pmix_tma_t *tma, size_t nmemb, size_t size)
+{
+    size_t total = nmemb * size;
+    void *p;
+
+    if (0 != nmemb && total / nmemb != size) {
+        return NULL; /* overflow */
+    }
+    p = arena_alloc(tma, total);
+    if (NULL != p) {
+        memset(p, 0, total);
+    }
+    return p;
+}
+
+static void *tma_shared_realloc(pmix_tma_t *tma, void *ptr, size_t size)
+{
+    void *fresh;
+    size_t old;
+
+    if (NULL == ptr) {
+        return arena_alloc(tma, size);
+    }
+    if (0 == size) {
+        return NULL;
+    }
+    old = arena_size_of(ptr);
+    if (size <= old) {
+        return ptr;
+    }
+    fresh = arena_alloc(tma, size);
+    if (NULL != fresh) {
+        memcpy(fresh, ptr, old);
+    }
+    return fresh;
+}
+
+static char *tma_shared_strdup(pmix_tma_t *tma, const char *s)
+{
+    size_t len = strlen(s) + 1;
+    char *p = (char *) arena_alloc(tma, len);
+
+    if (NULL != p) {
+        memcpy(p, s, len);
+    }
+    return p;
+}
+
+static void tma_shared_free(pmix_tma_t *tma, void *ptr)
+{
+    /* A bump allocator does not reclaim, exactly as gds/shmem3's does not.
+     * It still has to be non-NULL: PMIX_RELEASE tests tma_free to decide
+     * whether to hand the object back to the TMA or to libc free(), and a
+     * NULL here would send segment memory to free(). */
+    PMIX_HIDE_UNUSED_PARAMS(tma, ptr);
+}
+
+static void tma_shared_init(pmix_tma_t *tma, arena_hdr_t *hdr)
+{
+    tma->tma_malloc = tma_shared_malloc;
+    tma->tma_calloc = tma_shared_calloc;
+    tma->tma_realloc = tma_shared_realloc;
+    tma->tma_strdup = tma_shared_strdup;
+    tma->tma_free = tma_shared_free;
+    tma->data_context = hdr;
+    tma->data_ptr = NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* Everything the two processes share lives here, at the front of the   */
+/* segment.                                                            */
+/* ------------------------------------------------------------------ */
+
+#define NKIDS      6
+#define NSPINS     200000
+#define NKEYS      64
+#define NSLOTS     40
+
+typedef struct {
+    arena_hdr_t arena;
+    pmix_tma_t tma;
+    /* Objects the parent builds before forking. */
+    pmix_object_t *shared_obj;
+    pmix_hash_table_t *ht;
+    pmix_pointer_array_t *pa;
+    /* One result slot per child, so output is not interleaved. */
+    int kid_ok[NKIDS];
+    int kid_detail[NKIDS];
+    /* Start barrier. Without it the children tend to run one after another
+     * -- each is cheap enough to finish before the next is scheduled -- and
+     * a broken (non-atomic) count then survives by luck. Holding them all
+     * at the gate until every one is up puts them in the segment at the
+     * same time, which is the condition under test. */
+    atomic_int ready;
+    atomic_int go;
+} shared_t;
+
+static shared_t *sh = NULL;
+
+/* ------------------------------------------------------------------ */
+/* The reference count across processes                                 */
+/* ------------------------------------------------------------------ */
+
+/* Each child hammers retain/release on one object in the segment and then
+ * drops exactly one net reference. If the count is a genuine C11 atomic in
+ * shared memory, the parent sees exactly 1 left afterwards. A lost update
+ * shows up as a count above 1 (leak) or below it (premature destruction).
+ *
+ * This is the property the move off pthread_mutex_t bought: that mutex was
+ * embedded in the object, lived in the segment, and was never initialized
+ * PTHREAD_PROCESS_SHARED, so this arithmetic was undefined. */
+static void test_refcount_across_processes(void)
+{
+    pmix_object_t *obj = sh->shared_obj;
+    int i, count;
+    pid_t kids[NKIDS];
+
+    /* one reference for each child to drop, plus the parent's own */
+    for (i = 0; i < NKIDS; i++) {
+        PMIX_RETAIN(obj);
+    }
+    report("refcount: parent staged 1 + NKIDS references",
+           (NKIDS + 1) == obj->obj_reference_count);
+
+    for (i = 0; i < NKIDS; i++) {
+        kids[i] = fork();
+        if (0 == kids[i]) {
+            int j;
+            /* line up, then start together */
+            atomic_fetch_add_explicit(&sh->ready, 1, memory_order_release);
+            while (0 == atomic_load_explicit(&sh->go, memory_order_acquire)) {
+                /* spin */
+            }
+            /* balanced traffic first: contention without a net change */
+            for (j = 0; j < NSPINS; j++) {
+                PMIX_RETAIN(obj);
+                pmix_obj_update(obj, -1);
+            }
+            /* then the one reference this child owns */
+            pmix_obj_update(obj, -1);
+            _exit(0);
+        }
+        if (0 > kids[i]) {
+            report("refcount: fork failed", 0);
+            return;
+        }
+    }
+    while (NKIDS > atomic_load_explicit(&sh->ready, memory_order_acquire)) {
+        /* wait for every child to reach the gate */
+    }
+    atomic_store_explicit(&sh->go, 1, memory_order_release);
+
+    for (i = 0; i < NKIDS; i++) {
+        int status = 0;
+        waitpid(kids[i], &status, 0);
+    }
+
+    count = obj->obj_reference_count;
+    report("refcount: exactly the parent's reference survives NKIDS children",
+           1 == count);
+    if (1 != count) {
+        fprintf(stdout, "        (count was %d, expected 1 after %d children x %d spins)\n",
+                count, NKIDS, NSPINS);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Containers built in the segment, read from another process           */
+/* ------------------------------------------------------------------ */
+
+/* pmix_hash_table_t and pmix_pointer_array_t allocate through the object's
+ * TMA rather than libc so that their storage lands in the segment. If any
+ * of it came from the heap instead, a second process would read its own
+ * unrelated memory at that address -- or nothing mapped at all. */
+static void test_containers_read_from_another_process(void)
+{
+    uint32_t k;
+    int i;
+    pid_t kids[NKIDS];
+
+    for (i = 0; i < NKIDS; i++) {
+        kids[i] = fork();
+        if (0 == kids[i]) {
+            int ok = 1, detail = 0;
+            void *val = NULL;
+
+            /* every uint32 key the parent stored */
+            for (k = 0; k < NKEYS; k++) {
+                if (PMIX_SUCCESS != pmix_hash_table_get_value_uint32(sh->ht, k, &val)
+                    || (uintptr_t) val != (uintptr_t) (k + 1000)) {
+                    ok = 0;
+                    detail = 1;
+                    break;
+                }
+            }
+            /* a key that was never stored still reports not-found */
+            if (ok && PMIX_ERR_NOT_FOUND
+                          != pmix_hash_table_get_value_uint32(sh->ht, NKEYS + 1, &val)) {
+                ok = 0;
+                detail = 2;
+            }
+            /* the ptr-keyed entry, whose key bytes the table copied into
+             * the segment through the TMA */
+            if (ok) {
+                const char *pkey = "shared-ptr-key";
+                if (PMIX_SUCCESS
+                        != pmix_hash_table_get_value_ptr(sh->ht, pkey, strlen(pkey), &val)
+                    || (uintptr_t) val != 0x5150) {
+                    ok = 0;
+                    detail = 3;
+                }
+            }
+            /* and the pointer array */
+            if (ok) {
+                int s;
+                for (s = 0; s < NSLOTS; s++) {
+                    if ((uintptr_t) pmix_pointer_array_get_item(sh->pa, s)
+                        != (uintptr_t) (s + 1)) {
+                        ok = 0;
+                        detail = 4;
+                        break;
+                    }
+                }
+            }
+            sh->kid_ok[i] = ok;
+            sh->kid_detail[i] = detail;
+            _exit(ok ? 0 : 1);
+        }
+        if (0 > kids[i]) {
+            report("containers: fork failed", 0);
+            return;
+        }
+    }
+
+    {
+        int all = 1, worst = 0;
+        for (i = 0; i < NKIDS; i++) {
+            int status = 0;
+            waitpid(kids[i], &status, 0);
+            if (!sh->kid_ok[i]) {
+                all = 0;
+                worst = sh->kid_detail[i];
+            }
+        }
+        report("containers: every child read the parent's hash table and pointer array",
+               all);
+        if (!all) {
+            static const char *why[] = {"?", "uint32 lookup", "absent-key lookup",
+                                        "ptr-key lookup", "pointer array"};
+            fprintf(stdout, "        (first failure: %s)\n",
+                    why[(worst >= 0 && worst <= 4) ? worst : 0]);
+        }
+    }
+}
+
+/* A child writes, the parent reads afterwards. Only one process mutates at
+ * a time: these containers are not internally synchronized, and that is
+ * deliberate -- see src/class/AGENTS.md. What is being checked is that the
+ * *storage* is genuinely shared in both directions, not that concurrent
+ * mutation is safe. It is not. */
+static void test_child_writes_visible_to_parent(void)
+{
+    pid_t kid;
+    int status = 0;
+    void *val = NULL;
+    int idx;
+
+    kid = fork();
+    if (0 == kid) {
+        pmix_hash_table_set_value_uint32(sh->ht, 9000, (void *) (uintptr_t) 0xabcd);
+        sh->kid_detail[0] = pmix_pointer_array_add(sh->pa, (void *) (uintptr_t) 0xfeed);
+        _exit(0);
+    }
+    if (0 > kid) {
+        report("child writes: fork failed", 0);
+        return;
+    }
+    waitpid(kid, &status, 0);
+
+    report("child writes: parent finds the key the child stored",
+           PMIX_SUCCESS == pmix_hash_table_get_value_uint32(sh->ht, 9000, &val)
+               && (uintptr_t) val == 0xabcd);
+
+    idx = sh->kid_detail[0];
+    report("child writes: parent finds the pointer the child added",
+           0 <= idx && (uintptr_t) pmix_pointer_array_get_item(sh->pa, idx) == 0xfeed);
+}
+
+/* An object created with PMIX_NEW(type, tma) must both live in the segment
+ * and carry the allocator forward, or a container it builds would quietly
+ * allocate from the heap. */
+static void test_objects_land_in_the_segment(void)
+{
+    unsigned char *lo = seg_base;
+    unsigned char *hi = seg_base + SEG_SIZE;
+
+    report("segment: the shared object was allocated inside it",
+           (unsigned char *) sh->shared_obj >= lo && (unsigned char *) sh->shared_obj < hi);
+    report("segment: the hash table was allocated inside it",
+           (unsigned char *) sh->ht >= lo && (unsigned char *) sh->ht < hi);
+    report("segment: the pointer array was allocated inside it",
+           (unsigned char *) sh->pa >= lo && (unsigned char *) sh->pa < hi);
+
+    report("segment: the hash table reports a custom allocator",
+           NULL != pmix_obj_get_tma(&sh->ht->super));
+    report("segment: the pointer array reports a custom allocator",
+           NULL != pmix_obj_get_tma(&sh->pa->super));
+
+    /* the containers' own storage, not just their headers */
+    report("segment: the hash table's slot array is inside it",
+           (unsigned char *) sh->ht->ht_table >= lo
+               && (unsigned char *) sh->ht->ht_table < hi);
+    report("segment: the pointer array's slots are inside it",
+           (unsigned char *) sh->pa->addr >= lo && (unsigned char *) sh->pa->addr < hi);
+    report("segment: the pointer array's free_bits are inside it",
+           (unsigned char *) sh->pa->free_bits >= lo
+               && (unsigned char *) sh->pa->free_bits < hi);
+}
+
+/* ------------------------------------------------------------------ */
+
+static int build_shared_state(void)
+{
+    uint32_t k;
+    int i;
+    const char *pkey = "shared-ptr-key";
+
+    seg_base = (unsigned char *) mmap(NULL, SEG_SIZE, PROT_READ | PROT_WRITE,
+                                      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (MAP_FAILED == (void *) seg_base) {
+        perror("mmap");
+        return -1;
+    }
+
+    /* The shared header sits at the front; the arena is everything after. */
+    sh = (shared_t *) seg_base;
+    memset(sh, 0, sizeof(*sh));
+    atomic_init(&sh->ready, 0);
+    atomic_init(&sh->go, 0);
+    sh->arena.cursor = (sizeof(shared_t) + ALIGNMENT - 1) & ~((size_t) ALIGNMENT - 1);
+    sh->arena.capacity = SEG_SIZE;
+    tma_shared_init(&sh->tma, &sh->arena);
+
+    sh->shared_obj = (pmix_object_t *) PMIX_NEW(pmix_list_item_t, &sh->tma);
+    if (NULL == sh->shared_obj) {
+        fprintf(stderr, "could not allocate the shared object\n");
+        return -1;
+    }
+
+    sh->ht = PMIX_NEW(pmix_hash_table_t, &sh->tma);
+    if (NULL == sh->ht || PMIX_SUCCESS != pmix_hash_table_init(sh->ht, NKEYS * 4)) {
+        fprintf(stderr, "could not build the shared hash table\n");
+        return -1;
+    }
+    for (k = 0; k < NKEYS; k++) {
+        if (PMIX_SUCCESS
+            != pmix_hash_table_set_value_uint32(sh->ht, k, (void *) (uintptr_t) (k + 1000))) {
+            fprintf(stderr, "could not populate the shared hash table\n");
+            return -1;
+        }
+    }
+
+    sh->pa = PMIX_NEW(pmix_pointer_array_t, &sh->tma);
+    if (NULL == sh->pa
+        || PMIX_SUCCESS != pmix_pointer_array_init(sh->pa, NSLOTS * 2, NSLOTS * 8, 8)) {
+        fprintf(stderr, "could not build the shared pointer array\n");
+        return -1;
+    }
+    for (i = 0; i < NSLOTS; i++) {
+        if (0 > pmix_pointer_array_add(sh->pa, (void *) (uintptr_t) (i + 1))) {
+            fprintf(stderr, "could not populate the shared pointer array\n");
+            return -1;
+        }
+    }
+
+    /* The ptr-keyed entry goes in last: it is the one whose *key bytes*
+     * the table copies through the TMA, so it only works if set_value_ptr
+     * really is allocating from the segment. */
+    if (PMIX_SUCCESS
+        != pmix_hash_table_set_value_ptr(sh->ht, pkey, strlen(pkey),
+                                         (void *) (uintptr_t) 0x5150)) {
+        fprintf(stderr, "could not store the shared ptr key\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== src/class cross-process (TMA) tests ===\n\n");
+
+    if (0 != build_shared_state()) {
+        fprintf(stdout, "\nResults: could not set up the shared segment\n\n");
+        return 1;
+    }
+
+    test_objects_land_in_the_segment();
+    test_containers_read_from_another_process();
+    test_child_writes_visible_to_parent();
+    test_refcount_across_processes();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/class/class_value_array.c
+++ b/test/unit/class/class_value_array.c
@@ -369,6 +369,68 @@ static void test_many_appends(void)
 
 /* ------------------------------------------------------------------ */
 
+/* pmix_value_array_init() assigned realloc()'s result straight back into
+ * array_items. On failure that leaks whatever the array already owned and
+ * leaves a NULL buffer behind the item size and alloc size the same call
+ * has just committed -- the array then claims one element of capacity it
+ * does not have. The identical correction was already made in
+ * pmix_value_array_reserve() and pmix_value_array_set_size(); init was
+ * missed. A zero item size is now rejected outright too: every offset in
+ * the class is index * array_item_sizeof, so a zero collapses the whole
+ * array onto one address. */
+static void test_init_argument_checking(void)
+{
+    pmix_value_array_t va;
+
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+
+    report("init with item size 0: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_value_array_init(&va, 0));
+    report("rejected init leaves no allocation", NULL == va.array_items);
+    report("rejected init leaves item size 0", 0 == va.array_item_sizeof);
+    report("rejected init leaves alloc size 0", 0 == va.array_alloc_size);
+
+    /* a good init still works afterwards */
+    report("init(sizeof(int)) after rejection: PMIX_SUCCESS",
+           PMIX_SUCCESS == pmix_value_array_init(&va, sizeof(int)));
+    report("good init: item size recorded", sizeof(int) == va.array_item_sizeof);
+    report("good init: capacity seeded to 1", 1 == va.array_alloc_size);
+    report("good init: size is 0", 0 == pmix_value_array_get_size(&va));
+
+    PMIX_DESTRUCT(&va);
+}
+
+/* Re-initializing a live array must not lose the elements it is holding on
+ * the way to a clean, empty one, and must not leak the old buffer. */
+static void test_reinit_over_a_populated_array(void)
+{
+    pmix_value_array_t va;
+    int v;
+
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+    pmix_value_array_init(&va, sizeof(int));
+
+    v = 11; pmix_value_array_append_item(&va, &v);
+    v = 22; pmix_value_array_append_item(&va, &v);
+    v = 33; pmix_value_array_append_item(&va, &v);
+    report("populated: size is 3", 3 == pmix_value_array_get_size(&va));
+
+    report("re-init over a populated array: PMIX_SUCCESS",
+           PMIX_SUCCESS == pmix_value_array_init(&va, sizeof(long)));
+    report("re-init: size back to 0", 0 == pmix_value_array_get_size(&va));
+    report("re-init: item size is the new one", sizeof(long) == va.array_item_sizeof);
+    report("re-init: buffer is live", NULL != va.array_items);
+
+    {
+        long l = 7;
+        report("re-init: append works", PMIX_SUCCESS == pmix_value_array_append_item(&va, &l));
+        report("re-init: element reads back",
+               7 == PMIX_VALUE_ARRAY_GET_ITEM(&va, long, 0));
+    }
+
+    PMIX_DESTRUCT(&va);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -388,6 +450,8 @@ int main(int argc, char **argv)
     test_destruct_leaves_constructed_state();
     test_reserve_failure_preserves_contents();
     test_many_appends();
+    test_init_argument_checking();
+    test_reinit_over_a_populated_array();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;


### PR DESCRIPTION
A review of `src/class` — the object model and the container classes
built on it — and the fixes, tests and guidance that came out of it.

Six commits, each independently buildable and green, ordered so a bisect
lands somewhere useful:

1. **Repair init, teardown and argument checking in src/class** — the
   bug fixes, no behaviour changes beyond them.
2. **Correct the double-checked lock behind lazy class initialization.**
3. **Drop the dead `tma_memmove` and `item_free` members** — the layout
   change; see below.
4. **Export the class descriptors declared in installed headers** — the
   one PRRTE cares about.
5. **Add regression and cross-process coverage.**
6. **Record it in the news and the guides.**

## The defects worth calling out

**An uninitialized field read as a string.** `pmix_hash_table_construct()`
initialized every member except `ht_label`, and `src/util/pmix_hash.c`
prints that field at four sites behind only a NULL test. `PMIX_NEW` does
not zero its allocation, so every table that does not set its own label —
`gds/shmem3`'s and the mca base's among them — carried garbage there.

**`PMIX_DESTRUCT` on a `PMIX_*_STATIC_INIT` object segfaulted.** Those
macros tag the object with the *base* class descriptor, which is
pre-marked initialized and so never gets its constructor/destructor
arrays built. They were `NULL`, and both `pmix_obj_run_*` walk them with
`while (NULL != *array)` — precisely the "defined state so an early
failure path can tear it down" case the macros exist for.

**Two guards absent from every build that ships** — one inside
`#if PMIX_ENABLE_DEBUG`, one a bare `assert()`. `configure` adds
`-DNDEBUG` whenever `--enable-debug` is off, so `assert` is the same trap
in different clothes. That is now written down.

Plus: ring-buffer teardown leaving `tail` live over a freed array, two
failed-`realloc` paths, `pmix_list_insert` accepting a negative index,
`pmix_hash_table_init2` not validating its ratios, and
`pmix_next_poweroftwo` shifting a signed int by 31 and 32.

## The layout change (commit 3)

`tma_memmove` and `item_free` were written and never read. Both live in
structures `gds/shmem3` builds inside the segment it shares with its
local clients, so removing them moves every field below.

**No further `gds/shmem` rename is needed, and that was checked rather
than assumed:** the `shmem2` → `shmem3` rename earlier in this cycle has
not appeared in any release — every release branch still ships `shmem2`
and no tag contains the rename — and one rename covers every layout
change made before the new name ships. Once `shmem3` releases, the next
such change needs `shmem4`. `pmix_object_t` goes 104 → 96 bytes,
`pmix_list_t` 248 → 232.

## The visibility sweep (commit 4)

PRRTE has no object system of its own; it uses this one directly. It
touches ten PMIx-owned descriptors and one of them,
`pmix_mca_base_var_file_value_t`, was hidden — a program doing what
`prun_common.c` does fails to link against a default-visibility
`libpmix`. `test/unit` could not link at all in that configuration.

The rule applied is a boundary: every class declared in an **installed**
header gets an exported descriptor; classes in non-installed headers stay
hidden. Two audit traps are documented, because both caught me out — the
export can be applied at the declaration *or* the definition (so grepping
headers overstates the problem: of 59 bare declarations, only 31 were
genuinely hidden), and "installed" must be read off an install tree, not
parsed out of the `Makefile.am`s.

Result: 134 descriptors, 103 exported. The 31 still hidden are correctly
hidden — 27 private to a single `.c`, 4 `gds/hash` internals.

## Testing

`test/unit/class` goes from 9 programs to 10. Every regression case was
verified by reintroducing the defect in an **optimized** build; four
crash outright when their fix is backed out.

`class_tma_shared` is new and is the only cross-process program: it
builds the TMA-aware containers and a refcounted object inside a real
`MAP_SHARED` segment and checks from forked children that the storage and
the count are genuinely shared — two claims the guide made that were
never tested. It is explicit about what it does *not* model (its second
process comes from `fork()`, so segment negotiation and attach stay with
`gds/shmem3`).

The double-checked lock was verified with ThreadSanitizer, not by
inspection: seven data races in `pmix_class_initialize` against the old
code, none against the new.

| | Linux (container) | macOS (native, arm64) |
|---|---|---|
| `--enable-debug` | `make check` 80/80 | class 10/10, unit 35/35, util 20/20 |
| `--disable-debug`, default visibility | 15/15 + class 10/10 | class 10/10 |

Zero compiler warnings in every configuration. Docs build clean.
