### PR TITLE
Support nested data arrays, and bound how deeply they may nest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,6 +254,7 @@ test/unit/compress
 test/unit/preg
 test/unit/bfrops_regex2
 test/unit/bfrops_alloc_inherit
+test/unit/nested_darray
 test/unit/gds_fallback
 test/unit/pmix_log
 test/unit/collective_status

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -608,14 +608,13 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
         daptr = <pmix_data_array_t*>array[0].array
         n = 0
         for item in mylist:
-            daptr[n].type = item['val_type']
-            daptr[n].size = len(item['value'])
-            daptr[n].array = <pmix_data_array_t*> malloc(sizeof(pmix_data_array_t))
-            if not daptr[n].array:
-                return PMIX_ERR_NOMEM
-            mydaptr = <pmix_data_array_t*>daptr[n].array
+            # each element is a complete data array in its own right,
+            # stored inline in the block - not a pointer to one - and is
+            # described the same way as the enclosing array
+            daptr[n].type = item['type']
+            daptr[n].size = len(item['array'])
             try:
-                rc = pmix_load_darray(mydaptr, daptr[n].type, item['value'])
+                rc = pmix_load_darray(&daptr[n], daptr[n].type, item['array'])
                 if PMIX_SUCCESS != rc:
                     return rc
             except:
@@ -974,11 +973,10 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         n = 0
         list = []
         while n < array.size:
-            if not daptr[n].array:
-                return PMIX_ERR_NOMEM
-            mydaptr = <pmix_data_array_t*>daptr[n].array
+            # each element is a complete data array stored inline in the
+            # block - an empty one legitimately carries a NULL array
             try:
-                d = pmix_unload_darray(mydaptr)
+                d = pmix_unload_darray(&daptr[n])
             except:
                 return PMIX_ERR_NOT_SUPPORTED
             list.append(d)

--- a/docs/man/man5/pmix_data_array_t.5.rst
+++ b/docs/man/man5/pmix_data_array_t.5.rst
@@ -47,6 +47,15 @@ the caller does not fill in is a valid empty array (``PMIX_UNDEF``,
 ``size`` 0) rather than uninitialized memory, and destructing the outer
 array recursively releases every element.
 
+Nesting is bounded. PMIx refuses to pack or unpack an array nested more
+deeply inside other arrays than the ``bfrops_base_max_array_depth`` MCA
+parameter permits |mdash| 100 levels by default, or unlimited if the
+parameter is set to zero. The limit counts every form of nesting, both an
+array whose element type is ``PMIX_DATA_ARRAY`` and the ordinary case of
+an array reached through a `pmix_value_t`, because each level of either
+costs the receiver a frame of recursion while costing the sender only a
+few bytes on the wire.
+
 The `pmix_data_array_t` structure is the mechanism by which a collection of
 values is conveyed through a single :ref:`pmix_value_t(5) <man5-pmix_value_t>`
 or :ref:`pmix_info_t(5) <man5-pmix_info_t>`: the containing structure references

--- a/docs/man/man5/pmix_data_array_t.5.rst
+++ b/docs/man/man5/pmix_data_array_t.5.rst
@@ -37,6 +37,16 @@ contiguous block of ``size`` elements, all of the same PMIx datatype ``type``.
   element is of the C type corresponding to ``type`` (for example, an ``array``
   of :ref:`pmix_info_t(5) <man5-pmix_info_t>` when ``type`` is ``PMIX_INFO``).
 
+``PMIX_DATA_ARRAY`` is itself a legal element type: when ``type`` is
+``PMIX_DATA_ARRAY``, ``array`` points at a contiguous block of ``size``
+`pmix_data_array_t` structures, each a complete array in its own right
+(and each free to declare a different element type). The elements are
+stored inline in the block |mdash| they are not pointers to arrays
+elsewhere. Constructing such an array zeroes every element, so an element
+the caller does not fill in is a valid empty array (``PMIX_UNDEF``,
+``size`` 0) rather than uninitialized memory, and destructing the outer
+array recursively releases every element.
+
 The `pmix_data_array_t` structure is the mechanism by which a collection of
 values is conveyed through a single :ref:`pmix_value_t(5) <man5-pmix_value_t>`
 or :ref:`pmix_info_t(5) <man5-pmix_info_t>`: the containing structure references

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,23 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - A pmix_data_array_t whose element type is PMIX_DATA_ARRAY is now
+   supported end-to-end. It has always packed - and printed - as a
+   contiguous block of pmix_data_array_t descriptors, exactly as
+   pmix_data_array_t.5.rst describes any array of its declared type,
+   but nothing else agreed: construct had no arm for the type and so
+   quietly produced a NULL array, which made unpack of a nested array
+   fail with PMIX_ERR_NOMEM on a machine that was not out of memory;
+   copy refused it with PMIX_ERR_NOT_SUPPORTED, so PMIx_Value_xfer
+   could not carry one; and destruct treated the block as a single
+   descriptor, ignoring size and never freeing the block, so it leaked
+   for size > 1 and dereferenced NULL for size 0. All four now use the
+   documented layout. The Python bindings had built a third layout
+   again - each element pointing at one further descriptor, with the
+   element's size set to the inner count - and now load and unload the
+   elements in place; a nested element is described with the same
+   {'type', 'array'} dict as the enclosing array, not the {'val_type',
+   'value'} form of a value (see openpmix#4054)
  - Implemented PMIx_Group_invite_nb, which was previously inert: it
    resolved the invitation, invoked the caller's callback, and stopped
    without announcing anything at all - no PMIX_GROUP_INVITE_FAILED, no

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,17 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - Bounded how deeply data arrays may be nested inside one another when
+   packed or unpacked. Each level of nesting costs the sender only a
+   type tag and a size on the wire but costs the receiver a frame of
+   recursion in the unpacker, so a small message could describe a nest
+   deep enough to exhaust the stack. The limit is the new
+   bfrops_base_max_array_depth MCA parameter, 100 by default and
+   unlimited if set to zero, and it counts every form of nesting - an
+   array whose element type is PMIX_DATA_ARRAY, and the ordinary array
+   / info / value chain alike. Both ends enforce it: the sender refuses
+   to build such a message rather than emitting one the far side is
+   bound to reject
  - A pmix_data_array_t whose element type is PMIX_DATA_ARRAY is now
    supported end-to-end. It has always packed - and printed - as a
    contiguous block of pmix_data_array_t descriptors, exactly as

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -75,6 +75,7 @@ struct pmix_bfrops_globals_t {
     bool selected;
     size_t initial_size;
     size_t threshold_size;
+    unsigned int max_array_depth;
     pmix_bfrop_buffer_type_t default_type;
 };
 typedef struct pmix_bfrops_globals_t pmix_bfrops_globals_t;
@@ -90,6 +91,39 @@ PMIX_EXPORT extern pmix_bfrops_globals_t pmix_bfrops_globals;
  * buffer size to additively increasing it
  */
 #define PMIX_BFROP_DEFAULT_THRESHOLD_SIZE 1024
+/*
+ * The default limit on how deeply data arrays may be nested inside
+ * one another. Each level of nesting costs the sender only a type
+ * tag and a size on the wire - roughly two bytes - but costs the
+ * receiver a frame of recursion in the unpacker, so a message of
+ * around a hundred kilobytes can otherwise exhaust an ordinary 8MB
+ * stack. This is a backstop against that, not a judgement about how
+ * deep data ought to be: it is set orders of magnitude above any
+ * nesting the library or its users have reason to build, and orders
+ * of magnitude below the depth that actually threatens the stack.
+ * Zero means "no limit"
+ */
+#define PMIX_BFROP_DEFAULT_MAX_ARRAY_DEPTH 100
+
+/*
+ * The recursive array packer and unpacker each track how deep they
+ * are. The counter cannot live on the buffer: pmix_buffer_t appears
+ * in installed headers and can be placed in shared memory read by
+ * processes built against a different PMIx, so its layout is not
+ * ours to change. Per-thread is equivalent in practice - a pack or
+ * unpack runs to completion on the thread that started it, and
+ * invokes no user code that could start another
+ */
+#if PMIX_C_HAVE__THREAD_LOCAL
+#    define PMIX_BFROP_THREAD_LOCAL _Thread_local
+#elif PMIX_C_HAVE___THREAD
+#    define PMIX_BFROP_THREAD_LOCAL __thread
+#else
+/* no thread-local storage: the counter is shared, so concurrent
+ * operations may over- or under-count each other. The limit still
+ * bounds the recursion of any single operation, which is the point */
+#    define PMIX_BFROP_THREAD_LOCAL
+#endif
 
 /*
  * Internal type corresponding to size_t.  Do not use this in

--- a/src/mca/bfrops/base/bfrop_base_frame.c
+++ b/src/mca/bfrops/base/bfrop_base_frame.c
@@ -55,6 +55,7 @@ pmix_bfrops_globals_t pmix_bfrops_globals = {
     .initialized = false,
     .initial_size = 0,
     .threshold_size = 0,
+    .max_array_depth = PMIX_BFROP_DEFAULT_MAX_ARRAY_DEPTH,
 #if PMIX_ENABLE_DEBUG
     .default_type = PMIX_BFROP_BUFFER_FULLY_DESC
 #else
@@ -81,6 +82,13 @@ static int pmix_bfrop_register(pmix_mca_base_register_flag_t flags)
                                "extending by a smaller value",
                                PMIX_MCA_BASE_VAR_TYPE_SIZE_T,
                                &pmix_bfrops_globals.threshold_size);
+
+    pmix_bfrops_globals.max_array_depth = PMIX_BFROP_DEFAULT_MAX_ARRAY_DEPTH;
+    pmix_mca_base_var_register("pmix", "bfrops", "base", "max_array_depth",
+                               "Maximum depth to which data arrays may be nested inside "
+                               "one another when packed or unpacked (0 = no limit)",
+                               PMIX_MCA_BASE_VAR_TYPE_UNSIGNED_INT,
+                               &pmix_bfrops_globals.max_array_depth);
 
 #if PMIX_ENABLE_DEBUG
     pmix_bfrops_globals.default_type = PMIX_BFROP_BUFFER_FULLY_DESC;

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -35,6 +35,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_show_help.h"
 
 #include "src/mca/bfrops/base/base.h"
 
@@ -818,8 +819,8 @@ pmix_status_t pmix_bfrops_base_pack_pinfo(pmix_pointer_array_t *regtypes, pmix_b
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_pack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
-                                           const void *src, int32_t num_vals, pmix_data_type_t type)
+static pmix_status_t pack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                 const void *src, int32_t num_vals, pmix_data_type_t type)
 {
     pmix_data_array_t *p = (pmix_data_array_t *) src;
     pmix_status_t ret;
@@ -858,6 +859,34 @@ pmix_status_t pmix_bfrops_base_pack_darray(pmix_pointer_array_t *regtypes, pmix_
         }
     }
     return PMIX_SUCCESS;
+}
+
+/* How many arrays the pack running on this thread is nested inside */
+static PMIX_BFROP_THREAD_LOCAL unsigned int array_depth = 0;
+
+/* An array may hold arrays, so packing one recurses - both directly,
+ * when the element type is PMIX_DATA_ARRAY, and through the value and
+ * info packers when it is not. Bound that recursion here, where every
+ * level of nesting of either kind must pass, so that we do not emit a
+ * message our peer will refuse (or that would sink its stack) */
+pmix_status_t pmix_bfrops_base_pack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                           const void *src, int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    if (0 < pmix_bfrops_globals.max_array_depth &&
+        pmix_bfrops_globals.max_array_depth <= array_depth) {
+        pmix_show_help("help-pmix-runtime.txt", "bfrops:array_depth", true,
+                       "pack", (unsigned long) array_depth + 1,
+                       (unsigned long) pmix_bfrops_globals.max_array_depth);
+        return PMIX_ERR_PACK_FAILURE;
+    }
+
+    array_depth++;
+    ret = pack_darray(regtypes, buffer, src, num_vals, type);
+    array_depth--;
+
+    return ret;
 }
 
 pmix_status_t pmix_bfrops_base_pack_rank(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -52,6 +52,10 @@ pmix_status_t pmix_bfrops_base_tma_value_xfer(pmix_value_t *p,
                                               pmix_tma_t *tma);
 
 static inline
+void pmix_bfrops_base_tma_data_array_destruct(pmix_data_array_t *d,
+                                              pmix_tma_t *tma);
+
+static inline
 char* pmix_bfrops_base_tma_buffer_extend(pmix_buffer_t *buffer,
                                          size_t bytes_to_add,
                                          pmix_tma_t *tma)
@@ -2972,9 +2976,32 @@ pmix_status_t pmix_bfrops_base_tma_copy_darray(pmix_data_array_t **dest,
         }
         break;
     }
-    case PMIX_DATA_ARRAY:
-        rc = PMIX_ERR_NOT_SUPPORTED; // don't support iterative arrays
+    case PMIX_DATA_ARRAY: {
+        p->array = pmix_tma_calloc(tma, src->size, sizeof(pmix_data_array_t));
+        if (PMIX_UNLIKELY(NULL == p->array)) {
+            rc = PMIX_ERR_NOMEM;
+            break;
+        }
+        pmix_data_array_t *const pd = (pmix_data_array_t *)p->array;
+        pmix_data_array_t *const sd = (pmix_data_array_t *)src->array;
+        for (size_t n = 0; n < src->size; n++) {
+            pmix_data_array_t *tmp = NULL;
+            rc = pmix_bfrops_base_tma_copy_darray(&tmp, &sd[n], PMIX_DATA_ARRAY, tma);
+            if (PMIX_SUCCESS != rc) {
+                /* release the elements we did copy - tell destruct how
+                 * many of them are actually there before letting it run */
+                p->size = n;
+                pmix_bfrops_base_tma_data_array_destruct(p, tma);
+                break;
+            }
+            /* we want the copied contents, not the descriptor the
+             * recursive call wrapped them in - take ownership of the
+             * former and discard the latter */
+            pd[n] = *tmp;
+            pmix_tma_free(tma, tmp);
+        }
         break;
+    }
     case PMIX_QUERY: {
         p->array = pmix_bfrops_base_tma_query_create(src->size, tma);
         if (PMIX_UNLIKELY(NULL == p->array)) {
@@ -3532,9 +3559,19 @@ void pmix_bfrops_base_tma_data_array_destruct(pmix_data_array_t *d,
         case PMIX_PROC_INFO:
             pmix_bfrops_base_tma_proc_info_free(d->array, d->size, tma);
             break;
-        case PMIX_DATA_ARRAY:
-            pmix_bfrops_base_tma_data_array_destruct(d->array, tma);
+        case PMIX_DATA_ARRAY: {
+            /* an array of this type is empty rather more often than the
+             * others - an unpacked zero-length one never allocates, and
+             * construct zeroes the elements it hands back - so check */
+            if (NULL != d->array) {
+                pmix_data_array_t *const da = (pmix_data_array_t *)d->array;
+                for (size_t n = 0; n < d->size; n++) {
+                    pmix_bfrops_base_tma_data_array_destruct(&da[n], tma);
+                }
+                pmix_tma_free(tma, d->array);
+            }
             break;
+        }
         case PMIX_QUERY:
             pmix_bfrops_base_tma_query_free(d->array, d->size, tma);
             break;
@@ -3642,6 +3679,14 @@ void pmix_bfrops_base_tma_data_array_construct(pmix_data_array_t *p,
 
         } else if (PMIX_QUERY == type) {
             p->array = pmix_bfrops_base_tma_query_create(num, tma);
+
+        } else if (PMIX_DATA_ARRAY == type) {
+            /* an array whose elements are themselves data arrays: the
+             * block holds "num" complete pmix_data_array_t descriptors,
+             * which is what pack, unpack, and print all assume. Zero
+             * them so an element the caller never fills is a valid
+             * empty array (PMIX_UNDEF, size 0) rather than garbage */
+            p->array = pmix_tma_calloc(tma, num, sizeof(pmix_data_array_t));
 
         } else if (PMIX_APP == type) {
             p->array = pmix_bfrops_base_tma_app_create(num, tma);

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -31,6 +31,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_show_help.h"
 
 #include "src/mca/bfrops/base/base.h"
 #include "src/mca/bfrops/bfrops_types.h"
@@ -1182,8 +1183,8 @@ pmix_status_t pmix_bfrops_base_unpack_pinfo(pmix_pointer_array_t *regtypes, pmix
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
-                                             void *dest, int32_t *num_vals, pmix_data_type_t type)
+static pmix_status_t unpack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                   void *dest, int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_data_array_t *ptr;
     int32_t i, n, m;
@@ -1235,6 +1236,34 @@ pmix_status_t pmix_bfrops_base_unpack_darray(pmix_pointer_array_t *regtypes, pmi
         }
     }
     return PMIX_SUCCESS;
+}
+
+/* How many arrays the unpack running on this thread is nested inside */
+static PMIX_BFROP_THREAD_LOCAL unsigned int array_depth = 0;
+
+/* Every level of array nesting - an element type of PMIX_DATA_ARRAY, or
+ * the ordinary array/info/value chain - comes back through here, so this
+ * is where the recursion is bounded. It has to be: a peer describes each
+ * level in a type tag and a size, so a couple of bytes of message buy a
+ * stack frame, and nothing else in the unpacker limits how many */
+pmix_status_t pmix_bfrops_base_unpack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
+                                             void *dest, int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+
+    if (0 < pmix_bfrops_globals.max_array_depth &&
+        pmix_bfrops_globals.max_array_depth <= array_depth) {
+        pmix_show_help("help-pmix-runtime.txt", "bfrops:array_depth", true,
+                       "unpack", (unsigned long) array_depth + 1,
+                       (unsigned long) pmix_bfrops_globals.max_array_depth);
+        return PMIX_ERR_UNPACK_FAILURE;
+    }
+
+    array_depth++;
+    ret = unpack_darray(regtypes, buffer, dest, num_vals, type);
+    array_depth--;
+
+    return ret;
 }
 
 pmix_status_t pmix_bfrops_base_unpack_rank(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,

--- a/src/runtime/help-pmix-runtime.txt
+++ b/src/runtime/help-pmix-runtime.txt
@@ -60,6 +60,20 @@ A received msg header indicates a size that is too large:
 If you believe this msg is legitimate, please increase the
 max msg size via the ptl_base_max_msg_size parameter.
 #
+[bfrops:array_depth]
+A data array is nested more deeply inside other data arrays than
+this PMIx library is willing to %s:
+
+  Depth reached:   %lu
+  Depth limit:     %lu
+
+Each level of nesting costs only a few bytes on the wire but a stack
+frame in the library, so the depth is bounded by default. If your data
+is legitimately this deeply nested, raise the limit with the
+bfrops_base_max_array_depth parameter (0 removes it entirely). Both
+ends of the connection must permit the depth: the sender refuses to
+build the message, and the receiver refuses to interpret it.
+#
 [tool:no-server]
 A call was made to PMIx_tool_connect_to_server, but no information
 was given as to which server the tool should be connected. Accepted

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -991,6 +991,23 @@ class TestDataArrayConversion(unittest.TestCase):
          {'type': pmix.PMIX_INFO,
           'array': [{'key': "foo", 'flags': 0, 'value': INFO_ARRAY_OUT,
                      'val_type': pmix.PMIX_DATA_ARRAY}]}),
+        # an array whose *element type* is itself PMIX_DATA_ARRAY - each
+        # element is a complete array, not a value wrapping one
+        ("darray-of-darrays",
+         {'type': pmix.PMIX_DATA_ARRAY,
+          'array': [{'type': pmix.PMIX_INT, 'array': [1, 2, 3]},
+                    {'type': pmix.PMIX_STRING, 'array': ["abc", "def"]}]},
+         None),
+        # nesting to a second level, and an element array carrying infos
+        ("darray-of-darrays-deep",
+         {'type': pmix.PMIX_DATA_ARRAY,
+          'array': [INFO_ARRAY,
+                    {'type': pmix.PMIX_DATA_ARRAY,
+                     'array': [{'type': pmix.PMIX_SIZE, 'array': [7, 8]}]}]},
+         {'type': pmix.PMIX_DATA_ARRAY,
+          'array': [INFO_ARRAY_OUT,
+                    {'type': pmix.PMIX_DATA_ARRAY,
+                     'array': [{'type': pmix.PMIX_SIZE, 'array': [7, 8]}]}]}),
         ("string", {'type': pmix.PMIX_STRING,
                     'array': ["abc", "def", "efg"]}, None),
         ("bool", {'type': pmix.PMIX_BOOL, 'array': ['False', 'True']},

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+check_PROGRAMS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
 
-TESTS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+TESTS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
 
 client_api_SOURCES = \
         client_api.c
@@ -87,6 +87,12 @@ bfrops_alloc_inherit_SOURCES = \
         bfrops_alloc_inherit.c
 bfrops_alloc_inherit_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 bfrops_alloc_inherit_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+nested_darray_SOURCES = \
+        nested_darray.c
+nested_darray_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+nested_darray_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 gds_fallback_SOURCES = \
@@ -181,4 +187,4 @@ iof_pattern_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern

--- a/test/unit/nested_darray.c
+++ b/test/unit/nested_darray.c
@@ -18,6 +18,9 @@
 #include "include/pmix.h"
 #include "include/pmix_server.h"
 #include "src/include/pmix_globals.h"
+/* for pmix_bfrops_globals.max_array_depth: the depth-cap tests below
+ * need to stand in for a peer that does not share our limit */
+#include "src/mca/bfrops/base/base.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -422,6 +425,208 @@ cleanup:
 }
 
 /* ------------------------------------------------------------------ */
+/* depth cap                                                           */
+/* ------------------------------------------------------------------ */
+
+/* Build a chain of "levels" nested arrays; the innermost one holds
+ * ints, every outer one holds a single array. Packing it takes exactly
+ * "levels" nested trips through the darray packer. */
+static int build_chain(pmix_data_array_t *d, int levels)
+{
+    int *iptr;
+
+    if (1 == levels) {
+        PMIx_Data_array_construct(d, 2, PMIX_INT);
+        if (NULL == d->array) {
+            return 0;
+        }
+        iptr = (int *) d->array;
+        iptr[0] = 7;
+        iptr[1] = 8;
+        return 1;
+    }
+
+    PMIx_Data_array_construct(d, 1, PMIX_DATA_ARRAY);
+    if (NULL == d->array) {
+        return 0;
+    }
+    return build_chain((pmix_data_array_t *) d->array, levels - 1);
+}
+
+/* pack a chain "levels" deep and report what the packer said */
+static pmix_status_t pack_chain(pmix_data_buffer_t *buf, int levels)
+{
+    pmix_data_array_t src;
+    pmix_status_t rc;
+
+    if (!build_chain(&src, levels)) {
+        return PMIX_ERR_NOMEM;
+    }
+    rc = PMIx_Data_pack(NULL, buf, &src, 1, PMIX_DATA_ARRAY);
+    PMIx_Data_array_destruct(&src);
+
+    return rc;
+}
+
+/* Nesting up to the limit has to keep working - the cap is there to
+ * bound a hostile peer, not to break legitimate data. */
+static void test_depth_at_limit_is_accepted(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_data_array_t dst;
+    pmix_status_t rc;
+    int32_t count;
+    int ok = 0;
+
+    memset(&dst, 0, sizeof(dst));
+    PMIx_Data_buffer_construct(&buf);
+
+    rc = pack_chain(&buf, (int) pmix_bfrops_globals.max_array_depth);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    pack at the limit failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &dst, &count, PMIX_DATA_ARRAY);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    unpack at the limit failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+    ok = 1;
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    PMIx_Data_array_destruct(&dst);
+    report("nesting to the depth limit round-trips", ok);
+}
+
+/* One level past the limit is refused at pack time, so we never emit a
+ * message the far side is bound to reject. */
+static void test_depth_past_limit_is_refused_by_pack(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int ok = 0;
+
+    PMIx_Data_buffer_construct(&buf);
+
+    rc = pack_chain(&buf, (int) pmix_bfrops_globals.max_array_depth + 1);
+    if (PMIX_ERR_PACK_FAILURE == rc) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    pack past the limit returned %s\n", PMIx_Error_string(rc));
+    }
+
+    PMIx_Data_buffer_destruct(&buf);
+    report("nesting past the depth limit is refused by pack", ok);
+}
+
+/* The receiving side cannot rely on the sender's limit: a peer that
+ * does not share it - or is not trying to be a peer at all - describes
+ * an arbitrarily deep nest in a handful of bytes. Stand in for one by
+ * lifting the cap just long enough to build the message. */
+static void test_depth_past_limit_is_refused_by_unpack(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_data_array_t dst;
+    unsigned int save;
+    pmix_status_t rc;
+    int32_t count;
+    int ok = 0;
+
+    memset(&dst, 0, sizeof(dst));
+    PMIx_Data_buffer_construct(&buf);
+
+    save = pmix_bfrops_globals.max_array_depth;
+    pmix_bfrops_globals.max_array_depth = save + 8;
+    rc = pack_chain(&buf, (int) save + 3);
+    pmix_bfrops_globals.max_array_depth = save;
+
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    could not build the deep message: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &dst, &count, PMIX_DATA_ARRAY);
+    if (PMIX_ERR_UNPACK_FAILURE == rc) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    unpack of a too-deep message returned %s\n", PMIx_Error_string(rc));
+    }
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    PMIx_Data_array_destruct(&dst);
+    report("nesting past the depth limit is refused by unpack", ok);
+}
+
+/* The limit is what the MCA parameter says it is, including "no limit" */
+static void test_limit_follows_the_parameter(void)
+{
+    pmix_data_buffer_t buf;
+    unsigned int save;
+    pmix_status_t rc;
+    int ok = 1;
+
+    save = pmix_bfrops_globals.max_array_depth;
+
+    /* tightened */
+    pmix_bfrops_globals.max_array_depth = 2;
+    PMIx_Data_buffer_construct(&buf);
+    rc = pack_chain(&buf, 3);
+    PMIx_Data_buffer_destruct(&buf);
+    if (PMIX_ERR_PACK_FAILURE != rc) {
+        fprintf(stdout, "    depth 3 under a limit of 2 returned %s\n", PMIx_Error_string(rc));
+        ok = 0;
+    }
+
+    /* and switched off */
+    pmix_bfrops_globals.max_array_depth = 0;
+    PMIx_Data_buffer_construct(&buf);
+    rc = pack_chain(&buf, 24);
+    PMIx_Data_buffer_destruct(&buf);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    depth 24 with the limit off returned %s\n", PMIx_Error_string(rc));
+        ok = 0;
+    }
+
+    pmix_bfrops_globals.max_array_depth = save;
+    report("the depth limit follows bfrops_base_max_array_depth", ok);
+}
+
+/* The depth counter is incremented and released around each level, so
+ * a refusal must not leave it charged against the next pack. */
+static void test_refusal_does_not_poison_the_buffer(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int i, ok = 1;
+
+    PMIx_Data_buffer_construct(&buf);
+
+    for (i = 0; i < 10; i++) {
+        rc = pack_chain(&buf, (int) pmix_bfrops_globals.max_array_depth + 1);
+        if (PMIX_ERR_PACK_FAILURE != rc) {
+            fprintf(stdout, "    refusal %d returned %s\n", i, PMIx_Error_string(rc));
+            ok = 0;
+            break;
+        }
+        rc = pack_chain(&buf, (int) pmix_bfrops_globals.max_array_depth);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stdout, "    legal pack after refusal %d returned %s\n",
+                    i, PMIx_Error_string(rc));
+            ok = 0;
+            break;
+        }
+    }
+
+    PMIx_Data_buffer_destruct(&buf);
+    report("a refused pack leaves the depth counter uncharged", ok);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -450,6 +655,13 @@ int main(int argc, char **argv)
 
     /* print */
     test_print_value();
+
+    /* depth cap */
+    test_depth_at_limit_is_accepted();
+    test_depth_past_limit_is_refused_by_pack();
+    test_depth_past_limit_is_refused_by_unpack();
+    test_limit_follows_the_parameter();
+    test_refusal_does_not_poison_the_buffer();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 

--- a/test/unit/nested_darray.c
+++ b/test/unit/nested_darray.c
@@ -1,0 +1,459 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for a pmix_data_array_t whose element type is itself
+ * PMIX_DATA_ARRAY. The block holds "size" complete pmix_data_array_t
+ * descriptors, which is what pack, unpack, copy, print, construct, and
+ * destruct must all agree on. Construct used to have no arm for the
+ * type (so unpack failed with PMIX_ERR_NOMEM), copy refused it outright,
+ * and destruct treated the block as a single descriptor.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL,
+    .client_finalized = NULL,
+    .abort = NULL,
+    .fence_nb = NULL,
+    .direct_modex = NULL,
+    .publish = NULL,
+    .lookup = NULL,
+    .unpublish = NULL,
+    .spawn = NULL,
+    .connect = NULL,
+    .disconnect = NULL,
+    .register_events = NULL,
+    .deregister_events = NULL,
+    .notify_event = NULL,
+    .query = NULL,
+    .tool_connected = NULL,
+    .log = NULL,
+    .allocate = NULL,
+    .job_control = NULL,
+    .monitor = NULL,
+    .group = NULL
+};
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* the fixture: an array of two arrays, one of ints and one of strings  */
+/* ------------------------------------------------------------------ */
+
+static int build_fixture(pmix_data_array_t *outer)
+{
+    pmix_data_array_t *elem;
+    int *iptr;
+    char **sptr;
+
+    PMIx_Data_array_construct(outer, 2, PMIX_DATA_ARRAY);
+    if (NULL == outer->array) {
+        fprintf(stdout, "    construct of the outer array returned NULL\n");
+        return 0;
+    }
+    elem = (pmix_data_array_t *) outer->array;
+
+    PMIx_Data_array_construct(&elem[0], 3, PMIX_INT);
+    if (NULL == elem[0].array) {
+        fprintf(stdout, "    construct of element 0 returned NULL\n");
+        return 0;
+    }
+    iptr = (int *) elem[0].array;
+    iptr[0] = 1;
+    iptr[1] = 2;
+    iptr[2] = 3;
+
+    PMIx_Data_array_construct(&elem[1], 2, PMIX_STRING);
+    if (NULL == elem[1].array) {
+        fprintf(stdout, "    construct of element 1 returned NULL\n");
+        return 0;
+    }
+    sptr = (char **) elem[1].array;
+    sptr[0] = strdup("abc");
+    sptr[1] = strdup("def");
+
+    return 1;
+}
+
+static int check_fixture(pmix_data_array_t *outer)
+{
+    pmix_data_array_t *elem;
+    int *iptr;
+    char **sptr;
+
+    if (PMIX_DATA_ARRAY != outer->type || 2 != outer->size || NULL == outer->array) {
+        fprintf(stdout, "    outer array is type %d size %lu array %p\n",
+                (int) outer->type, (unsigned long) outer->size, outer->array);
+        return 0;
+    }
+    elem = (pmix_data_array_t *) outer->array;
+
+    if (PMIX_INT != elem[0].type || 3 != elem[0].size || NULL == elem[0].array) {
+        fprintf(stdout, "    element 0 is type %d size %lu array %p\n",
+                (int) elem[0].type, (unsigned long) elem[0].size, elem[0].array);
+        return 0;
+    }
+    iptr = (int *) elem[0].array;
+    if (1 != iptr[0] || 2 != iptr[1] || 3 != iptr[2]) {
+        fprintf(stdout, "    element 0 holds %d, %d, %d\n", iptr[0], iptr[1], iptr[2]);
+        return 0;
+    }
+
+    if (PMIX_STRING != elem[1].type || 2 != elem[1].size || NULL == elem[1].array) {
+        fprintf(stdout, "    element 1 is type %d size %lu array %p\n",
+                (int) elem[1].type, (unsigned long) elem[1].size, elem[1].array);
+        return 0;
+    }
+    sptr = (char **) elem[1].array;
+    if (NULL == sptr[0] || 0 != strcmp(sptr[0], "abc") ||
+        NULL == sptr[1] || 0 != strcmp(sptr[1], "def")) {
+        fprintf(stdout, "    element 1 holds '%s', '%s'\n",
+                NULL == sptr[0] ? "(null)" : sptr[0],
+                NULL == sptr[1] ? "(null)" : sptr[1]);
+        return 0;
+    }
+
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* construct / destruct                                                */
+/* ------------------------------------------------------------------ */
+
+/* Construct must allocate a block of descriptors, not fall through to
+ * the "unknown type" arm that leaves the array NULL. */
+static void test_construct_allocates(void)
+{
+    pmix_data_array_t d;
+    pmix_data_array_t *elem;
+    size_t n;
+    int ok = 0;
+
+    PMIx_Data_array_construct(&d, 3, PMIX_DATA_ARRAY);
+    if (NULL == d.array) {
+        fprintf(stdout, "    construct left the array NULL\n");
+        goto cleanup;
+    }
+    if (PMIX_DATA_ARRAY != d.type || 3 != d.size) {
+        fprintf(stdout, "    construct recorded type %d size %lu\n",
+                (int) d.type, (unsigned long) d.size);
+        goto cleanup;
+    }
+
+    /* every element must be a valid empty array, so that destructing a
+     * partially filled block is safe */
+    ok = 1;
+    elem = (pmix_data_array_t *) d.array;
+    for (n = 0; n < 3; n++) {
+        if (PMIX_UNDEF != elem[n].type || 0 != elem[n].size || NULL != elem[n].array) {
+            fprintf(stdout, "    element %lu is not empty: type %d size %lu array %p\n",
+                    (unsigned long) n, (int) elem[n].type,
+                    (unsigned long) elem[n].size, elem[n].array);
+            ok = 0;
+            break;
+        }
+    }
+
+cleanup:
+    PMIx_Data_array_destruct(&d);
+    report("construct allocates a block of PMIX_DATA_ARRAY descriptors", ok);
+}
+
+/* Destruct must release the whole block and reset the descriptor. */
+static void test_destruct_resets(void)
+{
+    pmix_data_array_t d;
+    int ok = 0;
+
+    if (!build_fixture(&d)) {
+        goto cleanup;
+    }
+
+    PMIx_Data_array_destruct(&d);
+
+    if (NULL == d.array && 0 == d.size && PMIX_UNDEF == d.type) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    destruct left type %d size %lu array %p\n",
+                (int) d.type, (unsigned long) d.size, d.array);
+    }
+
+cleanup:
+    report("destruct releases the block and resets the descriptor", ok);
+}
+
+/* Build and tear the whole structure down repeatedly. Destruct used to
+ * walk only the first element and never free the block itself, so this
+ * is where a leak or a double free shows up under a memory checker. */
+static void test_construct_destruct_cycles(void)
+{
+    pmix_data_array_t d;
+    int i, ok = 1;
+
+    for (i = 0; i < 1000; i++) {
+        if (!build_fixture(&d)) {
+            ok = 0;
+            break;
+        }
+        if (!check_fixture(&d)) {
+            ok = 0;
+            PMIx_Data_array_destruct(&d);
+            break;
+        }
+        PMIx_Data_array_destruct(&d);
+    }
+
+    report("1000 construct/destruct cycles", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* pack / unpack                                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_pack_unpack_roundtrip(void)
+{
+    pmix_data_array_t src, dst;
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t count;
+    int ok = 0;
+
+    memset(&dst, 0, sizeof(dst));
+    PMIx_Data_buffer_construct(&buf);
+
+    if (!build_fixture(&src)) {
+        goto cleanup;
+    }
+
+    rc = PMIx_Data_pack(NULL, &buf, &src, 1, PMIX_DATA_ARRAY);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    pack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &dst, &count, PMIX_DATA_ARRAY);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    unpack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    ok = check_fixture(&dst);
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    PMIx_Data_array_destruct(&src);
+    PMIx_Data_array_destruct(&dst);
+    report("pack/unpack round-trip", ok);
+}
+
+/* The same trip through a pmix_value_t, which is how a nested array
+ * actually reaches the wire in practice. */
+static void test_pack_unpack_via_value(void)
+{
+    pmix_value_t val;
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t count;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&val);
+    PMIx_Data_buffer_construct(&buf);
+
+    val.type = PMIX_DATA_ARRAY;
+    val.data.darray = (pmix_data_array_t *) malloc(sizeof(pmix_data_array_t));
+    if (NULL == val.data.darray) {
+        goto cleanup;
+    }
+    if (!build_fixture(val.data.darray)) {
+        goto cleanup;
+    }
+
+    rc = PMIx_Data_pack(NULL, &buf, &val, 1, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    pack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    PMIX_VALUE_DESTRUCT(&val);
+    PMIX_VALUE_CONSTRUCT(&val);
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &val, &count, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    unpack failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    if (PMIX_DATA_ARRAY != val.type || NULL == val.data.darray) {
+        fprintf(stdout, "    unpacked value is type %d\n", (int) val.type);
+        goto cleanup;
+    }
+    ok = check_fixture(val.data.darray);
+
+cleanup:
+    PMIx_Data_buffer_destruct(&buf);
+    PMIX_VALUE_DESTRUCT(&val);
+    report("pack/unpack via pmix_value_t", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* copy                                                                */
+/* ------------------------------------------------------------------ */
+
+/* PMIx_Value_xfer used to return PMIX_ERR_NOT_SUPPORTED here. */
+static void test_value_xfer(void)
+{
+    pmix_value_t vsrc, vdst;
+    pmix_data_array_t *sd, *dd;
+    pmix_status_t rc;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&vsrc);
+    PMIX_VALUE_CONSTRUCT(&vdst);
+
+    vsrc.type = PMIX_DATA_ARRAY;
+    vsrc.data.darray = (pmix_data_array_t *) malloc(sizeof(pmix_data_array_t));
+    if (NULL == vsrc.data.darray) {
+        goto cleanup;
+    }
+    if (!build_fixture(vsrc.data.darray)) {
+        goto cleanup;
+    }
+
+    rc = PMIx_Value_xfer(&vdst, &vsrc);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    PMIx_Value_xfer failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    if (PMIX_DATA_ARRAY != vdst.type || NULL == vdst.data.darray) {
+        fprintf(stdout, "    copied value is type %d\n", (int) vdst.type);
+        goto cleanup;
+    }
+    if (!check_fixture(vdst.data.darray)) {
+        goto cleanup;
+    }
+
+    /* it has to be a deep copy: nothing in the copy may alias the
+     * source, or destructing both is a double free */
+    sd = (pmix_data_array_t *) vsrc.data.darray->array;
+    dd = (pmix_data_array_t *) vdst.data.darray->array;
+    if (sd == dd || sd[0].array == dd[0].array || sd[1].array == dd[1].array) {
+        fprintf(stdout, "    copy aliases the source\n");
+        goto cleanup;
+    }
+
+    ok = 1;
+
+cleanup:
+    PMIX_VALUE_DESTRUCT(&vsrc);
+    PMIX_VALUE_DESTRUCT(&vdst);
+    report("PMIx_Value_xfer deep-copies a nested array", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* print                                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_print_value(void)
+{
+    pmix_value_t val;
+    char *output = NULL;
+    pmix_status_t rc;
+    int ok = 0;
+
+    PMIX_VALUE_CONSTRUCT(&val);
+
+    val.type = PMIX_DATA_ARRAY;
+    val.data.darray = (pmix_data_array_t *) malloc(sizeof(pmix_data_array_t));
+    if (NULL == val.data.darray) {
+        goto cleanup;
+    }
+    if (!build_fixture(val.data.darray)) {
+        goto cleanup;
+    }
+
+    rc = PMIx_Data_print(&output, NULL, &val, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "    PMIx_Data_print failed: %s\n", PMIx_Error_string(rc));
+        goto cleanup;
+    }
+
+    /* the outer array and both of its elements must appear */
+    if (NULL != output && '\0' != output[0] &&
+        NULL != strstr(output, "PMIX_DATA_ARRAY") &&
+        NULL != strstr(output, "abc")) {
+        ok = 1;
+    } else {
+        fprintf(stdout, "    print output missing expected content: %s\n",
+                NULL == output ? "(null)" : output);
+    }
+
+cleanup:
+    free(output);
+    PMIX_VALUE_DESTRUCT(&val);
+    report("PMIx_Data_print renders the nested array", ok);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== nested PMIX_DATA_ARRAY unit tests ===\n\n");
+
+    /* construct / destruct */
+    test_construct_allocates();
+    test_destruct_resets();
+    test_construct_destruct_cycles();
+
+    /* pack / unpack */
+    test_pack_unpack_roundtrip();
+    test_pack_unpack_via_value();
+
+    /* copy */
+    test_value_xfer();
+
+    /* print */
+    test_print_value();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #4054.

### Make a nested data array work everywhere, not just in pack

A `pmix_data_array_t` whose element type is `PMIX_DATA_ARRAY` packed and
printed as a contiguous block of `pmix_data_array_t` descriptors — the layout
`pmix_data_array_t.5.rst` describes for an array of any declared type — but
nothing else agreed with those two:

- **construct** had no arm for the type, so it fell through to the "unknown
  type" case and quietly handed back a NULL array. `unpack_darray` constructs
  before filling, so a peer that packed a nested array made the receiver fail
  with `PMIX_ERR_NOMEM` on a machine that was not out of memory.
- **copy** refused the type with `PMIX_ERR_NOT_SUPPORTED`, which is what a
  caller of `PMIx_Value_xfer` saw.
- **destruct** treated the block as a single descriptor regardless of `size`:
  elements past the first were never released, the block itself was never
  freed, and a legitimately empty array dereferenced NULL.

All four now use the documented layout. Construct zeroes the block so an
element the caller never fills is a valid empty array; destruct recurses over
`size` elements and then frees the block.

The Python bindings had invented a third layout — each element's `array`
pointing at one further descriptor, with the element's `size` set to the inner
element count — which lines up with nothing on the C side and made packing a
Python-built nested array read `size` elements out of a one-element
allocation. They now load and unload elements in place, and describe a nested
element with the same `{'type', 'array'}` dict as the enclosing array (which
is what unload already produced; load previously read `{'val_type', 'value'}`,
so the two could not round-trip to each other).

### Bound how deeply data arrays may nest

Unpacking recurses — directly when the element type is `PMIX_DATA_ARRAY`, and
through the value and info unpackers otherwise — and nothing limited how far.
Each level costs the sender about two bytes on the wire but the receiver a
frame of recursion. Measured on an 8MB stack: a chain 100 deep is a 203-byte
message; 50,000 deep (100KB) still unpacks; **60,000 deep (120KB) packs fine
and segfaults the process that unpacks it.**

New `bfrops_base_max_array_depth` MCA parameter, 100 by default, zero meaning
no limit. It is a backstop rather than a judgement about how deep data ought
to be: 100 is far above anything the library or its users have reason to build
(the full test suite never reaches five) and far below the measured cliff.
Exceeding it fails with `PMIX_ERR_PACK_FAILURE` / `PMIX_ERR_UNPACK_FAILURE`
and shows a help topic naming the parameter to raise. Pack enforces the same
limit as unpack so a sender fails where it can act on the failure instead of
emitting a message the far side is bound to reject.

The counter is thread-local rather than a field on `pmix_buffer_t`. Per-buffer
would be the more precise home, but `pmix_buffer_t` is installed under
`$(includedir)/pmix` and can land in a gds shared memory segment — a data array
of `PMIX_BUFFER` gets there through the TMA copy path — which a process built
against a different PMIx may attach to. Per-thread is equivalent in practice: a
pack or unpack runs to completion on the thread that started it and invokes no
user code that could begin another.

### Testing

- New `test/unit/nested_darray.c`, wired into `make check`: construct,
  destruct, 1000 build/tear cycles, pack/unpack bare and through a
  `pmix_value_t`, `PMIx_Value_xfer` with an aliasing check, print, and five
  depth-cap cases including a too-deep message built with the cap lifted to
  stand in for a peer that does not share our limit. Against the unpatched
  library the same binary dies with SIGSEGV.
- Two nested cases added to the bindings' array-conversion table in
  `test/python/test_bindings.py`, which run the C destructor on every pass.
  103/103 pass against a locally built extension.
- Full `make check`: 84 pass, 0 fail. Warning-free under `--enable-devel-check`.
  Docs rebuild clean; man page and news updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)