### PR TITLE
Check the arguments callers get wrong in src/class, and make 'make check' actually run the suite

### DIFF
--- a/.github/actions/mlnx/entrypoint.sh
+++ b/.github/actions/mlnx/entrypoint.sh
@@ -150,7 +150,19 @@ if [ "$jenkins_test_build" = "yes" ]; then
     cd test
     export PMIX_MCA_pcompress_base_silence_warning=1
     echo "Running make check ..."
-    make $make_opt check || (cat test-suite.log && exit 12)
+    # On failure, dump every test-suite.log there is -- not just this
+    # directory's. "make check" here recurses into unit/, unit/class/ and
+    # unit/util/, and a failure in one of those writes its log there, so
+    # the old "cat test-suite.log" printed "No such file or directory"
+    # and the CI output carried no diagnostics at all. (It also swallowed
+    # the intended exit 12, since the && never fired once cat failed.)
+    if ! make $make_opt check; then
+        for log in $(find . -name test-suite.log -print); do
+            echo "======================== $log ========================"
+            cat "$log"
+        done
+        exit 12
+    fi
     echo "Make check complete"
     echo "========================  TEST COMPLETE  ========================="
 fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,24 @@ if PMIX_TESTS_EXAMPLES
 SUBDIRS += . test examples
 endif
 
+# Say so when "make check" has nothing to run. Without this, configuring
+# --without-tests-examples leaves test/ out of SUBDIRS entirely, so "make
+# check" recurses into nothing and exits 0 -- a result identical to a
+# clean full run. The same silent-skip shape (a conditional SUBDIRS) hid
+# the whole of test/ from every default-visibility build for as long as
+# the WANT_HIDDEN condition was there; see the note in test/Makefile.am.
+if !PMIX_TESTS_EXAMPLES
+check-local:
+	@echo "==============================================================="
+	@echo "NOTE: no tests were run."
+	@echo ""
+	@echo "This tree was configured --without-tests-examples, so test/ is"
+	@echo "not in SUBDIRS and 'make check' had nothing to descend into."
+	@echo "This is a success only in the sense that nothing failed."
+	@echo "Reconfigure with --with-tests-examples to run the suite."
+	@echo "==============================================================="
+endif
+
 pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
 

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md: The PMIx dockerswarm test harness
+
+This directory holds the multi-node test harness: a ten-container Docker
+swarm (plus a native macOS mode) that exercises PMIx in the
+configurations a developer's own `make check` cannot produce. Read the
+top-level [`AGENTS.md`](../../AGENTS.md) first for the project-wide
+rules.
+
+**[`README.md`](README.md) is the authoritative document for this
+directory** — 500+ lines covering what each runner does, how the swarm is
+brought up, cleanup hygiene, and a section per suite. This file is the
+short orientation an agent needs before touching anything here; when the
+two disagree, the README wins, and please fix this file.
+
+## What is here
+
+| Script | Subject |
+|--------|---------|
+| `build.sh` | Builds the image, PMIx, PRRTE (and optionally Open MPI) into the `pmix-build` volume |
+| `run-tests.sh` | The group construct/invite/destruct cases across real servers — the core multi-node suite |
+| `run-group-events.sh` | Group event delivery |
+| `run-topology.sh` | Topology / hwloc behavior |
+| `run-python.sh` | The Python bindings |
+| `run-class-tests.sh` | The `src/class` unit suite, in the two configurations nobody develops in (README §11) |
+| `run-client-tests.sh` | The `src/client` API suite with ranks behind different servers (README §12) |
+| `swarm-common.sh` | **Sourced, never executed.** `$PMIX_SWARM` naming and the one copy of `cleanup_swarm` |
+
+## Things that will bite you
+
+- **`swarm-common.sh` is sourced on the host, but most work happens
+  inside a `docker run ... bash -c '...'` string.** A helper function
+  defined there is *not* available in that string. Duplicated logic
+  inside those strings has to be kept in step by hand — which is why
+  `cleanup_swarm` lives in exactly one place and the runners call it
+  from the host side.
+
+- **An uninstalled libtool `check_PROGRAM` is a `/bin/sh` wrapper, not
+  an executable.** The binary is under `.libs/`. Copying the wrapper
+  anywhere else produces a script that reports `.libs/<prog> does not
+  exist` and exits 1. `run-class-tests.sh` staged the wrapper for a
+  while, so its ten-node pass silently ran nothing at all.
+
+- **A renamed or deleted MCA component directory wedges every existing
+  build directory in the volume.** Automake records each component's
+  `configure.m4` as a prerequisite of `aclocal.m4`; when one disappears
+  (`gds/shmem2` → `gds/shmem3`), make decides `aclocal.m4` is stale,
+  shells out to `aclocal-1.<n>`, and dies — the image carries no
+  autotools. `build.sh` now detects a missing recorded prerequisite and
+  reconfigures; anywhere else, delete `config.status` and re-run
+  `configure`. The error message names `aclocal`, never the component.
+
+- **`set -e` does not fire for a failing command in a non-final position
+  of an `&&` list.** `make && make install` therefore swallows a build
+  failure and reports success over a stale install. Write the two as
+  separate statements. Several runners carry a comment saying so.
+
+- **Ten containers on one host share a kernel and a CPU set.** A
+  "ten-node" pass is a contention and load pass, not a distributed one,
+  unless the thing under test genuinely crosses a server boundary. Say
+  which you mean; `run-class-tests.sh` is explicit that its ten-node
+  stage is only meaningful for the one multi-process program in that
+  suite.
+
+- **The build volume outlives your branch.** `pmix-build` persists
+  across runs and across checkouts, so a tree in it can be older than
+  the source you are testing. When results make no sense, check what is
+  actually in `/opt/prte` before doubting the code.
+
+## Adding a runner
+
+Follow the shape of the existing ones: source `swarm-common.sh`, use
+`swarm_up_or_die`, print `PASS`/`FAIL`/`SKIP` per case through the local
+`ok`/`bad`/`skp` helpers, and exit non-zero if anything failed. Derive
+the list of things to run from the relevant `Makefile.am` rather than
+repeating it, so a new test is picked up without editing the script.
+Then add a numbered section to [`README.md`](README.md) describing what
+it covers and — just as important — what it deliberately does not.

--- a/contrib/dockerswarm/CLAUDE.md
+++ b/contrib/dockerswarm/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -473,6 +473,31 @@ tests the maintainer's configuration.** And: **an in-tree grep is not
 evidence that an interface is unused** — `libpmix`'s internal headers
 are installed, and things build against them.
 
+### Two defects in the harness itself
+
+Worth knowing about, because both hid behind a green-looking run.
+
+**The ten-node contention pass had never run anything.** It staged the
+programs with `cp test/unit/class/$p`, but in an uninstalled libtool build
+that path is a `/bin/sh` **wrapper**; the executable is under `.libs/`.
+The copied wrapper looked for `.libs/$p` relative to its new home, did not
+find it, and exited 1 — on all ten nodes, every time, with a message the
+runner discarded. It stages `.libs/$p` now (falling back to the plain
+path). If you write a runner that ships `check_PROGRAMS` anywhere else,
+remember this.
+
+**A component rename wedges every pre-existing build directory.**
+Automake records each component's `configure.m4` as a prerequisite of
+`aclocal.m4`. Rename or delete a component directory — `gds/shmem2` →
+`gds/shmem3` — and one of those prerequisites no longer exists, so GNU
+make decides `aclocal.m4` must be remade, shells out to `aclocal-1.<n>`,
+and dies: this image ships no autotools. The build directory is then
+unusable for good, and the error ("`aclocal-1.18` is missing") points
+nowhere near the cause. `build.sh` now checks the recorded prerequisites
+and reconfigures from scratch when one has gone missing. If you hit this
+in a tree `build.sh` does not manage, the fix is the same: delete
+`config.status` and re-run `configure`.
+
 > **Note on the `macos` half.** Autoconf refuses an out-of-tree build while
 > the source directory itself holds a `config.status`. `build.sh` resolves
 > that by running `make distclean` on your tree; a test script has no

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -142,6 +142,30 @@ build_linux() {
                     rm -f config.status
                 fi
             fi
+            # Reconfigure when the *component set* has changed under us.
+            # Automake records every configure.m4 it folded into aclocal.m4
+            # as a prerequisite of aclocal.m4. Rename or delete a component
+            # directory -- gds/shmem2 -> gds/shmem3, say -- and one of those
+            # prerequisites no longer exists, so GNU make decides aclocal.m4
+            # must be remade, shells out to aclocal-1.<n>, and dies: this
+            # image ships no autotools. The build directory is then wedged
+            # for good, and the message ("aclocal-1.18 is missing") points
+            # nowhere near the cause. A stale prerequisite means the tree
+            # has to be configured again from scratch.
+            if [ -f config.status ] && [ -f Makefile ]; then
+                _ts=$(sed -n "s/^top_srcdir *= *//p" Makefile | head -1)
+                _stale=""
+                for _m in $(sed -n "/^am__aclocal_m4_deps *=/,/[^\\\\]$/p" Makefile \
+                            | tr " " "\n" | grep "\.m4$"); do
+                    _m=${_m//\$(top_srcdir)/$_ts}
+                    [ -e "$_m" ] || { _stale="$_m"; break; }
+                done
+                if [ -n "$_stale" ]; then
+                    echo "   (component set changed -- $_stale is gone; reconfiguring)"
+                    find . -name config.cache -delete 2>/dev/null || true
+                    rm -f config.status
+                fi
+            fi
             [ -f config.status ] || /pmix-src/configure --prefix=/opt/prte/pmix --enable-debug $pyopt
             # NOTE: deliberately two statements, not "make && make install".
             # set -e does NOT fire for a failing command in a non-final

--- a/contrib/dockerswarm/run-class-tests.sh
+++ b/contrib/dockerswarm/run-class-tests.sh
@@ -117,7 +117,14 @@ test_linux() {
             # Stage them so the nodes can run the same binaries.
             mkdir -p /opt/prte/tests-class/debug
             for p in $PROGS; do
-                cp "test/unit/class/$p" /opt/prte/tests-class/debug/ 2>/dev/null || true
+                # Stage the real ELF binary, not the libtool wrapper.
+                # An uninstalled libtool target leaves a /bin/sh wrapper at
+                # test/unit/class/$p and puts the executable under .libs/.
+                # Copying the wrapper anywhere else gives you a script that
+                # says .libs/$p does not exist and exits 1 -- which is what
+                # the ten-node pass below was reporting on every node.
+                cp "test/unit/class/.libs/$p" /opt/prte/tests-class/debug/ 2>/dev/null \
+                    || cp "test/unit/class/$p" /opt/prte/tests-class/debug/ 2>/dev/null || true
             done
         '
     rc=$?
@@ -143,7 +150,14 @@ test_linux() {
             make -j"$(nproc)" -C test/unit/class check
             mkdir -p /opt/prte/tests-class/opt
             for p in $PROGS; do
-                cp "test/unit/class/$p" /opt/prte/tests-class/opt/ 2>/dev/null || true
+                # Stage the real ELF binary, not the libtool wrapper.
+                # An uninstalled libtool target leaves a /bin/sh wrapper at
+                # test/unit/class/$p and puts the executable under .libs/.
+                # Copying the wrapper anywhere else gives you a script that
+                # says .libs/$p does not exist and exits 1 -- which is what
+                # the ten-node pass below was reporting on every node.
+                cp "test/unit/class/.libs/$p" /opt/prte/tests-class/opt/ 2>/dev/null \
+                    || cp "test/unit/class/$p" /opt/prte/tests-class/opt/ 2>/dev/null || true
             done
         '
     rc=$?

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,42 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Closed five more argument-checking holes in the src/class container
+   classes, all of them invisible in the configuration developers build
+   in. The hotel's three room-number accessors - pmix_hotel_checkout,
+   pmix_hotel_checkout_and_return_occupant and pmix_hotel_knock - tested
+   the lower bound of room_num with an if and the upper bound with an
+   assert, and configure adds -DNDEBUG whenever --enable-debug is off, so
+   no build that ships checked it: checkout then wrote through rooms[]
+   past the end of the array and pushed a second out-of-bounds write into
+   unoccupied_rooms[]. Callers pass a cached cd->room, and a destructed
+   hotel reached the same place through room 0. pmix_ring_buffer_push had
+   no guard at all where pop and poke both have one, so pushing to a ring
+   that was never initialized, or one already destructed, dereferenced a
+   NULL addr. pmix_value_array_reserve was missing the zero-item-size
+   check its two siblings carry, and since glibc answers realloc(NULL, 0)
+   with a non-NULL zero-byte block it reported success and committed a
+   capacity over storage that did not exist. The hash table's "one key
+   type per table" check sat inside PMIX_ENABLE_DEBUG, so mixing key
+   types was silent in a shipping build - leaking every copied ptr key
+   and rehashing live entries through the low bytes of a key pointer; it
+   is unconditional now, with only its diagnostic still behind the switch,
+   and its TMA exemption (needed because a shared segment's method
+   pointers mean nothing to a peer) is now covered by a cross-process
+   test. The ptr key family also rejects a NULL or zero-length key rather
+   than dereferencing it. pmix_bitmap_set_max_size did not validate its
+   argument, and because the cap is stored as a word count a negative bit
+   count wrapped round to a stored cap of zero, failing every later init
+   and set_bit far from the call that was actually wrong
+ - Fixed the dockerswarm class-test harness, whose ten-node pass had
+   never actually run anything: it staged the libtool wrapper script
+   rather than the executable under .libs, so every node reported that
+   the binary did not exist. contrib/dockerswarm/build.sh now also
+   detects a build directory whose component set has changed underneath
+   it - the gds/shmem2 to gds/shmem3 rename left every pre-existing tree
+   permanently unbuildable, because a configure.m4 recorded as a
+   prerequisite of aclocal.m4 no longer existed and make tried to run an
+   aclocal the image does not carry
  - Repaired a set of init, teardown and argument-checking defects in the
    src/class container classes. pmix_hash_table_construct() left ht_label
    uninitialized, and that field is read and printed by src/util/pmix_hash.c

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,17 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Stopped "make -j check" from failing test/unit. Most of that
+   directory's tests drive a real PMIx server through simptest, which
+   comes up in the scheduler role - a node-wide singleton that claims a
+   fixed rendezvous file, so the second server to want it is refused by
+   design. Automake's parallel harness starts several at once, and all
+   but one lost the race. The directory is now marked .NOTPARALLEL,
+   which costs nothing measurable: the whole suite still runs under -j
+   in well under a minute. This was not a new defect, only an
+   unreachable one - the CI job that builds with "make -j check"
+   configures with default visibility, and so never descended into
+   test/unit until the SUBDIRS gate above was removed
  - Made "make check" actually run the test suite. test/Makefile.am
    wrapped its whole SUBDIRS line in "if !WANT_HIDDEN", so unless the
    tree was configured --disable-visibility a top-level make check ran

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,24 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Made "make check" actually run the test suite. test/Makefile.am
+   wrapped its whole SUBDIRS line in "if !WANT_HIDDEN", so unless the
+   tree was configured --disable-visibility a top-level make check ran
+   the 15 programs in test/ itself, printed "# FAIL: 0", and silently
+   skipped test/unit, test/unit/class, test/unit/util, test/simple and
+   test/topologies. The optimized, default-visibility configuration -
+   the one those tests most need to cover, and the one users get - was
+   therefore never exercised by make check, and nothing said so. The
+   condition is no longer true now that the class descriptors declared
+   in installed headers are exported: all five subdirectories build and
+   pass with symbol visibility on, verified in five configurations
+   across both primary platforms - Linux/gcc and macOS/clang, debug and
+   optimized - with 80 tests passing and no warnings in every one. Two guards against a repeat: test/Makefile.am now fails
+   check-local if SUBDIRS ever comes out empty rather than recursing
+   into nothing and reporting success, and the top-level Makefile.am
+   prints a "no tests were run" notice when configured
+   --without-tests-examples, which produces the same silent success one
+   level up
  - Closed five more argument-checking holes in the src/class container
    classes, all of them invisible in the configuration developers build
    in. The hotel's three room-number accessors - pmix_hotel_checkout,

--- a/src/class/AGENTS.md
+++ b/src/class/AGENTS.md
@@ -838,7 +838,18 @@ consumable internal surface — keep them clean.
   are private to a single `.c` (no header declaration at all) and 4 are
   `gds/hash` component internals (`pmix_session_t`, `pmix_job_t`,
   `pmix_apptrkr_t`, `pmix_nodeinfo_t`) whose header is not installed. No
-  class declared in an installed header is hidden.
+  class declared in an installed header is hidden. Re-confirmed since,
+  with the `nm -m` recipe above, against a native macOS/clang
+  default-visibility build — same 134/103/31.
+
+  **That state is now load-bearing for the test suite, not just for
+  downstream consumers.** `test/Makefile.am` used to skip its entire
+  `SUBDIRS` unless the tree was configured `--disable-visibility`,
+  because these programs reach internal symbols; completing the exports
+  is what made the condition removable, and `make check` now descends
+  into `test/unit` in every configuration. If you hide a descriptor that
+  an installed header declares, you will break the suite as well as
+  PRRTE.
 - **Keep it warning-free and portable.** This code runs on every platform
   PMIx supports and is compiled with `-Werror` in CI. Use the
   `__pmix_attribute_*__` wrappers and `PMIX_HIDE_UNUSED_PARAMS` rather

--- a/src/class/AGENTS.md
+++ b/src/class/AGENTS.md
@@ -454,6 +454,35 @@ Two more things about this class that will surprise you:
   reading concurrently is a data race, and a table mapped read-only in
   a shared segment would fault on a lookup. If you ever need a genuinely
   const lookup, that assignment is what has to move.
+- **The "one key type per table" rule is enforced by one pointer
+  compare, and that compare used to be debug-only.** It sat inside
+  `#if PMIX_ENABLE_DEBUG`, so in every build that ships, mixing key
+  types was *silent*: the entry point simply retargeted
+  `ht_type_methods`, after which a ptr-keyed table had no
+  `elt_destructor` — every copied key leaked — while `pmix_hash_grow`
+  and `pmix_hash_table_remove_elt_at` rehashed its elements through
+  `key.u32`, i.e. the low bytes of a key *pointer*, scattering live
+  entries to slots no later lookup would probe. It is unconditional
+  now; only the `pmix_output` is still behind the switch.
+
+  **The TMA exemption in that check is load-bearing and must stay.**
+  `ht_type_methods` points at a file-scope static in whichever process
+  last touched the table, and that address means nothing to a peer that
+  has mapped the same `gds/shmem3` segment — a peer comparing it against
+  its own would refuse every lookup of a table it can read perfectly
+  well. The condition is `NULL == pmix_obj_get_tma(&ht->super) && ...`
+  for exactly that reason. Making the check unconditional is what turned
+  this from documentation into a live dependency: before, an optimized
+  build had nothing for a TMA table to be exempt *from*.
+  `test/unit/class/class_tma_shared` pins it, and deleting the exemption
+  makes that program fail to build its shared state at all.
+- **The ptr family validates its key.** A NULL key walks straight into
+  `pmix_hash_hash_key_ptr()` and is dereferenced; a zero `key_size`
+  makes every key compare equal to every other (`memcmp` of 0 bytes is
+  0) and asks the allocator for a 0-byte block, whose answer is
+  implementation-defined — NULL on some platforms, which the setter
+  would have reported as an out-of-memory that never happened. All three
+  ptr entry points now return `PMIX_ERR_BAD_PARAM` for either.
 - Every entry point starts with `key % capacity`, and capacity is zero
   until `pmix_hash_table_init` runs. The guard that catches that used to
   be `#if PMIX_ENABLE_DEBUG`, so an optimized build took a SIGFPE where
@@ -504,6 +533,17 @@ correct because `tail == head` whenever the ring is full. That invariant
 is not asserted anywhere. Do not "simplify" that function without
 convincing yourself of it.
 
+**`pmix_ring_buffer_push` was the one accessor with no guard at all.**
+`pop` has always tested `tail == -1` and `poke` `size <= i`, but `push`
+went straight to `addr[ring->head]` — so a ring that had only been
+`PMIX_NEW`'d or `PMIX_CONSTRUCT`'d, or one already destructed,
+dereferenced the NULL `addr` instead of declining. Given this class's
+consumers are out of tree (see above), that is the least forgivable place
+to leave a hole. It now returns NULL when there is no storage, which is
+the same answer as "the ring was not full" — an unfortunate conflation,
+but the only value the signature has to give, and strictly better than
+the fault. All three accessors also tolerate a NULL ring now.
+
 `tail == -1` is this class's "nothing has been pushed yet" flag, and it is
 the field the teardown and re-init paths kept forgetting: the destructor
 freed `addr` and zeroed `size` but left `head`/`tail` alone, so
@@ -529,6 +569,18 @@ slot), and holds the grown buffer aside rather than assigning a failed
 `realloc` back over the live one — the correction `reserve` and
 `set_size` already carried.
 
+**`pmix_value_array_reserve` was the last member of the
+init/reserve/set_size trio still missing that zero-item-size check, and
+it is the worst place to miss it.** On an array that has only been
+`PMIX_CONSTRUCT`'d, `array_item_sizeof` is 0, so `reserve` asked
+`realloc()` for `0 * size` bytes — and glibc answers `realloc(NULL, 0)`
+with a *non-NULL* pointer to a zero-byte block. `reserve` then reported
+success and committed `array_alloc_size = size` over that empty block,
+after which `set_size` saw enough capacity to skip growing and every
+element write went into the heap past the end of it. When you add a
+guard to one member of a family here, check the siblings in the same
+edit; this directory has now had the same omission four times.
+
 ### `pmix_bitmap_t` — auto-expanding bit array
 
 A bitmap over `uint64_t` words. `set_bit` auto-expands the array to fit
@@ -537,6 +589,15 @@ A bitmap over `uint64_t` words. `set_bit` auto-expands the array to fit
 rather than expanding. Provides find-first-unset-and-set, whole-bitmap
 and/or/xor, population counts, copy, compare, and a `_get_string`
 debugging dump. Not TMA-aware.
+
+`pmix_bitmap_set_max_size` was the one entry point in the file that did
+not validate its argument. Because the stored cap is a *word* count
+converted with `((size_t) max_size + 63) / 64`, a negative bit count
+became `(size_t) -1`, whose `+ 63` wrapped round to 62, which divided
+down to a stored cap of **zero words** — the call reported success and
+every later `init`/`set_bit` then failed with `PMIX_ERR_BAD_PARAM` a long
+way from the call that actually got it wrong. It rejects `max_size <= 0`
+now.
 
 `max_size` is a public *bit* count on the way in and a **word** count once
 stored (`pmix_bitmap_set_max_size` converts); the constructor and
@@ -690,8 +751,20 @@ consumable internal surface — keep them clean.
   `pmix_pointer_array_test_and_set_item` guarded its index with
   `assert(index >= 0)` alone, so a negative index wrote below the start
   of `addr` in exactly the builds that matter — while its sibling
-  `pmix_pointer_array_set_item` had always rejected it outright. If the
-  check is about *caller input*, write an `if` and return an error.
+  `pmix_pointer_array_set_item` had always rejected it outright. The
+  hotel's three room-number accessors had the same shape and were worse:
+  `pmix_hotel_checkout`, `pmix_hotel_checkout_and_return_occupant` and
+  `pmix_hotel_knock` each tested the *lower* bound with an `if` and the
+  *upper* bound with `assert(room_num < hotel->num_rooms)`, so a shipped
+  build did not check it at all — and `checkout` then **wrote** through
+  `rooms[room_num]` past the end of the array and pushed a second
+  out-of-bounds write into `unoccupied_rooms[]` via
+  `++last_unoccupied_room`. A destructed hotel (`num_rooms` 0, `rooms`
+  NULL) reached the same place through room 0, and every caller passes a
+  cached `cd->room`. All three now test both bounds unconditionally. If
+  the check is about *caller input*, write an `if` and return an error —
+  and wrap it in `PMIX_UNLIKELY()` so the branch predictor pays for the
+  path that never happens, not the one that always does.
 - **Leave objects in the constructed state when you destruct them.**
   The destructors here now do (`pmix_list_destruct` always did — it
   calls the constructor). Freeing a pointer and leaving it in the struct

--- a/src/class/pmix_bitmap.c
+++ b/src/class/pmix_bitmap.c
@@ -25,10 +25,12 @@
 #include "src/include/pmix_config.h"
 
 #include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include "pmix_common.h"
 #include "src/class/pmix_bitmap.h"
+#include "src/include/pmix_prefetch.h"
 
 /* The number of bits in the underlying type of the bitmap field
  * in the pmix_bitmap_t struct
@@ -57,7 +59,14 @@ static void pmix_bitmap_destruct(pmix_bitmap_t *bm)
 
 int pmix_bitmap_set_max_size(pmix_bitmap_t *bm, int max_size)
 {
-    if (NULL == bm) {
+    /* A non-positive cap is not a cap. Left unchecked, the conversion
+     * below ran it through size_t: max_size == -1 became (size_t) -1,
+     * which the "+ 63" wrapped to 62, which divided down to 0 -- a stored
+     * cap of zero words, so every later pmix_bitmap_init() and
+     * pmix_bitmap_set_bit() returned PMIX_ERR_BAD_PARAM from a long way
+     * away from the call that actually got it wrong. Every other entry
+     * point in this file validates its arguments unconditionally. */
+    if (PMIX_UNLIKELY(NULL == bm || max_size <= 0)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -139,8 +148,9 @@ int pmix_bitmap_set_bit(pmix_bitmap_t *bm, int bit)
          valid and we simply expand the bitmap */
 
         new_size = index + 1;
-        if (new_size > bm->max_size)
+        if (new_size > bm->max_size) {
             new_size = bm->max_size;
+        }
 
         /* New size is just a multiple of the original size to fit in
          the index. Hold the grown pointer aside until it is in hand:
@@ -234,7 +244,10 @@ int pmix_bitmap_set_all_bits(pmix_bitmap_t *bm)
 int pmix_bitmap_find_and_set_first_unset_bit(pmix_bitmap_t *bm, int *position)
 {
     int i = 0;
-    uint64_t temp, all_ones = 0xffffffffffffffffUL;
+    /* UINT64_MAX, not 0xffffffffffffffffUL: unsigned long is 32 bits on
+     * 32-bit Linux and on Windows, and the literal form invites exactly
+     * the width mistake this file has had before. */
+    uint64_t temp, all_ones = UINT64_MAX;
 
     if (NULL == bm) {
         return PMIX_ERR_BAD_PARAM;
@@ -421,15 +434,17 @@ int pmix_bitmap_num_set_bits(pmix_bitmap_t *bm, int len)
     i_len = len / SIZE_OF_BASE_TYPE + (len % SIZE_OF_BASE_TYPE == 0 ? 0 : 1);
 
     for (i = 0; i < i_len && i < bm->array_size; ++i) {
-        if (0 == (val = bm->bitmap[i]))
+        if (0 == (val = bm->bitmap[i])) {
             continue;
+        }
         if (i == i_len - 1 && len % SIZE_OF_BASE_TYPE != 0) {
             /* Mask out the bits above len. The shift distance runs to 63,
              * so it has to be applied to an unsigned 64-bit value: shifting
              * a signed 1LL by 63 overflows the sign bit and is undefined. */
             val = val & ((1ULL << (len - i * SIZE_OF_BASE_TYPE)) - 1);
-            if (0 == val)
+            if (0 == val) {
                 continue;
+            }
         }
         /*  Peter Wegner in CACM 3 (1960), 322. This method goes through as many
          *  iterations as there are set bits. */

--- a/src/class/pmix_hash_table.c
+++ b/src/class/pmix_hash_table.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -329,18 +329,29 @@ pmix_hash_table_get_value_uint32(pmix_hash_table_t *ht, uint32_t key, void **val
 #endif
         return PMIX_ERROR;
     }
+    /* A table holds exactly one key type at a time, and this check is the
+     * only thing that enforces it. It used to sit inside
+     * "#if PMIX_ENABLE_DEBUG", so in every build that ships, mixing key
+     * types was silent: the assignment below simply retargets
+     * ht_type_methods, and from that point on a ptr-keyed table has no
+     * elt_destructor (every copied key leaks) while pmix_hash_grow() and
+     * pmix_hash_table_remove_elt_at() rehash its elements through
+     * key.u32 -- the low bytes of a key pointer -- scattering live
+     * entries to slots no later lookup will probe. One pointer compare,
+     * on a path that already does a division, does not buy that. Only
+     * the diagnostic belongs behind the debug switch.
+     *
+     * The TMA exemption is real and stays: a table living in a shared
+     * segment may carry method pointers another process installed, which
+     * mean nothing in this address space. */
+    if (PMIX_UNLIKELY(NULL == pmix_obj_get_tma(&ht->super) && NULL != ht->ht_type_methods
+                      && &pmix_hash_type_methods_uint32 != ht->ht_type_methods)) {
 #if PMIX_ENABLE_DEBUG
-    // First check if the hash table is using a non-standard heap manager. Skip
-    // this debug check because use of a shared-memory TMA may trigger an error
-    // since some processes may have not yet updated their function pointers
-    // (done below).
-    if (NULL == pmix_obj_get_tma(&ht->super) &&
-        NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint32 != ht->ht_type_methods) {
         pmix_output(0, "pmix_hash_table_get_value_uint32:"
                        "hash table is for a different key type");
+#endif
         return PMIX_ERROR;
     }
-#endif
 
     ht->ht_type_methods = &pmix_hash_type_methods_uint32;
     for (ii = key % capacity;; ii += 1) {
@@ -378,18 +389,17 @@ pmix_hash_table_set_value_uint32(pmix_hash_table_t *ht, uint32_t key, void *valu
 #endif
         return PMIX_ERR_BAD_PARAM;
     }
+    /* One key type per table; see pmix_hash_table_get_value_uint32() for
+     * why this check is not inside "#if PMIX_ENABLE_DEBUG" and why the
+     * TMA exemption is. */
+    if (PMIX_UNLIKELY(NULL == pmix_obj_get_tma(&ht->super) && NULL != ht->ht_type_methods
+                      && &pmix_hash_type_methods_uint32 != ht->ht_type_methods)) {
 #if PMIX_ENABLE_DEBUG
-    // First check if the hash table is using a non-standard heap manager. Skip
-    // this debug check because use of a shared-memory TMA may trigger an error
-    // since some processes may have not yet updated their function pointers
-    // (done below).
-    if (NULL == pmix_obj_get_tma(&ht->super) &&
-        NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint32 != ht->ht_type_methods) {
         pmix_output(0, "pmix_hash_table_set_value_uint32:"
                        "hash table is for a different key type");
+#endif
         return PMIX_ERROR;
     }
-#endif
 
     ht->ht_type_methods = &pmix_hash_type_methods_uint32;
     for (ii = key % capacity;; ii += 1) {
@@ -435,24 +445,24 @@ int pmix_hash_table_remove_value_uint32(pmix_hash_table_t *ht, uint32_t key)
 #endif
         return PMIX_ERROR;
     }
+    /* One key type per table; see pmix_hash_table_get_value_uint32() for
+     * why this check is not inside "#if PMIX_ENABLE_DEBUG" and why the
+     * TMA exemption is. */
+    if (PMIX_UNLIKELY(NULL == pmix_obj_get_tma(&ht->super) && NULL != ht->ht_type_methods
+                      && &pmix_hash_type_methods_uint32 != ht->ht_type_methods)) {
 #if PMIX_ENABLE_DEBUG
-    // First check if the hash table is using a non-standard heap manager. Skip
-    // this debug check because use of a shared-memory TMA may trigger an error
-    // since some processes may have not yet updated their function pointers
-    // (done below).
-    if (NULL == pmix_obj_get_tma(&ht->super) &&
-        NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint32 != ht->ht_type_methods) {
         pmix_output(0, "pmix_hash_table_remove_value_uint32:"
                        "hash table is for a different key type");
+#endif
         return PMIX_ERROR;
     }
-#endif
 
     ht->ht_type_methods = &pmix_hash_type_methods_uint32;
     for (ii = key % capacity;; ii += 1) {
         pmix_hash_element_t *elt;
-        if (ii == capacity)
+        if (ii == capacity) {
             ii = 0;
+        }
         elt = &ht->ht_table[ii];
         if (!elt->valid) {
             return PMIX_ERR_NOT_FOUND;
@@ -492,18 +502,17 @@ pmix_hash_table_get_value_uint64(pmix_hash_table_t *ht, uint64_t key, void **val
 #endif
         return PMIX_ERROR;
     }
+    /* One key type per table; see pmix_hash_table_get_value_uint32() for
+     * why this check is not inside "#if PMIX_ENABLE_DEBUG" and why the
+     * TMA exemption is. */
+    if (PMIX_UNLIKELY(NULL == pmix_obj_get_tma(&ht->super) && NULL != ht->ht_type_methods
+                      && &pmix_hash_type_methods_uint64 != ht->ht_type_methods)) {
 #if PMIX_ENABLE_DEBUG
-    // First check if the hash table is using a non-standard heap manager. Skip
-    // this debug check because use of a shared-memory TMA may trigger an error
-    // since some processes may have not yet updated their function pointers
-    // (done below).
-    if (NULL == pmix_obj_get_tma(&ht->super) &&
-        NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint64 != ht->ht_type_methods) {
         pmix_output(0, "pmix_hash_table_get_value_uint64:"
                        "hash table is for a different key type");
+#endif
         return PMIX_ERROR;
     }
-#endif
 
     ht->ht_type_methods = &pmix_hash_type_methods_uint64;
     for (ii = key % capacity;; ii += 1) {
@@ -541,18 +550,17 @@ pmix_hash_table_set_value_uint64(pmix_hash_table_t *ht, uint64_t key, void *valu
 #endif
         return PMIX_ERR_BAD_PARAM;
     }
+    /* One key type per table; see pmix_hash_table_get_value_uint32() for
+     * why this check is not inside "#if PMIX_ENABLE_DEBUG" and why the
+     * TMA exemption is. */
+    if (PMIX_UNLIKELY(NULL == pmix_obj_get_tma(&ht->super) && NULL != ht->ht_type_methods
+                      && &pmix_hash_type_methods_uint64 != ht->ht_type_methods)) {
 #if PMIX_ENABLE_DEBUG
-    // First check if the hash table is using a non-standard heap manager. Skip
-    // this debug check because use of a shared-memory TMA may trigger an error
-    // since some processes may have not yet updated their function pointers
-    // (done below).
-    if (NULL == pmix_obj_get_tma(&ht->super) &&
-        NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint64 != ht->ht_type_methods) {
         pmix_output(0, "pmix_hash_table_set_value_uint64:"
                        "hash table is for a different key type");
+#endif
         return PMIX_ERROR;
     }
-#endif
 
     ht->ht_type_methods = &pmix_hash_type_methods_uint64;
     for (ii = key % capacity;; ii += 1) {
@@ -598,18 +606,17 @@ pmix_hash_table_remove_value_uint64(pmix_hash_table_t *ht, uint64_t key)
 #endif
         return PMIX_ERROR;
     }
+    /* One key type per table; see pmix_hash_table_get_value_uint32() for
+     * why this check is not inside "#if PMIX_ENABLE_DEBUG" and why the
+     * TMA exemption is. */
+    if (PMIX_UNLIKELY(NULL == pmix_obj_get_tma(&ht->super) && NULL != ht->ht_type_methods
+                      && &pmix_hash_type_methods_uint64 != ht->ht_type_methods)) {
 #if PMIX_ENABLE_DEBUG
-    // First check if the hash table is using a non-standard heap manager. Skip
-    // this debug check because use of a shared-memory TMA may trigger an error
-    // since some processes may have not yet updated their function pointers
-    // (done below).
-    if (NULL == pmix_obj_get_tma(&ht->super) &&
-        NULL != ht->ht_type_methods && &pmix_hash_type_methods_uint64 != ht->ht_type_methods) {
         pmix_output(0, "pmix_hash_table_remove_value_uint64:"
                        "hash table is for a different key type");
+#endif
         return PMIX_ERROR;
     }
-#endif
 
     ht->ht_type_methods = &pmix_hash_type_methods_uint64;
     for (ii = key % capacity;; ii += 1) {
@@ -682,18 +689,28 @@ pmix_hash_table_get_value_ptr(pmix_hash_table_t *ht, const void *key, size_t key
 #endif
         return PMIX_ERROR;
     }
+    /* The ptr family hashes and memcmp's the caller's key bytes, and the
+     * setter memcpy's them into storage it owns. A NULL key walks into
+     * pmix_hash_hash_key_ptr() and dereferences it; a zero key_size makes
+     * every key compare equal to every other (memcmp of 0 bytes is 0) and
+     * asks the allocator for a 0-byte block, whose answer is
+     * implementation-defined -- NULL on some platforms, which this code
+     * would report as an out-of-memory that never happened. Neither is a
+     * usable key, so say so. */
+    if (PMIX_UNLIKELY(NULL == key || 0 == key_size)) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    /* One key type per table; see pmix_hash_table_get_value_uint32() for
+     * why this check is not inside "#if PMIX_ENABLE_DEBUG" and why the
+     * TMA exemption is. */
+    if (PMIX_UNLIKELY(NULL == pmix_obj_get_tma(&ht->super) && NULL != ht->ht_type_methods
+                      && &pmix_hash_type_methods_ptr != ht->ht_type_methods)) {
 #if PMIX_ENABLE_DEBUG
-    // First check if the hash table is using a non-standard heap manager. Skip
-    // this debug check because use of a shared-memory TMA may trigger an error
-    // since some processes may have not yet updated their function pointers
-    // (done below).
-    if (NULL == pmix_obj_get_tma(&ht->super) &&
-        NULL != ht->ht_type_methods && &pmix_hash_type_methods_ptr != ht->ht_type_methods) {
         pmix_output(0, "pmix_hash_table_get_value_ptr:"
                        "hash table is for a different key type");
+#endif
         return PMIX_ERROR;
     }
-#endif
 
     ht->ht_type_methods = &pmix_hash_type_methods_ptr;
     for (ii = pmix_hash_hash_key_ptr(key, key_size) % capacity;; ii += 1) {
@@ -732,18 +749,20 @@ pmix_hash_table_set_value_ptr(pmix_hash_table_t *ht, const void *key, size_t key
 #endif
         return PMIX_ERR_BAD_PARAM;
     }
+    if (PMIX_UNLIKELY(NULL == key || 0 == key_size)) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    /* One key type per table; see pmix_hash_table_get_value_uint32() for
+     * why this check is not inside "#if PMIX_ENABLE_DEBUG" and why the
+     * TMA exemption is. */
+    if (PMIX_UNLIKELY(NULL == pmix_obj_get_tma(&ht->super) && NULL != ht->ht_type_methods
+                      && &pmix_hash_type_methods_ptr != ht->ht_type_methods)) {
 #if PMIX_ENABLE_DEBUG
-    // First check if the hash table is using a non-standard heap manager. Skip
-    // this debug check because use of a shared-memory TMA may trigger an error
-    // since some processes may have not yet updated their function pointers
-    // (done below).
-    if (NULL == pmix_obj_get_tma(&ht->super) &&
-        NULL != ht->ht_type_methods && &pmix_hash_type_methods_ptr != ht->ht_type_methods) {
         pmix_output(0, "pmix_hash_table_set_value_ptr:"
                        "hash table is for a different key type");
+#endif
         return PMIX_ERROR;
     }
-#endif
 
     ht->ht_type_methods = &pmix_hash_type_methods_ptr;
     for (ii = pmix_hash_hash_key_ptr(key, key_size) % capacity;; ii += 1) {
@@ -797,18 +816,20 @@ pmix_hash_table_remove_value_ptr(pmix_hash_table_t *ht, const void *key, size_t 
 #endif
         return PMIX_ERROR;
     }
+    if (PMIX_UNLIKELY(NULL == key || 0 == key_size)) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    /* One key type per table; see pmix_hash_table_get_value_uint32() for
+     * why this check is not inside "#if PMIX_ENABLE_DEBUG" and why the
+     * TMA exemption is. */
+    if (PMIX_UNLIKELY(NULL == pmix_obj_get_tma(&ht->super) && NULL != ht->ht_type_methods
+                      && &pmix_hash_type_methods_ptr != ht->ht_type_methods)) {
 #if PMIX_ENABLE_DEBUG
-    // First check if the hash table is using a non-standard heap manager. Skip
-    // this debug check because use of a shared-memory TMA may trigger an error
-    // since some processes may have not yet updated their function pointers
-    // (done below).
-    if (NULL == pmix_obj_get_tma(&ht->super) &&
-        NULL != ht->ht_type_methods && &pmix_hash_type_methods_ptr != ht->ht_type_methods) {
         pmix_output(0, "pmix_hash_table_remove_value_ptr:"
                        "hash table is for a different key type");
+#endif
         return PMIX_ERROR;
     }
-#endif
 
     ht->ht_type_methods = &pmix_hash_type_methods_ptr;
     for (ii = pmix_hash_hash_key_ptr(key, key_size) % capacity;; ii += 1) {

--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -6,7 +6,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -227,6 +227,13 @@ static inline pmix_status_t pmix_hotel_checkin(pmix_hotel_t *hotel, void *occupa
 /**
  * Same as pmix_hotel_checkin(), but slightly optimized for when the
  * caller *knows* that there is a room available.
+ *
+ * "Knows" is load-bearing and unchecked: on a full hotel this reads
+ * unoccupied_rooms[-1] and drives last_unoccupied_room further negative.
+ * There is no error channel here by design -- that is the whole
+ * difference from pmix_hotel_checkin(). If you cannot prove a room is
+ * free at the call site, call pmix_hotel_checkin() instead; the saving
+ * is one predictable branch.
  */
 static inline void pmix_hotel_checkin_with_res(pmix_hotel_t *hotel, void *occupant, int *room_num)
 {
@@ -259,9 +266,17 @@ static inline void pmix_hotel_checkout(pmix_hotel_t *hotel, int room_num)
 {
     pmix_hotel_room_t *room;
 
-    /* Bozo check */
-    assert(room_num < hotel->num_rooms);
-    if (0 > room_num) {
+    /* Bozo check. Both bounds are tested unconditionally: an assert() is
+     * not a guard here, because config/pmix.m4 adds -DNDEBUG whenever
+     * --enable-debug is off, so in every build that ships the upper bound
+     * used to be no check at all. A room_num at or above num_rooms then
+     * indexed past rooms[] and this function *wrote* through it
+     * (room->occupant = NULL), deleted an event out of garbage, and pushed
+     * a second out-of-bounds write into unoccupied_rooms[]. A destructed
+     * or never-init'd hotel -- num_rooms 0, rooms NULL -- reached the same
+     * place through room_num 0. Callers hand in a cached cd->room, which
+     * is exactly the kind of value that goes stale. */
+    if (PMIX_UNLIKELY(0 > room_num || room_num >= hotel->num_rooms)) {
         /* occupant wasn't checked in */
         return;
     }
@@ -302,9 +317,10 @@ static inline void pmix_hotel_checkout_and_return_occupant(pmix_hotel_t *hotel, 
 {
     pmix_hotel_room_t *room;
 
-    /* Bozo check */
-    assert(room_num < hotel->num_rooms);
-    if (0 > room_num) {
+    /* Bozo check -- both bounds, unconditionally. See the note in
+     * pmix_hotel_checkout() for why an assert() on the upper bound was
+     * not one in any build that ships. */
+    if (PMIX_UNLIKELY(0 > room_num || room_num >= hotel->num_rooms)) {
         /* occupant wasn't checked in */
         *occupant = NULL;
         return;
@@ -338,10 +354,11 @@ static inline void pmix_hotel_checkout_and_return_occupant(pmix_hotel_t *hotel, 
  */
 static inline bool pmix_hotel_is_empty(pmix_hotel_t *hotel)
 {
-    if (hotel->last_unoccupied_room == hotel->num_rooms - 1)
+    if (hotel->last_unoccupied_room == hotel->num_rooms - 1) {
         return true;
-    else
+    } else {
         return false;
+    }
 }
 
 /**
@@ -358,11 +375,12 @@ static inline void pmix_hotel_knock(pmix_hotel_t *hotel, int room_num, void **oc
 {
     pmix_hotel_room_t *room;
 
-    /* Bozo check */
-    assert(room_num < hotel->num_rooms);
-
+    /* Bozo check -- both bounds, unconditionally. See the note in
+     * pmix_hotel_checkout(). This one only reads, but reading rooms[]
+     * out of bounds is still a fault waiting to happen, and every caller
+     * of this function walks an index range it computed elsewhere. */
     *occupant = NULL;
-    if (0 > room_num) {
+    if (PMIX_UNLIKELY(0 > room_num || room_num >= hotel->num_rooms)) {
         /* occupant wasn't checked in */
         return;
     }

--- a/src/class/pmix_list.c
+++ b/src/class/pmix_list.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -124,8 +124,9 @@ bool pmix_list_insert(pmix_list_t *list, pmix_list_item_t *item, long long idx)
 #endif
         /* pointer to element 0 */
         ptr = list->pmix_list_sentinel.pmix_list_next;
-        for (i = 0; i < idx - 1; i++)
+        for (i = 0; i < idx - 1; i++) {
             ptr = ptr->pmix_list_next;
+        }
 
         next = ptr->pmix_list_next;
         item->pmix_list_next = next;

--- a/src/class/pmix_pointer_array.h
+++ b/src/class/pmix_pointer_array.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -205,8 +205,12 @@ PMIX_EXPORT bool pmix_pointer_array_test_and_set_item(pmix_pointer_array_t *tabl
 static inline void pmix_pointer_array_remove_all(pmix_pointer_array_t *array)
 {
     int i;
-    if (array->number_free == array->size)
-        return; /* nothing to do here this time (the array is already empty) */
+    if (array->number_free == array->size) {
+        /* nothing to do here this time (the array is already empty).
+         * This also covers the un-init'd array, where both are 0 and
+         * free_bits/addr are still NULL. */
+        return;
+    }
 
     array->lowest_free = 0;
     array->number_free = array->size;

--- a/src/class/pmix_ring_buffer.c
+++ b/src/class/pmix_ring_buffer.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2010      Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,6 +106,22 @@ void *pmix_ring_buffer_push(pmix_ring_buffer_t *ring, void *ptr)
 {
     char *p = NULL;
 
+    /* There is no storage until pmix_ring_buffer_init() has run, and none
+     * again after the destructor has run. Both of the other accessors
+     * already survive that state -- pop() tests "tail == -1" and poke()
+     * tests "size <= i" -- but this one went straight to addr[head] and
+     * dereferenced NULL. It is the easiest of the three to reach: a ring
+     * that was only PMIX_NEW'd, or one being pushed to on a teardown path
+     * that has already destructed it.
+     *
+     * Answering NULL is the same answer as "the ring was not full", which
+     * is unfortunate but is the only value this signature has to give. It
+     * is still strictly better than the fault, and a caller that pushes
+     * into an un-init'd ring has a bug either way. */
+    if (PMIX_UNLIKELY(NULL == ring || NULL == ring->addr || 0 >= ring->size)) {
+        return NULL;
+    }
+
     if (NULL != ring->addr[ring->head]) {
         p = (char *) ring->addr[ring->head];
         if (ring->tail == ring->size - 1) {
@@ -130,6 +146,9 @@ void *pmix_ring_buffer_pop(pmix_ring_buffer_t *ring)
 {
     char *p = NULL;
 
+    if (PMIX_UNLIKELY(NULL == ring)) {
+        return NULL;
+    }
     if (-1 == ring->tail) {
         /* nothing has been put on the ring yet */
         p = NULL;
@@ -154,6 +173,9 @@ void *pmix_ring_buffer_poke(pmix_ring_buffer_t *ring, int i)
     char *p = NULL;
     int offset;
 
+    if (PMIX_UNLIKELY(NULL == ring)) {
+        return NULL;
+    }
     if (ring->size <= i || -1 == ring->tail) {
         p = NULL;
     } else if (i < 0) {

--- a/src/class/pmix_ring_buffer.h
+++ b/src/class/pmix_ring_buffer.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2010      Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +29,7 @@
 #include "src/include/pmix_config.h"
 
 #include "src/class/pmix_object.h"
+#include "src/include/pmix_prefetch.h"
 #include "src/util/pmix_output.h"
 
 BEGIN_C_DECLS
@@ -91,6 +92,11 @@ PMIX_EXPORT int pmix_ring_buffer_init(pmix_ring_buffer_t *ring, int size);
  *
  * @return Pointer to displaced item, NULL if ring
  *         is not yet full
+ *
+ * NULL is also returned, and nothing is stored, if the ring has no
+ * storage -- it was never pmix_ring_buffer_init()'ed, or it has been
+ * destructed. The two cases are indistinguishable in the return value;
+ * this signature has nowhere else to put the distinction.
  */
 PMIX_EXPORT void *pmix_ring_buffer_push(pmix_ring_buffer_t *ring, void *ptr);
 

--- a/src/class/pmix_value_array.c
+++ b/src/class/pmix_value_array.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,7 +54,7 @@ int pmix_value_array_set_size(pmix_value_array_t *array, size_t size)
      * zero one is fatal, not a debug-only curiosity. It used to be checked
      * only under --enable-debug, which left an optimized build computing
      * every address as items + index*0. */
-    if (0 == array->array_item_sizeof) {
+    if (PMIX_UNLIKELY(0 == array->array_item_sizeof)) {
         return PMIX_ERR_BAD_PARAM;
     }
 

--- a/src/class/pmix_value_array.h
+++ b/src/class/pmix_value_array.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +29,7 @@
 #endif /* HAVE_STRINGS_H */
 
 #include "src/class/pmix_object.h"
+#include "src/include/pmix_prefetch.h"
 #if PMIX_ENABLE_DEBUG
 #    include "src/util/pmix_output.h"
 #endif
@@ -80,7 +81,7 @@ static inline int pmix_value_array_init(pmix_value_array_t *array, size_t item_s
     /* Every offset in this class is computed from the item size, so a zero
      * one makes the array silently degenerate: each element lands at the
      * same address and remove_item memmoves nothing. */
-    if (0 == item_sizeof) {
+    if (PMIX_UNLIKELY(0 == item_sizeof)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -110,6 +111,19 @@ static inline int pmix_value_array_init(pmix_value_array_t *array, size_t item_s
 
 static inline int pmix_value_array_reserve(pmix_value_array_t *array, size_t size)
 {
+    /* The sibling of the check pmix_value_array_init() and
+     * pmix_value_array_set_size() already carry; this one was missed, and
+     * it is the worst place to miss it. On an array that was only
+     * PMIX_CONSTRUCT'd, array_item_sizeof is 0, so the realloc() below asks
+     * for 0 bytes -- and glibc answers realloc(NULL, 0) with a non-NULL
+     * pointer to a zero-byte block. This function then reported success and
+     * committed array_alloc_size = size over it, after which set_size()
+     * saw enough room to skip growing and PMIX_VALUE_ARRAY_SET_ITEM wrote
+     * straight into the heap past that empty block. */
+    if (PMIX_UNLIKELY(0 == array->array_item_sizeof)) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     if (size > array->array_alloc_size) {
         /* Hold the new pointer aside: on failure realloc() leaves the old
          * allocation valid, and the previous code overwrote it with NULL -
@@ -187,8 +201,9 @@ PMIX_EXPORT int pmix_value_array_set_size(pmix_value_array_t *array, size_t size
 static inline void *pmix_value_array_get_item(pmix_value_array_t *array, size_t item_index)
 {
     if (item_index >= array->array_size
-        && pmix_value_array_set_size(array, item_index + 1) != PMIX_SUCCESS)
+        && PMIX_SUCCESS != pmix_value_array_set_size(array, item_index + 1)) {
         return NULL;
+    }
     return array->array_items + (item_index * array->array_item_sizeof);
 }
 
@@ -230,8 +245,9 @@ static inline int pmix_value_array_set_item(pmix_value_array_t *array, size_t it
 {
     int rc;
     if (item_index >= array->array_size
-        && (rc = pmix_value_array_set_size(array, item_index + 1)) != PMIX_SUCCESS)
+        && PMIX_SUCCESS != (rc = pmix_value_array_set_size(array, item_index + 1))) {
         return rc;
+    }
     memcpy(array->array_items + (item_index * array->array_item_sizeof), item,
            array->array_item_sizeof);
     return PMIX_SUCCESS;
@@ -275,7 +291,7 @@ static inline int pmix_value_array_remove_item(pmix_value_array_t *array, size_t
      * (array_size - item_index - 1) in size_t arithmetic: an out-of-range
      * index does not read one element too far, it wraps to an enormous
      * count and walks the heap. One compare is not worth that. */
-    if (item_index >= array->array_size) {
+    if (PMIX_UNLIKELY(item_index >= array->array_size)) {
 #if PMIX_ENABLE_DEBUG
         pmix_output(0, "pmix_value_array_remove_item: invalid index %lu\n",
                     (unsigned long) item_index);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,16 +25,44 @@
 # $HEADER$
 #
 
-if !WANT_HIDDEN
-# these tests use internal symbols
-# use --disable-visibility
+# NOTE: this list used to be wrapped in "if !WANT_HIDDEN", on the grounds
+# that these programs use internal symbols and so need
+# --disable-visibility. The effect was that a default-visibility tree ran
+# the handful of programs in this directory, printed "# FAIL: 0", and
+# silently skipped every one of the subdirectories below -- so an
+# optimized build, which is the configuration those tests exist to cover,
+# was never actually tested by "make check". Nothing said so.
+#
+# The condition is no longer true. Every internal symbol these programs
+# reach is exported, so all five subdirectories build and pass with
+# symbol visibility on. Verified in five configurations across both
+# primary platforms -- Linux/gcc {--enable-debug --disable-visibility,
+# --enable-debug, --disable-debug} and macOS/clang {--enable-debug,
+# --disable-debug} -- 80 tests passing and zero warnings in each. A
+# default-visibility macOS build also confirms the symbol state this
+# depends on: of 134 class descriptors in libpmix, 103 are exported and
+# the 31 hidden ones are all private to a single .c or to gds/hash,
+# whose header is not installed. If you find a test that genuinely cannot link
+# without --disable-visibility, the right fix is PMIX_EXPORT on what it
+# needs -- see the export rule in src/class/AGENTS.md -- not a condition
+# here that removes the whole tree from "make check" without a word.
 SUBDIRS = simple sshot util unit topologies
 
 if WANT_PYTHON_BINDINGS
 SUBDIRS += python
 endif
 
-endif
+# Tripwire for the above. An empty SUBDIRS makes "make check" recurse into
+# nothing and report success, which is indistinguishable from a clean run
+# and is exactly how the WANT_HIDDEN condition hid this whole tree. If a
+# future condition empties the list, fail here rather than pass quietly.
+check-local:
+	@if test -z "$(SUBDIRS)"; then \
+	    echo "ERROR: test/Makefile.am SUBDIRS is empty -- 'make check' just"; \
+	    echo "       recursed into nothing and would have reported success."; \
+	    echo "       See the note above SUBDIRS in test/Makefile.am."; \
+	    exit 1; \
+	fi
 
 headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h \
         test_publish.h test_spawn.h test_cd.h test_resolve_peers.h test_error.h \

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -105,22 +105,46 @@ reasons.** If the whole `run_*.pl` family fails at once, rerun under
 `TMPDIR=$(mktemp -d) make check` before investigating; see the top-level
 guide's "Building and Testing".
 
-**In a default-visibility tree, a top-level `make check` never reaches
-this directory at all.** `test/Makefile.am` wraps its `SUBDIRS` line in
-`if !WANT_HIDDEN` — these programs use internal symbols, so the tree is
-only descended into when configured `--disable-visibility`. Without it,
-`make check` runs the 15 programs in `test/` itself, prints `# FAIL: 0`,
-and silently skips `unit/`, `unit/class/`, `unit/util/` and `simple/`.
-Two consequences worth knowing:
+**This directory was invisible to `make check` in any tree not
+configured `--disable-visibility`, and that has been fixed — know the
+shape of it.** `test/Makefile.am` wrapped its whole `SUBDIRS` line in
+`if !WANT_HIDDEN`, on the grounds that these programs use internal
+symbols. The effect was that a default-visibility build ran the 15
+programs in `test/` itself, printed `# FAIL: 0`, and silently skipped
+`unit/`, `unit/class/`, `unit/util/`, `simple/` and `topologies/`. So the
+optimized configuration these tests exist to cover was never actually
+tested by `make check`, and nothing said so.
 
-- To exercise this suite in an optimized default-visibility build you
-  must name the directory: `make -C test/unit check`.
-- Doing that alone gives you 13 failures in the `run_grp*.pl` /
-  `run_monitor.pl` family, all reporting `./simptest: No such file or
-  directory` (exit 127) — because `test/simple` was skipped by the same
-  guard and never built. `make -C test/simple` first, then the suite is
-  green. That failure signature is *not* the stale-`$TMPDIR` one above,
-  and not a defect; check whether the binary exists before chasing it.
+The condition is gone: every internal symbol these programs reach is now
+exported, and all five subdirectories build and pass with visibility on.
+Verified in five configurations across both primary platforms —
+Linux/gcc (`--enable-debug --disable-visibility`, `--enable-debug`,
+`--disable-debug`) and macOS/clang (`--enable-debug`, `--disable-debug`)
+— 80 tests passing and zero warnings in every one. The macOS
+default-visibility build also confirms the symbol state the whole thing
+rests on, using the `nm` audit described in
+[`src/class/AGENTS.md`](../../src/class/AGENTS.md): 134 class
+descriptors, 103 exported, and the 31 hidden ones all private to a
+single `.c` or to `gds/hash`, whose header is not installed. **No class
+declared in an installed header is hidden** — which is precisely why
+these programs link now and did not before.
+
+Two things guard against a repeat, and both were tested by triggering
+them:
+
+- `test/Makefile.am` has a `check-local` that **fails** if `SUBDIRS` ever
+  comes out empty, rather than letting `make check` recurse into nothing
+  and report success.
+- The top-level `Makefile.am` prints a loud "no tests were run" notice
+  when the tree is configured `--without-tests-examples`, which drops
+  `test/` from `SUBDIRS` one level up and produces exactly the same
+  silent, successful nothing.
+
+If you hit a test that genuinely cannot link without
+`--disable-visibility`, the fix is `PMIX_EXPORT` on what it needs (see
+the export rule in [`src/class/AGENTS.md`](../../src/class/AGENTS.md)),
+not a condition here that removes the tree from `make check` without a
+word.
 
 **Do not run this suite against an `--enable-test-build` tree.** Its
 shimmed `pcompress`/`psec` components are non-functional by design, so

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -146,6 +146,20 @@ the export rule in [`src/class/AGENTS.md`](../../src/class/AGENTS.md)),
 not a condition here that removes the tree from `make check` without a
 word.
 
+**These tests do not run in parallel, deliberately.**
+[`Makefile.am`](Makefile.am) is marked `.NOTPARALLEL:`. Most of `TESTS`
+drives a real PMIx server through `test/simple`'s `simptest`, which comes
+up in the **scheduler** role — a node-wide singleton that claims a fixed
+`$TMPDIR/pmix.sched.<host>` rendezvous file. Automake's parallel harness
+gives each test its own `.log` target, so `make -j check` starts several
+at once and every one but the winner dies with `PMIX_ERR_INIT` and "Only
+one server can fill a given role on a node at a time". That is the server
+enforcing a real invariant, not flakiness. Do not paper over it by giving
+each test a private `$TMPDIR`: two schedulers on one node is exactly the
+configuration PMIx forbids, so a suite arranged that way would be testing
+something users cannot have. If you want concurrency here, the tests have
+to stop being schedulers.
+
 **Do not run this suite against an `--enable-test-build` tree.** Its
 shimmed `pcompress`/`psec` components are non-functional by design, so
 `preg` and `compress` will fail for reasons that are not defects.

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -105,6 +105,23 @@ reasons.** If the whole `run_*.pl` family fails at once, rerun under
 `TMPDIR=$(mktemp -d) make check` before investigating; see the top-level
 guide's "Building and Testing".
 
+**In a default-visibility tree, a top-level `make check` never reaches
+this directory at all.** `test/Makefile.am` wraps its `SUBDIRS` line in
+`if !WANT_HIDDEN` — these programs use internal symbols, so the tree is
+only descended into when configured `--disable-visibility`. Without it,
+`make check` runs the 15 programs in `test/` itself, prints `# FAIL: 0`,
+and silently skips `unit/`, `unit/class/`, `unit/util/` and `simple/`.
+Two consequences worth knowing:
+
+- To exercise this suite in an optimized default-visibility build you
+  must name the directory: `make -C test/unit check`.
+- Doing that alone gives you 13 failures in the `run_grp*.pl` /
+  `run_monitor.pl` family, all reporting `./simptest: No such file or
+  directory` (exit 127) — because `test/simple` was skipped by the same
+  guard and never built. `make -C test/simple` first, then the suite is
+  green. That failure signature is *not* the stale-`$TMPDIR` one above,
+  and not a defect; check whether the binary exists before chasing it.
+
 **Do not run this suite against an `--enable-test-build` tree.** Its
 shimmed `pcompress`/`psec` components are non-functional by design, so
 `preg` and `compress` will fail for reasons that are not defects.

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -26,6 +26,29 @@ SUBDIRS = util class
 # Point the tests at the components in the build tree so that "make
 # check" does not require a prior "make install". See the comments in
 # test/pmix_test_env.sh.in.
+# Run this directory's tests one at a time, even under "make -j".
+#
+# Most of TESTS below drives a real PMIx server through test/simple's
+# simptest, and simptest comes up in the *scheduler* role. A scheduler is
+# a node-wide singleton: it claims a fixed rendezvous file
+# ($TMPDIR/pmix.sched.<host>), and the second server to want that file is
+# refused by design, with "Only one server can fill a given role on a node
+# at a time". Automake's parallel test harness gives each test its own
+# .log target, so "make -j check" starts several of them at once and all
+# but one lose the race. The failure is not flaky and not environmental --
+# it is the server correctly enforcing its own invariant.
+#
+# This was invisible for as long as test/Makefile.am's SUBDIRS was gated
+# on !WANT_HIDDEN, because the CI job that builds with "make -j check"
+# configures with default visibility and so never descended in here.
+#
+# Do not "fix" this by giving each test a private TMPDIR to hide the
+# collision: two schedulers on one node is precisely the configuration
+# PMIx forbids, and a test suite that arranges one is testing something
+# users cannot have. If you want these to run concurrently, they need to
+# stop being schedulers, not stop seeing each other.
+.NOTPARALLEL:
+
 AM_TESTS_ENVIRONMENT = . $(abs_top_builddir)/test/pmix_test_env.sh;
 
 noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl

--- a/test/unit/class/AGENTS.md
+++ b/test/unit/class/AGENTS.md
@@ -82,21 +82,17 @@ The tree everyone develops in — and the one
   [`src/class/AGENTS.md`](../../../src/class/AGENTS.md), including why
   grepping the headers for `PMIX_EXPORT` gives the wrong answer.
 
-**And in a default-visibility tree, `make check` from the top does not
-run this suite at all.** `test/Makefile.am` wraps its whole `SUBDIRS`
-line in `if !WANT_HIDDEN` — these programs use internal symbols, so the
-tree is only descended into when configured `--disable-visibility`.
-Configure without it and a top-level `make check` runs the 15 programs
-in `test/` itself, reports `# FAIL: 0`, and never enters `unit/`,
-`unit/class/`, `unit/util/` or `simple/`. Nothing warns you. That is why
-`contrib/dockerswarm/run-class-tests.sh` invokes
-`make -C test/unit/class check` directly rather than relying on the
-recursion — and why, when you want to know whether this suite passes in
-an optimized default-visibility build, you have to say so explicitly:
-
-```sh
-make -C test/unit/class check      # not "make check" from the top
-```
+**Until recently, a default-visibility tree did not run this suite at
+all.** `test/Makefile.am` wrapped its whole `SUBDIRS` line in
+`if !WANT_HIDDEN`, so unless you configured `--disable-visibility`, a
+top-level `make check` ran the 15 programs in `test/` itself, reported
+`# FAIL: 0`, and never entered `unit/class/`. The configuration this
+suite most needs to be run in was the one it was never run in, and
+nothing warned you. The condition is gone (see
+[`../AGENTS.md`](../AGENTS.md) for what replaced it), and
+`contrib/dockerswarm/run-class-tests.sh` still invokes
+`make -C test/unit/class check` directly, which is why its coverage was
+real throughout.
 
 So a green run here proves less than it looks like it does. Several
 cases in the suite are labelled `(all builds)` precisely because they

--- a/test/unit/class/AGENTS.md
+++ b/test/unit/class/AGENTS.md
@@ -82,6 +82,22 @@ The tree everyone develops in — and the one
   [`src/class/AGENTS.md`](../../../src/class/AGENTS.md), including why
   grepping the headers for `PMIX_EXPORT` gives the wrong answer.
 
+**And in a default-visibility tree, `make check` from the top does not
+run this suite at all.** `test/Makefile.am` wraps its whole `SUBDIRS`
+line in `if !WANT_HIDDEN` — these programs use internal symbols, so the
+tree is only descended into when configured `--disable-visibility`.
+Configure without it and a top-level `make check` runs the 15 programs
+in `test/` itself, reports `# FAIL: 0`, and never enters `unit/`,
+`unit/class/`, `unit/util/` or `simple/`. Nothing warns you. That is why
+`contrib/dockerswarm/run-class-tests.sh` invokes
+`make -C test/unit/class check` directly rather than relying on the
+recursion — and why, when you want to know whether this suite passes in
+an optimized default-visibility build, you have to say so explicitly:
+
+```sh
+make -C test/unit/class check      # not "make check" from the top
+```
+
 So a green run here proves less than it looks like it does. Several
 cases in the suite are labelled `(all builds)` precisely because they
 only distinguish old code from new in an *optimized* build.
@@ -100,12 +116,39 @@ touching the script. It is not a multi-node test and does not pretend to
 be — with the single exception of `class_tma_shared`, these are
 single-process data structures.
 
+One caveat about its ten-node contention pass: it used to fail on all ten
+nodes for a reason that had nothing to do with the library. It staged
+`test/unit/class/$p`, which in an uninstalled libtool build is a `/bin/sh`
+**wrapper**, not the executable — that lives under `.libs/`. The copied
+wrapper then reported `.libs/$p does not exist` and exited 1 everywhere,
+so that pass had never actually run anything. It stages `.libs/$p` now,
+falling back to the plain path. If you add a runner that ships
+`check_PROGRAMS` to another machine, remember this.
+
 A third gap worth knowing about: **a bare `assert()` is debug-only here
 too.** `config/pmix.m4` adds `-DNDEBUG` whenever `--enable-debug` is off,
 so asserts vanish in every shipping build exactly as a
 `#if PMIX_ENABLE_DEBUG` block does. A case that only proves "the assert
 fires" proves nothing about the library users get; write it against the
 return value instead.
+
+The most recent sweep of `src/class` turned up five more defects of
+exactly these two shapes, and every one of them is now pinned by a case
+that was *verified by reintroducing it in the optimized build*:
+
+| Case | Program | What backing the fix out does |
+|------|---------|-------------------------------|
+| `out-of-range room number` | `class_hotel` | **SIGSEGV** — `pmix_hotel_checkout`'s upper bound was an `assert()` only, so it wrote past `rooms[]` |
+| `push without storage` | `class_ring_buffer` | **SIGSEGV** — `pmix_ring_buffer_push` had no guard at all, unlike `pop`/`poke` |
+| `reserve requires an item size` | `class_value_array` | `reserve` succeeds on a zero item size, committing capacity over a 0-byte block |
+| `key type mixing is refused` | `class_hash_table` | 8 cases fail — the check was inside `#if PMIX_ENABLE_DEBUG` |
+| `set_max_size argument checking` | `class_bitmap` | 5 cases fail — a negative cap silently stored 0 and bricked the bitmap |
+
+Note the shape of the hash-table case in particular: asserting merely
+`PMIX_SUCCESS != rc` there is **not** discriminating, because without the
+check a wrong-type *get* simply probes past the entry and reports
+`PMIX_ERR_NOT_FOUND`. It has to assert `PMIX_ERROR == rc`. Watch for that
+whenever "the call fails" is the property under test — pick the code.
 
 ## What these tests deliberately do not do
 
@@ -173,6 +216,25 @@ inside it, and forks. Children read the containers back; one child writes
 and the parent reads the result; and six children hammer retain/release on
 one object and drop one net reference each, after which the parent checks
 that exactly its own reference survives.
+
+It now also pins the **TMA exemption** in `pmix_hash_table.c`'s key-type
+check. That exemption only became load-bearing when the check stopped
+being debug-only: before, an optimized build had nothing for a TMA table
+to be exempt *from*. Now the `NULL == pmix_obj_get_tma(&ht->super)`
+clause is the only thing keeping `gds/shmem3`'s tables readable in the
+builds that ship, because `ht_type_methods` points at a file-scope static
+in whichever process last touched the table and that address is
+meaningless to a peer. Delete the clause and this program does not even
+get through `build_shared_state()`.
+
+That case is also why this program deliberately puts **both** `uint32`
+and `ptr` keys in one table — a thing no other test here does, and a
+thing that would be a caller bug on an ordinary heap-backed table
+(the ptr key storage would never be freed, and a later grow or removal
+would rehash those elements through `key.u32`). It is safe here only
+because the table never grows or removes after the mixing, and it is
+present on purpose, to demonstrate the exemption. Do not copy the
+pattern into the other programs.
 
 Two things to preserve if you extend it:
 

--- a/test/unit/class/class_bitmap.c
+++ b/test/unit/class/class_bitmap.c
@@ -572,6 +572,48 @@ static void test_static_init_matches_constructor(void)
     PMIX_DESTRUCT(&ctor);
 }
 
+/* Regression: pmix_bitmap_set_max_size() was the one entry point in this
+ * file that did not validate its argument. The cap is stored as a word
+ * count, converted with "((size_t) max_size + 63) / 64" -- so a negative
+ * bit count became (size_t) -1, whose "+ 63" wrapped round to 62, which
+ * divided down to a stored cap of *zero words*. The call reported success
+ * and every later init() and set_bit() then failed with
+ * PMIX_ERR_BAD_PARAM, a long way from the call that actually got it
+ * wrong. Zero was accepted the same way.
+ *
+ * (all builds -- this was never gated on PMIX_ENABLE_DEBUG, just absent) */
+static void test_set_max_size_argument_checking(void)
+{
+    pmix_bitmap_t bm;
+
+    PMIX_CONSTRUCT(&bm, pmix_bitmap_t);
+
+    report("set_max_size(-1): PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_bitmap_set_max_size(&bm, -1));
+    report("set_max_size(0): PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_bitmap_set_max_size(&bm, 0));
+    report("set_max_size(NULL): PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_bitmap_set_max_size(NULL, 64));
+
+    /* the rejected calls must not have touched the cap: the bitmap is
+     * still uncapped and a plain init still works. Before the fix the
+     * negative call left max_size at 0 and this init returned BAD_PARAM. */
+    report("rejected set_max_size left the bitmap usable",
+           PMIX_SUCCESS == pmix_bitmap_init(&bm, 128));
+    report("rejected set_max_size left the size right", 128 <= pmix_bitmap_size(&bm));
+    report("rejected set_max_size left growth working",
+           PMIX_SUCCESS == pmix_bitmap_set_bit(&bm, 4095));
+
+    /* a real cap still behaves */
+    report("set_max_size(256): PMIX_SUCCESS", PMIX_SUCCESS == pmix_bitmap_set_max_size(&bm, 256));
+    report("capped: a bit inside the cap is accepted",
+           PMIX_SUCCESS == pmix_bitmap_set_bit(&bm, 255));
+    report("capped: a bit beyond the cap is refused",
+           PMIX_ERR_BAD_PARAM == pmix_bitmap_set_bit(&bm, 4096));
+
+    PMIX_DESTRUCT(&bm);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -599,6 +641,7 @@ int main(int argc, char **argv)
     test_reinit();
     test_count_bits_null_guard();
     test_static_init_matches_constructor();
+    test_set_max_size_argument_checking();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_hash_table.c
+++ b/test/unit/class/class_hash_table.c
@@ -466,6 +466,91 @@ static void test_next_poweroftwo(void)
     report("next_poweroftwo(INT_MIN) is 0", 0 == pmix_next_poweroftwo(INT_MIN));
 }
 
+/* Regression (all builds): "one key type per table" is enforced by a single
+ * pointer compare that used to sit inside "#if PMIX_ENABLE_DEBUG". In every
+ * build that ships, mixing key types was therefore silent -- the entry point
+ * simply retargeted ht_type_methods, and from that moment a ptr-keyed table
+ * had no elt_destructor (so every copied key leaked) while pmix_hash_grow()
+ * and pmix_hash_table_remove_elt_at() rehashed its elements through
+ * key.u32, i.e. the low bytes of a key pointer, scattering live entries to
+ * slots no later lookup would probe.
+ *
+ * The check is unconditional now, so the wrong-type call is refused and the
+ * table is left exactly as it was. Backing the fix out makes the "declines"
+ * cases fail in an optimized build; the "still intact" cases are what
+ * demonstrates the corruption it was hiding. */
+static void test_key_type_mixing_is_refused(void)
+{
+    pmix_hash_table_t ht;
+    const char *key = "the-key";
+    void *val = NULL;
+    uint32_t k32;
+    void *node = NULL;
+
+    PMIX_CONSTRUCT(&ht, pmix_hash_table_t);
+    report("mixing: init succeeds", PMIX_SUCCESS == pmix_hash_table_init(&ht, 8));
+    report("mixing: ptr set succeeds",
+           PMIX_SUCCESS == pmix_hash_table_set_value_ptr(&ht, key, strlen(key), (void *) 0x1234));
+
+    /* Every uint32/uint64 entry point must refuse this table, and refuse
+     * it with PMIX_ERROR specifically: a plain "not PMIX_SUCCESS" is not
+     * a discriminating assertion here, because without the check a get
+     * simply probes past the ptr entry and reports PMIX_ERR_NOT_FOUND. */
+    report("mixing: uint32 get declines",
+           PMIX_ERROR == pmix_hash_table_get_value_uint32(&ht, 1, &val));
+    report("mixing: uint32 set declines",
+           PMIX_ERROR == pmix_hash_table_set_value_uint32(&ht, 1, (void *) 0x1));
+    report("mixing: uint32 remove declines",
+           PMIX_ERROR == pmix_hash_table_remove_value_uint32(&ht, 1));
+    report("mixing: uint64 get declines",
+           PMIX_ERROR == pmix_hash_table_get_value_uint64(&ht, 1, &val));
+    report("mixing: uint64 set declines",
+           PMIX_ERROR == pmix_hash_table_set_value_uint64(&ht, 1, (void *) 0x1));
+    report("mixing: uint64 remove declines",
+           PMIX_ERROR == pmix_hash_table_remove_value_uint64(&ht, 1));
+
+    /* and the ptr table is intact: the rejected calls neither retargeted
+     * the methods nor added an entry of their own. Note the refused set
+     * above is what this catches -- without the check it inserts, and the
+     * matching refused remove would have taken it away again, so check
+     * the count here rather than after a set/remove pair. */
+    report("mixing: the table still holds exactly one entry",
+           1 == pmix_hash_table_get_size(&ht));
+
+    /* the reverse direction too: a uint32 table refuses ptr and uint64 */
+    report("mixing: remove_all resets the key type",
+           PMIX_SUCCESS == pmix_hash_table_remove_all(&ht));
+    report("mixing: uint32 set on the reused table",
+           PMIX_SUCCESS == pmix_hash_table_set_value_uint32(&ht, 7, (void *) 0x77));
+    report("mixing: ptr get on a uint32 table declines",
+           PMIX_ERROR == pmix_hash_table_get_value_ptr(&ht, key, strlen(key), &val));
+    report("mixing: uint64 set on a uint32 table declines",
+           PMIX_ERROR == pmix_hash_table_set_value_uint64(&ht, 7, (void *) 0x77));
+    report("mixing: the uint32 table still holds exactly one entry",
+           1 == pmix_hash_table_get_size(&ht));
+    k32 = 0;
+    report("mixing: the uint32 entry is still there",
+           PMIX_SUCCESS == pmix_hash_table_get_first_key_uint32(&ht, &k32, &val, &node));
+    report("mixing: it is the key we stored", 7 == k32 && (void *) 0x77 == val);
+
+    /* the ptr family also rejects an unusable key outright: a NULL one is
+     * dereferenced by the hash, and a zero-length one compares equal to
+     * every other key while asking the allocator for a 0-byte block. */
+    report("mixing: remove_all again", PMIX_SUCCESS == pmix_hash_table_remove_all(&ht));
+    report("ptr key: NULL key is refused",
+           PMIX_ERR_BAD_PARAM == pmix_hash_table_set_value_ptr(&ht, NULL, 4, (void *) 0x1));
+    report("ptr key: zero-length key is refused",
+           PMIX_ERR_BAD_PARAM == pmix_hash_table_set_value_ptr(&ht, key, 0, (void *) 0x1));
+    report("ptr key: NULL key refused on get",
+           PMIX_ERR_BAD_PARAM == pmix_hash_table_get_value_ptr(&ht, NULL, 4, &val));
+    report("ptr key: zero-length key refused on remove",
+           PMIX_ERR_BAD_PARAM == pmix_hash_table_remove_value_ptr(&ht, key, 0));
+    report("ptr key: a real key still works",
+           PMIX_SUCCESS == pmix_hash_table_set_value_ptr(&ht, key, strlen(key), (void *) 0x9));
+
+    PMIX_DESTRUCT(&ht);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -486,6 +571,7 @@ int main(int argc, char **argv)
     test_construct_initializes_label();
     test_init2_rejects_bad_ratios();
     test_next_poweroftwo();
+    test_key_type_mixing_is_refused();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_hotel.c
+++ b/test/unit/class/class_hotel.c
@@ -347,6 +347,63 @@ static void test_reinit(void)
     PMIX_DESTRUCT(&h);
 }
 
+/* Regression (all builds): the upper bound on room_num used to be an
+ * assert() and nothing else, so in every build that ships -- config/pmix.m4
+ * adds -DNDEBUG whenever --enable-debug is off -- a room number at or above
+ * num_rooms was not checked at all. checkout() then *wrote* through
+ * rooms[room_num] past the end of the array, and pushed a second
+ * out-of-bounds write into unoccupied_rooms[] by way of
+ * ++last_unoccupied_room. The lower bound was always an "if".
+ *
+ * These cases are written against observable bookkeeping rather than
+ * against a fault, so they say something in an optimized build: an
+ * out-of-range room must leave occupancy exactly as it found it. Backing
+ * the fix out aborts on the assert in a debug build and corrupts
+ * last_unoccupied_room here in an optimized one. */
+static void test_out_of_range_room_number(void)
+{
+    pmix_hotel_t h;
+    int room = -1;
+    int saved;
+    void *occupant = (void *) 0xdeadbeef;
+
+    PMIX_CONSTRUCT(&h, pmix_hotel_t);
+    report("out-of-range: init succeeds",
+           PMIX_SUCCESS == pmix_hotel_init(&h, 4, NULL, 0, dummy_evict));
+    report("out-of-range: checkin works", PMIX_SUCCESS == pmix_hotel_checkin(&h, (void *) 0x1, &room));
+    saved = h.last_unoccupied_room;
+
+    /* one past the end, and far past the end */
+    pmix_hotel_checkout(&h, 4);
+    pmix_hotel_checkout(&h, 99999);
+    report("out-of-range: checkout past the end changes no bookkeeping",
+           saved == h.last_unoccupied_room);
+    report("out-of-range: the real occupant is still checked in", !pmix_hotel_is_empty(&h));
+
+    pmix_hotel_checkout_and_return_occupant(&h, 4, &occupant);
+    report("out-of-range: checkout_and_return past the end yields NULL", NULL == occupant);
+    occupant = (void *) 0xdeadbeef;
+    pmix_hotel_knock(&h, 77, &occupant);
+    report("out-of-range: knock past the end yields NULL", NULL == occupant);
+    report("out-of-range: still no bookkeeping change", saved == h.last_unoccupied_room);
+
+    /* the room that really is occupied still works */
+    pmix_hotel_knock(&h, room, &occupant);
+    report("out-of-range: the in-range room still answers", (void *) 0x1 == occupant);
+
+    PMIX_DESTRUCT(&h);
+
+    /* A destructed hotel has num_rooms 0 and a NULL rooms[]; room 0 is
+     * "in range" by the old lower-bound-only test and dereferenced NULL. */
+    occupant = (void *) 0xdeadbeef;
+    pmix_hotel_checkout(&h, 0);
+    pmix_hotel_checkout_and_return_occupant(&h, 0, &occupant);
+    report("destructed hotel: checkout of room 0 is a no-op, not a fault", NULL == occupant);
+    occupant = (void *) 0xdeadbeef;
+    pmix_hotel_knock(&h, 0, &occupant);
+    report("destructed hotel: knock at room 0 is a no-op, not a fault", NULL == occupant);
+}
+
 /* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
@@ -366,6 +423,7 @@ int main(int argc, char **argv)
     test_static_init();
     test_destruct_leaves_constructed_state();
     test_reinit();
+    test_out_of_range_room_number();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_ring_buffer.c
+++ b/test/unit/class/class_ring_buffer.c
@@ -339,6 +339,55 @@ static void test_static_init_matches_constructor(void)
     PMIX_DESTRUCT(&ctor);
 }
 
+/* Regression (all builds): push() was the one accessor with no guard at
+ * all. pop() has always tested "tail == -1" and poke() "size <= i", but
+ * push() went straight to addr[head] -- so a ring that had only been
+ * PMIX_NEW'd/PMIX_CONSTRUCT'd, or one already destructed, dereferenced the
+ * NULL addr instead of declining. That is the easiest state in this class
+ * to reach by accident: a teardown path that pushes one last item after
+ * the ring is gone.
+ *
+ * Backing the fix out segfaults here in every configuration -- there is no
+ * assert on this path in either one. */
+static void test_push_without_storage(void)
+{
+    pmix_ring_buffer_t ring;
+    pmix_ring_buffer_t stat = PMIX_RING_BUFFER_STATIC_INIT;
+
+    PMIX_CONSTRUCT(&ring, pmix_ring_buffer_t);
+    report("no storage: push on a constructed-but-un-init'd ring declines",
+           NULL == pmix_ring_buffer_push(&ring, (void *) 0x1));
+    report("no storage: nothing was recorded", NULL == ring.addr && 0 == ring.size);
+    report("no storage: pop still says empty", NULL == pmix_ring_buffer_pop(&ring));
+
+    report("no storage: push on a STATIC_INIT ring declines",
+           NULL == pmix_ring_buffer_push(&stat, (void *) 0x2));
+
+    /* and after a destruct, which is the same state by a different route */
+    report("no storage: init succeeds", PMIX_SUCCESS == pmix_ring_buffer_init(&ring, 4));
+    pmix_ring_buffer_push(&ring, (void *) 0x3);
+    PMIX_DESTRUCT(&ring);
+    report("no storage: push on a destructed ring declines",
+           NULL == pmix_ring_buffer_push(&ring, (void *) 0x4));
+    report("no storage: destructed ring still reports empty",
+           NULL == pmix_ring_buffer_pop(&ring));
+
+    /* a NULL ring is answered rather than dereferenced, in all three */
+    report("NULL ring: push returns NULL", NULL == pmix_ring_buffer_push(NULL, (void *) 0x5));
+    report("NULL ring: pop returns NULL", NULL == pmix_ring_buffer_pop(NULL));
+    report("NULL ring: poke returns NULL", NULL == pmix_ring_buffer_poke(NULL, 0));
+
+    /* the ring is still usable once it really has storage. Reconstruct
+     * first -- PMIX_DESTRUCT twice on one object is a contract violation
+     * the object system's magic-ID assert catches, and this suite does
+     * not do it. */
+    PMIX_CONSTRUCT(&ring, pmix_ring_buffer_t);
+    report("no storage: re-init succeeds", PMIX_SUCCESS == pmix_ring_buffer_init(&ring, 2));
+    report("no storage: push then works", NULL == pmix_ring_buffer_push(&ring, (void *) 0x6));
+    report("no storage: pop returns it", (void *) 0x6 == pmix_ring_buffer_pop(&ring));
+    PMIX_DESTRUCT(&ring);
+}
+
 /* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
@@ -358,6 +407,7 @@ int main(int argc, char **argv)
     test_destruct_resets_head_and_tail();
     test_reinit_without_reconstruct();
     test_static_init_matches_constructor();
+    test_push_without_storage();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/class/class_tma_shared.c
+++ b/test/unit/class/class_tma_shared.c
@@ -458,6 +458,54 @@ static void test_objects_land_in_the_segment(void)
                && (unsigned char *) sh->pa->free_bits < hi);
 }
 
+/* The key-type check in pmix_hash_table.c is now unconditional -- it used
+ * to be compiled out unless --enable-debug, so in an optimized build there
+ * was nothing for a TMA table to be exempt *from*. Now there is, and the
+ * "NULL == pmix_obj_get_tma(&ht->super)" clause is the only thing keeping
+ * gds/shmem3's tables working in the builds that ship.
+ *
+ * Why the exemption has to exist: ht_type_methods points at a static in
+ * whichever process last touched the table. In a segment shared between a
+ * server and its clients that address means nothing to a peer, so a peer
+ * comparing it against its own would reject every lookup of a table it can
+ * read perfectly well. This case pins that: a TMA-backed table answers
+ * lookups regardless of what its methods pointer currently says.
+ *
+ * Deleting the exemption makes these fail here, and makes gds/shmem3
+ * unusable in an optimized build. */
+static void test_tma_table_is_exempt_from_the_key_type_check(void)
+{
+    void *val = NULL;
+    const char *pkey = "shared-ptr-key";
+    const struct pmix_hash_type_methods_t *saved;
+
+    report("tma exemption: the table really is TMA-backed",
+           NULL != pmix_obj_get_tma(&sh->ht->super));
+
+    /* a uint32 lookup, then a ptr lookup, on the one table -- each retargets
+     * ht_type_methods, and neither may be refused because the table is in a
+     * shared segment */
+    report("tma exemption: uint32 lookup answered",
+           PMIX_SUCCESS == pmix_hash_table_get_value_uint32(sh->ht, 1, &val));
+    saved = sh->ht->ht_type_methods;
+    report("tma exemption: ptr lookup answered on the same table",
+           PMIX_SUCCESS == pmix_hash_table_get_value_ptr(sh->ht, pkey, strlen(pkey), &val));
+    report("tma exemption: the methods pointer did move",
+           saved != sh->ht->ht_type_methods);
+    report("tma exemption: uint32 lookup still answered afterwards",
+           PMIX_SUCCESS == pmix_hash_table_get_value_uint32(sh->ht, 2, &val));
+
+    /* and a methods pointer that means nothing in this address space -- what
+     * a peer mapping another process's segment actually sees -- must not
+     * make the table unreadable either */
+    sh->ht->ht_type_methods = (const struct pmix_hash_type_methods_t *) (uintptr_t) 0xdeadbeef;
+    report("tma exemption: a foreign methods pointer does not block a lookup",
+           PMIX_SUCCESS == pmix_hash_table_get_value_uint32(sh->ht, 3, &val));
+    report("tma exemption: the lookup repaired the methods pointer",
+           (const struct pmix_hash_type_methods_t *) (uintptr_t) 0xdeadbeef
+               != sh->ht->ht_type_methods);
+}
+
 /* ------------------------------------------------------------------ */
 
 static int build_shared_state(void)
@@ -539,6 +587,7 @@ int main(int argc, char **argv)
     }
 
     test_objects_land_in_the_segment();
+    test_tma_table_is_exempt_from_the_key_type_check();
     test_containers_read_from_another_process();
     test_child_writes_visible_to_parent();
     test_refcount_across_processes();

--- a/test/unit/class/class_value_array.c
+++ b/test/unit/class/class_value_array.c
@@ -431,6 +431,49 @@ static void test_reinit_over_a_populated_array(void)
     PMIX_DESTRUCT(&va);
 }
 
+/* Regression (all builds): pmix_value_array_reserve() was the one member of
+ * the init/reserve/set_size trio still missing the "item size is zero"
+ * check, and it is the worst place to miss it. On an array that has only
+ * been PMIX_CONSTRUCT'd, array_item_sizeof is 0, so reserve() asked
+ * realloc() for 0 * size == 0 bytes -- and glibc answers realloc(NULL, 0)
+ * with a non-NULL pointer to a zero-byte block. reserve() then reported
+ * success and committed array_alloc_size = size over that empty block,
+ * after which set_size() saw enough capacity to skip growing and every
+ * subsequent element write went into the heap past the end of it.
+ *
+ * The visible symptom without the fix is that reserve() succeeds; with it,
+ * PMIX_ERR_BAD_PARAM. (Under a hardened allocator the old code may instead
+ * abort in the eventual write, which is also a fail.) */
+static void test_reserve_requires_an_item_size(void)
+{
+    pmix_value_array_t va;
+    int v = 42;
+
+    PMIX_CONSTRUCT(&va, pmix_value_array_t);
+
+    report("reserve before init: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_value_array_reserve(&va, 100));
+    report("rejected reserve committed no capacity", 0 == va.array_alloc_size);
+    report("rejected reserve left the buffer alone", NULL == va.array_items);
+
+    /* the sibling checks, for the record: both already had this guard */
+    report("set_size before init: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_value_array_set_size(&va, 100));
+    report("init with item size 0: PMIX_ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_value_array_init(&va, 0));
+
+    /* once the array really has an item size, reserve works as before */
+    report("init succeeds", PMIX_SUCCESS == pmix_value_array_init(&va, sizeof(int)));
+    report("reserve after init: PMIX_SUCCESS", PMIX_SUCCESS == pmix_value_array_reserve(&va, 100));
+    report("reserve after init: capacity committed", 100 <= va.array_alloc_size);
+    report("reserve after init: size unchanged", 0 == pmix_value_array_get_size(&va));
+    report("reserved array accepts an append",
+           PMIX_SUCCESS == pmix_value_array_append_item(&va, &v));
+    report("reserved array reads it back", 42 == PMIX_VALUE_ARRAY_GET_ITEM(&va, int, 0));
+
+    PMIX_DESTRUCT(&va);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -452,6 +495,7 @@ int main(int argc, char **argv)
     test_many_appends();
     test_init_argument_checking();
     test_reinit_over_a_populated_array();
+    test_reserve_requires_an_item_size();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;


### PR DESCRIPTION
Follow-on to the recent `src/class` work. A deep review of the directory turned up five more argument-checking defects, all but one of them unreachable in the configuration everyone develops in — and then the reason *why* they kept being unreachable, which turned out to be the more interesting finding.

## The defects

| Where | Defect | Reverting the fix |
|---|---|---|
| `pmix_hotel_checkout` / `_and_return_occupant` / `_knock` | Lower bound on `room_num` was an `if`; the **upper bound was `assert()` only**. `configure` adds `-DNDEBUG` whenever `--enable-debug` is off, so no shipping build checked it — `checkout` **wrote** through `rooms[]` past the end of the array and pushed a second out-of-bounds write into `unoccupied_rooms[]` via `++last_unoccupied_room`. Callers pass a cached `cd->room`; a destructed hotel (`num_rooms` 0, `rooms` NULL) got there through room 0. | **SIGSEGV** |
| `pmix_ring_buffer_push` | No guard at all, where `pop` tests `tail == -1` and `poke` tests `size <= i`. A ring only `PMIX_NEW`'d, or already destructed, dereferenced the NULL `addr`. This class's consumers are downstream projects building against the installed internal headers. | **SIGSEGV** |
| `pmix_value_array_reserve` | Missing the zero-`item_sizeof` check its two siblings carry. glibc answers `realloc(NULL, 0)` with a **non-NULL** zero-byte block, so `reserve` reported success and committed `array_alloc_size` over it; `set_size` then saw enough capacity to skip growing and element writes went into the heap past the end. | 3 assertions |
| `pmix_hash_table` (9 entry points) | The "one key type per table" check sat inside `#if PMIX_ENABLE_DEBUG`. Shipping builds mixed key types **silently**: a ptr-keyed table lost its `elt_destructor` (every copied key leaked) while `pmix_hash_grow` / `pmix_hash_table_remove_elt_at` rehashed elements through `key.u32` — the low bytes of a key *pointer* — scattering live entries to slots no lookup probes. The ptr family also dereferenced a NULL key. | 8 assertions |
| `pmix_bitmap_set_max_size` | No validation. The cap is stored as a *word* count via `((size_t) max_size + 63) / 64`, so `-1` became `(size_t) -1`, `+63` wrapped to 62, `/64` → a stored cap of **zero** — every later `init`/`set_bit` then failed far from the actual mistake. | 5 assertions |

New guards are wrapped in `PMIX_UNLIKELY`. Also braced the remaining single-statement conditionals in these files and replaced `0xffffffffffffffffUL` with `UINT64_MAX` (`unsigned long` is 32 bits on 32-bit Linux and Windows — the width mistake `pmix_bitmap.c` has had before).

One risk this introduces, now covered: making the hash-table check unconditional makes its **TMA exemption** load-bearing in optimized builds for the first time. It is the only thing keeping `gds/shmem3`'s tables readable, since `ht_type_methods` points at a file-scope static in whichever process last touched the table. `class_tma_shared` pins it cross-process; delete the clause and that program cannot build its shared state.

## `make check` was not running the test suite

`test/Makefile.am` wrapped its whole `SUBDIRS` line in `if !WANT_HIDDEN`, on the grounds that these programs use internal symbols. The effect: unless the tree was configured `--disable-visibility`, `make check` ran the 15 programs in `test/` itself, printed `# FAIL: 0`, and silently skipped `test/unit`, `test/unit/class`, `test/unit/util`, `test/simple` and `test/topologies`. **The optimized default-visibility configuration — the one those tests exist to cover, and the one users get — was never exercised by `make check`, and the result was indistinguishable from a clean full run.**

That premise is no longer true. Completing the exports in 9c7f664 (class descriptors declared in installed headers) is what made the condition removable. All five subdirectories build and pass with visibility on; **removing the condition takes a default-visibility tree from 15 tests to 80.**

The guard and the missing exports were the same bug from two directions: the exports were incomplete, so the tests could not link with visibility on, so the tests were excluded from the build where visibility is on, so nobody discovered the exports were incomplete.

Two tripwires so the shape cannot recur silently, both verified by triggering them rather than by inspection:

- `test/Makefile.am` gains a `check-local` that **fails** if `SUBDIRS` ever comes out empty.
- The top-level `Makefile.am` prints a loud `NOTE: no tests were run.` when configured `--without-tests-examples`, which drops `test/` from `SUBDIRS` one level up and produces the same silent success.

## Harness fixes

- **`run-class-tests.sh`'s ten-node pass had never run anything.** It staged `test/unit/class/$p` — a libtool *wrapper script*; the executable is under `.libs/`. All ten nodes exited 1 every time, and the runner discarded the message.
- **`build.sh` could not recover a build directory whose component set changed.** Automake records each component's `configure.m4` as a prerequisite of `aclocal.m4`; the `gds/shmem2` → `gds/shmem3` rename removed one, so `make` decided `aclocal.m4` was stale, shelled out to `aclocal-1.18`, and died — the image ships no autotools. Every pre-existing tree in the build volume was wedged, with an error naming `aclocal` and never the component. It now detects a missing recorded prerequisite and reconfigures.

## Verification

Every defect fix is pinned by a regression case **verified by reintroducing the defect in an optimized build** — two of them segfault outright when the fix is backed out. Worth noting one trap: asserting `PMIX_SUCCESS != rc` on the hash-table cases is *not* discriminating, because without the check a wrong-type get simply probes past the entry and reports `PMIX_ERR_NOT_FOUND`; it has to assert `PMIX_ERROR == rc`. The first version of that case passed with the defect reintroduced for exactly that reason.

Five configurations, two platforms, two compilers — **80 tests passing and zero warnings in every one**:

| Platform | Configuration | |
|---|---|---|
| Linux / gcc | `--enable-debug --disable-visibility` | 80/80 |
| Linux / gcc | `--enable-debug` (default visibility) | 80/80 |
| Linux / gcc | `--disable-debug --disable-devel-check` | 80/80 |
| macOS / clang 21 | `--enable-debug` (`-Werror -pedantic -Wall -Wextra`) | 80/80 |
| macOS / clang 21 | `--disable-debug --disable-devel-check` | 80/80 |

Plus `contrib/dockerswarm/run-class-tests.sh linux`: 4 passed, 0 failed — both configurations built in the container and both green on all ten nodes at once.

The macOS default-visibility build also re-confirms the symbol state this rests on, via the `nm -m` audit in `src/class/AGENTS.md`: **134 class descriptors, 103 exported, and the 31 hidden ones all private to a single `.c` or to `gds/hash`, whose header is not installed.** No class declared in an installed header is hidden.

## Note for reviewers

This touches `Makefile.am` at the top level and in `test/`, so a plain `make` in an existing build tree will want automake. Run `autogen.pl` (or refresh `Makefile.in`) before rebuilding.
