### PR TITLE
Say plainly that invite/join ignores the context-id directive

### DIFF
--- a/docs/man/man3/PMIx_Group_invite.3.rst
+++ b/docs/man/man3/PMIx_Group_invite.3.rst
@@ -186,6 +186,17 @@ The following attributes are relevant to this operation:
 * ``PMIX_GROUP_ASSIGN_CONTEXT_ID`` (bool) |mdash| request that the resource
   manager assign a unique numerical (``size_t``) context ID to the group. The
   value is returned in the ``PMIX_GROUP_CONSTRUCT_COMPLETE`` event.
+
+  .. caution::
+
+     **This directive is not currently honored on the invite/join path**, and
+     is accepted without effect: no context ID is assigned, and none appears in
+     the ``PMIX_GROUP_CONSTRUCT_COMPLETE`` event. Only the host environment can
+     mint a unique ID, and a group formed by invitation involves no server
+     collective through which it could be asked. Tracked as
+     `openpmix#4068 <https://github.com/openpmix/openpmix/issues/4068>`_. Use
+     :ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>` if the group
+     requires a context ID.
 * ``PMIX_TIMEOUT`` (int) |mdash| bound how long the leader's library waits for a
   live invitee to respond. An invitee that does not respond within the specified
   number of seconds is treated as a failed invitation (see

--- a/docs/man/man3/PMIx_Group_join.3.rst
+++ b/docs/man/man3/PMIx_Group_join.3.rst
@@ -117,8 +117,11 @@ conditions.
 An accepting process learns of that outcome from the leader's
 ``PMIX_GROUP_CONSTRUCT_COMPLETE`` or ``PMIX_GROUP_CONSTRUCT_ABORT`` event, so it is
 those events that complete this call, and ``results`` carries what the leader
-announced about the group |mdash| its ``PMIX_GROUP_ID`` and ``PMIX_GROUP_MEMBERSHIP``
-(and its ``PMIX_GROUP_CONTEXT_ID``, if the leader requested that one be assigned).
+announced about the group |mdash| its ``PMIX_GROUP_ID`` and its
+``PMIX_GROUP_MEMBERSHIP``. Note that a group formed by invitation does not
+currently carry a ``PMIX_GROUP_CONTEXT_ID``, even if the leader asked for one:
+see the caution under
+:ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>`.
 Loss of the leader before the construct resolves completes the call with
 ``PMIX_GROUP_LEADER_FAILED``, since the construct can no longer resolve.
 


### PR DESCRIPTION
Documentation-only. Follow-up to #4067, and the interim measure proposed in #4068.

`PMIx_Group_invite.3.rst` lists `PMIX_GROUP_ASSIGN_CONTEXT_ID` among the
directives it accepts and promises the value back in the
`PMIX_GROUP_CONSTRUCT_COMPLETE` event. It does no such thing: `invite_setup()`
scans for `PMIX_TIMEOUT` and `PMIX_GROUP_OPTIONAL` and nothing else, so the
request is dropped without a diagnostic and the group forms without an ID.

Honoring it is not a client-side change — only the host can mint an ID unique
in its scope, and a group formed by invitation involves no server collective
through which one could be asked — so that is tracked separately as #4068.
Until it lands, say so where a caller will actually look, and point at
`PMIx_Group_construct`, which does honor it.

This also corrects the join page. #4067 added a description of what an
accepted join now returns, and said the results carry a context ID "if the
leader requested that one be assigned" — forward-looking wording for something
that cannot happen today. My error; caught while writing up #4068.

Docs build clean with Sphinx enabled, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)