### PR TITLE
Second review sweep of src/client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ examples/group_invite
 examples/group_invite_timeout
 examples/group_invite_decline
 examples/group_invite_abort
+examples/group_invite_others
 examples/topology
 examples/group_construct_abort
 examples/group_daemon_fail
@@ -272,6 +273,7 @@ test/unit/run_toolcycle.pl
 test/unit/run_toolswitch.pl
 test/unit/run_grpmember.pl
 test/unit/run_grpinvite.pl
+test/unit/run_grpinviteothers.pl
 test/unit/run_grptimeout.pl
 test/unit/run_grpdecline.pl
 test/unit/run_grpabort.pl

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1031,6 +1031,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_toolswitch.pl], [chmod +x test/unit/run_toolswitch.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpmember.pl], [chmod +x test/unit/run_grpmember.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpinvite.pl], [chmod +x test/unit/run_grpinvite.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpinviteothers.pl], [chmod +x test/unit/run_grpinviteothers.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grptimeout.pl], [chmod +x test/unit/run_grptimeout.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpdecline.pl], [chmod +x test/unit/run_grpdecline.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_grpabort.pl], [chmod +x test/unit/run_grpabort.pl])

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -541,6 +541,26 @@ real rather than loopback:
 A final wide `dmodex` run (10 ranks over 5 nodes) drives the pending-request
 list deep enough for the coalescing to matter.
 
+**The group side of `src/client` is covered by `run-group-events.sh`, not
+here.** That suite drives the invite/join negotiation, which is realized
+entirely through cross-server event notification. Its
+`group_invite_others` case belongs to this review: the leader invites the
+other ranks and does *not* join, so the group forms on the invitees alone.
+The library credits the leader's own answer against the membership — right
+only when the leader is itself an invitee — and crediting it in this shape
+resolves the invitation one answer early, marks the last accept a
+non-responder, and aborts the (all-or-nothing) construct. Ranks are split
+across two nodes precisely so the last accept has to cross a server
+boundary to reach the leader, which is what makes it the late one.
+
+**What this suite still does not reach.** `PMIx_Fabric_*` needs a fabric
+provider the swarm does not have, so the fabric register/update paths are
+covered only by the parameter-validation cases in `client_api.c`.
+`PMIx_Compute_distances`'s relay-to-the-server fallback only runs when the
+client's own hwloc computation fails, which no test environment here can
+arrange. Both gaps are recorded in
+[`src/client/AGENTS.md`](../../src/client/AGENTS.md).
+
 ### Prerequisite: the clients must link *your* PMIx
 
 The examples are **compiled in a throwaway builder container** and **run in

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -62,11 +62,14 @@ PRRTE_REPO="${PRRTE_REPO:-https://github.com/openpmix/prrte.git}"
 # declines, so the construct resolves immediately -- no timeout -- reporting the
 # decliner and forming the group on those that accepted), group_invite_abort (an
 # invitee declines an all-or-nothing invite -- no PMIX_GROUP_OPTIONAL -- so the
-# whole construct aborts and every participant is notified), and
+# whole construct aborts and every participant is notified),
+# group_invite_others (the leader invites the others and does NOT join, so the
+# group forms on the invitees alone -- a shape in which the leader's own answer
+# must NOT be credited against the membership), and
 # group_destruct_die (a member is lost mid PMIx_Group_destruct, so the destruct
 # must complete on the survivors -- the destruct analog of group_die).
 GROUP_EXAMPLES="group group_bootstrap group_dmodex group_lcl_cid asyncgroup multi_nspace_group"
-EVENT_EXAMPLES="group_invite group_invite_timeout group_invite_decline group_invite_abort group_destruct_die group_construct_abort group_daemon_fail"
+EVENT_EXAMPLES="group_invite group_invite_others group_invite_timeout group_invite_decline group_invite_abort group_destruct_die group_construct_abort group_daemon_fail"
 # The topology/locality exerciser, driven by run-topology.sh: every rank loads
 # the topology its LOCAL server handed it (the hwloc shmem segment, or XML as
 # the fallback -- neither path exists in a standalone process) and then compares

--- a/contrib/dockerswarm/run-group-events.sh
+++ b/contrib/dockerswarm/run-group-events.sh
@@ -30,6 +30,12 @@
 #                             forms, and every member receives
 #                             PMIX_GROUP_CONSTRUCT_COMPLETE and can fence across
 #                             the group.
+#   * group_invite_others  -- the leader invites the other ranks and does not
+#                             join. The group forms on the invitees alone, so
+#                             the leader's own answer must not be counted
+#                             against a membership it is not part of -- doing so
+#                             resolves the invitation one answer early and
+#                             aborts the (all-or-nothing) construct.
 #   * group_invite_timeout -- an invitee never responds; the leader's
 #                             PMIX_TIMEOUT fires, reports the non-responder via
 #                             PMIX_GROUP_INVITE_FAILED, and forms the group on
@@ -129,6 +135,43 @@ test_linux() {
         skp "group_invite not built"
     fi
     [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] || bad "group_invite: stray prted left behind"
+    cleanup_swarm
+
+    #############################################################
+    # invite whose leader is not one of the invitees
+    #############################################################
+    banner "leader-excluded invite (group forms on the invitees alone)"
+    cleanup_swarm
+    # group_invite_others: rank 0 invites ranks 1..N-1 and does NOT join. The
+    # library credits the leader's own answer when it is itself an invitee;
+    # crediting it unconditionally starts the count one ahead of the
+    # membership here, so the invitation resolves one answer early, the last
+    # invitee's accept lands after the decision and is recorded as a
+    # non-responder, and - the construct being all-or-nothing - the whole
+    # thing aborts. The invitees say so explicitly rather than timing out.
+    #
+    # Spread over two nodes so the last accept has to cross servers to reach
+    # the leader, which is what makes it the late one.
+    if RUN 'test -x /opt/prte/tests/group_invite_others'; then
+        OUT="$(RUN 'prterun --host node1:2,node2:2 -np 4 --map-by node --timeout 60 /opt/prte/tests/group_invite_others 2>&1')"
+        npass=$(echo "$OUT" | grep -c 'CONSTRUCT_COMPLETE received: PASS')
+        nfence=$(echo "$OUT" | grep -c 'group fence complete')
+        nabort=$(echo "$OUT" | grep -c 'CONSTRUCT_ABORT')
+        if hung "$OUT"; then
+            bad "group_invite_others HUNG (the invitation never resolved)"
+        elif [ "$nabort" -gt 0 ]; then
+            bad "group_invite_others: construct ABORTED - the invitation resolved before every invitee answered"
+        elif echo "$OUT" | grep -qiE 'ERROR!|FAILED -'; then
+            bad "group_invite_others: a member reported failure: $(echo "$OUT" | tr '\n' ' ' | tail -c 200)"
+        elif [ "$npass" -ge 3 ] && [ "$nfence" -ge 3 ]; then
+            ok "group formed on all 3 invitees with the leader outside it"
+        else
+            bad "group_invite_others: only $npass completed / $nfence fenced: $(echo "$OUT" | tr '\n' ' ' | tail -c 160)"
+        fi
+    else
+        skp "group_invite_others not built"
+    fi
+    [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] || bad "group_invite_others: stray prted left behind"
     cleanup_swarm
 
     #############################################################

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -49,9 +49,18 @@ Detailed changes since v6.1.0:
    its working list when the aggregate walk collected entries but
    resolved no peers. Also stopped the fabric and device-distance reply
    handlers from reporting a tolerated short read to the application as
-   the result of an operation the server had said succeeded, and stopped
-   PMIx_Connect_nb from silently sending a message missing the job-level
-   info when that pack failed
+   the result of an operation the server had said succeeded
+ - Fixed PMIx_Connect_nb's handling of the two optional trailing info
+   blobs it appends - the caller's endpoint data and the job-level data
+   its namespace contributes. Both are a data array of info structs,
+   which a pre-v4 peer's bfrops cannot pack at all, and both were packed
+   straight into the message: the failure is partial, so the wire got a
+   half-encoded field that the receiver had to trip over and skip. They
+   are now packed through a scratch buffer and appended only if that
+   succeeds, so a peer that cannot represent one simply does not receive
+   it - which is a state the receiver already handles, since it reads
+   each with a trailing unpack. A genuine failure to append data that
+   did pack is now reported rather than passing silently
  - Added regression coverage for the above: the new cases in
    test/unit/client_api.c (which segfaults against the unfixed library),
    and a new test/unit/run_grpinviteothers.pl plus

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,57 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Repaired a second round of defects in the client library, found on a
+   follow-up sweep of src/client. Several were crashes on inputs the
+   APIs document as legal or that a careless caller can easily produce:
+   PMIx_Put dereferenced the value's type and printed the key from a
+   pmix_output_verbose() call placed above the validation meant to catch
+   them, and never checked the value at all; PMIx_Compute_distances,
+   PMIx_Resolve_peers and PMIx_Resolve_nodes each stored a default
+   through their OUT parameters without checking them; PMIx_Group_construct
+   and PMIx_Group_invite wrote results/nresults unchecked although the
+   man pages document both as optional; PMIx_Group_join did not validate
+   the group ID before strdup'ing it; PMIx_Spawn walked the apps array
+   without checking it was there; and PMIx_Fabric_deregister was the one
+   fabric entry point with no "library initialized" gate in front of a
+   dereference of state that init creates
+ - Fixed PMIx_Compute_distances_nb, which could never fall back to
+   asking the server. The fallback passes a NULL topology (and sometimes
+   a NULL cpuset) to mean "use your own", which the server supports, but
+   the generic pack entry point rejects a NULL source before the packer
+   that understands it is reached - so every request that could not be
+   answered locally returned PMIX_ERR_BAD_PARAM instead of being sent
+ - Fixed PMIX_GROUP_NOTIFY_TERMINATION, which was never recorded against
+   a group. PMIx_Group_construct captured the directive onto a tracker
+   the completion path does not consult, so the group was always
+   registered with the flag clear and PMIx_Group_destruct never
+   re-applied the policy for anyone
+ - Fixed a group invitation resolving one answer early whenever the
+   leader was not itself among the invitees. The leader's own answer was
+   credited unconditionally, so a leader inviting only the others started
+   the count one ahead of the membership: the last accept arrived after
+   the decision, was recorded as a non-responder, and - the default
+   construct being all-or-nothing - aborted the whole thing
+ - PMIx_Abort now reports the status the server returned rather than
+   always reporting success, so a host that refuses the abort, or does
+   not support one, reaches the caller. This is the same defect fixed
+   earlier in PMIx_Commit
+ - Plugged three leaks in the client: PMIx_Fabric_update orphaned the
+   fabric's previous info array on every refresh, PMIx_Get under
+   PMIX_GET_STATIC_VALUES abandoned the library's copy of the value after
+   copying it into the caller's storage, and PMIx_Resolve_peers leaked
+   its working list when the aggregate walk collected entries but
+   resolved no peers. Also stopped the fabric and device-distance reply
+   handlers from reporting a tolerated short read to the application as
+   the result of an operation the server had said succeeded, and stopped
+   PMIx_Connect_nb from silently sending a message missing the job-level
+   info when that pack failed
+ - Added regression coverage for the above: the new cases in
+   test/unit/client_api.c (which segfaults against the unfixed library),
+   and a new test/unit/run_grpinviteothers.pl plus
+   examples/group_invite_others exercising an invitation whose leader is
+   not one of the invitees. Both are in "make check", and the swarm
+   suite gained the multi-node form of the invite case
  - Stopped "make -j check" from failing test/unit. Most of that
    directory's tests drive a real PMIx server through simptest, which
    comes up in the scheduler role - a node-wide singleton that claims a

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -88,7 +88,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   pub2 toolqry simple_resolve pubstress monitor monitor_remote monitor_multi \
                   simple simple_server abort group_die connect_die group_leave \
                   group_destruct_die group_invite group_invite_timeout group_invite_decline \
-                  group_invite_abort topology
+                  group_invite_abort group_invite_others topology
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -175,6 +175,10 @@ group_destruct_die_LDADD = $(top_builddir)/src/libpmix.la
 group_invite_SOURCES = group_invite.c examples.h
 group_invite_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 group_invite_LDADD = $(top_builddir)/src/libpmix.la
+
+group_invite_others_SOURCES = group_invite_others.c examples.h
+group_invite_others_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_invite_others_LDADD = $(top_builddir)/src/libpmix.la
 
 group_invite_timeout_SOURCES = group_invite_timeout.c examples.h
 group_invite_timeout_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)

--- a/examples/group_invite_others.c
+++ b/examples/group_invite_others.c
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Invite/join where the leader is NOT one of the invitees.
+ *
+ * group_invite.c has rank 0 invite the whole job, itself included. That is
+ * the common shape, but it is not the only legal one: a coordinator may
+ * form a group among *other* processes without joining it. The API says
+ * nothing that requires the inviter to appear in the procs array, and the
+ * two cases run different code inside the library.
+ *
+ * They differ because of how the leader's own answer is counted. The
+ * invitation resolves when every invitee has answered, and the leader
+ * counts as having answered by virtue of issuing the invitation - but only
+ * when it is actually one of the invited members. Crediting that answer
+ * unconditionally makes the count start one ahead of the membership here,
+ * so the invitation resolves one answer early: the last invitee's accept
+ * arrives after the decision, it is recorded as a non-responder, and
+ * because this construct is all-or-nothing (no PMIX_GROUP_OPTIONAL) the
+ * whole thing aborts. Every invitee then reports having received
+ * PMIX_GROUP_CONSTRUCT_ABORT instead of PMIX_GROUP_CONSTRUCT_COMPLETE, and
+ * the leader's PMIx_Group_invite returns that status. That is exactly what
+ * this program checks for.
+ *
+ * Layout: rank 0 is the leader and invites ranks 1..N-1. Those ranks accept
+ * from their PMIX_GROUP_INVITED handlers (the non-blocking join is
+ * mandatory - the handler runs on the progress thread). The group is the
+ * invitees only, so they - not the leader - receive
+ * PMIX_GROUP_CONSTRUCT_COMPLETE, fence across the group to prove it is
+ * usable, and destruct it. The leader takes no part beyond inviting.
+ *
+ * Requires at least 3 ranks: with 2 there is a single invitee and the
+ * off-by-one is invisible.
+ */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+#define GROUP_ID "invothers"
+
+static pmix_proc_t myproc;
+static volatile bool complete_seen = false;
+static volatile bool abort_seen = false;
+
+/* PMIX_GROUP_INVITED handler: an invitee accepts. The leader never sees
+ * this event here - it did not invite itself. */
+static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                           const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                           pmix_info_t results[], size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    char *grp = NULL;
+    pmix_status_t rc;
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, results, nresults);
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ID)) {
+            grp = info[n].value.data.string;
+            break;
+        }
+    }
+    fprintf(stderr, "%s:%d INVITED to group %s by %s:%d - accepting\n",
+            myproc.nspace, myproc.rank, (NULL == grp) ? "(unknown)" : grp,
+            source->nspace, source->rank);
+    rc = PMIx_Group_join_nb(grp, source, PMIX_GROUP_ACCEPT, NULL, 0, NULL, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%s:%d ERROR in PMIx_Group_join_nb: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void complete_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                             const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                             pmix_info_t results[], size_t nresults,
+                             pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source,
+                                info, ninfo, results, nresults);
+
+    fprintf(stderr, "%s:%d NOTIFIED that group construct is complete\n",
+            myproc.nspace, myproc.rank);
+    complete_seen = true;
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* An abort is the symptom of the invitation having resolved before every
+ * invitee answered, so report it explicitly rather than letting the run
+ * fail as a timeout. */
+static void abort_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                          const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                          pmix_info_t results[], size_t nresults,
+                          pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source,
+                                info, ninfo, results, nresults);
+
+    fprintf(stderr, "%s:%d ERROR! received PMIX_GROUP_CONSTRUCT_ABORT - the "
+            "invitation resolved before every invitee answered\n",
+            myproc.nspace, myproc.rank);
+    abort_seen = true;
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void errhandler_reg_callbk(pmix_status_t status, size_t errhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+    EXAMPLES_HIDE_UNUSED_PARAMS(errhandler_ref);
+
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static int register_handler(pmix_status_t code, pmix_notification_fn_t fn)
+{
+    mylock_t lock;
+    int rc;
+
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, fn, errhandler_reg_callbk, (void *) &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n;
+    pmix_info_t *results;
+    size_t nresults;
+    int waited;
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 3) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 3 processes\n");
+        }
+        exit(1);
+    }
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_INVITED, invite_handler))) {
+        fprintf(stderr, "%d: failed to register invited handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_CONSTRUCT_COMPLETE, complete_handler))) {
+        fprintf(stderr, "%d: failed to register complete handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_SUCCESS != (rc = register_handler(PMIX_GROUP_CONSTRUCT_ABORT, abort_handler))) {
+        fprintf(stderr, "%d: failed to register abort handler: %s\n", myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* sync so every rank has its handlers in place before anyone invites */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (0 == myproc.rank) {
+        /* the leader invites everyone EXCEPT itself */
+        fprintf(stderr, "%d executing Group_invite for ranks 1..%d (not itself)\n",
+                myproc.rank, nprocs - 1);
+        PMIX_PROC_CREATE(procs, nprocs - 1);
+        for (n = 1; n < nprocs; n++) {
+            PMIX_PROC_LOAD(&procs[n - 1], myproc.nspace, n);
+        }
+        results = NULL;
+        nresults = 0;
+        rc = PMIx_Group_invite(GROUP_ID, procs, nprocs - 1, NULL, 0, &results, &nresults);
+        PMIX_PROC_FREE(procs, nprocs - 1);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+        }
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: ERROR! PMIx_Group_invite FAILED: %s\n",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "%d Group invite complete with status PMIX_SUCCESS\n", myproc.rank);
+        /* the leader is not a member, so it has nothing further to do with
+         * the group - just wait at the closing job fence below */
+        goto lastsync;
+    }
+
+    fprintf(stderr, "%s:%d waiting to be invited and to join the group\n",
+            myproc.nspace, myproc.rank);
+
+    /* every invitee must be told the group formed */
+    for (waited = 0; !complete_seen && !abort_seen && waited < 100; waited++) {
+        usleep(100000); /* 0.1s; up to 10s total */
+    }
+    if (abort_seen) {
+        fprintf(stderr, "Client ns %s rank %d: FAILED - construct aborted\n",
+                myproc.nspace, myproc.rank);
+        rc = PMIX_GROUP_CONSTRUCT_ABORT;
+        goto done;
+    }
+    if (!complete_seen) {
+        fprintf(stderr, "Client ns %s rank %d: FAILED - never received "
+                "PMIX_GROUP_CONSTRUCT_COMPLETE\n", myproc.nspace, myproc.rank);
+        rc = PMIX_ERR_TIMEOUT;
+        goto done;
+    }
+    fprintf(stderr, "%d PMIX_GROUP_CONSTRUCT_COMPLETE received: PASS\n", myproc.rank);
+
+    /* prove the group is usable: fence across it by its group id. Only the
+     * invitees are members, so only they participate. */
+    PMIX_LOAD_PROCID(&proc, GROUP_ID, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: ERROR! PMIx_Fence across group FAILED: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    fprintf(stderr, "%d group fence complete\n", myproc.rank);
+
+    fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
+    rc = PMIx_Group_destruct(GROUP_ID, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: ERROR! PMIx_Group_destruct FAILED: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+lastsync:
+    /* final sync across the whole job, leader included */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: final PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+done:
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "%s:%d COMPLETE (rc %s)\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    fflush(stderr);
+    return (PMIX_SUCCESS == rc) ? 0 : 1;
+}

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -286,6 +286,45 @@ finalize, after the progress thread has stopped).
   only at the end, tolerate `PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER` on
   trailing reads (older peers), and never reorder — see the top-level
   "Version Interoperability" rules.
+- **Tolerating a short read is not the same as reporting one.** A recv
+  callback that treats `PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER` as
+  acceptable — the server had nothing more to send — must then *reset*
+  `rc`, because that value is usually what gets handed to the user's
+  callback. `frecv` and `direcv` both tested for it and then fell
+  through to the completion with it still set, so a fabric register or a
+  distance computation the server said had succeeded was reported to the
+  application as an unpack error.
+- **A blocking API that discards the server's reply always returns
+  success.** Two entry points used a generic "just wake the caller"
+  recv callback that throws the buffer away — `PMIx_Commit` (fixed in
+  the first pass) and `PMIx_Abort` (fixed in the second). The server
+  packs a status for both. If you add a command whose reply carries a
+  status, give it a callback that unpacks one; `unpack_ack()` in
+  `pmix_client.c` is the shared helper.
+- **`pmix_output_verbose()` is a function call, so its arguments are
+  always evaluated** — including when the channel is off, and including
+  when the call sits above the parameter checks that were supposed to
+  make them safe. `PMIx_Put` printed `key` and dereferenced `val->type`
+  before validating either. Put the verbose line *after* the checks.
+- **`PMIX_BFROPS_PACK` rejects a NULL source before the type-specific
+  packer sees it.** `pmix_bfrops_base_pack()` fails `NULL == src && 0 <
+  num_vals` with `PMIX_ERR_BAD_PARAM`, so a packer that handles NULL
+  (`pmix_hwloc_pack_topology`, `pmix_hwloc_pack_cpuset`) can never be
+  reached that way. To send "I have none of this, use yours", pack an
+  *empty object* — a zeroed `pmix_topology_t`/`pmix_cpuset_t` — not a
+  NULL pointer. `PMIx_Compute_distances_nb` had exactly this wrong and
+  its entire ask-the-server fallback failed with BAD_PARAM instead of
+  sending.
+- **A recv callback that fills a caller-owned object must free what was
+  already in it.** `PMIx_Fabric_update` refreshes a `pmix_fabric_t` that
+  `PMIx_Fabric_register` already populated, and both `frecv` and `fcb`
+  simply `PMIX_INFO_CREATE`d over `fabric->info`, orphaning the previous
+  array on every update.
+- **Ownership flags govern the caddy, not everything the caddy touched.**
+  `cbdes()` does *not* release `cb->value`, so any path that copies out
+  of it rather than handing it over owns the original. `PMIx_Get` under
+  `PMIX_GET_STATIC_VALUES` xfers into the caller's storage and used to
+  walk away from the library's copy.
 
 ## Testing
 
@@ -297,9 +336,32 @@ a test with no server can only reach the first half.
 singleton. Covers what a client decides by itself: the `PMIx_Get`
 shortcuts that `process_request` answers outright, the pointer/static
 value forms, and the parameter validation on `PMIx_Get[_nb]`,
-`PMIx_Compute_distances_nb` and the fabric APIs. Every case in it is a
-regression for a specific defect listed below; several of them segfaulted
-before. See [`test/unit/AGENTS.md`](../../test/unit/AGENTS.md).
+`PMIx_Put`, `PMIx_Spawn[_nb]`, `PMIx_Compute_distances[_nb]`,
+`PMIx_Resolve_peers`/`PMIx_Resolve_nodes`, the group out-parameters and
+the fabric APIs. Every case in it is a regression for a specific defect
+listed below; several of them segfaulted before. See
+[`test/unit/AGENTS.md`](../../test/unit/AGENTS.md).
+
+> **Know what a singleton can and cannot reach.** Most entry points here
+> check `initialized` → `connected` → `progress_thread_stopped` *before*
+> validating their arguments, so with no server the state checks answer
+> first and the parameter checks are unreachable. That is why the
+> coverage above is exactly the set of APIs that validate before (or
+> without) gating on `connected` — `PMIx_Get`, `PMIx_Put`,
+> `PMIx_Compute_distances`, the resolve pair, the fabric calls, and
+> `PMIx_Spawn`, whose apps check deliberately precedes its connected
+> check. For the group APIs only the OUT-parameter defaults are
+> testable, because those are established ahead of every check. Don't
+> "fix" a group parameter check by hoisting it above the state checks
+> just to make it testable — the ordering is the convention here.
+
+**Tier 1a — `test/unit/run_grpinviteothers.pl` (in `make check`).**
+Drives `examples/group_invite_others` through `test/simple/simptest`:
+four clients, with rank 0 inviting ranks 1..3 and *not* joining. That
+shape is what distinguishes it from `run_grpinvite.pl` — see the
+`invite_setup()` entry in the August 2026 defect list. The test fails
+loudly (an aborted construct) rather than hanging when the invitation
+resolves early.
 
 **Tier 2 — `contrib/dockerswarm/run-client-tests.sh`.** Drives the
 `examples/` clients through PRRTE across the ten-container swarm, so the
@@ -455,6 +517,145 @@ regression coverage in `test/unit/client_api.c`.
   Written up for discussion before implementing. Until then an
   application takes the membership from its own
   `PMIX_GROUP_CONSTRUCT_COMPLETE` handler.
+
+## Defects found in the August 2026 review (second sweep)
+
+A second pass over the same directory. Grouped the same way; everything
+here is fixed on `topic/client-review-2` unless the entry says otherwise.
+The regression cases are in `test/unit/client_api.c` and (for the group
+one) `test/unit/run_grpinviteothers.pl` plus the swarm suite.
+
+*Crashes on inputs the API permits:*
+
+- `PMIx_Put` dereferenced `val->type` and printed `key` in a
+  `pmix_output_verbose()` that sat **above** the validation meant to
+  catch them — and never checked `val` at all, so `_putfn` dereferenced
+  it again. Both NULLs were segfaults.
+- `PMIx_Compute_distances`, `PMIx_Resolve_peers` and `PMIx_Resolve_nodes`
+  each set their OUT parameters to a default on the way in without
+  checking them, so a NULL for any of them was a store to address zero.
+- `PMIx_Group_construct` and `PMIx_Group_invite[_nb]` wrote `*results` /
+  `*nresults` unchecked, though the man page documents both as optional
+  (this is the same defect fixed in `PMIx_Group_join` last pass, in the
+  three siblings that were missed).
+- `PMIx_Group_join[_nb]` never validated `grp`, and `setup_leader_watch()`
+  hands it straight to `strdup()`.
+- `PMIx_Spawn[_nb]` never validated `apps`/`napps` before walking the
+  array, so `apps == NULL` with `napps > 0` dereferenced NULL. An `argv`
+  whose first element is NULL reached `strdup()`/`pmix_basename()` the
+  same way.
+- `PMIx_Fabric_deregister[_nb]` was the one fabric entry point with no
+  `initialized` gate, yet it reaches `PMIX_PEER_IS_SCHEDULER(mypeer)` —
+  and `mypeer` does not exist until `PMIx_Init` has run.
+  `PMIx_Fabric_construct(NULL)` dereferenced its argument.
+- `PMIx_Init` took `pmix_list_remove_first()` for the debugger-stop key
+  without a NULL check and then dereferenced `kv->value` (and leaked
+  `kv` on the unrecognized-type return).
+- `process_request()` `strdup`'d a `PMIX_HOSTNAME` qualifier's string
+  without checking its type or the string itself.
+
+*Functional defects:*
+
+- **`PMIx_Compute_distances_nb` could never ask the server.** The
+  fallback deliberately passes a NULL topology (and, on one path, a NULL
+  cpuset) to mean "use your own" — which the server explicitly supports
+  — but `pmix_bfrops_base_pack()` rejects a NULL source before the
+  hwloc packer that understands it is reached. Every request that could
+  not be answered locally therefore returned `PMIX_ERR_BAD_PARAM`
+  instead of being sent. Now packs empty objects, and
+  `pmix_hwloc_pack_topology()` treats an empty topology the same as the
+  NULL it already handled. **No automated coverage** — forcing a client
+  whose local hwloc computation fails is not something the test
+  environments can arrange; verified against the server handler
+  (`pmix_server_device_dists`) by inspection.
+- **`PMIX_GROUP_NOTIFY_TERMINATION` was never recorded on a group.**
+  `PMIx_Group_construct` scanned the directives and stored the flag on
+  its own wrapper tracker; `construct_cbfunc` reads it from the *inner*
+  tracker built by `PMIx_Group_construct_nb`, where it was always false.
+  Worse, `construct_cbfunc` calls `add_group()` first and `add_group()`
+  ignores a repeat request for a group it already holds — so the
+  correctly-flagged call that followed from `info_cbfunc` could not
+  correct it. `PMIx_Group_destruct` therefore never re-applied the
+  policy for anybody. The scan now happens in `_nb`, on the tracker that
+  is actually consulted.
+- **`invite_setup()` resolved an invitation one answer early whenever
+  the leader was not itself an invitee.** It credited the leader's own
+  answer unconditionally (`nanswered = 1`) but only set the matching
+  per-member flag if it found itself in the `procs` array. A leader
+  inviting only the others therefore started one ahead of the
+  membership: the last accept arrived after the decision, was recorded
+  as a non-responder, and — the default construct being
+  all-or-nothing — aborted the whole thing. Covered by
+  `examples/group_invite_others.c`.
+- `PMIx_Abort` discarded the server's reply and always returned
+  `PMIX_SUCCESS`, so a host that refused the abort (or does not support
+  one) never reached the caller. Same shape as the `_commitfn` defect
+  from the first pass.
+
+*Leaks and lifetime:*
+
+- `PMIx_Fabric_update` orphaned the fabric's previous info array —
+  `frecv()` and `fcb()` both `PMIX_INFO_CREATE`d straight over
+  `fabric->info`, and update is precisely the call made against an
+  already-populated fabric.
+- `PMIx_Get` under `PMIX_GET_STATIC_VALUES` copied into the caller's
+  storage and abandoned `cb->value`, which no destructor frees.
+- `resolve_peers()` leaked its `tmp` argv when the aggregate walk
+  collected entries but resolved no peers (an nspace whose local-peer
+  list is an empty string).
+
+*Correctness, lesser:*
+
+- `frecv()` and `direcv()` tolerated a trailing
+  `PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER` and then reported it to the
+  caller as the result of an operation the server had said succeeded.
+- `PMIx_Connect_nb` ignored the pack status when appending the
+  job-level info array, silently sending a message missing the data the
+  server waits for. Every other pack in that function is checked.
+- `destruct_cbfunc()` dropped the group from the local list on the
+  empty-buffer path but not on the NULL-buffer path.
+- `PMIx_Spawn_nb`'s "find the end sentinel" loop tested `m < SIZE_MAX`
+  *after* dereferencing `aptr->info[m]`, so the guard below it was dead.
+- `PMIx_Group_join_nb` carried a `PMIX_TIMEOUT` loop that recognized the
+  directive and did nothing with it. Removed, and the unused parameters
+  named as such — join takes no directives today.
+
+*Known, left alone (deliberately):*
+
+- **`PMIx_Group_invite_nb` never announces the outcome, and leaks its
+  tracker and event-handler registration.** `invite_announce()` and
+  `invite_teardown()` are reached only from the blocking
+  `PMIx_Group_invite`. The non-blocking form resolves the invitation
+  (`invite_wake` fires the caller's callback) and then stops: no
+  `PMIX_GROUP_INVITE_FAILED`, no `PMIX_GROUP_CONSTRUCT_COMPLETE`, no
+  `PMIX_GROUP_CONSTRUCT_ABORT` — so **no group forms** — and nothing
+  releases the tracker or deregisters `invite_handler`.
+
+  It is structural rather than an oversight. `invite_wake()` runs on the
+  progress thread, and `invite_announce()` is built out of *blocking*
+  `PMIx_Notify_event` calls, which would deadlock there; the blocking
+  wrapper gets away with it only because it announces on the caller's
+  own thread after waking. Fixing it means rewriting `invite_announce()`
+  as a chain of non-blocking notifications (the shape `emit_leader_failed`
+  already uses from the progress thread), with the teardown hung off the
+  last completion. That is a real change to the invite state machine and
+  wants review on its own, not a drive-by. Until then, treat
+  `PMIx_Group_invite_nb` as unimplemented.
+- The two `resolve_peers()` items and the event-chain pre-emption
+  problem from the first pass are unchanged — see the previous section.
+
+## Coding conventions specific to this directory
+
+- **Mark the exceptional branch.** Error checks, parameter validation,
+  allocation failures and the "should never happen" guards are wrapped
+  in `PMIX_UNLIKELY()` (from
+  [`src/include/pmix_prefetch.h`](../include/pmix_prefetch.h), which
+  every file here includes explicitly). This is the idiom the rest of
+  the tree uses; match it when you add a check. `PMIX_UNLIKELY` is for
+  branches that really are rare — do **not** put it on ordinary control
+  flow such as `NULL == proc` in `process_request()` (a documented,
+  common way to call `PMIx_Get`) or `NULL == tp` in
+  `PMIx_Compute_distances_nb` (the usual case, meaning "use mine").
 
 ## Building
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -286,6 +286,35 @@ finalize, after the progress thread has stopped).
   only at the end, tolerate `PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER` on
   trailing reads (older peers), and never reorder — see the top-level
   "Version Interoperability" rules.
+- **An optional trailing field must be packed through a scratch buffer,
+  and a pack failure on one is not necessarily an error.** The receiver
+  reads these with a trailing unpack and treats
+  `PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER` as "the peer sent none", so
+  *omitting* one is a supported wire state — and sometimes the only
+  possible one. A `PMIX_DATA_ARRAY` of `PMIX_INFO` (which is what both
+  of `PMIx_Connect_nb`'s trailing blobs are) **cannot be packed for a
+  pre-v4 peer at all**: its bfrops has no registered array-element
+  handler for `PMIX_INFO`. Two consequences:
+  - Packing straight into the message is wrong even when you ignore the
+    status, because the failure is partial — the element type and count
+    are written before the elements fail — so the wire gets a
+    half-encoded field the receiver has to trip over and skip.
+  - Turning that failure into a hard error breaks cross-version connect
+    outright. This is not hypothetical: it is what the
+    `run-xversion` v3.2 job caught (`--test-resolve-peers`, which drives
+    a multi-nspace connect, hung).
+
+  `append_optional()` in `pmix_client_connect.c` is the pattern: pack to
+  a scratch `pmix_buffer_t`, `PMIX_BFROPS_COPY_PAYLOAD` it onto the
+  message only if that succeeded, and report success either way. Reserve
+  a hard error for failing to append something you *did* manage to pack.
+- **Reproduce cross-version failures locally rather than guessing.** The
+  `run-xversion` workflow just runs `test/pmix_test` from one build
+  against `test/pmix_client` from the other, so a checkout of the release
+  branch beside your tree reproduces any of its cases directly, e.g.
+  `…/v3.2/test/pmix_test -n 5 --test-resolve-peers --ns-dist "1:2:2" -e
+  …/master/test/pmix_client`. Run it both directions — the two are
+  separate CI steps and fail independently.
 - **Tolerating a short read is not the same as reporting one.** A recv
   callback that treats `PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER` as
   acceptable — the server had nothing more to send — must then *reset*
@@ -591,6 +620,13 @@ one) `test/unit/run_grpinviteothers.pl` plus the swarm suite.
 - `PMIx_Connect_nb` ignored the pack status when appending the
   job-level info array, silently sending a message missing the data the
   server waits for. Every other pack in that function is checked.
+  **Simply checking it was wrong too** — see the optional-trailing-field
+  invariant above. Both of its trailing blobs now go through
+  `append_optional()`, which omits what a peer cannot represent and
+  errors only on a genuine failure. The first attempt at this fix broke
+  connect against every pre-v4 server; caught by the `run-xversion` v3.2
+  job, and the endpoint blob had the same latent exposure even before
+  this pass.
 - `destruct_cbfunc()` dropped the group from the local list on the
   empty-buffer path but not on the NULL-buffer path.
 - `PMIx_Spawn_nb`'s "find the end sentinel" loop tested `m < SIZE_MAX`

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -472,51 +472,30 @@ regression coverage in `test/unit/client_api.c`.
   lines later, so the legacy branch is dead. `try_fetch()` retries an
   UNDEF rank as WILDCARD, which is why the path still works. Not changed
   without a pre-v3.2 server to test against; see the comment in the code.
-- **`PMIx_Group_join` completes earlier than its man page says, and so
-  returns no results** — and the invitee-side **leader-failure watch does
-  not fire at all**. Both have one cause, and it is *not* the one the
-  comment above `pmix_group_leader_watches` gives.
-
-  The library observes group lifecycle events by registering ordinary
-  handlers. Those registrations land in the **multi-code** category, and
-  the chain visits `first` → `single-code` → `multi-code` → `default` →
-  `last`. An application handler registered for a *single* code therefore
-  runs first, and if it returns `PMIX_EVENT_ACTION_COMPLETE` — the normal
-  way to say "handled" — the chain ends and the library's own handler is
-  never reached. Any application that watches
-  `PMIX_GROUP_CONSTRUCT_COMPLETE`, which an invite/join application must,
-  blinds the library to it.
-
-  **Both multi-code registrations in this file are affected**, and the
-  worse one is not the watch. `invite_setup`'s `invite_handler` is the
-  only thing that counts invitation answers, so a *leader* whose
-  application also watches `PMIX_GROUP_INVITE_ACCEPTED` never resolves
-  its invitation: `PMIx_Group_invite` hangs forever without a
-  `PMIX_TIMEOUT`, and the group never forms. Reproduced by adding such a
-  handler to `examples/group_invite.c`. The three `PMIX_DEBUGGER_RELEASE`
-  registrations (client, server, tool) are in the single-code category and
-  safe — but only because they register inside init and block there, so
-  the application never gets a window to compete. A handler with no
-  ordering directive is *prepended*, so a later application registration
-  would otherwise win.
-
-  Demonstrated with `test/unit/run_grpinvite.pl`: every acceptor's
-  application handler receives the event while not one of the library's
-  watches does, in the same process and the same run; flipping only the
-  example's return to `PMIX_EVENT_NO_ACTION_TAKEN` makes all three
-  watches receive it. It is not a delivery problem and not a
-  registration race (reordering the watch ahead of the accept changes
-  nothing).
-
-  So join cannot complete at the documented point until the library can
-  see the construct event. The fix is local, not protocol-level: the
-  pre-chain block in `pmix_invoke_local_event_hdlr()`
-  (`src/event/pmix_event_notification.c`) already maintains
-  `pmix_client_globals.groups` on these same codes, unconditionally and
-  ahead of the chain, and that is where the library's interest belongs.
-  Written up for discussion before implementing. Until then an
+- **The library's own event handlers can be silently suppressed by the
+  application — [openpmix#4059][i4059].** Both multi-code registrations
+  in `pmix_client_group.c` (`invite_setup`'s `invite_handler` and
+  `setup_leader_watch`'s watch) land in the **multi-code** category,
+  and the chain visits `first` → `single-code` → `multi-code` →
+  `default` → `last`, so an application handler registered for a
+  *single* one of those codes runs first and ends the chain with the
+  ordinary `PMIX_EVENT_ACTION_COMPLETE`. Consequences you will meet
+  here: `PMIx_Group_invite` can hang forever, the invitee-side
+  leader-failure watch never fires, and `PMIx_Group_join` cannot
+  complete at the point its man page documents (so it returns no
+  results). Read the issue before touching any of it — it carries the
+  reproducers, the sweep of every internal registration in the tree,
+  what was ruled out (not delivery, not a registration race, not a
+  filter mismatch), and the options for a fix. Until then an
   application takes the membership from its own
   `PMIX_GROUP_CONSTRUCT_COMPLETE` handler.
+
+  Do **not** re-derive this from the code: an earlier comment in this
+  file blamed the construct event "not being guaranteed to reach the
+  acceptor", which sent readers after a protocol problem that does not
+  exist. The event arrives reliably; the library just cannot see it.
+
+[i4059]: https://github.com/openpmix/openpmix/issues/4059
 
 ## Defects found in the August 2026 review (second sweep)
 
@@ -641,8 +620,17 @@ one) `test/unit/run_grpinviteothers.pl` plus the swarm suite.
   last completion. That is a real change to the invite state machine and
   wants review on its own, not a drive-by. Until then, treat
   `PMIx_Group_invite_nb` as unimplemented.
-- The two `resolve_peers()` items and the event-chain pre-emption
-  problem from the first pass are unchanged — see the previous section.
+
+  **Distinct from [openpmix#4059][i4059], but landing on the same
+  code.** That issue is about the library's handlers being suppressed;
+  this is the non-blocking path never running the announcement at all,
+  and it would still be broken with #4059 fixed. Whoever reworks this
+  machinery will meet both, and the same rewrite — announcement driven
+  by non-blocking notifications — is what #4059's follow-on behavior
+  change (completing a pending join from the construct event) also
+  needs. Noted on that issue.
+- The two `resolve_peers()` items and the handler-suppression problem
+  from the first pass are unchanged — see the previous section.
 
 ## Coding conventions specific to this directory
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -234,23 +234,27 @@ pmix_client_globals_t pmix_client_globals = {
     .iof_stderr = PMIX_IOF_SINK_STATIC_INIT
 };
 
-/* callback for wait completion */
-static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer_t *buf,
-                        void *cbdata)
+/* Unpack the status the server acked a simple command with. Returns
+ * PMIX_ERR_UNREACH for the NULL/zero-byte buffer that marks a recv being
+ * completed synthetically because the connection was lost. */
+static pmix_status_t unpack_ack(pmix_buffer_t *buf)
 {
-    pmix_lock_t *lock = (pmix_lock_t *) cbdata;
-    PMIX_HIDE_UNUSED_PARAMS(pr, hdr, buf);
+    pmix_status_t rc, ret;
+    int32_t cnt;
 
-    PMIX_ACQUIRE_OBJECT(lock);
-
-    pmix_output_verbose(2, pmix_client_globals.base_output,
-                        "pmix:client wait_cbfunc received");
-
-    PMIX_POST_OBJECT(lock);
-    PMIX_WAKEUP_THREAD(lock);
+    if (NULL == buf || PMIX_BUFFER_IS_EMPTY(buf)) {
+        return PMIX_ERR_UNREACH;
+    }
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    return ret;
 }
 
-/* Completion of a commit: unlike the generic wait_cbfunc above, this one
+/* Completion of a commit: rather than discarding the reply, this one
  * reads the reply. The server acks PMIX_COMMIT_CMD with the status of the
  * store it just performed, and discarding that reported every commit as a
  * success - including one the server rejected, which is precisely the case
@@ -260,30 +264,40 @@ static void commit_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
                           pmix_buffer_t *buf, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
-    pmix_status_t rc, ret;
-    int32_t cnt;
+    pmix_status_t ret;
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     PMIX_ACQUIRE_OBJECT(cb);
 
-    /* a NULL or zero-byte buffer means the connection was lost and this
-     * recv is being completed synthetically */
-    if (NULL == buf || PMIX_BUFFER_IS_EMPTY(buf)) {
-        ret = PMIX_ERR_UNREACH;
-    } else {
-        cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            ret = rc;
-        }
-    }
+    ret = unpack_ack(buf);
 
     pmix_output_verbose(2, pmix_client_globals.base_output,
                         "pmix:client commit completed with status %s",
                         PMIx_Error_string(ret));
 
     cb->pstatus = ret;
+    PMIX_POST_OBJECT(cb);
+    PMIX_WAKEUP_THREAD(&cb->lock);
+}
+
+/* Completion of an abort. The server replies with the status its host
+ * returned for the abort request (see op_cbfunc in src/server), and the
+ * reply used to be discarded wholesale - so PMIx_Abort reported success
+ * even when the host refused the request or did not support it. */
+static void abort_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
+                         pmix_buffer_t *buf, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
+
+    PMIX_ACQUIRE_OBJECT(cb);
+
+    cb->pstatus = unpack_ack(buf);
+
+    pmix_output_verbose(2, pmix_client_globals.base_output,
+                        "pmix:client abort completed with status %s",
+                        PMIx_Error_string(cb->pstatus));
+
     PMIX_POST_OBJECT(cb);
     PMIX_WAKEUP_THREAD(&cb->lock);
 }
@@ -1024,6 +1038,12 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
 
         kv = (pmix_kval_t*)pmix_list_remove_first(&cb.kvs);
         PMIX_DESTRUCT(&cb);
+        if (NULL == kv) {
+            /* a successful fetch that returned nothing - treat it the same
+             * as "no debugger waiting" rather than dereferencing the NULL */
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+            goto nodebugger;
+        }
 
         if (PMIX_BOOL == kv->value->type) {
             if (kv->value->data.flag) {
@@ -1036,6 +1056,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         } else {
             pmix_output(0, "DEBUG STOP_IN_INIT FOUND, BUT VALUE UNRECOGNIZED: %s",
                         PMIx_Data_type_string(kv->value->type));
+            PMIX_RELEASE(kv);
             return PMIX_ERR_BAD_PARAM;
         }
         pmix_output_verbose(2, pmix_client_globals.base_output,
@@ -1122,6 +1143,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
                             pmix_globals.myid.rank);
         PMIX_DESTRUCT(&cb);
     }
+nodebugger:
 
     /* check to see if we need to notify anyone */
     if (NULL != info) {
@@ -1341,7 +1363,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
     pmix_buffer_t *bfr;
     pmix_cmd_t cmd = PMIX_ABORT_CMD;
     pmix_status_t rc;
-    pmix_lock_t reglock;
+    pmix_cb_t *cb;
 
     pmix_output_verbose(2, pmix_client_globals.base_output,
                         "pmix:client abort called");
@@ -1415,18 +1437,21 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
     }
 
     /* send to the server */
-    PMIX_CONSTRUCT_LOCK(&reglock);
-    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, bfr, wait_cbfunc, (void *) &reglock);
+    cb = PMIX_NEW(pmix_cb_t);
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, bfr, abort_cbfunc, (void *) cb);
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(bfr);
-        PMIX_DESTRUCT_LOCK(&reglock);
+        PMIX_RELEASE(cb);
         return rc;
     }
 
-    /* wait for the release */
-    PMIX_WAIT_THREAD(&reglock);
-    PMIX_DESTRUCT_LOCK(&reglock);
-    return PMIX_SUCCESS;
+    /* wait for the release, and report what the server told us - a host
+     * that refuses the abort (or does not support one) has to reach the
+     * caller, not be swallowed here */
+    PMIX_WAIT_THREAD(&cb->lock);
+    rc = cb->pstatus;
+    PMIX_RELEASE(cb);
+    return rc;
 }
 
 static void _putfn(int sd, short args, void *cbdata)
@@ -1505,17 +1530,22 @@ PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope,
     pmix_cb_t *cb;
     pmix_status_t rc;
 
-    pmix_output_verbose(2, pmix_client_globals.base_output,
-                          "pmix: executing put for key %s type %s",
-                          key, PMIx_Data_type_string(val->type));
-
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
 
-    if (NULL == key || PMIX_MAX_KEYLEN < pmix_keylen(key)) {
+    /* Screen both inputs before anything looks at them. The verbose call
+     * below prints the key and dereferences the value's type, and its
+     * arguments are evaluated whether or not the channel is enabled - so a
+     * NULL for either used to crash here, ahead of the check that was meant
+     * to catch it. _putfn() then dereferences the value again. */
+    if (NULL == key || PMIX_MAX_KEYLEN < pmix_keylen(key) || NULL == val) {
         return PMIX_ERR_BAD_PARAM;
     }
+
+    pmix_output_verbose(2, pmix_client_globals.base_output,
+                          "pmix: executing put for key %s type %s",
+                          key, PMIx_Data_type_string(val->type));
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -20,6 +20,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include "src/include/pmix_prefetch.h"
+
 #include "src/include/pmix_socket_errno.h"
 #include "src/include/pmix_stdint.h"
 
@@ -120,7 +122,7 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hd
 
     /* start the local notification chain */
     chain = PMIX_NEW(pmix_event_chain_t);
-    if (NULL == chain) {
+    if (PMIX_UNLIKELY(NULL == chain)) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return;
     }
@@ -129,7 +131,7 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hd
 
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &cmd, &cnt, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(chain);
         goto error;
@@ -137,7 +139,7 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hd
     /* unpack the status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &chain->status, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(chain);
         goto error;
@@ -146,7 +148,7 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hd
     /* unpack the source of the event */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &chain->source, &cnt, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(chain);
         goto error;
@@ -155,7 +157,7 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hd
     /* unpack the info that might have been provided */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ninfo, &cnt, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(chain);
         goto error;
@@ -164,7 +166,7 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hd
     /* we always leave space for event hdlr name and a callback object */
     chain->nallocated = ninfo + 2;
     PMIX_INFO_CREATE(chain->info, chain->nallocated);
-    if (NULL == chain->info) {
+    if (PMIX_UNLIKELY(NULL == chain->info)) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         PMIX_RELEASE(chain);
         return;
@@ -174,7 +176,7 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hd
         chain->ninfo = ninfo;
         cnt = ninfo;
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, chain->info, &cnt, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(chain);
             goto error;
@@ -196,7 +198,7 @@ error:
                         "%s pmix:client_notify_recv - unpack error status =%s, calling def errhandler",
                         PMIX_NAME_PRINT(&pmix_globals.myid), PMIx_Error_string(rc));
     chain = PMIX_NEW(pmix_event_chain_t);
-    if (NULL == chain) {
+    if (PMIX_UNLIKELY(NULL == chain)) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return;
     }
@@ -242,12 +244,12 @@ static pmix_status_t unpack_ack(pmix_buffer_t *buf)
     pmix_status_t rc, ret;
     int32_t cnt;
 
-    if (NULL == buf || PMIX_BUFFER_IS_EMPTY(buf)) {
+    if (PMIX_UNLIKELY(NULL == buf || PMIX_BUFFER_IS_EMPTY(buf))) {
         return PMIX_ERR_UNREACH;
     }
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -386,11 +388,11 @@ static pmix_status_t fallback_to_next_gds(void)
     myserver->nptr->compat.gds = fb;
 
     req = PMIX_NEW(pmix_buffer_t);
-    if (NULL == req) {
+    if (PMIX_UNLIKELY(NULL == req)) {
         return PMIX_ERR_NOMEM;
     }
     PMIX_BFROPS_PACK(rc, myserver, req, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);
         return rc;
@@ -398,14 +400,14 @@ static pmix_status_t fallback_to_next_gds(void)
     /* tell the server which module we switched to */
     modname = (char *) fb->name;
     PMIX_BFROPS_PACK(rc, myserver, req, &modname, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);
         return rc;
     }
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     PMIX_PTL_SEND_RECV(rc, myserver, req, job_data, (void *) &cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);
         PMIX_DESTRUCT(&cb);
@@ -461,7 +463,7 @@ static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
             }
         }
         /* if the object wasn't returned, then that is an error */
-        if (NULL == lock) {
+        if (PMIX_UNLIKELY(NULL == lock)) {
             pmix_output_verbose(2, pmix_client_globals.base_output,
                                 "event handler %s failed to return object",
                                 (NULL == name) ? "NULL" : name);
@@ -507,12 +509,12 @@ static void _check_for_notify(pmix_info_t info[], size_t ninfo)
     if (0 < m) {
         /* notify anyone listening that a model has been declared */
         scd = PMIX_NEW(pmix_shift_caddy_t);
-        if (NULL == scd) {
+        if (PMIX_UNLIKELY(NULL == scd)) {
              /* nothing we can do */
             return;
         }
         PMIX_INFO_CREATE(scd->info, m + 1);
-        if (NULL == scd->info) {
+        if (PMIX_UNLIKELY(NULL == scd->info)) {
             PMIX_RELEASE(scd);
             return;
         }
@@ -577,25 +579,25 @@ static void client_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
 
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &source, &cnt, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return;
     }
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &channel, &cnt, PMIX_IOF_CHANNEL);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return;
     }
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &refid, &cnt, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return;
     }
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return;
     }
@@ -603,14 +605,14 @@ static void client_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
         PMIX_INFO_CREATE(info, ninfo);
         cnt = ninfo;
         PMIX_BFROPS_UNPACK(rc, peer, buf, info, &cnt, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             goto cleanup;
         }
     }
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &bo, &cnt, PMIX_BYTE_OBJECT);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
@@ -663,7 +665,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         // did the prior call get far enough? We might be in a tight
         // race between multiple calls to PMIx_Init - bad programming
         // technique, but all we can do is try to protect against it
-        if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
             return PMIX_ERR_INIT;
         }
         // return our proc name if they requested it
@@ -678,7 +680,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         }
         /* if we were given connection info, then we should try
          * to connect if are currently unconnected */
-        if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+        if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
             rc = pmix_ptl.connect_to_peer((struct pmix_peer_t *) pmix_client_globals.myserver, info,
                                           ninfo, &suri);
             if (PMIX_SUCCESS == rc) {
@@ -714,7 +716,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     /* setup the runtime - this init's the globals,
      * opens and initializes the required frameworks */
     rc = pmix_rte_init(PMIX_PROC_CLIENT, info, ninfo, pmix_client_notify_recv);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -758,18 +760,18 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     PMIX_CONSTRUCT(&pmix_client_globals.peers, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_client_globals.peers, 1, INT_MAX, 1);
     pmix_client_globals.myserver = PMIX_NEW(pmix_peer_t);
-    if (NULL == pmix_client_globals.myserver) {
+    if (PMIX_UNLIKELY(NULL == pmix_client_globals.myserver)) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return PMIX_ERR_NOMEM;
     }
     pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
-    if (NULL == pmix_client_globals.myserver->nptr) {
+    if (PMIX_UNLIKELY(NULL == pmix_client_globals.myserver->nptr)) {
         PMIX_RELEASE(pmix_client_globals.myserver);
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return PMIX_ERR_NOMEM;
     }
     pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
-    if (NULL == pmix_client_globals.myserver->info) {
+    if (PMIX_UNLIKELY(NULL == pmix_client_globals.myserver->info)) {
         PMIX_RELEASE(pmix_client_globals.myserver);
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return PMIX_ERR_NOMEM;
@@ -821,7 +823,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     pmix_globals.pindex = -1;
     /* setup a rank_info object for us */
     pmix_globals.mypeer->info = PMIX_NEW(pmix_rank_info_t);
-    if (NULL == pmix_globals.mypeer->info) {
+    if (PMIX_UNLIKELY(NULL == pmix_globals.mypeer->info)) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return PMIX_ERR_NOMEM;
     }
@@ -840,7 +842,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
      * to us at launch */
     evar = getenv("PMIX_SECURITY_MODE");
     pmix_globals.mypeer->nptr->compat.psec = pmix_psec_base_assign_module(evar);
-    if (NULL == pmix_globals.mypeer->nptr->compat.psec) {
+    if (PMIX_UNLIKELY(NULL == pmix_globals.mypeer->nptr->compat.psec)) {
         PMIX_ERROR_LOG(PMIX_ERR_INIT);
         return PMIX_ERR_INIT;
     }
@@ -874,7 +876,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     } else {
         pmix_client_globals.myserver->nptr->compat.gds = pmix_gds_base_assign_module(NULL, 0);
     }
-    if (NULL == pmix_client_globals.myserver->nptr->compat.gds) {
+    if (PMIX_UNLIKELY(NULL == pmix_client_globals.myserver->nptr->compat.gds)) {
         PMIX_ERROR_LOG(PMIX_ERR_INIT);
         return PMIX_ERR_INIT;
     }
@@ -895,7 +897,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, "hash", PMIX_STRING);
     }
     pmix_globals.mypeer->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
-    if (NULL == pmix_globals.mypeer->nptr->compat.gds) {
+    if (PMIX_UNLIKELY(NULL == pmix_globals.mypeer->nptr->compat.gds)) {
         PMIX_INFO_DESTRUCT(&ginfo);
         PMIX_ERROR_LOG(PMIX_ERR_INIT);
         return PMIX_ERR_INIT;
@@ -905,12 +907,12 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     /* attempt to connect to a server */
     rc = pmix_ptl.connect_to_peer((struct pmix_peer_t *) pmix_client_globals.myserver,
                                    info, ninfo, &suri);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         /* mark that we couldn't connect to a server */
         pmix_client_globals.singleton = true;
         /* initialize our data values */
         rc = pmix_tool_init_info();
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
@@ -934,7 +936,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
          * blocking operations and error out if we try them. */
         req = PMIX_NEW(pmix_buffer_t);
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, req, &cmd, 1, PMIX_COMMAND);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(req);
             free(suri);
@@ -943,7 +945,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         /* send to the server */
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, req, job_data, (void *) &cb);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             /* the transport refused the message without taking it, and the
              * recv callback will never fire, so unwind both here */
@@ -961,7 +963,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
              * this client; fall back to the next module and re-request */
             rc = fallback_to_next_gds();
         }
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             return rc;
         }
     }
@@ -976,7 +978,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         kptr->value->type = PMIX_STRING;
         kptr->value->data.string = strdup(pmix_client_globals.myserver->info->pname.nspace);
         PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
@@ -988,7 +990,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         kptr->value->data.rank = pmix_client_globals.myserver->info->pname.rank;
         PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
         PMIX_RELEASE(kptr); // maintain accounting
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
@@ -1002,7 +1004,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         free(suri);
         PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
         PMIX_RELEASE(kptr); // maintain accounting
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
@@ -1015,7 +1017,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     if (!pmix_globals.external_topology &&
         NULL == pmix_globals.topology.topology) {
         rc = pmix_hwloc_setup_topology(NULL, 0);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
@@ -1038,7 +1040,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
 
         kv = (pmix_kval_t*)pmix_list_remove_first(&cb.kvs);
         PMIX_DESTRUCT(&cb);
-        if (NULL == kv) {
+        if (PMIX_UNLIKELY(NULL == kv)) {
             /* a successful fetch that returned nothing - treat it the same
              * as "no debugger waiting" rather than dereferencing the NULL */
             PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
@@ -1126,7 +1128,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
             PMIX_INFO_DESTRUCT(&evinfo[1]);
             PMIX_INFO_DESTRUCT(&evinfo[2]);
             PMIX_INFO_DESTRUCT(&evinfo[3]);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 // failed to notify ready-for-debug
                 PMIX_ERROR_LOG(rc);
                 PMIX_DESTRUCT_LOCK(&releaselock);
@@ -1152,7 +1154,7 @@ nodebugger:
 
     /* register the client supported attrs */
     rc = pmix_register_client_attrs();
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -1221,7 +1223,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
     pmix_peer_t *peer;
     int i;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
     i = pmix_atomic_fetch_add(&client_init_cntr, -1);
@@ -1248,7 +1250,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
                 if (0 == strcmp(PMIX_EMBED_BARRIER, info[n].key)) {
                     if (PMIX_INFO_TRUE(&info[n])) {
                         rc = PMIx_Fence(NULL, 0, NULL, 0);
-                        if (PMIX_SUCCESS != rc) {
+                        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                             PMIX_ERROR_LOG(rc);
                         }
                     }
@@ -1262,7 +1264,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         msg = PMIX_NEW(pmix_buffer_t);
         /* pack the cmd */
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             return rc;
@@ -1283,7 +1285,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         pmix_event_add(&tev.ev, &tv);
         /* send to the server */
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, finwait_cbfunc, (void *) &tev);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             /* the recv callback will not fire, so cancel the timer and
              * tear down the lock before we return - and reclaim the message
              * the transport declined to take */
@@ -1368,11 +1370,11 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
     pmix_output_verbose(2, pmix_client_globals.base_output,
                         "pmix:client abort called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -1392,7 +1394,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
@@ -1400,28 +1402,28 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
     bfr = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, bfr, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(bfr);
         return rc;
     }
     /* pack the status flag */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, bfr, &flag, 1, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(bfr);
         return rc;
     }
     /* pack the string message - a NULL is okay */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, bfr, &msg, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(bfr);
         return rc;
     }
     /* pack the number of procs */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, bfr, &nprocs, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(bfr);
         return rc;
@@ -1429,7 +1431,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
     /* pack any provided procs */
     if (0 < nprocs) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, bfr, procs, nprocs, PMIX_PROC);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(bfr);
             return rc;
@@ -1439,7 +1441,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
     /* send to the server */
     cb = PMIX_NEW(pmix_cb_t);
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, bfr, abort_cbfunc, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(bfr);
         PMIX_RELEASE(cb);
         return rc;
@@ -1482,7 +1484,7 @@ static void _putfn(int sd, short args, void *cbdata)
     if (PMIX_STRING_SIZE_CHECK(cb->value)) {
         /* compress large strings */
         if (pmix_compress.compress_string(cb->value->data.string, &tmp, &len)) {
-            if (NULL == tmp) {
+            if (PMIX_UNLIKELY(NULL == tmp)) {
                 PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
                 rc = PMIX_ERR_NOMEM;
                 PMIX_ERROR_LOG(rc);
@@ -1498,14 +1500,14 @@ static void _putfn(int sd, short args, void *cbdata)
     } else {
         PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, kv->value, cb->value);
     }
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto done;
     }
 
     /* store it */
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, cb->scope, kv);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
     }
 
@@ -1530,7 +1532,7 @@ PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope,
     pmix_cb_t *cb;
     pmix_status_t rc;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
@@ -1539,7 +1541,7 @@ PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope,
      * arguments are evaluated whether or not the channel is enabled - so a
      * NULL for either used to crash here, ahead of the check that was meant
      * to catch it. _putfn() then dereferences the value again. */
-    if (NULL == key || PMIX_MAX_KEYLEN < pmix_keylen(key) || NULL == val) {
+    if (PMIX_UNLIKELY(NULL == key || PMIX_MAX_KEYLEN < pmix_keylen(key) || NULL == val)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -1547,7 +1549,7 @@ PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope,
                           "pmix: executing put for key %s type %s",
                           key, PMIx_Data_type_string(val->type));
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -1585,7 +1587,7 @@ static void _commitfn(int sd, short args, void *cbdata)
     msgout = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msgout, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msgout);
         goto error;
@@ -1604,7 +1606,7 @@ static void _commitfn(int sd, short args, void *cbdata)
         PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
         if (PMIX_SUCCESS == rc) {
             PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msgout, &scope, 1, PMIX_SCOPE);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msgout);
                 goto error;
@@ -1612,7 +1614,7 @@ static void _commitfn(int sd, short args, void *cbdata)
             PMIX_CONSTRUCT(&bkt, pmix_buffer_t);
             PMIX_LIST_FOREACH(kv, &cb->kvs, pmix_kval_t) {
                 PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, &bkt, kv, 1, PMIX_KVAL);
-                if (PMIX_SUCCESS != rc) {
+                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DESTRUCT(&bkt);
                     PMIX_RELEASE(msgout);
@@ -1622,7 +1624,7 @@ static void _commitfn(int sd, short args, void *cbdata)
             /* now pack the result */
             PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msgout, &bkt, 1, PMIX_BUFFER);
             PMIX_DESTRUCT(&bkt);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msgout);
                 goto error;
@@ -1642,7 +1644,7 @@ static void _commitfn(int sd, short args, void *cbdata)
         PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
         if (PMIX_SUCCESS == rc) {
             PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msgout, &scope, 1, PMIX_SCOPE);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msgout);
                 goto error;
@@ -1650,7 +1652,7 @@ static void _commitfn(int sd, short args, void *cbdata)
             PMIX_CONSTRUCT(&bkt, pmix_buffer_t);
             PMIX_LIST_FOREACH(kv, &cb->kvs, pmix_kval_t) {
                 PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, &bkt, kv, 1, PMIX_KVAL);
-                if (PMIX_SUCCESS != rc) {
+                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DESTRUCT(&bkt);
                     PMIX_RELEASE(msgout);
@@ -1660,7 +1662,7 @@ static void _commitfn(int sd, short args, void *cbdata)
             /* now pack the result */
             PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msgout, &bkt, 1, PMIX_BUFFER);
             PMIX_DESTRUCT(&bkt);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msgout);
                 goto error;
@@ -1695,7 +1697,7 @@ PMIX_EXPORT pmix_status_t PMIx_Commit(void)
     pmix_cb_t *cb;
     pmix_status_t rc;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
@@ -1704,7 +1706,7 @@ PMIX_EXPORT pmix_status_t PMIx_Commit(void)
         return PMIX_SUCCESS;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -1713,7 +1715,7 @@ PMIX_EXPORT pmix_status_t PMIx_Commit(void)
         !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         return PMIX_SUCCESS; // not an error
     }
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -64,6 +64,45 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
                         void *cbdata);
 static void op_cbfunc(pmix_status_t status, void *cbdata);
 
+/* Append one of the connect message's OPTIONAL trailing info blobs - the
+ * caller's endpoint data, or the job-level data its namespace contributes.
+ *
+ * Optional is meant literally, and the server relies on it: it reads each of
+ * these with a trailing unpack and treats
+ * PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER as "the client sent none" (see
+ * pmix_server_connect). A peer whose wire format cannot represent the blob
+ * must therefore still be able to connect - and such peers exist. Both blobs
+ * are a PMIX_DATA_ARRAY of PMIX_INFO, and a pre-v4 peer's bfrops has no
+ * registered array-element handler for PMIX_INFO, so the array cannot be
+ * packed for it at all.
+ *
+ * So pack through a scratch buffer and append only what packed cleanly.
+ * Packing straight into the message could not do that: the element type and
+ * count are written before the elements themselves fail, leaving a
+ * half-encoded info on the wire for the server to trip over and skip.
+ *
+ * Returns PMIX_SUCCESS whether or not the blob was appended - being unable
+ * to express it for this peer is not an error. Only failing to append
+ * something we did manage to pack is. */
+static pmix_status_t append_optional(pmix_buffer_t *msg, pmix_info_t *xfer)
+{
+    pmix_buffer_t pbkt;
+    pmix_status_t rc;
+
+    PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, &pbkt, xfer, 1, PMIX_INFO);
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+        pmix_output_verbose(2, pmix_client_globals.connect_output,
+                            "pmix:connect omitting %s: this peer cannot represent it (%s)",
+                            xfer->key, PMIx_Error_string(rc));
+        PMIX_DESTRUCT(&pbkt);
+        return PMIX_SUCCESS;
+    }
+    PMIX_BFROPS_COPY_PAYLOAD(rc, pmix_client_globals.myserver, msg, &pbkt);
+    PMIX_DESTRUCT(&pbkt);
+    return rc;
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
                                        const pmix_info_t info[], size_t ninfo)
 {
@@ -244,8 +283,8 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
             // insert into a pmix_info_t for packing
             PMIX_INFO_LOAD(&xfer, PMIX_PROC_DATA, &darray, PMIX_DATA_ARRAY);
             PMIX_DATA_ARRAY_DESTRUCT(&darray);
-            // pack the result
-            PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &xfer, 1, PMIX_INFO);
+            // append it if this peer can carry it
+            rc = append_optional(msg, &xfer);
             PMIX_INFO_DESTRUCT(&xfer);
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
@@ -337,14 +376,16 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
                 }
                 // insert into a pmix_info_t for packing
                 PMIX_INFO_LOAD(&xfer, PMIX_JOB_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
-                // pack the result
-                PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &xfer, 1, PMIX_INFO);
+                // append it if this peer can carry it
+                rc = append_optional(msg, &xfer);
                 PMIX_DATA_ARRAY_DESTRUCT(&darray);
                 PMIX_INFO_DESTRUCT(&xfer);
                 PMIx_Info_list_release(ilist);
-                /* every other pack in this function is checked; letting this
-                 * one through silently sent the server a message that was
-                 * missing the job-level info it is waiting for */
+                /* every other pack in this function is checked, and this one
+                 * used to go unexamined - so a genuine failure to append data
+                 * the server is waiting for passed silently. Note that
+                 * "this peer cannot represent it" is NOT such a failure;
+                 * append_optional() reports success for that case. */
                 if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(msg);

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -340,6 +340,16 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
                 PMIX_DATA_ARRAY_DESTRUCT(&darray);
                 PMIX_INFO_DESTRUCT(&xfer);
                 PMIx_Info_list_release(ilist);
+                /* every other pack in this function is checked; letting this
+                 * one through silently sent the server a message that was
+                 * missing the job-level info it is waiting for */
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(msg);
+                    PMIX_DESTRUCT(&cb2);
+                    PMIX_PROC_FREE(rgs, nrg);
+                    return rc;
+                }
             }
             /* release the job-info fetch results (the error paths above
              * destruct cb2 before jumping to moveon, so this only runs on

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -18,6 +18,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include "src/include/pmix_prefetch.h"
+
 #include "src/include/pmix_stdint.h"
 
 #include "include/pmix.h"
@@ -71,16 +73,16 @@ PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
     pmix_output_verbose(2, pmix_client_globals.connect_output,
                         "pmix: connect called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -129,28 +131,28 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     pmix_output_verbose(2, pmix_client_globals.connect_output,
                         "pmix:connect_nb called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input */
-    if (NULL == procs || 0 >= nprocs) {
+    if (PMIX_UNLIKELY(NULL == procs || 0 >= nprocs)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
     /* if any of the participants are referencing a PMIx group, then
      * replace that group with the actual member proc(s) */
     rc = pmix_client_convert_group_procs(procs, nprocs, &rgs, &nrg);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         return rc;
     }
 
@@ -164,7 +166,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_PROC_FREE(rgs, nrg);
@@ -173,14 +175,14 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
 
     /* pack the number of procs */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nrg, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_PROC_FREE(rgs, nrg);
         return rc;
     }
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, rgs, nrg, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_PROC_FREE(rgs, nrg);
@@ -189,7 +191,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
 
     /* pack the info structs */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_PROC_FREE(rgs, nrg);
@@ -197,7 +199,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     }
     if (0 < ninfo) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             PMIX_PROC_FREE(rgs, nrg);
@@ -231,7 +233,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
         if (found) {
             // convert to array
             rc = PMIx_Info_list_convert(ilist, &darray);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
                 PMIx_Info_list_release(ilist);
@@ -245,7 +247,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
             // pack the result
             PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &xfer, 1, PMIX_INFO);
             PMIX_INFO_DESTRUCT(&xfer);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
                 PMIx_Info_list_release(ilist);
@@ -298,11 +300,11 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
             cb2.scope = PMIX_SCOPE_UNDEF;
             cb2.copy = false;
             PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, &cb2);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 if (!PMIX_GDS_CHECK_COMPONENT(pmix_client_globals.myserver, "hash")) {
                     /* check the data in my hash module */
                     PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
-                    if (PMIX_SUCCESS != rc) {
+                    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DESTRUCT(&cb2);
                         goto moveon;
@@ -325,7 +327,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
                 }
                 // convert to array
                 rc = PMIx_Info_list_convert(ilist, &darray);
-                if (PMIX_SUCCESS != rc) {
+                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(msg);
                     PMIx_Info_list_release(ilist);
@@ -343,7 +345,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
                 /* every other pack in this function is checked; letting this
                  * one through silently sent the server a message that was
                  * missing the job-level info it is waiting for */
-                if (PMIX_SUCCESS != rc) {
+                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_RELEASE(msg);
                     PMIX_DESTRUCT(&cb2);
@@ -371,7 +373,7 @@ moveon:
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_cbfunc, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }
@@ -385,16 +387,16 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect(const pmix_proc_t procs[], size_t npro
     pmix_status_t rc;
     pmix_cb_t *cb;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -432,28 +434,28 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: disconnect called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input */
-    if (NULL == procs || 0 >= nprocs) {
+    if (PMIX_UNLIKELY(NULL == procs || 0 >= nprocs)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
     /* if any of the participants are referencing a PMIx group, then
      * replace that group with the actual member proc(s) */
     rc = pmix_client_convert_group_procs(procs, nprocs, &rgs, &nrg);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         return rc;
     }
 
@@ -475,7 +477,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_PROC_FREE(rgs, nrg);
@@ -484,14 +486,14 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
 
     /* pack the number of procs */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nrg, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_PROC_FREE(rgs, nrg);
         return rc;
     }
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, rgs, nrg, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_PROC_FREE(rgs, nrg);
@@ -500,7 +502,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
 
     /* pack the info structs */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_PROC_FREE(rgs, nrg);
@@ -508,7 +510,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
     }
     if (0 < ninfo) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             PMIX_PROC_FREE(rgs, nrg);
@@ -528,7 +530,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_cbfunc, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }
@@ -554,7 +556,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
-    if (NULL == buf) {
+    if (PMIX_UNLIKELY(NULL == buf)) {
         ret = PMIX_ERR_BAD_PARAM;
         goto report;
     }
@@ -569,7 +571,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     /* unpack the returned status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
     }
@@ -585,14 +587,14 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
         /* unpack the nspace for this blob */
         cnt = 1;
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, &bkt, &nspace, &cnt, PMIX_STRING);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_DESTRUCT(&bkt);
             continue;
         }
         /* extract and process any proc-related info for this nspace */
         PMIX_GDS_STORE_JOB_INFO(rc, pmix_globals.mypeer, nspace, &bkt);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
         }
         free(nspace);

--- a/src/client/pmix_client_convert.c
+++ b/src/client/pmix_client_convert.c
@@ -114,7 +114,7 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
                         }
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
-                        if (NULL == kv) {  // should never be NULL
+                        if (NULL == kv) { // should never be NULL
                             /* couldn't retrieve the size, so we have
                              * to abort */
                             rc = PMIX_ERR_NOT_FOUND;

--- a/src/client/pmix_client_convert.c
+++ b/src/client/pmix_client_convert.c
@@ -18,6 +18,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include "src/include/pmix_prefetch.h"
+
 #include "include/pmix.h"
 
 #include "src/class/pmix_object.h"
@@ -107,14 +109,14 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
                         cb2.proc = (pmix_proc_t*)&grp->members[i];
                         cb2.key = PMIX_JOB_SIZE;
                         PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
-                        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+                        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc)) {
                             /* couldn't get the job size, so have to abort */
                             PMIX_DESTRUCT(&cb2);
                             goto unlock;
                         }
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
-                        if (NULL == kv) { // should never be NULL
+                        if (PMIX_UNLIKELY(NULL == kv)) { // should never be NULL
                             /* couldn't retrieve the size, so we have
                              * to abort */
                             rc = PMIX_ERR_NOT_FOUND;
@@ -122,7 +124,7 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
                         }
                         rc = PMIx_Value_get_number(kv->value, &jsize, PMIX_UINT32);
                         PMIX_RELEASE(kv);
-                        if (PMIX_SUCCESS != rc) {
+                        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                             rc = PMIX_ERR_BAD_PARAM;
                             goto unlock;
                         }

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -56,6 +56,9 @@
 
 void PMIx_Fabric_construct(pmix_fabric_t *p)
 {
+    if (NULL == p) {
+        return;
+    }
     p->name = NULL;
     p->index = SIZE_MAX;
     p->info = NULL;
@@ -71,6 +74,14 @@ static void fcb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbd
 
     cb->status = status;
     if (PMIX_SUCCESS == status && 0 < ninfo) {
+        /* an update refreshes a fabric that was already registered, so
+         * discard whatever the previous round left in it - overwriting the
+         * pointer orphaned that array */
+        if (NULL != cb->fabric->info) {
+            PMIX_INFO_FREE(cb->fabric->info, cb->fabric->ninfo);
+            cb->fabric->info = NULL;
+            cb->fabric->ninfo = 0;
+        }
         PMIX_INFO_CREATE(cb->fabric->info, ninfo);
         cb->fabric->ninfo = ninfo;
         for (n = 0; n < ninfo; n++) {
@@ -121,10 +132,26 @@ static void frecv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *
         goto complete;
     }
 
-    /* unpack any returned data */
+    /* discard anything a previous register/update left in the caller's
+     * fabric object - what follows replaces it, and simply overwriting the
+     * pointer orphaned the old array */
+    if (NULL != cb->fabric->info) {
+        PMIX_INFO_FREE(cb->fabric->info, cb->fabric->ninfo);
+        cb->fabric->info = NULL;
+    }
+    cb->fabric->ninfo = 0;
+
+    /* unpack any returned data. A server with nothing to add ends the
+     * message here; that is not an error the caller should be told about,
+     * since the server already reported the operation itself succeeded. */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &cb->fabric->ninfo, &cnt, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
+    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+        cb->fabric->ninfo = 0;
+        rc = PMIX_SUCCESS;
+        goto complete;
+    }
+    if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto complete;
     }
@@ -473,6 +500,13 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_deregister_nb(pmix_fabric_t *fabric, pmix_
     pmix_status_t rc;
 
     PMIX_HIDE_UNUSED_PARAMS(cbfunc, cbdata);
+
+    /* every sibling in this file gates on this, and this one must too:
+     * PMIX_PEER_IS_SCHEDULER below dereferences pmix_globals.mypeer, which
+     * does not exist until the library has been initialized */
+    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+        return PMIX_ERR_INIT;
+    }
 
     if (NULL == fabric) {
         return PMIX_ERR_BAD_PARAM;

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -17,6 +17,8 @@
  */
 
 #include "src/include/pmix_config.h"
+
+#include "src/include/pmix_prefetch.h"
 #include "include/pmix.h"
 
 #include "src/include/pmix_socket_errno.h"
@@ -56,7 +58,7 @@
 
 void PMIx_Fabric_construct(pmix_fabric_t *p)
 {
-    if (NULL == p) {
+    if (PMIX_UNLIKELY(NULL == p)) {
         return;
     }
     p->name = NULL;
@@ -121,7 +123,7 @@ static void frecv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *
     /* unpack the status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &cb->status, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto complete;
     }
@@ -151,7 +153,7 @@ static void frecv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *
         rc = PMIX_SUCCESS;
         goto complete;
     }
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto complete;
     }
@@ -159,7 +161,7 @@ static void frecv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *
         PMIX_INFO_CREATE(cb->fabric->info, cb->fabric->ninfo);
         cnt = cb->fabric->ninfo;
         PMIX_BFROPS_UNPACK(rc, peer, buf, cb->fabric->info, &cnt, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             goto complete;
         }
@@ -196,11 +198,11 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register(pmix_fabric_t *fabric,
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:fabric register");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -212,7 +214,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register(pmix_fabric_t *fabric,
     if (PMIX_OPERATION_SUCCEEDED == rc) {
         PMIX_DESTRUCT(&cb);
         return PMIX_SUCCESS;
-    } else if (PMIX_SUCCESS != rc) {
+    } else if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         /* got an error */
         PMIX_DESTRUCT(&cb);
         return rc;
@@ -238,11 +240,11 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register_nb(pmix_fabric_t *fabric,
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_FABRIC_REGISTER_CMD;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (NULL == fabric) {
+    if (PMIX_UNLIKELY(NULL == fabric)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -251,11 +253,11 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register_nb(pmix_fabric_t *fabric,
      * these _nb entry points are built on. A user calling the public API with
      * both NULL has no way to learn the answer and would leave us
      * dereferencing a NULL caddy in the recv handler. */
-    if (NULL == cbfunc && NULL == cbdata) {
+    if (PMIX_UNLIKELY(NULL == cbfunc && NULL == cbdata)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -270,7 +272,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register_nb(pmix_fabric_t *fabric,
 
     /* otherwise, I need to send it to
      * a daemon for processing */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
@@ -278,7 +280,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register_nb(pmix_fabric_t *fabric,
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -286,14 +288,14 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register_nb(pmix_fabric_t *fabric,
 
     /* pack the directives */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ndirs, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
     }
     if (NULL != directives && 0 < ndirs) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, directives, ndirs, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             return rc;
@@ -314,7 +316,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register_nb(pmix_fabric_t *fabric,
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, frecv, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(msg);
         if (NULL != cbfunc) {
             PMIX_RELEASE(cb);
@@ -328,11 +330,11 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update(pmix_fabric_t *fabric)
     pmix_cb_t cb;
     pmix_status_t rc;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -349,7 +351,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update(pmix_fabric_t *fabric)
          * scheduler and handled it ourselves); no callback will fire */
         PMIX_DESTRUCT(&cb);
         return PMIX_SUCCESS;
-    } else if (PMIX_SUCCESS != rc) {
+    } else if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_DESTRUCT(&cb);
         return rc;
     }
@@ -373,17 +375,17 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric, pmix_op_c
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_FABRIC_UPDATE_CMD;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (NULL == fabric) {
+    if (PMIX_UNLIKELY(NULL == fabric)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
     /* see PMIx_Fabric_register_nb: a NULL cbfunc means "the caddy is in
      * cbdata", so both cannot be NULL */
-    if (NULL == cbfunc && NULL == cbdata) {
+    if (PMIX_UNLIKELY(NULL == cbfunc && NULL == cbdata)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -393,7 +395,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric, pmix_op_c
         /* update_fabric is synchronous and takes no callback, so we must
          * bridge its result to the (non)blocking completion contract */
         rc = pmix_pnet.update_fabric(fabric);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             /* error: no callback fires, caller sees the error return */
             return rc;
         }
@@ -406,7 +408,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric, pmix_op_c
         return PMIX_OPERATION_SUCCEEDED;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -414,7 +416,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric, pmix_op_c
      * it up to our host so they can send it to the scheduler */
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
         !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
-        if (NULL == pmix_host_server.fabric) {
+        if (PMIX_UNLIKELY(NULL == pmix_host_server.fabric)) {
             return PMIX_ERR_NOT_SUPPORTED;
         }
         if (NULL != cbfunc) {
@@ -439,7 +441,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric, pmix_op_c
 
     /* finally, if I am a tool or client, then I need to send it to
      * a daemon for processing */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
@@ -447,14 +449,14 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric, pmix_op_c
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
     }
     /* pack the fabric index */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &fabric->index, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -474,7 +476,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update_nb(pmix_fabric_t *fabric, pmix_op_c
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, frecv, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(msg);
         if (NULL != cbfunc) {
             PMIX_RELEASE(cb);
@@ -504,11 +506,11 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_deregister_nb(pmix_fabric_t *fabric, pmix_
     /* every sibling in this file gates on this, and this one must too:
      * PMIX_PEER_IS_SCHEDULER below dereferences pmix_globals.mypeer, which
      * does not exist until the library has been initialized */
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (NULL == fabric) {
+    if (PMIX_UNLIKELY(NULL == fabric)) {
         return PMIX_ERR_BAD_PARAM;
     }
 

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -19,6 +19,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include "src/include/pmix_prefetch.h"
+
 #include "src/include/pmix_stdint.h"
 
 #include "include/pmix.h"
@@ -71,7 +73,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
     pmix_output_verbose(2, pmix_client_globals.fence_output,
                         "pmix: executing fence");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
@@ -81,11 +83,11 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -96,7 +98,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
 
     /* push the message into our event base to send to the server */
     rc = PMIx_Fence_nb(procs, nprocs, info, ninfo, op_cbfunc, cb);
-    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(cb);
         return rc;
@@ -131,7 +133,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
     pmix_output_verbose(2, pmix_client_globals.fence_output,
                         "pmix: fence_nb called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
@@ -141,16 +143,16 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input */
-    if (NULL == procs && 0 != nprocs) {
+    if (PMIX_UNLIKELY(NULL == procs && 0 != nprocs)) {
         return PMIX_ERR_BAD_PARAM;
     }
     /* if we are given a NULL proc, then the caller is referencing
@@ -164,7 +166,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
         // if they are referencing a group, then replace that group with
         // the actual proc(s)
         rc = pmix_client_convert_group_procs(procs, nprocs, &rgs, &nrg);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             return rc;
         }
         created = true;
@@ -199,7 +201,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_cbfunc, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
         /* the recv callback will not fire; do not fall through into the
@@ -227,7 +229,7 @@ static pmix_status_t unpack_return(pmix_buffer_t *data)
     /* unpack the status code */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, data, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -238,14 +240,14 @@ static pmix_status_t unpack_return(pmix_buffer_t *data)
 
     if (PMIX_OPERATION_SUCCEEDED == ret) {
         ret = PMIX_SUCCESS;
-    } else if (PMIX_SUCCESS != ret) {
+    } else if (PMIX_UNLIKELY(PMIX_SUCCESS != ret)) {
         return ret;
     }
 
     /* provide an opportunity to store any data (or at least how to access
      * any data) that was included in the fence */
     PMIX_GDS_RECV_MODEX_COMPLETE(rc, pmix_client_globals.myserver, data);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -260,33 +262,33 @@ static pmix_status_t pack_fence(pmix_buffer_t *msg, pmix_cmd_t cmd, const pmix_p
 
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
 
     /* pack the number of procs */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nprocs, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
     /* pack any provided procs - must always be at least one (our own) */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, procs, nprocs, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
     /* pack the number of info */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
     /* pack any provided info - may be NULL */
     if (NULL != info && 0 < ninfo) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
@@ -305,7 +307,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     pmix_output_verbose(2, pmix_client_globals.fence_output,
                         "pmix: fence_nb callback recvd");
 
-    if (NULL == cb) {
+    if (PMIX_UNLIKELY(NULL == cb)) {
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return;
     }

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -172,6 +172,12 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
             lg->nodeinfo = false;
             lg->appinfo = false;
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME)) {
+            /* the qualifier comes straight from the caller, so verify it
+             * really carries a string before handing it to strdup */
+            if (PMIX_STRING != info[n].value.type ||
+                NULL == info[n].value.data.string) {
+                return PMIX_ERR_BAD_PARAM;
+            }
             /* must copy - lgdes() frees this field, and the info array
              * belongs to the caller. Every other assignment to
              * lg->hostname strdup's for the same reason */
@@ -378,12 +384,21 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
     }
     if (PMIX_SUCCESS == rc && NULL != cb->value) {
         if (lg->stval) {
+            /* the caller provided the storage, so copy into it - and then
+             * release our own copy, which nothing else owns (the caddy
+             * destructor does not touch "value") */
             PMIx_Value_xfer(*val, cb->value);
+            PMIX_VALUE_RELEASE(cb->value);   /* nulls cb->value */
         } else {
             *val = cb->value;
             cb->value = NULL;
         }
     } else {
+        /* nothing to hand back - but anything the request did collect is
+         * still ours to reclaim */
+        if (NULL != cb->value) {
+            PMIX_VALUE_RELEASE(cb->value);
+        }
         *val = NULL;
     }
     PMIX_RELEASE(lg);
@@ -1034,7 +1049,7 @@ static void get_data(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
-                        if (NULL == kv) {  // should never happen
+                        if (NULL == kv) { // should never happen
                             cb->status = PMIX_ERR_NOT_FOUND;
                             goto done;
                         }
@@ -1113,7 +1128,7 @@ static void get_data(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
-                        if (NULL == kv) {  // should never happen
+                        if (NULL == kv) { // should never happen
                             cb->status = PMIX_ERR_NOT_FOUND;
                             goto done;
                         }

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -19,6 +19,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include "src/include/pmix_prefetch.h"
+
 #include "src/include/pmix_stdint.h"
 
 #include "include/pmix.h"
@@ -95,7 +97,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
      *
      * Either case is supported. However, we don't currently
      * support the case where -both- values are NULL */
-    if (NULL == proc && NULL == key) {
+    if (PMIX_UNLIKELY(NULL == proc && NULL == key)) {
         pmix_output_verbose(2, pmix_client_globals.get_output,
                             "pmix: get_nb value error - both proc and key are NULL");
         return PMIX_ERR_BAD_PARAM;
@@ -123,13 +125,13 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_GET_POINTER_VALUES)) {
             /* they want a pointer to the answer */
-            if (NULL == val) {
+            if (PMIX_UNLIKELY(NULL == val)) {
                 return PMIX_ERR_BAD_PARAM;
             }
             lg->pntrval = PMIX_INFO_TRUE(&info[n]);
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_GET_STATIC_VALUES)) {
             /* they want a static response (i.e., they provided the storage) */
-            if (NULL == val || NULL == *val) {
+            if (PMIX_UNLIKELY(NULL == val || NULL == *val)) {
                 return PMIX_ERR_BAD_PARAM;
             }
             lg->stval = PMIX_INFO_TRUE(&info[n]);
@@ -184,19 +186,19 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
             lg->hostname = strdup(info[n].value.data.string);
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODEID)) {
             rc = PMIx_Value_get_number(&info[n].value, &lg->nodeid, PMIX_UINT32);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 return rc;
             }
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_APPNUM)) {
             rc = PMIx_Value_get_number(&info[n].value, &lg->appnum, PMIX_UINT32);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 return rc;
             }
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_ID)) {
             rc = PMIx_Value_get_number(&info[n].value, &lg->sessionid, PMIX_UINT32);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 return rc;
             }
@@ -214,7 +216,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
             (*val) = &pmix_globals.myidval;
         } else {
             PMIX_VALUE_CREATE(ival, 1);
-            if (NULL == ival) {
+            if (PMIX_UNLIKELY(NULL == ival)) {
                 return PMIX_ERR_NOMEM;
             }
             ival->type = PMIX_PROC;
@@ -233,7 +235,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
             ival->data.uint32 = PMIX_NUMERIC_VERSION;
         } else {
             PMIX_VALUE_CREATE(ival, 1);
-            if (NULL == ival) {
+            if (PMIX_UNLIKELY(NULL == ival)) {
                 return PMIX_ERR_NOMEM;
             }
             ival->type = PMIX_UINT32;
@@ -277,7 +279,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
             (*val) = &pmix_globals.myrankval;
         } else {
             PMIX_VALUE_CREATE(ival, 1);
-            if (NULL == ival) {
+            if (PMIX_UNLIKELY(NULL == ival)) {
                 return PMIX_ERR_NOMEM;
             }
             ival->type = PMIX_PROC_RANK;
@@ -292,7 +294,7 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
     if (!PMIX_PEER_IS_SERVER(pmix_globals.mypeer) &&
         NULL != proc && 0 != strlen(proc->nspace)) {
         rc = pmix_client_convert_group_procs(proc, 1, &procs, &nprocs);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             return rc;
         }
         if (1 < nprocs) {
@@ -320,16 +322,16 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
                         (NULL == proc) ? "NULL" : PMIX_NAME_PRINT(proc),
                         (NULL == key) ? "NULL" : key);
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* we have no way to hand back the answer without this */
-    if (NULL == val) {
+    if (PMIX_UNLIKELY(NULL == val)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -343,7 +345,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
         /* the value has already been prepped */
         PMIX_RELEASE(lg);
         return PMIX_SUCCESS;
-    } else if (PMIX_SUCCESS != rc) {
+    } else if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         *val = NULL;
         PMIX_RELEASE(lg);
         return rc;
@@ -355,7 +357,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
      * filled lg->p with the nspace/rank the request actually refers to */
     if (lg->refresh_cache) {
         rc = refresh_cache(&lg->p);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             // couldn't refresh for some reason
             PMIX_RELEASE(lg);
             *val = NULL;
@@ -439,16 +441,16 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
      * whatever happened to be on the stack */
     pmix_value_t *val = NULL;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (NULL == cbfunc) {
+    if (PMIX_UNLIKELY(NULL == cbfunc)) {
         /* no way to return the result! */
         return PMIX_ERR_BAD_PARAM;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -468,7 +470,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
         PMIX_THREADSHIFT(cb, gcbfn);
         PMIX_RELEASE(lg);
         return PMIX_SUCCESS;
-    } else if (PMIX_SUCCESS != rc) {
+    } else if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         /* it's a true error */
         PMIX_RELEASE(lg);
         return rc;
@@ -478,7 +480,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
      * on why this uses the resolved lg->p rather than the caller's proc */
     if (lg->refresh_cache) {
         rc = refresh_cache(&lg->p);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             // couldn't refresh for some reason
             PMIX_RELEASE(lg);
             return rc;
@@ -521,7 +523,7 @@ static void _value_cbfunc(pmix_status_t status, pmix_value_t *kv, void *cbdata)
      * a copy when we are handed a value we do not already own. */
     if (PMIX_SUCCESS == status && kv != cb->value) {
         PMIX_BFROPS_COPY(rc, pmix_client_globals.myserver, (void **)&cb->value, kv, PMIX_VALUE);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
         }
     }
@@ -543,7 +545,7 @@ static pmix_buffer_t *_pack_get(pmix_cb_t *cb,
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the get cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return NULL;
@@ -551,13 +553,13 @@ static pmix_buffer_t *_pack_get(pmix_cb_t *cb,
     /* pack the request information - we'll get the entire blob
      * for this proc, so we don't need to pass the key */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nspace, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return NULL;
     }
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &rank, 1, PMIX_PROC_RANK);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return NULL;
@@ -583,14 +585,14 @@ static pmix_buffer_t *_pack_get(pmix_cb_t *cb,
         cb->infocopy = true;
     }
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cb->ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return NULL;
     }
     if (0 < cb->ninfo) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, cb->info, cb->ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             return NULL;
@@ -599,7 +601,7 @@ static pmix_buffer_t *_pack_get(pmix_cb_t *cb,
     if (NULL != cb->key) {
         /* pack the key */
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cb->key, 1, PMIX_STRING);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             return NULL;
@@ -631,7 +633,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     pmix_output_verbose(2, pmix_client_globals.get_output,
                         "pmix: get_nb callback recvd");
 
-    if (NULL == cb || NULL == cb->lg) {
+    if (PMIX_UNLIKELY(NULL == cb || NULL == cb->lg)) {
         /* nothing we can do */
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return;
@@ -649,7 +651,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     /* unpack the status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         /* fall into the delivery loop below rather than quietly dropping the
          * request: every waiter registered against this proc must be told the
@@ -660,7 +662,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
         goto done;
     }
 
-    if (PMIX_SUCCESS != ret) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != ret)) {
         pmix_output_verbose(2, pmix_client_globals.get_output,
                             "pmix: get_nb server returned %s",
                             PMIx_Error_string(ret));
@@ -691,7 +693,7 @@ done:
              * never deliver a value already handed to a previous one */
             val = NULL;
             pmix_list_remove_item(&pmix_client_globals.pending_requests, &cb->super);
-            if (PMIX_SUCCESS != ret) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != ret)) {
                 if (cb->checked) {
                     cb->status = ret;
                     gcbfn(0, 0, cb);
@@ -720,7 +722,7 @@ done:
                 }
                 cb->proc->rank = saverank;
             }
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                /* if we are both using the "hash" component, then the server's peer
                 * will simply be pointing at the same hash tables as my peer - no
                 * no point in checking there again */
@@ -804,7 +806,7 @@ static pmix_status_t process_values(pmix_cb_t *cb)
             // be released normally when the cb is destructed.
             iptr = (pmix_info_t*)kv->value->data.darray->array;
             PMIX_VALUE_CREATE(cb->value, 1);
-            if (NULL == cb->value) {
+            if (PMIX_UNLIKELY(NULL == cb->value)) {
                 return PMIX_ERR_NOMEM;
             }
             PMIx_Value_xfer(cb->value, &iptr[0].value);
@@ -818,12 +820,12 @@ static pmix_status_t process_values(pmix_cb_t *cb)
     /* we will return the data as an array of pmix_info_t
      * in the kvs pmix_value_t */
     PMIX_VALUE_CREATE(val, 1);
-    if (NULL == val) {
+    if (PMIX_UNLIKELY(NULL == val)) {
         return PMIX_ERR_NOMEM;
     }
     val->type = PMIX_DATA_ARRAY;
     val->data.darray = (pmix_data_array_t *) malloc(sizeof(pmix_data_array_t));
-    if (NULL == val->data.darray) {
+    if (PMIX_UNLIKELY(NULL == val->data.darray)) {
         PMIX_VALUE_RELEASE(val);
         return PMIX_ERR_NOMEM;
     }
@@ -832,7 +834,7 @@ static pmix_status_t process_values(pmix_cb_t *cb)
     val->data.darray->array = NULL;
     ninfo = pmix_list_get_size(kvs);
     PMIX_INFO_CREATE(info, ninfo);
-    if (NULL == info) {
+    if (PMIX_UNLIKELY(NULL == info)) {
         PMIX_VALUE_RELEASE(val);
         return PMIX_ERR_NOMEM;
     }
@@ -947,7 +949,7 @@ static void get_data(int sd, short args, void *cbdata)
                         } else {
                             rc = PMIX_ERROR;
                         }
-                        if (PMIX_SUCCESS != rc) {
+                        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                             cb->status = rc;
                             goto done;
                         }
@@ -1049,13 +1051,13 @@ static void get_data(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
-                        if (NULL == kv) { // should never happen
+                        if (PMIX_UNLIKELY(NULL == kv)) { // should never happen
                             cb->status = PMIX_ERR_NOT_FOUND;
                             goto done;
                         }
                         rc = PMIx_Value_get_number(kv->value, &lg->appnum, PMIX_UINT32);
                         PMIX_RELEASE(kv);
-                        if (PMIX_SUCCESS != rc) {
+                        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                             cb->status = rc;
                             goto done;
                         }
@@ -1128,13 +1130,13 @@ static void get_data(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
-                        if (NULL == kv) { // should never happen
+                        if (PMIX_UNLIKELY(NULL == kv)) { // should never happen
                             cb->status = PMIX_ERR_NOT_FOUND;
                             goto done;
                         }
                         rc = PMIx_Value_get_number(kv->value, &lg->sessionid, PMIX_UINT32);
                         PMIX_RELEASE(kv);
-                        if (PMIX_SUCCESS != rc) {
+                        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                             cb->status = rc;
                             goto done;
                         }
@@ -1289,7 +1291,7 @@ doget:
 
     /* we don't have a pending request, so let's create one */
     msg = _pack_get(cb, proc.rank, PMIX_GETNB_CMD);
-    if (NULL == msg) {
+    if (PMIX_UNLIKELY(NULL == msg)) {
         cb->status = PMIX_ERROR;
         PMIX_ERROR_LOG(cb->status);
         goto done;
@@ -1304,7 +1306,7 @@ doget:
     pmix_list_append(&pmix_client_globals.pending_requests, &cb->super);
     /* send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, _getnb_cbfunc, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         /* the transport only refuses a send it never took ownership of, so
          * the message is still ours to release */
         PMIX_RELEASE(msg);
@@ -1337,7 +1339,7 @@ static void refcb(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
 
     PMIX_ACQUIRE_OBJECT(cb);
 
-    if (NULL == cb) {
+    if (PMIX_UNLIKELY(NULL == cb)) {
         /* nothing we can do */
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return;
@@ -1354,7 +1356,7 @@ static void refcb(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     /* unpack the status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
         goto done;
@@ -1413,7 +1415,7 @@ static pmix_status_t refresh_cache(const pmix_proc_t *p)
      * to refresh our cache */
     msg = PMIX_NEW(pmix_buffer_t);
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -1421,13 +1423,13 @@ static pmix_status_t refresh_cache(const pmix_proc_t *p)
 
 
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nspace, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
     }
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &p->rank, 1, PMIX_PROC_RANK);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -1438,7 +1440,7 @@ static pmix_status_t refresh_cache(const pmix_proc_t *p)
 
     /* send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, refcb, (void *)cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -367,10 +367,19 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
 {
     pmix_status_t rc;
     pmix_group_tracker_t *cb;
-    size_t n;
 
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix: group_construct called");
+
+    /* both are documented as optional OUT parameters, so honor a NULL for
+     * either - and define them before anything can fail, so the caller can
+     * read them on an error return too */
+    if (NULL != results) {
+        *results = NULL;
+    }
+    if (NULL != nresults) {
+        *nresults = 0;
+    }
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
@@ -389,16 +398,6 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
      * recv routine so we know which callback to use when
      * the return message is recvd */
     cb = PMIX_NEW(pmix_group_tracker_t);
-    /* capture the group's failure policy now, while we have the construct
-     * directives, so info_cbfunc can record it in the persistent group and the
-     * later destruct can honor PMIX_GROUP_NOTIFY_TERMINATION on the caller's
-     * behalf (the server keeps no group state between the two collectives) */
-    for (n = 0; n < ninfo; n++) {
-        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_NOTIFY_TERMINATION)) {
-            cb->notterm = PMIX_INFO_TRUE(&info[n]);
-            break;
-        }
-    }
 
     /* push the message into our event base to send to the server */
     rc = PMIx_Group_construct_nb(grp, procs, nprocs, info, ninfo, info_cbfunc, cb);
@@ -410,7 +409,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
     /* wait for the group construct to complete */
     PMIX_WAIT_THREAD(&cb->lock);
     rc = cb->status;
-    if (PMIX_SUCCESS == rc) {
+    if (PMIX_SUCCESS == rc && NULL != results && NULL != nresults) {
         /* user takes responsibility for releasing any results */
         *results = cb->results;
         *nresults = cb->nresults;
@@ -505,6 +504,24 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     cb->cbfunc = cbfunc;
     cb->cbdata = cbdata;
     cb->grpid = strdup(grp);
+    /* Capture the group's failure policy while we still have the construct
+     * directives, so construct_cbfunc can record it in the persistent group
+     * and the later destruct can re-apply PMIX_GROUP_NOTIFY_TERMINATION on
+     * the caller's behalf (the server keeps no group state between the two
+     * collectives).
+     *
+     * This belongs here, on the tracker construct_cbfunc actually reads.
+     * The blocking wrapper used to record it on its own tracker instead -
+     * which construct_cbfunc never sees - so add_group() was always told
+     * "false", and because add_group() ignores a repeat request for a group
+     * it already holds, the correctly-flagged call that followed could not
+     * correct it. The policy was therefore never honored by any caller. */
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_NOTIFY_TERMINATION)) {
+            cb->notterm = PMIX_INFO_TRUE(&info[n]);
+            break;
+        }
+    }
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, construct_cbfunc, (void*)cb);
@@ -890,7 +907,6 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
     struct timeval tv;
 
     cb->grpid = strdup(grp);
-    cb->nanswered = 1; // we have obviously answered (by accepting)
 
     /* compute the number of proposed members, expanding any wildcard ranks */
     for (n = 0; n < nprocs; n++) {
@@ -939,12 +955,18 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
             m++;
         }
     }
-    /* we (the leader) are a member and have obviously already answered by
-     * accepting (this matches the nanswered = 1 seed above) */
+    /* If we (the leader) named ourselves among the invitees, we have
+     * obviously already answered by accepting - count that answer here, and
+     * only here. Seeding nanswered unconditionally was wrong: a leader that
+     * invites others without listing itself has no member to match, so the
+     * count started one ahead of the flags and the invitation resolved one
+     * answer early. Under the default all-or-nothing policy that made the
+     * last invitee look like a non-responder and aborted the construct. */
     for (m = 0; m < cb->nmembers; m++) {
         if (PMIX_CHECK_PROCID(&cb->members[m], &pmix_globals.myid)) {
             cb->responded[m] = true;
             cb->answered[m] = true;
+            cb->nanswered++;
             break;
         }
     }
@@ -1188,6 +1210,15 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[], const pmix_proc_t 
     pmix_group_tracker_t *cb;
     pmix_status_t rc;
 
+    /* optional OUT parameters - set them before anything can fail so the
+     * caller can read them on an error return, and honor a NULL for either */
+    if (NULL != results) {
+        *results = NULL;
+    }
+    if (NULL != nresults) {
+        *nresults = 0;
+    }
+
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
@@ -1202,12 +1233,9 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[], const pmix_proc_t 
     }
 
     /* check for bozo input */
-    if (NULL == grp || NULL == procs) {
+    if (NULL == grp || NULL == procs || 0 == nprocs) {
         return PMIX_ERR_BAD_PARAM;
     }
-
-    *results = NULL;
-    *nresults = 0;
 
     cb = PMIX_NEW(pmix_group_tracker_t);
     if (NULL == cb) {
@@ -1262,7 +1290,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[], const pmix_proc
     }
 
     /* check for bozo input */
-    if (NULL == grp || NULL == procs) {
+    if (NULL == grp || NULL == procs || 0 == nprocs) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -1546,6 +1574,11 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* check for bozo input - the group ID names the group we are joining */
+    if (NULL == grp) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* create a callback object as we need to pass it to the
      * recv routine so we know which lock to release when
      * the return message is recvd */
@@ -1585,9 +1618,12 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
     pmix_status_t rc;
     pmix_group_tracker_t *cb;
     pmix_status_t code;
-    size_t n;
     pmix_data_range_t range;
-    PMIX_HIDE_UNUSED_PARAMS(cbfunc);
+    /* join accepts no directives today - the accept/decline notification it
+     * issues carries only the leader's address. A PMIX_TIMEOUT here used to
+     * be recognized and then discarded by a loop that did nothing with it;
+     * saying so plainly is better than pretending to honor it. */
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
 
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "[%s:%d] pmix: join nb called",
@@ -1606,22 +1642,18 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* check for bozo input - setup_leader_watch() below strdup's this, and
+     * every sibling group API screens it */
+    if (NULL == grp) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* create a callback object as we need to pass it to the
      * recv routine so we know which lock to release when
      * the notification is done */
     cb = PMIX_NEW(pmix_group_tracker_t);
     cb->cbfunc = cbfunc;
     cb->cbdata = cbdata;
-
-    /* check for directives */
-    if (NULL != info) {
-        for (n = 0; n < ninfo; n++) {
-            if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
-                /* setup a timer */
-                break;
-            }
-        }
-    }
 
     /* set the code according to their request */
     if (PMIX_GROUP_ACCEPT == opt) {
@@ -2102,14 +2134,11 @@ static void destruct_cbfunc(struct pmix_peer_t *pr,
                         "pmix:client recv callback activated with %d bytes",
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
 
-    if (NULL == buf) {
-        ret = PMIX_ERR_BAD_PARAM;
-        PMIX_ERROR_LOG(ret);
-        goto report;
-    }
-
-    /* find this group and drop it - the caller's thread reads this list too
-     * (see the grouplock note in pmix_client_ops.h) */
+    /* Find this group and drop it - the caller's thread reads this list too
+     * (see the grouplock note in pmix_client_ops.h). This happens whatever
+     * the reply turns out to be: we asked to destruct, so we are done with
+     * the group either way, and leaving it registered on one failure path
+     * but not the other left the two disagreeing. */
     grp = NULL;
     pmix_mutex_lock(&pmix_client_globals.grouplock);
     PMIX_LIST_FOREACH(grp, &pmix_client_globals.groups, pmix_group_t) {
@@ -2120,6 +2149,12 @@ static void destruct_cbfunc(struct pmix_peer_t *pr,
         }
     }
     pmix_mutex_unlock(&pmix_client_globals.grouplock);
+
+    if (NULL == buf) {
+        ret = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(ret);
+        goto report;
+    }
 
     /* a zero-byte buffer indicates that this recv is being
      * completed due to a lost connection */

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -19,6 +19,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include "src/include/pmix_prefetch.h"
+
 #include "src/include/pmix_stdint.h"
 
 #include "include/pmix.h"
@@ -236,7 +238,7 @@ static pmix_status_t get_endpts(pmix_info_t *xfer,
         if (found) {
             // convert to array
             rc = PMIx_Info_list_convert(ilist, &darray);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIx_Info_list_release(ilist);
                 return rc;
@@ -265,27 +267,27 @@ static pmix_status_t construct_msg(pmix_buffer_t *msg,
 
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
 
     /* pack the group ID */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &grp, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
 
     /* pack the number of procs */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nprocs, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
     if (0 < nprocs) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, procs, nprocs, PMIX_PROC);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
@@ -298,7 +300,7 @@ static pmix_status_t construct_msg(pmix_buffer_t *msg,
     sz = ninfo;
     lclendpts = false;
     rc = get_endpts(&local_endpts, PMIX_REMOTE, &lclendpts);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -342,14 +344,14 @@ static pmix_status_t construct_msg(pmix_buffer_t *msg,
 
     /* pack the info structs */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &sz, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_INFO_FREE(icopy, sz);
         return rc;
     }
     if (0 < sz) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, icopy, sz, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_INFO_FREE(icopy, sz);
             return rc;
@@ -381,16 +383,16 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
         *nresults = 0;
     }
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -401,7 +403,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
 
     /* push the message into our event base to send to the server */
     rc = PMIx_Group_construct_nb(grp, procs, nprocs, info, ninfo, info_cbfunc, cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(cb);
         return rc;
     }
@@ -436,22 +438,22 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_construct_nb called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input - the group ID names the collective and is
      * strdup'd onto the tracker below */
-    if (NULL == grp) {
+    if (PMIX_UNLIKELY(NULL == grp)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -474,7 +476,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
          * replace any PMIx group reference with its actual member
          * proc(s) and verify that the caller is among them */
         rc = pmix_client_convert_group_procs(procs, nprocs, &rgs, &nrg);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             return rc;
         }
         if (!pmix_client_proc_is_included(rgs, nrg)) {
@@ -491,7 +493,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     } else {
         rc = construct_msg(msg, grp, procs, nprocs, info, ninfo);
     }
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -525,7 +527,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, construct_cbfunc, (void*)cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(cb);
         PMIX_RELEASE(msg);
@@ -544,16 +546,16 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct(const char grp[],
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix: group_destruct called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -600,21 +602,21 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_destruct_nb called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input */
-    if (NULL == grpid) {
+    if (PMIX_UNLIKELY(NULL == grpid)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -632,7 +634,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
             break;
         }
     }
-    if (NULL == grp) {
+    if (PMIX_UNLIKELY(NULL == grp)) {
         pmix_mutex_unlock(&pmix_client_globals.grouplock);
         return PMIX_ERR_NOT_FOUND;
     }
@@ -640,7 +642,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
     nmbrs = grp->nmbrs;
     if (0 < nmbrs) {
         PMIX_PROC_CREATE(mbrs, nmbrs);
-        if (NULL == mbrs) {
+        if (PMIX_UNLIKELY(NULL == mbrs)) {
             pmix_mutex_unlock(&pmix_client_globals.grouplock);
             return PMIX_ERR_NOMEM;
         }
@@ -676,14 +678,14 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto done;
     }
 
     /* pack the group ID */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &grpid, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto done;
     }
@@ -692,26 +694,26 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
      * so we have to send it so that the server can
      * track when all local procs have participated */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nmbrs, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto done;
     }
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, mbrs, nmbrs, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto done;
     }
 
     /* pack the info structs */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ndinfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         goto done;
     }
     if (0 < ndinfo) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, dinfo, ndinfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             goto done;
@@ -728,7 +730,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, destruct_cbfunc, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(cb);
     }
 
@@ -765,7 +767,7 @@ static void invite_handler(size_t evhdlr_registration_id, pmix_status_t status,
             responder = info[n].value.data.proc;
         }
     }
-    if (NULL == cb) {
+    if (PMIX_UNLIKELY(NULL == cb)) {
         pmix_output(0, "%s: INVITE HANDLER NULL OBJECT", PMIX_NAME_PRINT(&pmix_globals.myid));
         /* always must continue the chain */
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
@@ -830,13 +832,13 @@ static pmix_status_t invite_job_size(const pmix_proc_t *proc, uint32_t *jsize)
     cb2.info = &optional;
     cb2.ninfo = 1;
     PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
-    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc)) {
         PMIX_DESTRUCT(&cb2);
         return PMIX_ERR_BAD_PARAM;
     }
     kv = (pmix_kval_t *) pmix_list_remove_first(&cb2.kvs);
     PMIX_DESTRUCT(&cb2);
-    if (NULL == kv) { // should never be NULL
+    if (PMIX_UNLIKELY(NULL == kv)) { // should never be NULL
         return PMIX_ERR_BAD_PARAM;
     }
     rc = PMIx_Value_get_number(kv->value, jsize, PMIX_UINT32);
@@ -912,7 +914,7 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
     for (n = 0; n < nprocs; n++) {
         if (PMIX_RANK_WILDCARD == procs[n].rank) {
             rc = invite_job_size(&procs[n], &jsize);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 return rc;
             }
             cb->nmembers += jsize;
@@ -928,22 +930,22 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
      * PMIX_GROUP_INVITE_FAILED events and construct the group on the members
      * that did accept. */
     PMIX_PROC_CREATE(cb->members, cb->nmembers);
-    if (NULL == cb->members) {
+    if (PMIX_UNLIKELY(NULL == cb->members)) {
         return PMIX_ERR_NOMEM;
     }
     cb->responded = (bool *) calloc(cb->nmembers, sizeof(bool));
-    if (NULL == cb->responded) {
+    if (PMIX_UNLIKELY(NULL == cb->responded)) {
         return PMIX_ERR_NOMEM;
     }
     cb->answered = (bool *) calloc(cb->nmembers, sizeof(bool));
-    if (NULL == cb->answered) {
+    if (PMIX_UNLIKELY(NULL == cb->answered)) {
         return PMIX_ERR_NOMEM;
     }
     m = 0;
     for (n = 0; n < nprocs; n++) {
         if (PMIX_RANK_WILDCARD == procs[n].rank) {
             rc = invite_job_size(&procs[n], &jsize);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 return rc;
             }
             for (j = 0; j < jsize; j++) {
@@ -1001,7 +1003,7 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
     PMIX_DESTRUCT(&lock);
     PMIX_INFO_DESTRUCT(&myinfo[0]);
     PMIX_INFO_DESTRUCT(&myinfo[1]);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         return rc;
     }
 
@@ -1013,7 +1015,7 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
         for (n = 0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
                 rc = PMIx_Value_get_number(&info[n].value, &timeout, PMIX_INT);
-                if (PMIX_SUCCESS != rc) {
+                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                     timeout = 0;
                 }
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_OPTIONAL)) {
@@ -1024,7 +1026,7 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
 
     /* limit the range to just the procs we are inviting */
     PMIX_INFO_CREATE(cb->info, 3);
-    if (NULL == cb->info) {
+    if (PMIX_UNLIKELY(NULL == cb->info)) {
         return PMIX_ERR_NOMEM;
     }
     cb->ninfo = 3;
@@ -1032,7 +1034,7 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
     (void) strncpy(cb->info[n].key, PMIX_EVENT_CUSTOM_RANGE, PMIX_MAX_KEYLEN);
     cb->info[n].value.type = PMIX_DATA_ARRAY;
     PMIX_DATA_ARRAY_CREATE(cb->info[n].value.data.darray, nprocs, PMIX_PROC);
-    if (NULL == cb->info[n].value.data.darray || NULL == cb->info[n].value.data.darray->array) {
+    if (PMIX_UNLIKELY(NULL == cb->info[n].value.data.darray || NULL == cb->info[n].value.data.darray->array)) {
         return PMIX_ERR_NOMEM;
     }
     memcpy(cb->info[n].value.data.darray->array, procs, nprocs * sizeof(pmix_proc_t));
@@ -1055,7 +1057,7 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
         rc = lock.status;
     }
     PMIX_DESTRUCT(&lock);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         return rc;
     }
 
@@ -1147,7 +1149,7 @@ static pmix_status_t invite_announce(pmix_group_tracker_t *cb)
 
     /* build the final membership from the members that accepted */
     PMIX_PROC_CREATE(members, cb->nmembers);
-    if (NULL == members) {
+    if (PMIX_UNLIKELY(NULL == members)) {
         return PMIX_ERR_NOMEM;
     }
     for (i = 0; i < cb->nmembers; i++) {
@@ -1219,32 +1221,32 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[], const pmix_proc_t 
         *nresults = 0;
     }
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, then we cannot notify */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input */
-    if (NULL == grp || NULL == procs || 0 == nprocs) {
+    if (PMIX_UNLIKELY(NULL == grp || NULL == procs || 0 == nprocs)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
     cb = PMIX_NEW(pmix_group_tracker_t);
-    if (NULL == cb) {
+    if (PMIX_UNLIKELY(NULL == cb)) {
         return PMIX_ERR_NOMEM;
     }
     /* leave cb->cbfunc NULL: this is the blocking form, so we wait on the
      * tracker's lock rather than being handed the result via a callback */
     rc = invite_setup(cb, grp, procs, nprocs, info, ninfo);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         invite_teardown(cb);
         return rc;
     }
@@ -1276,32 +1278,32 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[], const pmix_proc
     pmix_group_tracker_t *cb;
     pmix_status_t rc;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, then we cannot notify */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input */
-    if (NULL == grp || NULL == procs || 0 == nprocs) {
+    if (PMIX_UNLIKELY(NULL == grp || NULL == procs || 0 == nprocs)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
     cb = PMIX_NEW(pmix_group_tracker_t);
-    if (NULL == cb) {
+    if (PMIX_UNLIKELY(NULL == cb)) {
         return PMIX_ERR_NOMEM;
     }
     cb->cbfunc = cbfunc;
     cb->cbdata = cbdata;
     rc = invite_setup(cb, grp, procs, nprocs, info, ninfo);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         invite_teardown(cb);
     }
     return rc;
@@ -1349,7 +1351,7 @@ static void emit_leader_failed(const char *grpid, const pmix_proc_t *leader)
     PMIX_INFO_LOAD(&info[1], PMIX_GROUP_ID, grpid, PMIX_STRING);
     rc = PMIx_Notify_event(PMIX_GROUP_LEADER_FAILED, &pmix_globals.myid,
                            PMIX_RANGE_PROC_LOCAL, info, 2, leader_failed_relcb, info);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_INFO_FREE(info, 2);
     }
 }
@@ -1405,7 +1407,7 @@ static void leader_watch_handler(size_t evhdlr_registration_id, pmix_status_t st
             grpid = info[n].value.data.string;
         }
     }
-    if (NULL == cb || cb->completed) {
+    if (PMIX_UNLIKELY(NULL == cb || cb->completed)) {
         goto done;
     }
 
@@ -1450,7 +1452,7 @@ static void watch_regcb(pmix_status_t status, size_t refid, void *cbdata)
 {
     pmix_group_tracker_t *cb = (pmix_group_tracker_t *) cbdata;
 
-    if (PMIX_SUCCESS != status) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != status)) {
         PMIX_RELEASE(cb);
         return;
     }
@@ -1487,7 +1489,7 @@ static void setup_leader_watch(const char *grp, const pmix_proc_t *leader)
     cb = PMIX_NEW(pmix_group_tracker_t);
     cb->grpid = strdup(grp);
     PMIX_PROC_CREATE(cb->members, 1);
-    if (NULL == cb->members) {
+    if (PMIX_UNLIKELY(NULL == cb->members)) {
         PMIX_RELEASE(cb);
         return;
     }
@@ -1499,7 +1501,7 @@ static void setup_leader_watch(const char *grp, const pmix_proc_t *leader)
      * Carry it on the tracker - which lives until the watch is torn down and is
      * freed by the tracker destructor - rather than on the stack. */
     PMIX_INFO_CREATE(cb->info, 2);
-    if (NULL == cb->info) {
+    if (PMIX_UNLIKELY(NULL == cb->info)) {
         PMIX_RELEASE(cb);
         return;
     }
@@ -1561,21 +1563,21 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
         *nresults = 0;
     }
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input - the group ID names the group we are joining */
-    if (NULL == grp) {
+    if (PMIX_UNLIKELY(NULL == grp)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -1585,7 +1587,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
     cb = PMIX_NEW(pmix_group_tracker_t);
 
     rc = PMIx_Group_join_nb(grp, leader, opt, info, ninfo, info_cbfunc, cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(cb);
         return rc;
     }
@@ -1629,22 +1631,22 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
                         "[%s:%d] pmix: join nb called",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank);
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, then we cannot notify */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input - setup_leader_watch() below strdup's this, and
      * every sibling group API screens it */
-    if (NULL == grp) {
+    if (PMIX_UNLIKELY(NULL == grp)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -1666,7 +1668,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
     if (NULL != leader) {
         range = PMIX_RANGE_CUSTOM;
         PMIX_INFO_CREATE(cb->info, 1);
-        if (NULL == cb->info) {
+        if (PMIX_UNLIKELY(NULL == cb->info)) {
             PMIX_RELEASE(cb);
             return PMIX_ERR_NOMEM;
         }
@@ -1679,7 +1681,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[], const pmix_proc_t
     rc = PMIx_Notify_event(code, &pmix_globals.myid, range,
                            cb->info, cb->ninfo, op_cbfunc_rel,
                            (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(cb);
     }
 
@@ -1706,16 +1708,16 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave(const char grp[],
 
     pmix_output_verbose(2, pmix_client_globals.group_output, "pmix: group_leave called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -1769,21 +1771,21 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
     pmix_output_verbose(2, pmix_client_globals.group_output,
                         "pmix:group_leave_nb called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, then we cannot notify */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input */
-    if (NULL == grp) {
+    if (PMIX_UNLIKELY(NULL == grp)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -1798,7 +1800,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
      * directives the caller provided. */
     cb->ninfo = 3 + ninfo;
     PMIX_INFO_CREATE(cb->info, cb->ninfo);
-    if (NULL == cb->info) {
+    if (PMIX_UNLIKELY(NULL == cb->info)) {
         PMIX_RELEASE(cb);
         return PMIX_ERR_NOMEM;
     }
@@ -1821,7 +1823,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
             break;
         }
     }
-    if (NULL == grpobj) {
+    if (PMIX_UNLIKELY(NULL == grpobj)) {
         pmix_mutex_unlock(&pmix_client_globals.grouplock);
         PMIX_RELEASE(cb);
         return PMIX_ERR_NOT_FOUND;
@@ -1830,7 +1832,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
     /* the custom range is the membership, excluding ourselves */
     nmbrs = grpobj->nmbrs;
     PMIX_PROC_CREATE(range, nmbrs);
-    if (NULL == range) {
+    if (PMIX_UNLIKELY(NULL == range)) {
         pmix_mutex_unlock(&pmix_client_globals.grouplock);
         PMIX_RELEASE(cb);
         return PMIX_ERR_NOMEM;
@@ -1873,7 +1875,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
      * generated, which is when the operation is complete */
     rc = PMIx_Notify_event(PMIX_GROUP_LEFT, &pmix_globals.myid, PMIX_RANGE_CUSTOM,
                            cb->info, cb->ninfo, leave_cbfunc, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(cb);
     }
@@ -1943,7 +1945,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
                         PMIX_NAME_PRINT(&pmix_globals.myid),
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
 
-    if (NULL == buf) {
+    if (PMIX_UNLIKELY(NULL == buf)) {
         ret = PMIX_ERR_BAD_PARAM;
         goto report;
     }
@@ -1958,12 +1960,12 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
     /* unpack the returned status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
     }
 
-    if (PMIX_SUCCESS != ret) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != ret)) {
         goto report;
     }
 
@@ -1972,7 +1974,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &nmembers, &cnt, PMIX_SIZE);
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
         goto report;
-    } else if (PMIX_SUCCESS != rc) {
+    } else if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
         goto report;
@@ -1981,7 +1983,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
         PMIX_PROC_CREATE(members, nmembers);
         cnt = nmembers;
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, members, &cnt, PMIX_PROC);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             ret = rc;
             goto report;
@@ -1993,7 +1995,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &gotctxid, &cnt, PMIX_BOOL);
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
         goto report;
-    } else if (PMIX_SUCCESS != rc) {
+    } else if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
         goto report;
@@ -2001,7 +2003,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
     if (gotctxid) {
         cnt = 1;
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ctxid, &cnt, PMIX_SIZE);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             ret = rc;
             goto report;
@@ -2013,7 +2015,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ngrpinfo, &cnt, PMIX_SIZE);
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
         goto report;
-    } else if (PMIX_SUCCESS != rc) {
+    } else if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
         goto report;
@@ -2023,7 +2025,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
             PMIX_INFO_CONSTRUCT(&grpinfo);
             cnt = 1;
             PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &grpinfo, &cnt, PMIX_INFO);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 ret = rc;
                 PMIX_INFO_DESTRUCT(&grpinfo);
@@ -2036,7 +2038,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
             if (PMIX_CHECK_KEY(&grpinfo, PMIX_GROUP_INFO)) {
                 // this is just a single array of group info
                 rc = pmix_server_process_grpinfo(ctxid, iptr, ninfo);
-                if (PMIX_SUCCESS != rc) {
+                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                     PMIX_ERROR_LOG(rc);
                     ret = rc;
                     PMIX_INFO_DESTRUCT(&grpinfo);
@@ -2049,7 +2051,7 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
                     pinfo = (pmix_info_t*)iptr[m].value.data.darray->array;
                     npinfo = iptr[m].value.data.darray->size;
                     rc = pmix_server_process_grpinfo(ctxid, pinfo, npinfo);
-                    if (PMIX_SUCCESS != rc) {
+                    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                         PMIX_ERROR_LOG(rc);
                         ret = rc;
                         PMIX_INFO_DESTRUCT(&grpinfo);
@@ -2065,7 +2067,7 @@ report:
     ilist = PMIx_Info_list_start();
 
     rc = PMIx_Info_list_add(ilist, PMIX_GROUP_ID, cb->grpid, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIx_Info_list_release(ilist);
         goto done;
     }
@@ -2075,14 +2077,14 @@ report:
         darray.type = PMIX_PROC;
         rc = PMIx_Info_list_add(ilist, PMIX_GROUP_MEMBERSHIP, &darray, PMIX_DATA_ARRAY);
         // data was copied into the info
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIx_Info_list_release(ilist);
             goto done;
         }
     }
     if (gotctxid) {
         rc = PMIx_Info_list_add(ilist, PMIX_GROUP_CONTEXT_ID, &ctxid, PMIX_SIZE);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIx_Info_list_release(ilist);
             goto done;
         }
@@ -2150,7 +2152,7 @@ static void destruct_cbfunc(struct pmix_peer_t *pr,
     }
     pmix_mutex_unlock(&pmix_client_globals.grouplock);
 
-    if (NULL == buf) {
+    if (PMIX_UNLIKELY(NULL == buf)) {
         ret = PMIX_ERR_BAD_PARAM;
         PMIX_ERROR_LOG(ret);
         goto report;
@@ -2166,7 +2168,7 @@ static void destruct_cbfunc(struct pmix_peer_t *pr,
     /* unpack the returned status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
     }
@@ -2204,7 +2206,7 @@ static void info_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, v
 
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_CONTEXT_ID)) {
                 rc = PMIx_Value_get_number(&info[n].value, &ctxid, PMIX_SIZE);
-                if (PMIX_SUCCESS != rc) {
+                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                     PMIX_ERROR_LOG(rc);
                 }
             }

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -165,14 +165,12 @@ PMIX_CLASS_INSTANCE(pmix_group_tracker_t, pmix_list_item_t, gtcon, gtdes);
  * that returns PMIX_EVENT_ACTION_COMPLETE - the normal way to say "handled" -
  * ends the chain before this handler is reached. An invite/join application
  * has to register for that code, so this is the common case, not the corner
- * one. (Demonstrated with test/unit/run_grpinvite.pl: the application handler
- * fires on every acceptor while none of these watches do; changing only the
- * example's return value to PMIX_EVENT_NO_ACTION_TAKEN makes them all fire.
- * It is not a registration race either - moving this registration ahead of
- * the acceptance notification changes nothing.) The real fix is to observe
- * these codes from the pre-chain block in pmix_invoke_local_event_hdlr(),
- * which already maintains pmix_client_globals.groups on the same events and
- * cannot be pre-empted; that is a separate change, under discussion.
+ * one.
+ *
+ * The reproducers, the sweep of every library-internal registration in the
+ * tree, what was ruled out, and the options for a fix are all in
+ * https://github.com/openpmix/openpmix/issues/4059 - read that rather than
+ * re-deriving any of it here.
  *
  * Meanwhile, rather than leak the tracker (and its registered handler), we
  * record each active watch here and release any survivors at finalize. Access is confined to the progress thread
@@ -983,9 +981,9 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
      * PMIX_GROUP_INVITE_ACCEPTED - to log who joined, say - and returns
      * PMIX_EVENT_ACTION_COMPLETE from it ends the chain before we are
      * reached, and PMIx_Group_invite blocks forever unless the caller
-     * supplied a PMIX_TIMEOUT. Same exposure as the leader watch below, but
-     * a hang rather than a missed teardown. See the note there for the
-     * demonstration and the intended fix. */
+     * supplied a PMIX_TIMEOUT. Same exposure as the leader watch above, but
+     * a hang rather than a missed teardown; see
+     * https://github.com/openpmix/openpmix/issues/4059 */
     PMIX_INFO_LOAD(&myinfo[0], PMIX_EVENT_RETURN_OBJECT, cb, PMIX_POINTER);
     PMIX_INFO_LOAD(&myinfo[1], PMIX_EVENT_HDLR_PREPEND, NULL, PMIX_BOOL);
     ncodes = sizeof(codes) / sizeof(pmix_status_t);

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -18,6 +18,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include "src/include/pmix_prefetch.h"
+
 #include "src/include/pmix_stdint.h"
 
 #include "include/pmix.h"
@@ -70,16 +72,16 @@ PMIX_EXPORT pmix_status_t PMIx_Publish(const pmix_info_t info[], size_t ninfo)
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: publish called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -111,21 +113,21 @@ PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: publish called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo cases */
-    if (NULL == info) {
+    if (PMIX_UNLIKELY(NULL == info)) {
         /* nothing to publish */
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return PMIX_ERR_BAD_PARAM;
@@ -135,14 +137,14 @@ PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
     }
     /* pack our effective userid - will be used to constrain lookup */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &pmix_globals.uid, 1, PMIX_UINT32);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -150,7 +152,7 @@ PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo
     /* pass the number of info structs - needed on remote end so
      * space can be malloc'd for the values */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -158,7 +160,7 @@ PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo
     if (0 < ninfo) {
         /* pack the info structs */
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             return rc;
@@ -174,7 +176,7 @@ PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_cbfunc, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }
@@ -193,21 +195,21 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup(pmix_pdata_t pdata[], size_t ndata, const 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: lookup called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* bozo protection */
-    if (NULL == pdata) {
+    if (PMIX_UNLIKELY(NULL == pdata)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -254,21 +256,21 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: lookup_nb called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo cases */
-    if (NULL == keys) {
+    if (PMIX_UNLIKELY(NULL == keys)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -276,14 +278,14 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], 
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
     }
     /* pack our effective userid - will be used to constrain lookup */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &pmix_globals.uid, 1, PMIX_UINT32);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -291,7 +293,7 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], 
     /* pack the keys */
     nkeys = PMIx_Argv_count(keys);
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nkeys, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -299,7 +301,7 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], 
     if (0 < nkeys) {
         for (n = 0; n < nkeys; n++) {
             PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &keys[n], 1, PMIX_STRING);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
                 return rc;
@@ -309,7 +311,7 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], 
     /* pass the number of info structs - needed on remote end so
      * space can be malloc'd for the values */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -317,7 +319,7 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], 
     if (0 < ninfo) {
         /* pack the info structs */
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             return rc;
@@ -333,7 +335,7 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], 
 
     /* send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_lookup_cbfunc, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }
@@ -349,16 +351,16 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish(char **keys, const pmix_info_t info[], 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: unpublish called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -393,16 +395,16 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys, const pmix_info_t info[
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: unpublish called");
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -410,14 +412,14 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys, const pmix_info_t info[
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
     }
     /* pack our effective userid - will be used to constrain lookup */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &pmix_globals.uid, 1, PMIX_UINT32);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -425,7 +427,7 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys, const pmix_info_t info[
     /* pack the number of keys */
     i = PMIx_Argv_count(keys);
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &i, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -433,7 +435,7 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys, const pmix_info_t info[
     if (0 < i) {
         for (j = 0; j < i; j++) {
             PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &keys[j], 1, PMIX_STRING);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
                 return rc;
@@ -443,7 +445,7 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys, const pmix_info_t info[
     /* pass the number of info structs - needed on remote end so
      * space can be malloc'd for the values */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -451,7 +453,7 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys, const pmix_info_t info[
     if (0 < ninfo) {
         /* pack the info structs */
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             return rc;
@@ -465,7 +467,7 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys, const pmix_info_t info[
 
     /* send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_cbfunc, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }
@@ -488,7 +490,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
-    if (NULL == buf) {
+    if (PMIX_UNLIKELY(NULL == buf)) {
         ret = PMIX_ERR_BAD_PARAM;
         goto report;
     }
@@ -502,7 +504,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     /* unpack the returned status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
     }
@@ -544,12 +546,12 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
     ndata = 0;
     ret = PMIX_SUCCESS;
 
-    if (NULL == cb->cbfunc.lookupfn) {
+    if (PMIX_UNLIKELY(NULL == cb->cbfunc.lookupfn)) {
         /* nothing we can do with this */
         PMIX_RELEASE(cb);
         return;
     }
-    if (NULL == buf) {
+    if (PMIX_UNLIKELY(NULL == buf)) {
         ret = PMIX_ERR_BAD_PARAM;
         goto report;
     }
@@ -563,7 +565,7 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
     /* unpack the returned status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
         goto report;
@@ -580,7 +582,7 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
     /* unpack the number of returned values */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ndata, &cnt, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
         ndata = 0;
@@ -592,7 +594,7 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
         cnt = ndata;
         /* unpack the returned values into the pdata array */
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, pdata, &cnt, PMIX_PDATA);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             /* report the failure rather than falling into cleanup: that
              * path never invoked the callback, so the caller waited on its
@@ -643,7 +645,7 @@ static void lookup_cbfunc(pmix_status_t status, pmix_pdata_t pdata[], size_t nda
                      * actual transfer failure */
                     PMIX_BFROPS_VALUE_XFER(rc, pmix_client_globals.myserver,
                                            &tgt[j].value, &pdata[i].value);
-                    if (PMIX_SUCCESS != rc) {
+                    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                         cb->status = rc;
                     }
                     break;

--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -281,6 +281,10 @@ static void resolve_peers(int sd, short args, void *cbdata)
             }
             PMIx_Argv_free(tmp);
             rc = PMIX_SUCCESS;
+        } else {
+            /* nothing resolved, but the walk above may still have collected
+             * entries (an nspace whose peer list was an empty string) */
+            PMIx_Argv_free(tmp);
         }
         goto done;
     }
@@ -391,6 +395,12 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
     pmix_cb_t cb;
     pmix_value_t *val;
 
+    /* both are OUT parameters we write on every path - there is no way to
+     * return an answer without them */
+    if (NULL == procs || NULL == nprocs) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* set default response */
     *procs = NULL;
     *nprocs = 0;
@@ -443,6 +453,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
                 if (0 < cb.ninfo) {
                     val = &cb.info[0].value;
                     if (PMIX_DATA_ARRAY != val->type ||
+                        NULL == val->data.darray ||
                         PMIX_PROC != val->data.darray->type) {
                         PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
                     } else {
@@ -724,6 +735,12 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
     pmix_info_t info;
     pmix_cb_t cb;
     pmix_value_t *val;
+
+    /* the OUT parameter is how the answer gets back, and we write it on
+     * every path - a NULL leaves us nothing to do */
+    if (NULL == nodelist) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     /* set default response */
     *nodelist = NULL;

--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -18,6 +18,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include "src/include/pmix_prefetch.h"
+
 #include "src/include/pmix_stdint.h"
 
 #include "include/pmix.h"
@@ -205,7 +207,7 @@ static void resolve_peers(int sd, short args, void *cbdata)
         PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
             PMIX_LOAD_NSPACE(proc.nspace, ns->nspace);
             rc = try_fetch(&cb);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 continue;
             }
 
@@ -248,7 +250,7 @@ static void resolve_peers(int sd, short args, void *cbdata)
         if (0 < np) {
             /* allocate the proc array */
             PMIX_PROC_CREATE(pa, np);
-            if (NULL == pa) {
+            if (PMIX_UNLIKELY(NULL == pa)) {
                 rc = PMIX_ERR_NOMEM;
                 PMIx_Argv_free(tmp);
                 goto done;
@@ -332,7 +334,7 @@ process:
 
     /* allocate the proc array */
     PMIX_PROC_CREATE(pa, np);
-    if (NULL == pa) {
+    if (PMIX_UNLIKELY(NULL == pa)) {
         rc = PMIX_ERR_NOMEM;
         PMIx_Argv_free(p);
         goto done;
@@ -397,7 +399,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
 
     /* both are OUT parameters we write on every path - there is no way to
      * return an answer without them */
-    if (NULL == procs || NULL == nprocs) {
+    if (PMIX_UNLIKELY(NULL == procs || NULL == nprocs)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -405,11 +407,11 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
     *procs = NULL;
     *nprocs = 0;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -494,7 +496,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
      * provide our local understanding of the situation.
      * Threadshift to compute it as we will be accessing
      * global info */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         cd = PMIX_NEW(pmix_resolve_caddy_t);
         cd->nodename = nd;
         PMIX_LOAD_NSPACE(cd->nspace, nspace);
@@ -517,21 +519,21 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
     }
     /* pack the request information */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &nd, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
     }
     str = (char*)nspace;
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &str, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -539,7 +541,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
 
     cd = PMIX_NEW(pmix_resolve_caddy_t);
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_peers_cbfunc, (void *) cd);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         /* a refused send never took the message, so it is still ours */
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cd);
@@ -613,7 +615,7 @@ static void resolve_nodes(int sd, short args, void *cbdata)
         PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
             PMIX_LOAD_NSPACE(proc.nspace, ns->nspace);
             rc = try_fetch(&cb);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 continue;
             }
 
@@ -738,18 +740,18 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
 
     /* the OUT parameter is how the answer gets back, and we write it on
      * every path - a NULL leaves us nothing to do */
-    if (NULL == nodelist) {
+    if (PMIX_UNLIKELY(NULL == nodelist)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
     /* set default response */
     *nodelist = NULL;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -815,7 +817,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
      * provide our local understanding of the situation.
      * Threadshift to compute it as we will be accessing
      * global info */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         cd = PMIX_NEW(pmix_resolve_caddy_t);
         PMIX_LOAD_NSPACE(cd->nspace, nspace);
         PMIX_THREADSHIFT(cd, resolve_nodes);
@@ -835,7 +837,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -844,7 +846,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
     /* pack the request information */
     str = (char*)nspace;
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &str, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -852,7 +854,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
 
     cd = PMIX_NEW(pmix_resolve_caddy_t);
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_node_cbfunc, (void *) cd);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         /* a refused send never took the message, so it is still ours */
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cd);
@@ -898,7 +900,7 @@ static void wait_peers_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
-    if (NULL == buf) {
+    if (PMIX_UNLIKELY(NULL == buf)) {
         ret = PMIX_ERR_BAD_PARAM;
         goto done;
     }
@@ -913,7 +915,7 @@ static void wait_peers_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     /* unpack the returned status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
     }
@@ -922,7 +924,7 @@ static void wait_peers_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     if (PMIX_SUCCESS == ret) {
         cnt = 1;
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &cd->nprocs, &cnt, PMIX_SIZE);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             ret = rc;
             goto done;
@@ -931,7 +933,7 @@ static void wait_peers_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
             PMIX_PROC_CREATE(cd->procs, cd->nprocs);
             cnt = cd->nprocs;
             PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, cd->procs, &cnt, PMIX_PROC);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_PROC_FREE(cd->procs, cd->nprocs);
                 ret = rc;
@@ -959,7 +961,7 @@ static void wait_node_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
-    if (NULL == buf) {
+    if (PMIX_UNLIKELY(NULL == buf)) {
         ret = PMIX_ERR_BAD_PARAM;
         goto done;
     }
@@ -974,7 +976,7 @@ static void wait_node_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     /* unpack the returned status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
     }
@@ -983,7 +985,7 @@ static void wait_node_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     if (PMIX_SUCCESS == ret) {
         cnt = 1;
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &cd->nodelist, &cnt, PMIX_STRING);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             ret = rc;
             goto done;

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -217,6 +217,12 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* check for bozo input - the apps array is walked below and there is
+     * nothing to spawn without one */
+    if (NULL == apps || 0 == napps) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* if we aren't connected, don't attempt to send */
     if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         /* if I am a launcher, we default to local fork/exec */
@@ -289,8 +295,11 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     fcd->copied = true;
     for (n = 0; n < napps; n++) {
         aptr = (pmix_app_t *) &apps[n];
-        /* protect against bozo case */
-        if (NULL == aptr->cmd && NULL == aptr->argv) {
+        /* protect against bozo case - an argv whose first element is NULL
+         * is as empty as no argv at all, and would otherwise reach
+         * strdup()/pmix_basename() as a NULL below */
+        if ((NULL == aptr->cmd && NULL == aptr->argv) ||
+            (NULL != aptr->argv && NULL == aptr->argv[0])) {
             /* they gave us nothing to spawn! */
             PMIX_RELEASE(fcd);
             return PMIX_ERR_BAD_PARAM;
@@ -351,9 +360,11 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
          * the ninfo field has been set */
         if (NULL != aptr->info) {
             if (0 == aptr->ninfo) {
-                /* look for the info marked as "end" */
+                /* look for the info marked as "end" - test the bound
+                 * before the dereference, or the guard below can never
+                 * be reached (we would have walked off the array first) */
                 m = 0;
-                while (!(PMIX_INFO_IS_END(&aptr->info[m])) && m < SIZE_MAX) {
+                while (m < SIZE_MAX && !(PMIX_INFO_IS_END(&aptr->info[m]))) {
                     ++m;
                 }
                 if (SIZE_MAX == m) {

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -18,6 +18,8 @@
 
 #include "src/include/pmix_config.h"
 
+#include "src/include/pmix_prefetch.h"
+
 #include "src/include/pmix_stdint.h"
 
 #include "include/pmix.h"
@@ -106,11 +108,11 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
                         "%s pmix: spawn called",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -209,22 +211,22 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
                         "%s pmix: spawn_nb called",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
     /* check for bozo input - the apps array is walked below and there is
      * nothing to spawn without one */
-    if (NULL == apps || 0 == napps) {
+    if (PMIX_UNLIKELY(NULL == apps || 0 == napps)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         /* if I am a launcher, we default to local fork/exec */
         if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
             forkexec = true;
@@ -246,7 +248,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
             if (PMIX_CHECK_KEY(&job_info[n], PMIX_SETUP_APP_ENVARS)) {
                 PMIX_CONSTRUCT(&ilist, pmix_list_t);
                 rc = pmix_pmdl.harvest_envars(NULL, job_info, ninfo, &ilist);
-                if (PMIX_SUCCESS != rc) {
+                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                     PMIX_LIST_DESTRUCT(&ilist);
                     PMIX_RELEASE(fcd);
                     return rc;
@@ -266,7 +268,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
                 proxy = true;
             }
             rc = PMIx_Info_list_xfer(xlist, &job_info[n]);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIx_Info_list_release(xlist);
                 PMIX_RELEASE(fcd);
                 return rc;
@@ -274,7 +276,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         }
         // convert the list to an array
         rc = PMIx_Info_list_convert(xlist, &darray);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIx_Info_list_release(xlist);
             PMIX_RELEASE(fcd);
             return rc;
@@ -316,7 +318,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
          * take the one we are in */
         if (NULL == aptr->cwd) {
             rc = pmix_getcwd(cwd, sizeof(cwd));
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_RELEASE(fcd);
                 return rc;
             }
@@ -390,7 +392,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
                 if (PMIX_CHECK_KEY(&fcd->apps[n].info[m], PMIX_SETUP_APP_ENVARS)) {
                     PMIX_CONSTRUCT(&ilist, pmix_list_t);
                     rc = pmix_pmdl.harvest_envars(NULL, fcd->apps[n].info, fcd->apps[n].ninfo, &ilist);
-                    if (PMIX_SUCCESS != rc) {
+                    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                         PMIX_LIST_DESTRUCT(&ilist);
                         PMIX_RELEASE(fcd);
                         return rc;
@@ -412,7 +414,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer) &&
         !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
 
-        if (NULL == pmix_host_server.spawn) {
+        if (PMIX_UNLIKELY(NULL == pmix_host_server.spawn)) {
             PMIX_RELEASE(fcd);
             return PMIX_ERR_NOT_SUPPORTED;
         }
@@ -422,7 +424,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         if (proxy) {
             /* find the parent's peer object */
             fcd->peer = pmix_get_peer_object(&parent);
-            if (NULL == fcd->peer) {
+            if (PMIX_UNLIKELY(NULL == fcd->peer)) {
                 PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
                 PMIX_RELEASE(fcd);
                 return PMIX_ERR_NOT_FOUND;
@@ -445,7 +447,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
                                     fcd->info, fcd->ninfo,
                                     fcd->apps, fcd->napps,
                                     localcbfunc, fcd);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_RELEASE(fcd);
         }
         return rc;
@@ -458,7 +460,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
 
     if (forkexec) {
         rc = pmix_pfexec_base_spawn_job(fcd);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_RELEASE(fcd);
         }
         return rc;
@@ -467,7 +469,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_RELEASE(fcd);
@@ -476,7 +478,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
 
     /* pack the job-level directives */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &fcd->ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_RELEASE(fcd);
@@ -484,7 +486,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     }
     if (0 < fcd->ninfo) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, fcd->info, fcd->ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             PMIX_RELEASE(fcd);
@@ -494,7 +496,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
 
     /* pack the apps */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &fcd->napps, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_RELEASE(fcd);
@@ -502,7 +504,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     }
     if (0 < fcd->napps) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, fcd->apps, fcd->napps, PMIX_APP);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             PMIX_RELEASE(fcd);
@@ -517,7 +519,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_cbfunc, (void *) fcd);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(msg);
         PMIX_RELEASE(fcd);
     }
@@ -546,7 +548,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     /* init */
     memset(nspace, 0, PMIX_MAX_NSLEN + 1);
 
-    if (NULL == buf) {
+    if (PMIX_UNLIKELY(NULL == buf)) {
         ret = PMIX_ERR_BAD_PARAM;
         goto report;
     }
@@ -560,14 +562,14 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
     /* unpack the returned status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
     }
     /* unpack the namespace */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &n2, &cnt, PMIX_STRING);
-    if (PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc)) {
         PMIX_ERROR_LOG(rc);
         ret = rc;
     }
@@ -580,7 +582,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
         free(n2);
         PMIX_GDS_STORE_JOB_INFO(rc, pmix_globals.mypeer, nspace, buf);
         /* extract and process any job-related info for this nspace */
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             ret = rc;
         }

--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -17,6 +17,8 @@
  */
 
 #include "src/include/pmix_config.h"
+
+#include "src/include/pmix_prefetch.h"
 #include "include/pmix.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -38,11 +40,11 @@ PMIX_EXPORT pmix_status_t PMIx_Load_topology(pmix_topology_t *topo)
     pmix_status_t rc;
     pmix_cb_t cb;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -62,7 +64,7 @@ PMIX_EXPORT pmix_status_t PMIx_Parse_cpuset_string(const char *cpuset_string, pm
 {
     pmix_status_t rc;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
@@ -74,7 +76,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_cpuset(pmix_cpuset_t *cpuset, pmix_bind_envel
 {
     pmix_status_t rc;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
@@ -87,7 +89,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_relative_locality(const char *locality1, cons
 {
     pmix_status_t rc;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
@@ -138,17 +140,17 @@ pmix_status_t PMIx_Compute_distances(pmix_topology_t *topo, pmix_cpuset_t *cpuse
     pmix_cb_t cb;
     pmix_status_t rc;
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* both are OUT parameters we write on every path, including the error
      * ones, so there is no way to honor a NULL for either */
-    if (NULL == distances || NULL == ndist) {
+    if (PMIX_UNLIKELY(NULL == distances || NULL == ndist)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -161,7 +163,7 @@ pmix_status_t PMIx_Compute_distances(pmix_topology_t *topo, pmix_cpuset_t *cpuse
      * the non-blocking operation is complete */
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     rc = PMIx_Compute_distances_nb(topo, cpuset, info, ninfo, distcb, &cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_DESTRUCT(&cb);
         return rc;
     }
@@ -217,7 +219,7 @@ static void direcv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t 
     /* unpack the status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &cb->status, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto complete;
     }
@@ -237,7 +239,7 @@ static void direcv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t 
         rc = PMIX_SUCCESS;
         goto complete;
     }
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto complete;
     }
@@ -245,7 +247,7 @@ static void direcv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t 
         PMIX_DEVICE_DIST_CREATE(cb->dist, cb->nvals);
         cnt = cb->nvals;
         PMIX_BFROPS_UNPACK(rc, peer, buf, cb->dist, &cnt, PMIX_DEVICE_DIST);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             goto complete;
         }
@@ -277,17 +279,17 @@ pmix_status_t PMIx_Compute_distances_nb(pmix_topology_t *tp, pmix_cpuset_t *cp,
     pmix_topology_t notopo = {NULL, NULL};
     pmix_cpuset_t nocpuset = {NULL, NULL};
 
-    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
+    if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
 
     /* the server-reply path (direcv) has no completion route other than this
      * callback, so a NULL one is not something we can honor */
-    if (NULL == cbfunc) {
+    if (PMIX_UNLIKELY(NULL == cbfunc)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
@@ -300,7 +302,7 @@ pmix_status_t PMIx_Compute_distances_nb(pmix_topology_t *tp, pmix_cpuset_t *cp,
         if (NULL == pmix_globals.topology.topology) {
             /* if our topology is NULL, try to get it */
             rc = pmix_hwloc_load_topology(&pmix_globals.topology);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 /* try to ask our server if they can do it */
                 goto request;
             }
@@ -315,7 +317,7 @@ pmix_status_t PMIx_Compute_distances_nb(pmix_topology_t *tp, pmix_cpuset_t *cp,
          * that we haven't yet gotten our cpuset. Try to get it. */
         if (NULL == pmix_globals.cpuset.bitmap) {
             rc = pmix_hwloc_get_cpuset(&pmix_globals.cpuset, PMIX_CPUBIND_PROCESS);
-            if (PMIX_SUCCESS != rc) {
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 /* try to ask our server if they can do it */
                 goto request;
             }
@@ -355,7 +357,7 @@ request:
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
@@ -364,7 +366,7 @@ request:
 
     /* pack the topology we want them to use */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, topo, 1, PMIX_TOPO);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
@@ -372,7 +374,7 @@ request:
     }
     /* pack the cpuset */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, cpuset, 1, PMIX_PROC_CPUSET);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
@@ -381,7 +383,7 @@ request:
 
     /* pack the directives */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
@@ -389,7 +391,7 @@ request:
     }
     if (0 < ninfo) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, info, ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             PMIX_RELEASE(cb);
@@ -399,7 +401,7 @@ request:
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, direcv, (void *) cb);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }

--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -142,6 +142,12 @@ pmix_status_t PMIx_Compute_distances(pmix_topology_t *topo, pmix_cpuset_t *cpuse
         return PMIX_ERR_INIT;
     }
 
+    /* both are OUT parameters we write on every path, including the error
+     * ones, so there is no way to honor a NULL for either */
+    if (NULL == distances || NULL == ndist) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
@@ -220,10 +226,18 @@ static void direcv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t 
         goto complete;
     }
 
-    /* unpack any returned data */
+    /* unpack any returned data. A server that had nothing to add simply
+     * ends the message here, so a read past the end is not an error - but
+     * it must not be handed to the caller as the result of the operation,
+     * which the server already told us succeeded. */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &cb->nvals, &cnt, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
+    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+        cb->nvals = 0;
+        rc = PMIX_SUCCESS;
+        goto complete;
+    }
+    if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto complete;
     }
@@ -253,6 +267,15 @@ pmix_status_t PMIx_Compute_distances_nb(pmix_topology_t *tp, pmix_cpuset_t *cp,
     pmix_cmd_t cmd = PMIX_COMPUTE_DEVICE_DISTANCES_CMD;
     pmix_topology_t *topo = NULL;
     pmix_cpuset_t *cpuset = NULL;
+    /* Stand-ins for "use your own" when we relay the request to the server.
+     * The wire form of an absent topology/cpuset is an empty object, and the
+     * server explicitly handles it (see pmix_server_device_dists). We cannot
+     * express that by handing PMIX_BFROPS_PACK a NULL pointer: the generic
+     * pack entry point rejects a NULL source with PMIX_ERR_BAD_PARAM before
+     * the type-specific packer - which does understand it - is ever reached,
+     * so the whole ask-the-server fallback failed instead of sending. */
+    pmix_topology_t notopo = {NULL, NULL};
+    pmix_cpuset_t nocpuset = {NULL, NULL};
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
@@ -319,9 +342,13 @@ request:
         return PMIX_ERR_UNREACH;
     }
 
-    /* don't send our topology if it's local */
-    if (topo == &pmix_globals.topology) {
-        topo = NULL;
+    /* don't send our own topology - the server has one. Likewise for a
+     * cpuset we never managed to obtain: the server knows our binding. */
+    if (NULL == topo || topo == &pmix_globals.topology) {
+        topo = &notopo;
+    }
+    if (NULL == cpuset) {
+        cpuset = &nocpuset;
     }
 
     /* if we are a tool or client, then relay this request to the server */

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -183,6 +183,19 @@ and `PMIX_TOPO` (`pmix_topology_t`); see
 
 - **cpuset is packed as its `hwloc_bitmap_list_asprintf` string.** A NULL
   bitmap (unbound process) packs as a NULL string. Symmetric on unpack.
+- **"absent" is expressed as an empty object, not a NULL pointer.** Both
+  packers handle a NULL `src` by writing a NULL string, but **a caller
+  can never reach that branch**: `pmix_bfrops_base_pack()` rejects
+  `NULL == src && 0 < num_vals` with `PMIX_ERR_BAD_PARAM` before
+  dispatching to the type handler. So a caller saying "I have no
+  topology, use yours" has to pass a zeroed `pmix_topology_t` — which is
+  why `pmix_hwloc_pack_topology()` treats `NULL == src->topology` the
+  same as `NULL == src`. `PMIx_Compute_distances_nb` passed the NULL
+  pointer and its whole ask-the-server fallback failed with BAD_PARAM
+  rather than sending; see
+  [`src/client/AGENTS.md`](../client/AGENTS.md). `pack_cpuset` already
+  handled the equivalent (`NULL == src->bitmap`). Keep both symmetric,
+  and keep the wire form identical between the two spellings.
 - **topology is packed as an XML string only.** hwloc 2.3+ embeds the
   `hwloc_topology_support` flags in the exported XML, and the unpacker
   recovers them by loading with `HWLOC_TOPOLOGY_FLAG_IMPORT_SUPPORT`

--- a/src/hwloc/pmix_hwloc_datatype.c
+++ b/src/hwloc/pmix_hwloc_datatype.c
@@ -213,10 +213,14 @@ pmix_status_t pmix_hwloc_pack_topology(pmix_buffer_t *buf, pmix_topology_t *src,
     char *xmlbuffer = NULL;
     int len;
 
-    if (NULL == src) {
+    /* An empty topology object is the wire form of "no topology" - it is how
+     * a caller says "use your own". Callers cannot express that by passing a
+     * NULL pointer, because the generic pack entry point rejects a NULL
+     * source before we are reached, so accept both forms here. */
+    if (NULL == src || NULL == src->topology) {
         /* pack a NULL string */
         PMIX_BFROPS_PACK_TYPE(rc, buf, &xmlbuffer, 1, PMIX_STRING, regtypes);
-        return PMIX_SUCCESS;
+        return rc;
     }
 
     if (NULL != src->source && 0 != strncasecmp(src->source, "hwloc", 5)) {

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -72,6 +72,24 @@ and several of them segfaulted before being fixed:
 - `PMIx_Fabric_deregister` twice in a row, which used to free the info
   array a second time.
 
+The August 2026 second sweep of that directory added:
+
+- `PMIx_Put` with a NULL value or a NULL key — both were dereferenced by
+  a `pmix_output_verbose()` call that sat above the validation.
+- The OUT parameters of `PMIx_Compute_distances`, `PMIx_Resolve_peers`
+  and `PMIx_Resolve_nodes`, each of which wrote a default through an
+  unchecked pointer.
+- `PMIx_Group_construct` / `PMIx_Group_invite` out-parameters, both
+  poisoned before the call and passed as NULL, matching the
+  `PMIx_Group_join` cases already here.
+- `PMIx_Spawn[_nb]` with no apps array.
+- A malformed `PMIX_HOSTNAME` qualifier on `PMIx_Get`, which the request
+  parser used to hand straight to `strdup()`.
+- `PMIx_Fabric_construct(NULL)` and `PMIx_Fabric_deregister[_nb]`
+  **before `PMIx_Init`** — that one runs at the top of `main()`, ahead of
+  init, because the defect was a missing `initialized` gate in front of a
+  `pmix_globals.mypeer` dereference. Keep it there.
+
 **What it cannot cover, and why.** A singleton has no server, so every
 path that round-trips — which is most of `src/client` — short-circuits
 before it starts. `PMIx_Fence` and `PMIx_Commit` return success without
@@ -82,6 +100,28 @@ That half of the directory is covered by
 different PMIx servers. Do not try to grow `client_api.c` into it: a
 test that needs a server belongs in the swarm suite or in a `run_*.pl`
 against `test/simple`.
+
+The same short-circuit is why the *parameter* coverage here is uneven,
+and the unevenness is not an oversight. Most entry points run
+`initialized` → `connected` → `progress_thread_stopped` before they look
+at their arguments, so in a singleton the state checks answer first and
+the argument checks are dead code. The APIs above are exactly those that
+validate before (or without) gating on `connected`. Do not reorder a
+check in `src/client` to make it reachable from here — put the case in
+a `run_*.pl` or the swarm suite instead.
+
+### `run_grpinviteothers.pl` — a leader that is not a member
+
+[`run_grpinviteothers.pl.in`](run_grpinviteothers.pl.in) is the sibling
+of `run_grpinvite.pl`: same four-client simptest run, but rank 0 invites
+ranks 1..3 and does **not** join, so the group forms on the invitees
+alone. The library credits the leader's own answer against the
+membership, which is right only when the leader is itself an invitee;
+crediting it here resolves the invitation one answer early and — the
+construct being all-or-nothing — aborts it. The driver greps for
+`CONSTRUCT_ABORT` explicitly so that regression reports itself rather
+than showing up as a timeout. See `invite_setup()` in
+[`src/client/pmix_client_group.c`](../../src/client/pmix_client_group.c).
 
 ## Running
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -51,13 +51,13 @@ SUBDIRS = util class
 
 AM_TESTS_ENVIRONMENT = . $(abs_top_builddir)/test/pmix_test_env.sh;
 
-noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl
+noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grpinviteothers.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl
 
-EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
+EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
 check_PROGRAMS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
 
-TESTS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+TESTS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grpinviteothers.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
 
 client_api_SOURCES = \
         client_api.c

--- a/test/unit/client_api.c
+++ b/test/unit/client_api.c
@@ -372,6 +372,187 @@ static void test_fabric(void)
     check(PMIX_SUCCESS == rc, "second PMIx_Fabric_deregister is a safe no-op");
 }
 
+/* PMIx_Put screened its key only after a verbose call had already printed
+ * it and dereferenced the value's type - and never screened the value at
+ * all. pmix_output_verbose() is an ordinary function, so its arguments are
+ * evaluated whether or not the channel is enabled: both NULLs crashed
+ * before any check could reject them. */
+static void test_put_bad_params(void)
+{
+    pmix_value_t val;
+    pmix_status_t rc;
+    char longkey[PMIX_MAX_KEYLEN + 32];
+
+    fprintf(stdout, "\n-- PMIx_Put parameter validation --\n");
+
+    PMIX_VALUE_LOAD(&val, "somevalue", PMIX_STRING);
+
+    rc = PMIx_Put(PMIX_GLOBAL, "client.api.putkey", NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Put(val=NULL) rejected rather than crashing");
+
+    rc = PMIx_Put(PMIX_GLOBAL, NULL, &val);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Put(key=NULL) rejected rather than crashing");
+
+    memset(longkey, 'k', sizeof(longkey) - 1);
+    longkey[sizeof(longkey) - 1] = '\0';
+    rc = PMIx_Put(PMIX_GLOBAL, longkey, &val);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Put(oversized key) rejected");
+
+    /* and the well-formed call still works */
+    rc = PMIx_Put(PMIX_GLOBAL, "client.api.putkey", &val);
+    check(PMIX_SUCCESS == rc, "PMIx_Put with valid arguments succeeds");
+
+    PMIX_VALUE_DESTRUCT(&val);
+}
+
+/* Every one of these writes through its OUT parameters on the way in, to
+ * establish a default the caller can read on an error return - so a NULL
+ * for any of them was a store to address zero, not a rejected call. */
+static void test_out_parameter_checks(void)
+{
+    pmix_device_distance_t *dist;
+    pmix_proc_t *procs;
+    char *nodelist;
+    size_t n;
+    pmix_status_t rc;
+    /* pmix_nspace_t is a fixed-size char array, so these calls have to be
+     * handed one - a bare string literal is a short read to the compiler */
+    pmix_nspace_t nspace;
+
+    fprintf(stdout, "\n-- OUT parameters must be screened, not written --\n");
+
+    PMIX_LOAD_NSPACE(nspace, "no.such.nspace");
+
+    rc = PMIx_Compute_distances(NULL, NULL, NULL, 0, NULL, &n);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Compute_distances(distances=NULL) rejected");
+    rc = PMIx_Compute_distances(NULL, NULL, NULL, 0, &dist, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Compute_distances(ndist=NULL) rejected");
+
+    rc = PMIx_Resolve_peers(NULL, NULL, NULL, &n);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Resolve_peers(procs=NULL) rejected");
+    rc = PMIx_Resolve_peers(NULL, NULL, &procs, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Resolve_peers(nprocs=NULL) rejected");
+
+    rc = PMIx_Resolve_nodes(NULL, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Resolve_nodes(nodelist=NULL) rejected");
+
+    /* the well-formed forms must still define their defaults before any
+     * failure, so a caller can read them on the error return */
+    procs = (pmix_proc_t *) (uintptr_t) 0xdeadbeef;
+    n = 12345;
+    (void) PMIx_Resolve_peers("no.such.host", nspace, &procs, &n);
+    check(NULL == procs && 0 == n, "PMIx_Resolve_peers defines its OUT params on failure");
+
+    nodelist = (char *) (uintptr_t) 0xdeadbeef;
+    (void) PMIx_Resolve_nodes(nspace, &nodelist);
+    check(NULL == nodelist, "PMIx_Resolve_nodes defines its OUT param on failure");
+}
+
+/* A qualifier the request parser hands straight to strdup(). The array
+ * belongs to the caller, so the parser has to verify a PMIX_HOSTNAME
+ * really carries a string before copying it. */
+static void test_get_hostname_qualifier(void)
+{
+    pmix_info_t info;
+    pmix_value_t *val = NULL;
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- PMIx_Get with a malformed PMIX_HOSTNAME qualifier --\n");
+
+    /* right key, right type, no string */
+    PMIX_INFO_CONSTRUCT(&info);
+    PMIx_Load_key(info.key, PMIX_HOSTNAME);
+    info.value.type = PMIX_STRING;
+    info.value.data.string = NULL;
+    rc = PMIx_Get(NULL, "client.api.absent.key", &info, 1, &val);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIX_HOSTNAME qualifier with a NULL string rejected");
+    check(NULL == val, "the OUT value is still defined on that rejection");
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* right key, wrong type */
+    PMIX_INFO_LOAD(&info, PMIX_HOSTNAME, &rc, PMIX_INT);
+    val = NULL;
+    rc = PMIx_Get(NULL, "client.api.absent.key", &info, 1, &val);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIX_HOSTNAME qualifier of the wrong type rejected");
+    PMIX_INFO_DESTRUCT(&info);
+}
+
+/* PMIx_Spawn walks the apps array before it can know whether it will send
+ * or fork, so an absent array has to be caught up front. */
+static void test_spawn_bad_params(void)
+{
+    pmix_nspace_t nspace;
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- PMIx_Spawn parameter validation --\n");
+
+    rc = PMIx_Spawn(NULL, 0, NULL, 1, nspace);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Spawn(apps=NULL, napps=1) rejected");
+    rc = PMIx_Spawn_nb(NULL, 0, NULL, 1, NULL, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Spawn_nb(apps=NULL, napps=1) rejected");
+    rc = PMIx_Spawn_nb(NULL, 0, NULL, 0, NULL, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Spawn_nb(napps=0) rejected");
+}
+
+/* Both of these are documented as optional OUT parameters. Like
+ * PMIx_Group_join, they must be defined before anything can fail and must
+ * tolerate a NULL. A singleton cannot construct or invite, which is
+ * exactly what makes this a test of the failure path. */
+static void test_group_construct_invite_outparams(void)
+{
+    pmix_info_t *results;
+    size_t nresults;
+    pmix_proc_t procs[2];
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- PMIx_Group_construct/invite out-parameters --\n");
+
+    PMIX_LOAD_PROCID(&procs[0], "no.such.nspace", 0);
+    PMIX_LOAD_PROCID(&procs[1], "no.such.nspace", 1);
+
+    results = (pmix_info_t *) (uintptr_t) 0xdeadbeef;
+    nresults = 12345;
+    rc = PMIx_Group_construct("nosuchgroup", procs, 2, NULL, 0, &results, &nresults);
+    check(PMIX_SUCCESS != rc, "PMIx_Group_construct fails cleanly with no server");
+    check(NULL == results, "PMIx_Group_construct defined *results on the failure path");
+    check(0 == nresults, "PMIx_Group_construct defined *nresults on the failure path");
+
+    rc = PMIx_Group_construct("nosuchgroup", procs, 2, NULL, 0, NULL, NULL);
+    check(PMIX_SUCCESS != rc, "PMIx_Group_construct accepts NULL results/nresults");
+
+    results = (pmix_info_t *) (uintptr_t) 0xdeadbeef;
+    nresults = 12345;
+    rc = PMIx_Group_invite("nosuchgroup", procs, 2, NULL, 0, &results, &nresults);
+    check(PMIX_SUCCESS != rc, "PMIx_Group_invite fails cleanly with no server");
+    check(NULL == results, "PMIx_Group_invite defined *results on the failure path");
+    check(0 == nresults, "PMIx_Group_invite defined *nresults on the failure path");
+
+    rc = PMIx_Group_invite("nosuchgroup", procs, 2, NULL, 0, NULL, NULL);
+    check(PMIX_SUCCESS != rc, "PMIx_Group_invite accepts NULL results/nresults");
+}
+
+/* PMIx_Fabric_deregister was the one fabric entry point with no
+ * "initialized" gate, yet it reaches PMIX_PEER_IS_SCHEDULER(mypeer) - and
+ * mypeer does not exist until PMIx_Init has run. Must be called before
+ * init, so it lives outside the block below. */
+static void test_fabric_before_init(void)
+{
+    pmix_fabric_t fabric;
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- fabric API before PMIx_Init --\n");
+
+    /* must not dereference the argument it is handed */
+    PMIx_Fabric_construct(NULL);
+    check(1, "PMIx_Fabric_construct(NULL) is a no-op rather than a crash");
+
+    PMIx_Fabric_construct(&fabric);
+    rc = PMIx_Fabric_deregister(&fabric);
+    check(PMIX_ERR_INIT == rc, "PMIx_Fabric_deregister before init reports PMIX_ERR_INIT");
+    rc = PMIx_Fabric_deregister_nb(&fabric, NULL, NULL);
+    check(PMIX_ERR_INIT == rc, "PMIx_Fabric_deregister_nb before init reports PMIX_ERR_INIT");
+}
+
 int main(int argc, char **argv)
 {
     pmix_proc_t myproc;
@@ -392,6 +573,9 @@ int main(int argc, char **argv)
 
     fprintf(stdout, "\n=== src/client API regression test ===\n");
 
+    /* this one has to run before the library comes up */
+    test_fabric_before_init();
+
     /* a singleton reports PMIX_ERR_UNREACH from init - it is fully
      * initialized, it just has no server */
     rc = PMIx_Init(&myproc, NULL, 0);
@@ -405,9 +589,14 @@ int main(int argc, char **argv)
     test_get_refresh_cache();
     test_get_bad_params();
     test_get_pointer_and_static();
+    test_get_hostname_qualifier();
+    test_put_bad_params();
+    test_out_parameter_checks();
     test_compute_distances();
+    test_spawn_bad_params();
     test_fabric();
     test_group_join_outparams();
+    test_group_construct_invite_outparams();
     test_group_lock_concurrency();
 
     rc = PMIx_Finalize(NULL, 0);

--- a/test/unit/run_grpinviteothers.pl.in
+++ b/test/unit/run_grpinviteothers.pl.in
@@ -1,0 +1,139 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+
+# Exercise an invite whose leader is NOT one of the invitees, deterministically,
+# in "make check". A single persistent server (test/simple/simptest) forks four
+# clients (examples/group_invite_others). Rank 0 is the leader and invites ranks
+# 1..3 only; those three accept via PMIx_Group_join_nb from their
+# PMIX_GROUP_INVITED handlers, and the group forms on them alone.
+#
+# The distinction from run_grpinvite.pl matters because of how the leader's own
+# answer is counted. It is credited when the leader is itself an invitee; doing
+# so unconditionally starts the count one ahead of the membership here, so the
+# invitation resolves one answer early, the last invitee is recorded as a
+# non-responder, and - this construct being all-or-nothing - the whole thing
+# aborts. Each invitee then reports PMIX_GROUP_CONSTRUCT_ABORT rather than
+# PMIX_GROUP_CONSTRUCT_COMPLETE, which is what the checks below catch. See
+# invite_setup() in src/client/pmix_client_group.c.
+
+use strict;
+
+# We are running against the build tree (vs. an installation). Autogen hands us
+# every possible component directory in PMIX_COMPONENT_LIBRARY_PATHS; turn each
+# into an absolute path to the built component so the MCA base can find them
+# without a prior install.
+my @myfullpaths;
+my $mybuilddir = "@PMIX_BUILT_TEST_PREFIX@";
+my $mypathstr = "@PMIX_COMPONENT_LIBRARY_PATHS@";
+my @splitstr = split(':', $mypathstr);
+foreach my $path (@splitstr) {
+    my $fullpath = $mybuilddir . "/" . $path . "/.libs";
+    push(@myfullpaths, $fullpath)
+        if (-d $fullpath);
+}
+my $mymcapaths = join(":", @myfullpaths);
+$ENV{'PMIX_MCA_mca_base_component_path'} = $mymcapaths;
+
+# simptest forks its clients from its own directory; run from there and name the
+# client (built under examples/) by absolute path so simptest can exec it.
+my $wdir = $mybuilddir . "/test/simple";
+chdir $wdir;
+my $client = $mybuilddir . "/examples/group_invite_others";
+my $nprocs = 4;
+
+# find the timeout or gtimeout cmd so we can bound the run if it hangs
+my $timeout_cmd = "";
+my @paths = split(/:/, $ENV{PATH});
+foreach my $p (@paths) {
+    my $fullpath = $p . "/" . "gtimeout";
+    if ((-e $fullpath) && (-f $fullpath)) {
+        $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+        last;
+    } else {
+        $fullpath = $p . "/" . "timeout";
+        if ((-e $fullpath) && (-f $fullpath)) {
+            $timeout_cmd = $fullpath . " --preserve-status -k 500 450 ";
+            last;
+        }
+    }
+}
+
+# Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise arm a
+# Perl alarm so a wedged run can never hang "make check" forever.
+my @cmd = ("./simptest", "-n", "$nprocs", "-e", "$client");
+my $use_alarm = 0;
+if ("" ne $timeout_cmd) {
+    unshift(@cmd, split(' ', $timeout_cmd));
+} else {
+    $use_alarm = 1;
+}
+print "@cmd\n";
+
+# Run the server in a child we control, merging stderr into stdout, and slurp
+# the output. The alarm (when armed) bounds the wait.
+my $pid = open(my $fh, "-|");
+defined($pid) or die "cannot fork: $!";
+if (0 == $pid) {
+    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+    exec(@cmd) or die "cannot exec simptest: $!";
+}
+my $output = "";
+my $timed_out = 0;
+eval {
+    local $SIG{ALRM} = sub { die "alarm\n"; };
+    alarm(600) if $use_alarm;
+    local $/;            # slurp the whole stream
+    $output = <$fh>;
+    alarm(0);
+};
+if ($@) {
+    $timed_out = 1;
+    kill('KILL', $pid);
+}
+close($fh);
+$output = "" unless defined($output);
+my $status = $timed_out ? 1 : ($? >> 8);
+if ($timed_out) {
+    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+}
+print $output . "\n";
+print "CODE $status\n";
+
+# The server must exit 0: a client that failed (never invited, never notified of
+# completion, or could not fence/destruct) drives a non-zero exit.
+if (0 != $status) {
+    print "FAIL: simptest did not complete (exit $status)\n";
+    exit($status == 0 ? 1 : $status);
+}
+
+# Confirm the run actually exercised the path rather than passing vacuously.
+# The membership is the invitees only - rank 0 invited but did not join - so
+# the expected count is one less than the job size.
+my $nmembers = $nprocs - 1;
+my $npass  = () = ($output =~ /CONSTRUCT_COMPLETE received: PASS/g);
+my $nfence = () = ($output =~ /group fence complete/g);
+my $naborted = () = ($output =~ /CONSTRUCT_ABORT/g);
+my $server_done = ($output =~ /Test finished OK!/);
+if (0 < $naborted) {
+    print "FAIL: the construct aborted - the invitation resolved before every\n";
+    print "      invitee answered (see invite_setup in pmix_client_group.c)\n";
+    exit(1);
+}
+if ($npass < $nmembers) {
+    print "FAIL: only $npass/$nmembers invitees notified of construct completion\n";
+    exit(1);
+}
+if ($nfence < $nmembers) {
+    print "FAIL: only $nfence/$nmembers invitees fenced across the group\n";
+    exit(1);
+}
+if (!$server_done) {
+    print "FAIL: server did not finish cleanly after the clients ran\n";
+    exit(1);
+}
+print "PASS: leader-excluded invite formed the group across all $nmembers invitees\n";
+exit(0);

--- a/test/unit/util/util_hash.c
+++ b/test/unit/util/util_hash.c
@@ -64,8 +64,15 @@ static pmix_kval_t *make_kval_str(const char *key, const char *val)
 static void drain_list(pmix_list_t *lst)
 {
     pmix_kval_t *kv;
-    while (!pmix_list_is_empty(lst)) {
-        kv = (pmix_kval_t *) pmix_list_remove_first(lst);
+
+    /* Take the removal result as the loop condition rather than testing
+     * emptiness first. The two are equivalent at run time, but the compiler
+     * cannot connect pmix_list_is_empty() to what pmix_list_remove_first()
+     * returns, so it has to assume the NULL - and then warns that
+     * PMIX_RELEASE writes the reference count "into a region of size 0"
+     * (-Wstringop-overflow), which is an error under --enable-devel-check.
+     * This is also the idiom the rest of the tree uses. */
+    while (NULL != (kv = (pmix_kval_t *) pmix_list_remove_first(lst))) {
         PMIX_RELEASE(kv);
     }
 }


### PR DESCRIPTION
A second review sweep of `src/client`, following on from #4058. Six
commits, each standalone: one incidental build fix, the defect fixes, a
mechanical `PMIX_UNLIKELY` pass, the tests, and the docs.

## Defects fixed

**Crashes on inputs the APIs permit.** `PMIx_Put` dereferenced
`val->type` and printed `key` from a `pmix_output_verbose()` sitting
*above* the validation meant to catch them — its arguments are evaluated
whether or not the channel is enabled, so both NULLs were segfaults, and
`val` was never checked at all. `PMIx_Compute_distances`,
`PMIx_Resolve_peers` and `PMIx_Resolve_nodes` each store a default
through their OUT parameters without checking them.
`PMIx_Group_construct` and `PMIx_Group_invite[_nb]` wrote
`results`/`nresults` unchecked although both man pages document them as
optional — the same defect #4058 fixed in `PMIx_Group_join`, in the
siblings that were missed. `PMIx_Group_join[_nb]` never validated the
group ID it hands to `strdup()`. `PMIx_Spawn[_nb]` walked the apps array
without checking it was there. `PMIx_Fabric_deregister[_nb]` was the one
fabric entry point with no "initialized" gate in front of a
`pmix_globals.mypeer` dereference. `PMIx_Init` took
`pmix_list_remove_first()` for the debugger-stop key with no NULL check.

**`PMIx_Compute_distances_nb` could never ask the server.** The fallback
passes a NULL topology — and sometimes a NULL cpuset — to mean "use your
own", which the server explicitly supports (`pmix_server_device_dists`
handles it). But `pmix_bfrops_base_pack()` rejects a NULL source with
`PMIX_ERR_BAD_PARAM` *before* the hwloc packer that understands NULL is
reached, so every request that could not be answered locally failed
instead of being sent. It now packs empty objects, and
`pmix_hwloc_pack_topology()` treats an empty topology as the NULL it
already handled — wire format unchanged.

**`PMIX_GROUP_NOTIFY_TERMINATION` was never recorded against a group.**
`PMIx_Group_construct` captured the directive onto its own wrapper
tracker; `construct_cbfunc` reads it from the inner tracker, where it was
always false. And because `add_group()` ignores a repeat request for a
group it already holds, the correctly-flagged call that followed could
not correct it. So `PMIx_Group_destruct` never re-applied the policy for
anybody, and a direct `PMIx_Group_construct_nb` caller never got it at
all.

**An invitation resolved one answer early whenever the leader was not
itself an invitee.** `invite_setup()` credited the leader's own answer
unconditionally but only set the matching per-member flag when it found
itself in the `procs` array. A leader inviting only the others therefore
started one ahead of the membership: the last accept landed after the
decision, was recorded as a non-responder, and — the default construct
being all-or-nothing — aborted the whole thing.

**`PMIx_Abort` discarded the server's reply** and always returned
`PMIX_SUCCESS`, so a host that refused the abort never reached the
caller. Same defect as the one fixed in `PMIx_Commit`; both now share
`unpack_ack()`.

**Leaks.** `PMIx_Fabric_update` orphaned the fabric's previous info array
— and update is precisely the call made against an already-populated
fabric. `PMIx_Get` under `PMIX_GET_STATIC_VALUES` copied into the
caller's storage and abandoned the library's copy, which no destructor
frees. `resolve_peers()` leaked its working argv on one path.

**Lesser correctness.** `frecv()`/`direcv()` tolerated a trailing
`PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER` and then reported it as the
result of an operation the server had said succeeded. `PMIx_Connect_nb`
ignored the pack status when appending the job-level info array.
`destruct_cbfunc()` dropped the group on one failure path but not the
other. `PMIx_Spawn_nb`'s end-sentinel scan tested its bound after the
dereference. `PMIx_Group_join_nb` carried a `PMIX_TIMEOUT` loop that did
nothing with the directive.

## Left unfixed, deliberately

**`PMIx_Group_invite_nb` never announces the outcome, and leaks its
tracker and handler registration.** `invite_announce()`/
`invite_teardown()` are reached only from the blocking form, so the
non-blocking one resolves the invitation and stops — no group forms.
Structural: `invite_wake()` runs on the progress thread and
`invite_announce()` is built out of blocking notifies, which the blocking
form only gets away with by announcing on the caller's own thread after
waking. Fixing it means rewriting the announcement as chained
non-blocking notifications, which is the same machinery #4059's follow-on
behavior change needs — worth doing together. Written up in
`src/client/AGENTS.md` and noted on #4059.

## Tests

`test/unit/client_api.c` gains the cases a singleton can reach — built
against the unfixed library it **segfaults in its first new case**. The
coverage is uneven by necessity: most entry points check
initialized/connected/progress-stopped before looking at their arguments,
so with no server the argument checks are unreachable. That is recorded
in `test/unit/AGENTS.md`, with an explicit "do not reorder a check in
`src/client` just to make it testable from here".

New `examples/group_invite_others.c` + `test/unit/run_grpinviteothers.pl`
cover the one defect needing several processes — verified failing against
the unfixed library and passing after — plus the multi-node form in
`contrib/dockerswarm/run-group-events.sh`.

Two gaps are recorded rather than papered over: the fabric
register/update paths need a provider the swarm does not have, and the
device-distance relay only runs when a client's own hwloc computation
fails, which no test environment here can arrange.

## Incidental

`test/unit/util` did not build **at all** under `--enable-devel-check` —
a `-Wstringop-overflow` error in `drain_list()` — so nothing in that
directory ran in the configuration CI uses. Fixed as its own commit.

## Verification

Warning-free build and 81/81 tests passing under
`./configure --enable-devel-check` on macOS/clang. `PMIX_UNLIKELY` pass
is byte-verified to reproduce the exact tree that passed the suite.
