### PR TITLE
Repair the defects found reviewing src/common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,6 +252,7 @@ test/sshot/mytopo.json
 test/sshot/testcoord
 
 test/unit/client_api
+test/unit/common_api
 test/unit/compress
 test/unit/preg
 test/unit/bfrops_regex2

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -23,6 +23,7 @@ two disagree, the README wins, and please fix this file.
 | `run-python.sh` | The Python bindings |
 | `run-class-tests.sh` | The `src/class` unit suite, in the two configurations nobody develops in (README §11) |
 | `run-client-tests.sh` | The `src/client` API suite with ranks behind different servers (README §12) |
+| `run-common-tests.sh` | The `src/common` role-shared API suite — query/log/job-control/allocation/monitor/IOF across separate servers (README §13) |
 | `swarm-common.sh` | **Sourced, never executed.** `$PMIX_SWARM` naming and the one copy of `cleanup_swarm` |
 
 ## Things that will bite you
@@ -60,6 +61,14 @@ two disagree, the README wins, and please fix this file.
   which you mean; `run-class-tests.sh` is explicit that its ten-node
   stage is only meaningful for the one multi-process program in that
   suite.
+
+- **A PRRTE `--output` qualifier attaches with a colon, not a comma.**
+  `file=NAME:pattern` selects PMIx's `PMIX_IOF_FILE_PATTERN` handling;
+  `file=NAME,pattern` is parsed as a second *directive* and rejected. Worse,
+  omitting the qualifier entirely is not an error — a name containing `%` is
+  then just a stem, and PMIx annotates it the default way. A pattern test
+  that forgets the qualifier passes against any library and proves nothing.
+  See README §13.
 
 - **The build volume outlives your branch.** `pmix-build` persists
   across runs and across checkouts, so a tree in it can be older than

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -30,6 +30,7 @@ is only the nickname.
 | `run-topology.sh` | Runs the **topology + locality** exerciser across real nodes: each rank loads the topology its *local* server published (hwloc shmem, with XML as the fallback) and compares `PMIX_LOCALITY_STRING` with every peer. The only place `src/hwloc` gets a multi-node answer -- on one host every peer is a node-mate, so a single-host run cannot tell a correct result from one that claims everything is local. Same `linux`/`macos` modes. |
 | `run-python.sh` | Runs the **Python bindings**: the standalone unit suite, the connected client/server round-trip, and Python PMIx clients spread across nodes. Same `linux`/`macos` modes. See §10. |
 | `run-client-tests.sh` | Runs the `src/client` API surface across the swarm, so the ranks sit behind **different** PMIx servers. This is the multi-node case for the client library: everything in `src/client` either answers locally or round-trips to a server, and a singleton exercises none of the second half. See §12. |
+| `run-common-tests.sh` | Runs the `src/common` role-shared APIs (query, log, job control, allocation, monitoring, IOF) across the swarm. This is the multi-node case for the shared layer: like `src/client`, almost everything in `src/common` either answers locally or round-trips to a server or host, and the monitor's local/remote split cannot even be entered on one node. See §13. |
 | `run-class-tests.sh` | Runs `test/unit/class` in the two configurations a developer's own `make check` does not cover: **Linux**, and **`--disable-debug`** with default symbol visibility. Deliberately *not* a multi-node test — see §11. |
 | `swarm-common.sh` | Sourced by all seven scripts above: which swarm to drive (`PMIX_SWARM`), how to reach a node, and how to clean one. The three runners each carried their own copy of that once, and the copies drifted. |
 | `python/` | The swarm's own Python clients (`swarm_client.py`, `swarm_group.py`, `swarm_cpuset.py`). |
@@ -84,6 +85,7 @@ docker compose up -d       # start pmix-node1 .. pmix-node10
 ./run-topology.sh linux    # topology handoff + cross-node locality
 ./run-python.sh linux      # Python bindings: units, round-trip, multi-node
 ./run-client-tests.sh linux # src/client APIs across separate PMIx servers
+./run-common-tests.sh linux # src/common role-shared APIs across separate servers
 
 # ---- native macOS (single host) ----
 ./build.sh macos           # native PMIx + PRRTE build under vpath-macos-*
@@ -92,6 +94,7 @@ docker compose up -d       # start pmix-node1 .. pmix-node10
 ./run-topology.sh macos    # single-host topology-handoff smoke
 ./run-python.sh macos      # single-host bindings smoke (most checks SKIP)
 ./run-client-tests.sh macos # single-host client smoke (one server, not the point)
+./run-common-tests.sh macos # single-host common-API smoke (one server)
 ```
 
 Rebuild after editing PMIx: rerun `./build.sh` (incremental). No image rebuild
@@ -630,3 +633,76 @@ connected paths a singleton cannot reach — a real server, real
 `PMIX_PTL_SEND_RECV` round-trips — but with one server it is a regression
 smoke pass, not the multi-server case above. Use it when you have changed
 `src/client` and want a quick answer before spending a swarm run.
+
+
+## 13. The `src/common` API suite (`run-common-tests.sh`)
+
+```
+./run-common-tests.sh linux    # across the swarm: several PMIx servers
+./run-common-tests.sh macos    # natively: one server, a smoke pass
+```
+
+`src/common` holds the public entry points shared by the client, server
+and tool roles — query, log, job control, allocation, session control,
+monitoring, credentials, IOF. Almost every one has the same shape: decide
+whether the request can be answered here, and otherwise pack it and
+round-trip it to a server or hand it up to the host.
+
+[`test/unit/common_api.c`](../../test/unit/common_api.c) covers the first
+half, because a singleton reaches nothing else — with no server,
+`PMIx_Query_info` answers only the two ABI-version keys, `PMIx_Log` falls
+back to the local `plog`, `PMIx_Job_control` and `PMIx_Allocation_request`
+stop at the "am I connected?" check, and `PMIx_Process_monitor` never gets
+as far as its local/remote split. This runner is the second half.
+
+### What spreading the ranks buys
+
+* **Query** — keys the local library does not hold take the full
+  pack → `PMIX_PTL_SEND_RECV` → `query_cbfunc` → results-list path,
+  including the "some of this resolved locally, ask for the rest" split
+  in `pmix_parse_localquery`.
+* **Log** — routes through the *server's* `plog` rather than the client's,
+  which is the only way the `PMIX_ERR_NOT_AVAILABLE` fallback in
+  `log_cbfunc` is ever taken.
+* **Job control and allocation** — reach a host that actually implements
+  them (prte does; `test/simple`'s `simptest` does not, which is why these
+  cannot be `run_*.pl` cases), so the completion path runs against a real
+  answer.
+* **Monitoring** — this is the reason to spread out at all.
+  `pmix_monitor_processing` sorts the requested targets into "local",
+  "remote" or both, and merges `pstat` results with the host's. On one
+  node every target is local, and the remote and mixed branches — where
+  the host upcall and the result merge live — are never entered.
+  `monitor_remote` and `monitor_multi` exist for exactly that.
+* **IOF** — the forwarding path only exists once a server holds the read
+  end of somebody else's stdout. The final case drives a job with
+  `--output "file=DIR/%h/rank%R:pattern"`, which makes `pmix_iof_setup`
+  expand the conversions and open per-rank sinks.
+
+### Two things about the IOF case that will waste your time
+
+**`PATTERN` is a qualifier on the `file` directive, not a directive.**
+It attaches with a colon (`file=NAME:pattern`); comma-separating it is
+rejected outright with "The specified output directive is not
+recognized". And **without** it, a name containing `%` is not an error
+and is not expanded — it is simply a stem with odd characters, and the
+files come out as `%h-rank%R.<nspace>.<rank>.err`. That is correct
+behavior, so a version of this case that omits the qualifier passes
+against any library and proves nothing.
+
+**`%h` names the host that WRITES the file, not the host the rank ran
+on.** For a forwarded stream that is the daemon which received it, so a
+four-rank job spread over two nodes can legitimately put every file under
+one hostname directory. `src/common/pmix_iof.h` documents it that way;
+PRRTE's `--help output` text says "the node the process ran on", which is
+the looser reading. The test therefore asserts only that the conversions
+were expanded at all — no `%` survives in any name — not which host they
+named.
+
+### macOS mode
+
+`./run-common-tests.sh macos` compiles the same clients against the
+in-tree library and runs them under a single local `prterun`. The
+connected query/log/job-control paths are real, but with one server the
+monitor's local/remote split collapses to "all local", so this is a
+regression smoke pass rather than the multi-server case above.

--- a/contrib/dockerswarm/run-common-tests.sh
+++ b/contrib/dockerswarm/run-common-tests.sh
@@ -1,0 +1,344 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Exercise the src/common role-shared APIs against real, *separate* PMIx
+# servers.
+#
+#   ./run-common-tests.sh linux    # in the 10-container swarm
+#                                  #   (requires: ./build.sh && docker compose up -d)
+#   ./run-common-tests.sh macos    # single-host subset natively
+#                                  #   (requires: ./build.sh macos)
+#
+# WHY THIS IS A MULTI-NODE TEST
+#
+# src/common holds the public entry points that are shared by the client,
+# server and tool roles -- query, log, job control, allocation, monitoring,
+# session control, credentials, IOF.  Almost every one of them is the same
+# shape: decide whether the request can be answered here, and if not, pack
+# it and round-trip it to a server (or hand it up to the host).
+# test/unit/common_api.c covers the first half -- what the library resolves
+# or rejects on its own -- because a singleton reaches nothing else: with no
+# server, PMIx_Query_info answers only the two ABI-version keys,
+# PMIx_Log falls back to the local plog, PMIx_Job_control and
+# PMIx_Allocation_request stop at the "am I connected?" check, and
+# PMIx_Process_monitor never gets as far as its local/remote split.
+#
+# This runner is the second half, and putting the ranks on different nodes
+# is what makes it real rather than loopback:
+#
+#   * PMIx_Query_info for keys the local library does not hold takes the
+#     full pack -> PMIX_PTL_SEND_RECV -> query_cbfunc -> results-list path,
+#     including the "partially resolved locally, ask for the rest" split
+#     that pmix_parse_localquery implements.
+#   * PMIx_Log routes through the server's plog rather than the client's,
+#     which is the only way the PMIX_ERR_NOT_AVAILABLE fallback in
+#     log_cbfunc is ever taken.
+#   * PMIx_Job_control and PMIx_Allocation_request reach a host that
+#     actually implements them, so the caddy's completion path -- the one
+#     that used to hand the caller's own directives back as the results --
+#     runs against a real answer.
+#   * The monitor examples are the point of spreading out at all:
+#     pmix_monitor_processing resolves the requested targets into "local",
+#     "remote", or both, and merges pstat results with the host's. On one
+#     node every target is local and the remote and mixed branches -- where
+#     the host upcall and the result merge live -- are never entered.
+#     monitor_remote and monitor_multi exist for exactly that.
+#
+# Prints PASS/FAIL per case and a summary; exits non-zero if anything failed.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+# RUN/ON, cleanup_swarm, swarm_up_or_die and the swarm naming (PMIX_SWARM,
+# NODE, IMAGE, VOLUME) all live in swarm-common.sh.
+. "$(dirname "$0")/swarm-common.sh"
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+# The examples this runner drives.  Each is an ordinary PMIx client that
+# calls one family of src/common entry points, so each one is a live test of
+# the shared layer rather than of the example.
+COMMON_EXAMPLES="${COMMON_EXAMPLES:-log jctrl alloc monitor monitor_multi monitor_remote}"
+
+# See the note in run-client-tests.sh: the PMIx these clients link against
+# must be the one build.sh installed into the shared volume, because they are
+# COMPILED in a throwaway builder container and RUN in the long-lived node
+# containers, and only the volume is the same in both.
+PMIX_PREFIX=/opt/prte/pmix
+
+OUT=""
+WANT=""
+EXTRA=""
+RC=0
+
+# Per-example launch geometry and the marker that says the client got all
+# the way through.  Ranks are always split across at least two nodes so that
+# "the answer is behind a different server" is the normal case rather than a
+# special one.
+#
+#   * monitor_remote and monitor_multi name targets that are deliberately
+#     NOT all on the requesting rank's node, which is the whole point: it is
+#     the only way pmix_monitor_processing's remote and mixed branches run.
+#   * alloc and jctrl need a host that implements allocate/job_control;
+#     prte does, and simptest does not, which is why these cannot be
+#     test/simple cases.
+cm_geom() {
+    HOSTS="node1:2,node2:2"; NP=4
+    WANT='PMIx_Finalize successfully completed'
+    EXTRA=""
+    case "$1" in
+        monitor_remote|monitor_multi)
+            # spread wider so "remote" means something: with ranks on three
+            # nodes a per-node or per-proc target list is guaranteed to
+            # straddle at least two servers
+            HOSTS="node1:2,node2:2,node3:2"; NP=6 ;;
+        alloc)
+            # the allocation request goes up to the scheduler, so keep the
+            # job small and leave the rest of the allocation free
+            HOSTS="node1:2,node2:2"; NP=2 ;;
+    esac
+}
+
+# Launch a client through a transient DVM with the geometry cm_geom picks.
+# --timeout bounds every launch so a genuine hang -- which is what most of
+# the defects this suite guards against actually look like -- surfaces as a
+# failure rather than stalling the suite.
+launch() {
+    local prog="$1"; shift
+    cm_geom "$prog"
+    OUT="$(RUN "prterun --host $HOSTS -np $NP --map-by node $EXTRA --timeout 60 /opt/prte/tests-common/$prog $* 2>&1")"
+    RC=$?
+}
+
+# Judge one launch.  A hang is always a failure; otherwise require the
+# completion marker and the absence of a crash.
+#
+# Deliberately NOT "any line mentioning PMIX_ERR_*": several of these
+# examples ask for things the swarm has no provider for -- alloc asks the
+# scheduler for resources prte will decline, and the monitors ask for
+# per-process statistics that pstat cannot always produce -- and the correct
+# answer there is an error the example prints and carries on from.  What
+# must never happen is a crash, a lost connection, or a client that never
+# reaches PMIx_Finalize.
+judge() {
+    local name="$1" what="$2"
+    if echo "$OUT" | grep -qiE 'time limit for job|timed out|DVM timeout'; then
+        bad "$name: HUNG (hit the launch timeout)"
+        return
+    fi
+    if [ -n "$WANT" ] && ! echo "$OUT" | grep -qiE "$WANT"; then
+        bad "$name: no completion (output: $(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+        return
+    fi
+    if [ "$RC" != 0 ]; then
+        bad "$name: exit $RC (output: $(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+        return
+    fi
+    if echo "$OUT" | grep -qiE 'Segmentation|core dumped|connection refused|: ERROR!'; then
+        bad "$name: $(echo "$OUT" | grep -iE 'Segmentation|core dumped|connection refused|: ERROR!' | head -1)"
+        return
+    fi
+    ok "$name: $what"
+}
+
+########################################################################
+# Linux: the 10-node swarm.
+########################################################################
+
+test_linux() {
+    local ex rc
+
+    swarm_up_or_die
+
+    banner "preflight: install present in shared volume"
+    if RUN 'command -v prterun prte pterm >/dev/null'; then
+        ok "prterun/prte/pterm on PATH"
+    else
+        bad "tools missing -- did ./build.sh run?"; return
+    fi
+
+    if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+        bad "build volume $VOLUME missing -- run ./build.sh first"
+        return
+    fi
+
+    # Same check the other runners make, for the same reason: the nodes are
+    # long-lived containers while the install they read is replaced under
+    # them, so a node that predates the current image runs a different PMIx
+    # than the builder container compiles against.
+    banner "preflight: containers are running the current image"
+    local imgid cimg imgn stalenodes=""
+    imgid=$(docker images --no-trunc --format '{{.ID}}' "$IMAGE" 2>/dev/null | head -1)
+    for imgn in $(seq 1 10); do
+        cimg=$(docker inspect "$NODE$imgn" --format '{{.Image}}' 2>/dev/null)
+        [ "$cimg" = "$imgid" ] || stalenodes="$stalenodes node$imgn"
+    done
+    if [ -z "$stalenodes" ]; then
+        ok "all 10 containers are on the current $IMAGE"
+    else
+        bad "containers predate $IMAGE:$stalenodes"
+        echo "     Recreate them: ${SWARM_ENV}docker compose up -d --force-recreate" >&2
+        return
+    fi
+
+    banner "preflight: PMIx installed in the shared volume"
+    if ON 1 "test -f $PMIX_PREFIX/include/pmix_common.h"; then
+        ok "PMIx headers/libs under $PMIX_PREFIX"
+    else
+        bad "no $PMIX_PREFIX in the volume -- run ./build.sh first"
+        return
+    fi
+
+    banner "build the common-API examples"
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e EXAMPLES="$COMMON_EXAMPLES" \
+        -e PFX="$PMIX_PREFIX" \
+        "$IMAGE" bash -euo pipefail -c '
+            mkdir -p /opt/prte/tests-common
+            for ex in $EXAMPLES; do
+                gcc -O0 -g -o "/opt/prte/tests-common/$ex" "/pmix-src/examples/$ex.c" \
+                    -I"$PFX/include" -I/pmix-src/examples \
+                    -L"$PFX/lib" -lpmix -Wl,-rpath,"$PFX/lib"
+            done
+        '
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        bad "could not build the common-API examples (rc=$rc)"
+        return
+    fi
+    ok "built: $COMMON_EXAMPLES"
+
+    banner "role-shared APIs across separate PMIx servers"
+    for ex in $COMMON_EXAMPLES; do
+        cleanup_swarm
+        if ! RUN "test -x /opt/prte/tests-common/$ex"; then
+            skp "$ex (not built)"; continue
+        fi
+        launch "$ex"
+        case "$ex" in
+            log)      judge "$ex" "PMIx_Log relayed through the local server" ;;
+            jctrl)    judge "$ex" "PMIx_Job_control handed to the host and answered" ;;
+            alloc)    judge "$ex" "PMIx_Allocation_request forwarded to the scheduler" ;;
+            monitor)  judge "$ex" "heartbeat monitoring registered and cancelled" ;;
+            monitor_multi)
+                      judge "$ex" "monitor over several targets on several nodes" ;;
+            monitor_remote)
+                      judge "$ex" "monitor whose targets are behind other servers" ;;
+            *)        judge "$ex" "completed" ;;
+        esac
+        [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] \
+            || bad "$ex: stray prted left behind"
+    done
+
+    # IOF is the other half of src/common that a singleton cannot reach: the
+    # forwarding path only exists once there is a server holding the read
+    # end of somebody else's stdout.  Driving a client with output-to-file
+    # makes pmix_iof_setup name and open the per-rank sinks, which is where
+    # the pattern expansion and the residual/line-splitting logic run.
+    #
+    # The PATTERN qualifier is what selects "the name is mine to compose"
+    # over the default "annotate the stem with nspace and rank". WITHOUT it
+    # a name containing '%' is not an error and not expanded -- it is just a
+    # stem with odd characters in it, and the files come out as
+    # "%h-rank%R.<nspace>.<rank>.err". That is the correct behavior, so the
+    # qualifier has to be here or this case silently tests nothing. Note it
+    # is a QUALIFIER on the file directive ("file=NAME:pattern"), not a
+    # directive of its own -- comma-separating it is rejected outright.
+    #
+    # %h expands to the host of the process WRITING the file, which for a
+    # forwarded stream is the daemon that received it rather than the one
+    # the rank ran on. That is what src/common/pmix_iof.h documents, and it
+    # is why this only asserts that the conversions were expanded at all,
+    # not which host they named.
+    #
+    # The pattern deliberately puts a conversion in the DIRECTORY part
+    # (%h/), because taking the dirname of the raw pattern would create a
+    # directory literally called "%h" and then fail to open the file in the
+    # one the pattern actually named.
+    banner "IOF output-to-file with a pattern, across nodes"
+    cleanup_swarm
+    if RUN 'test -x /opt/prte/tests-common/log'; then
+        OUT="$(RUN 'rm -rf /tmp/iofpat && mkdir -p /tmp/iofpat && prterun --host node1:2,node2:2 -np 4 --map-by node --timeout 60 --output "file=/tmp/iofpat/%h/rank%R:pattern" /opt/prte/tests-common/log 2>&1')"
+        RC=$?
+        if echo "$OUT" | grep -qiE 'time limit for job|timed out'; then
+            bad "iof-pattern: HUNG"
+        elif [ "$RC" != 0 ]; then
+            bad "iof-pattern: exit $RC"
+        elif RUN 'ls /tmp/iofpat/*/rank*.err >/dev/null 2>&1'; then
+            # nothing may be left holding a '%': an unexpanded conversion
+            # anywhere in the name means the walker did not run
+            if RUN 'ls /tmp/iofpat/* | grep -q "%"'; then
+                bad "iof-pattern: conversions left unexpanded ($(RUN 'ls -1 /tmp/iofpat/* 2>&1' | tr '\n' ' '))"
+            else
+                ok "iof-pattern: per-node directory and per-rank files named by the pattern"
+            fi
+        else
+            bad "iof-pattern: no expanded output files ($(RUN 'ls -1R /tmp/iofpat 2>&1' | tr '\n' ' '))"
+        fi
+    else
+        skp "iof-pattern (log not built)"
+    fi
+    cleanup_swarm
+}
+
+########################################################################
+# macOS: natively on this host.  One PMIx server, so the local/remote
+# split in the monitor collapses to "all local" -- but the connected
+# query/log/job-control paths a singleton cannot reach are still real.
+########################################################################
+
+test_macos() {
+    local ex prefix="$root/../build/master"
+
+    [ -d "$prefix" ] || prefix="/opt/prte/pmix"
+
+    banner "native single-host common-API pass"
+    if [ ! -x "$prefix/bin/prterun" ] && ! command -v prterun >/dev/null; then
+        skp "no prterun available -- run ./build.sh macos first"
+        return
+    fi
+
+    mac_isolate "$prefix" 2>/dev/null || true
+
+    for ex in $COMMON_EXAMPLES; do
+        local bin="/tmp/pmix-common-$ex.$$"
+        if ! cc -O0 -g -o "$bin" "$root/examples/$ex.c" \
+                -I"$root/include" -I"$root" \
+                -L"$root/src/.libs" -lpmix -Wl,-rpath,"$root/src/.libs" \
+                >/dev/null 2>&1; then
+            skp "$ex (would not compile against the in-tree library)"
+            continue
+        fi
+        OUT="$(prterun -np 4 --timeout 60 "$bin" 2>&1)"; RC=$?
+        WANT='PMIx_Finalize successfully completed'
+        judge "$ex" "completed against a single local server"
+        rm -f "$bin"
+    done
+
+    mac_done 2>/dev/null || true
+}
+
+case "$mode" in
+    linux) test_linux ;;
+    macos) test_macos ;;
+    *) echo "usage: $0 [linux|macos]" >&2; exit 2 ;;
+esac
+
+banner "summary"
+printf '  %d passed, %d failed, %d skipped\n\n' "$pass" "$fail" "$skip"
+[ "$fail" = 0 ]

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,55 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - A PMIx_Query_info that is outstanding when the connection to the
+   server is lost now returns PMIX_ERR_COMM_FAILURE instead of hanging.
+   The reply handler treated a zero-byte buffer with a bare return, so
+   the blocking form waited forever on a wakeup nobody would send
+ - PMIx_Process_monitor with PMIX_SEND_HEARTBEAT no longer hangs. The
+   non-blocking form sent the beat and returned success without ever
+   invoking the callback the blocking form was waiting on
+ - PMIx_Resource_block no longer completes twice when the host accepts
+   the request. The callback was invoked whether or not the host had
+   taken ownership, so a caller saw two completions - and a blocking
+   caller had its lock woken a second time after it had been destructed
+ - PMIx_Job_control on a server no longer returns the caller's own
+   directives as the operation's results. The caddy carried the
+   directives in the same fields used to stage the host's answer, so a
+   host that returned no info echoed the request back as the reply
+ - PMIx_Data_pack and PMIx_Data_unpack no longer release the peer they
+   looked up before using it. The peer was stored in a caddy whose
+   destructor releases that field, so packing for a process in another
+   namespace freed the peer out from under the pack - and out of the
+   server's client array
+ - A malformed directive value no longer crashes the library. PMIx_Log
+   read PMIX_LOG_SOURCE through the proc member of the value union,
+   PMIx_Query_info read its PMIX_PROCID/PMIX_NSPACE/PMIX_RANK qualifiers
+   the same way, PMIx_Process_monitor read its four target directives as
+   data arrays, and the IOF layer read PMIX_IOF_OUTPUT_TO_FILE and
+   PMIX_IOF_OUTPUT_TO_DIRECTORY as strings - none of them checking the
+   type the caller had actually set. All now return PMIX_ERR_BAD_PARAM
+   or ignore the directive
+ - PMIx_Query_info with a query carrying no keys, and PMIx_IOF_pull with
+   a source count and no source array, are rejected rather than
+   dereferenced
+ - XML-tagged output no longer emits invalid character references. Bytes
+   above 0x7f were read as signed and escaped as "&#-128;" style
+   references
+ - Listing the attributes of a registered function no longer overflows
+   its output buffer. The function name was copied into a fixed-width
+   line with no bound, so a host that registered a long name smashed the
+   stack of anything that listed that level - pmix_info included
+ - The pfexec kill sequence now escalates to SIGKILL as documented. The
+   escalation was conditional on the SIGTERM having failed to be
+   delivered, so a child that received SIGTERM and ignored it was left
+   running - and, having already been removed from the children list,
+   never reaped
+ - PMIx_Register_attributes, PMIx_Get_attribute_string and
+   PMIx_Get_attribute_name now reject a NULL name rather than passing it
+   to strdup or strcasecmp
+ - A reply whose status cannot be unpacked is reported as a failure.
+   Several handlers left the status at success, telling the caller the
+   operation had worked and simply returned no data
  - PMIx_Load_topology(NULL) and PMIx_Get_relative_locality with a NULL
    output pointer no longer segfault - both now return
    PMIX_ERR_BAD_PARAM. The two neighbouring hwloc entry points had

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -189,6 +189,37 @@ add or edit an entry point:
    banner, `#endif` guard comment, or `pmix_output_verbose` label still
    attached. Check that the banner, include-guard comment, and log
    strings actually name *this* file before you commit.
+8. **Never read a `pmix_value_t` union without checking `.type` first.**
+   This is the single most common defect in the directory. The value in a
+   caller-supplied `pmix_info_t` is whatever the application put there, so
+   `directives[n].value.data.proc`, `.data.string` and `.data.darray` are
+   all wild pointers until the type has been confirmed. The August 2026
+   sweep found this in `PMIx_Log` (`PMIX_LOG_SOURCE`), `PMIx_Query_info`
+   (the `PMIX_PROCID`/`PMIX_NSPACE`/`PMIX_RANK` qualifiers),
+   `PMIx_Process_monitor` (all four `PMIX_MONITOR_TARGET_*` directives),
+   `pmix_iof_check_flags` (`PMIX_IOF_OUTPUT_TO_FILE`/`_TO_DIRECTORY`) and
+   `pmix_pfexec` (`PMIX_FORKEXEC_AGENT`) — every one of them a segfault on
+   an ordinary application mistake. For a data array, confirm
+   `PMIX_DATA_ARRAY == value.type` **and** the array's own element type
+   before walking it; `target_array()` in `pmix_monitor.c` is the pattern.
+9. **A completion must happen exactly once, on every path.** The two
+   failure modes are symmetric and both appear here. *Never* — a request
+   that returns without invoking the callback hangs the blocking wrapper
+   forever (`PMIx_Process_monitor` with `PMIX_SEND_HEARTBEAT` did exactly
+   that). *Twice* — an upcall that reports completion itself **and**
+   returns `PMIX_SUCCESS` to say the host will call back delivers two
+   completions, and the second wakes a stack lock the caller has already
+   destructed (`_rbreq` in `pmix_alloc.c` did exactly that). When you hand
+   a request to `pmix_host_server.*`, the return value decides who
+   completes it: `PMIX_SUCCESS` means the host will, anything else
+   (including `PMIX_OPERATION_SUCCEEDED`) means you must.
+10. **Caddy fields you did not set are garbage, not zero.** `PMIX_NEW`
+   allocates with `malloc`, so every field a constructor skips starts as
+   whatever was on the heap. `scon()`/`qcon()` did not initialize
+   `status`, and `chcon()` in `pmix_pfexec.c` did not initialize
+   `exitcode`; all three are fixed, but the rule is general — when you add
+   a field to one of these structs, add it to the constructor in the same
+   change.
 
 ## pfexec-specific hazards
 
@@ -219,6 +250,42 @@ execs — and carries hazards the request files do not:
   (`waitpid(-1, ...)`), not just pfexec's — keep that in mind if you add
   another `waitpid` consumer.
 
+## What the August 2026 sweep changed
+
+A five-round review of this directory landed twenty-odd defects' worth of
+fixes. Three are worth knowing about because they change behavior rather
+than just hardening it:
+
+- **The pfexec kill sequence now always escalates to SIGKILL.** It used to
+  escalate only when the `SIGTERM` had failed to be *delivered*, which is
+  backwards: the case the sequence exists for is a child that receives
+  `SIGTERM` and ignores it, and such a child was left running — and,
+  having already been taken off the `children` list by the kill, never
+  reaped either. Every kill now costs one `timeout_before_sigkill` pause
+  (default 1s, MCA-tunable) before it completes.
+- **A malformed directive is now `PMIX_ERR_BAD_PARAM`, not a crash.** See
+  pitfall 8. Callers that were getting away with a mis-typed
+  `PMIX_LOG_SOURCE` or `PMIX_MONITOR_TARGET_*` now get an error.
+- **`pmix_iof_process_iof` and `process_cache` skip a request with no
+  requestor peer.** `pmix_globals.iof_requests` holds both server-side
+  requests (which have a peer to forward to) and requests a client — or a
+  launcher with an upstream server of its own — registered through
+  `PMIx_IOF_pull`, which do not. The server's push handler walks the whole
+  array, so it used to read through a NULL peer.
+
+### Known, deliberate, not a defect
+
+`wait_signal_callback` in `pmix_pfexec.c` reads
+`pmix_list_get_size(&pmix_pfexec_globals.children)` as an early-out, and it
+runs on `evauxbase` while that list belongs to `evbase`. That is a formal
+data race. It is left alone on purpose: the child is appended to the list
+before the `fork()` that can generate its `SIGCHLD`, so the count cannot be
+stale for a child we care about, and removing the guard would make pfexec
+`waitpid(-1)` on every `SIGCHLD` in a process that currently has no
+children of its own. If you do restructure it, replace the read with a
+counter maintained across all six add/remove sites rather than deleting
+the check.
+
 ## Building and testing
 
 Everything here compiles into `libpmix` with a plain top-level
@@ -234,6 +301,26 @@ caddy/ownership paths — the leaks and use-after-frees this code is prone
 to are exactly the class of bug valgrind catches and a smoke test does
 not. **Do not** run the functional suite against an `--enable-test-build`
 tree (see the top-level guide).
+
+Two suites cover this directory specifically, and they split the same way
+`src/client`'s do:
+
+- [`test/unit/common_api.c`](../../test/unit/common_api.c) — the
+  singleton half. Everything a client can decide or reject without a
+  server: the malformed-directive cases, the locally-resolved queries
+  (repeated 200x so a caddy leak shows up), `PMIx_Data_copy_payload`,
+  the IOF flag parser and XML escaper, and `PMIx_Register_attributes`.
+  Several of its cases segfault against an unfixed library rather than
+  merely failing — which is the point.
+- [`contrib/dockerswarm/run-common-tests.sh`](../../contrib/dockerswarm/run-common-tests.sh)
+  — the connected half. Query/log/job-control/allocation/monitor/IOF with
+  the ranks behind *different* PMIx servers. The monitor cases are the
+  reason it is multi-node at all: `pmix_monitor_processing`'s remote and
+  mixed branches cannot be entered on one node. See README §13 there.
+
+Do not try to grow `common_api.c` into the second list — a test that needs
+a server belongs in the swarm suite or in a `run_*.pl` against
+`test/simple`.
 
 ## When adding or modifying code here
 

--- a/src/common/pmix_alloc.c
+++ b/src/common/pmix_alloc.c
@@ -203,7 +203,12 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request(pmix_alloc_directive_t directi
     pmix_output_verbose(2, pmix_globals.debug_output, "%s pmix:allocate",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
-    /* set the default response */
+    /* set the default response - the caller's pointers are not
+     * screened anywhere else, and this is where we first write
+     * through them */
+    if (NULL == results || NULL == nresults) {
+        return PMIX_ERR_BAD_PARAM;
+    }
     *results = NULL;
     *nresults = 0;
 

--- a/src/common/pmix_alloc.c
+++ b/src/common/pmix_alloc.c
@@ -51,6 +51,11 @@ typedef struct {
 static void acon(pmix_alloc_caddy_t *p)
 {
     PMIX_CONSTRUCT_LOCK(&p->lock);
+    /* objects are malloc'd, not calloc'd - every field gets a value
+     * here even though the one call site fills them all in */
+    p->directive = 0;
+    p->info = NULL;
+    p->ninfo = 0;
     p->results = NULL;
     p->nresults = 0;
     p->cbfunc = NULL;
@@ -409,6 +414,13 @@ typedef struct {
 } pmix_rb_caddy_t;
 static void rbcon(pmix_rb_caddy_t *p)
 {
+    /* see the note in acon() */
+    p->directive = 0;
+    p->block = NULL;
+    p->units = NULL;
+    p->nunits = 0;
+    p->info = NULL;
+    p->ninfo = 0;
     p->cbfunc = NULL;
     p->cbdata = NULL;
 }

--- a/src/common/pmix_alloc.c
+++ b/src/common/pmix_alloc.c
@@ -508,7 +508,18 @@ static void _rbreq(int sd, short args, void *cbdata)
     rc = pmix_host_server.resource_block(&pmix_globals.myid, cd->directive, cd->block,
                                          cd->units, cd->nunits, cd->info, cd->ninfo,
                                          cd->cbfunc, cd->cbdata);
+    if (PMIX_SUCCESS == rc) {
+        /* the host accepted the request and will invoke the callback
+         * itself when it completes - we must not call it as well, or
+         * the caller sees two completions (and a blocking caller has
+         * its lock woken twice, the second time after it has been
+         * destructed) */
+        PMIX_RELEASE(cd);
+        return;
+    }
     if (PMIX_OPERATION_SUCCEEDED == rc) {
+        /* the host completed the operation immediately and will not
+         * call back, so we report the completion ourselves */
         rc = PMIX_SUCCESS;
     }
     if (NULL != cd->cbfunc) {

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -1584,6 +1584,7 @@ request:
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(qry);
+        PMIx_Argv_free(cache);
         return;
     }
     qry->query.nqual = PMIx_Argv_count(cache);
@@ -1602,6 +1603,11 @@ PMIX_EXPORT const char *pmix_attributes_lookup(const char *attr)
 {
     pmix_keyindex_t *const kidx = &pmix_globals.keyindex;
 
+    /* reached from the public PMIx_Get_attribute_string, so the name
+     * is whatever the caller passed */
+    if (NULL == attr) {
+        return NULL;
+    }
     if (NULL == kidx->table) {
         // we haven't been initialized yet - just return the string
         return attr;
@@ -1623,6 +1629,10 @@ PMIX_EXPORT const char *pmix_attributes_reverse_lookup(const char *attrstring)
 {
     pmix_keyindex_t *const kidx = &pmix_globals.keyindex;
 
+    /* reached from the public PMIx_Get_attribute_name */
+    if (NULL == attrstring) {
+        return NULL;
+    }
     if (NULL == kidx->table) {
         // we haven't been initialized yet - just return the string
         return attrstring;
@@ -1644,6 +1654,9 @@ PMIX_EXPORT const pmix_regattr_input_t *pmix_attributes_lookup_term(char *attr)
 {
     pmix_keyindex_t *const kidx = &pmix_globals.keyindex;
 
+    if (NULL == attr) {
+        return NULL;
+    }
     if (NULL == kidx->table) {
         // we haven't been initialized yet - just return the string
         return NULL;
@@ -1708,10 +1721,17 @@ void pmix_attributes_print_attrs(char ***ans, char *function,
     char line[PMIX_PRINT_ATTR_COLUMN_WIDTH], *tmp;
     size_t n, m, len;
 
-    /* print the function */
+    /* Print the function. The name was supplied by whoever registered
+     * it, so it can be longer than the line - truncate rather than run
+     * off the end of the buffer. Two slots are held back for the ':'
+     * and the terminator. */
     memset(line, ' ', PMIX_PRINT_ATTR_COLUMN_WIDTH);
+    len = strlen(function);
+    if ((PMIX_PRINT_ATTR_COLUMN_WIDTH - 2) < len) {
+        len = PMIX_PRINT_ATTR_COLUMN_WIDTH - 2;
+    }
     m = 0;
-    for (n = 0; n < strlen(function); n++) {
+    for (n = 0; n < len; n++) {
         line[m] = function[n];
         ++m;
     }
@@ -1868,8 +1888,15 @@ PMIX_EXPORT char **pmix_attributes_print_attr(char *level, char *function)
     memset(line, '=', PMIX_PRINT_ATTR_COLUMN_WIDTH);
     line[PMIX_PRINT_ATTR_COLUMN_WIDTH - 1] = '\0';
 
-    /* can be comma-delimited list of functions */
+    /* can be comma-delimited list of functions - an empty one splits to
+     * nothing at all, which is not something the walk below survives */
+    if (NULL == function) {
+        return ans;
+    }
     tmp = PMIx_Argv_split(function, ',');
+    if (NULL == tmp) {
+        return ans;
+    }
     for (n = 0; NULL != tmp[n]; n++) {
         PMIX_LIST_FOREACH (fnptr, lst, pmix_attribute_trk_t) {
             if (0 == strcmp(tmp[n], "all") || 0 == strcmp(tmp[n], fnptr->function)) {

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -147,6 +147,12 @@ PMIX_EXPORT pmix_status_t PMIx_Register_attributes(char *function, char *attrs[]
         return PMIX_ERR_INIT;
     }
 
+    /* the function name is compared against, and then duplicated, on
+     * the progress thread - neither survives being handed a NULL */
+    if (NULL == function) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
@@ -1395,6 +1401,7 @@ static void _get_attrs(pmix_list_t *lst, pmix_info_t *info, pmix_list_t *attrs)
                 dptr = pmix_attributes_lookup_term(tptr->attrs[m]);
                 if (NULL == dptr) {
                     PMIX_RELEASE(ip);
+                    PMIx_Argv_free(fns);
                     return;
                 }
                 regarray[m].type = dptr->type;
@@ -1420,9 +1427,13 @@ static void _get_fns(pmix_list_t *lst, char *key, pmix_list_t *attrs)
         ip = PMIX_NEW(pmix_infolist_t);
         tmp = PMIx_Argv_join(fns, ',');
         PMIX_INFO_LOAD(&ip->info, key, tmp, PMIX_STRING);
+        /* the info took its own copy of the joined string */
+        if (NULL != tmp) {
+            free(tmp);
+        }
         pmix_list_append(lst, &ip->super);
-        PMIx_Argv_free(fns);
     }
+    PMIx_Argv_free(fns);
 }
 
 // called from within an event

--- a/src/common/pmix_control.c
+++ b/src/common/pmix_control.c
@@ -89,6 +89,8 @@ static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     PMIX_BFROPS_UNPACK(rc, peer, buf, &results->ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
         PMIX_ERROR_LOG(rc);
+        results->status = rc;
+        results->ninfo = 0;
         goto complete;
     }
     if (0 < results->ninfo) {
@@ -98,6 +100,7 @@ static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         PMIX_BFROPS_UNPACK(rc, peer, buf, results->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            results->status = rc;
             goto complete;
         }
     }
@@ -114,6 +117,8 @@ complete:
     PMIX_RELEASE(cd);
 }
 
+/* completion callback for the blocking form - copies the results out
+ * of the caller's ownership and wakes the waiter */
 static void acb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
                 pmix_release_cbfunc_t release_fn, void *release_cbdata)
 {
@@ -121,9 +126,8 @@ static void acb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbd
     size_t n;
 
     cb->status = status;
-    if (0 < ninfo) {
-        // we ignore the info that was provided as that data belongs
-        // to the original caller
+    if (0 < ninfo && NULL != info) {
+        // the info belongs to whoever called us, so take our own copy
         cb->infocopy = true;
         PMIX_INFO_CREATE(cb->info, ninfo);
         cb->ninfo = ninfo;
@@ -134,12 +138,7 @@ static void acb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbd
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }
-    if (NULL == cb->cbfunc.infofn) {
-        PMIX_WAKEUP_THREAD(&cb->lock);
-    } else {
-        cb->cbfunc.infofn(cb->status, cb->info, cb->ninfo, cb->cbdata,
-                          relcbfunc, (void*)cb);
-    }
+    PMIX_WAKEUP_THREAD(&cb->lock);
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Job_control(const pmix_proc_t targets[], size_t ntargets,
@@ -159,6 +158,14 @@ PMIX_EXPORT pmix_status_t PMIx_Job_control(const pmix_proc_t targets[], size_t n
 
     pmix_output_verbose(2, pmix_globals.debug_output, "%s pmix:job_ctrl",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
+
+    /* set the default response */
+    if (NULL != results) {
+        *results = NULL;
+    }
+    if (NULL != nresults) {
+        *nresults = 0;
+    }
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when
@@ -188,6 +195,24 @@ PMIX_EXPORT pmix_status_t PMIx_Job_control(const pmix_proc_t targets[], size_t n
     return rc;
 }
 
+/* completion callback for the host's job_control operation. The caddy
+ * carries the *caller's directives* in its info field, so those fields
+ * must not be reused to stage the host's answer - doing so echoes the
+ * directives back to the caller as if they were the results whenever
+ * the host returns none. Pass the host's arrays straight through */
+static void jctrl_hostcb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
+                         pmix_release_cbfunc_t release_fn, void *release_cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t *) cbdata;
+
+    if (NULL != cb->cbfunc.infofn) {
+        cb->cbfunc.infofn(status, info, ninfo, cb->cbdata, release_fn, release_cbdata);
+    } else if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+    PMIX_RELEASE(cb);
+}
+
 static void _jctrlnb(int sd, short args, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
@@ -195,7 +220,17 @@ static void _jctrlnb(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     rc = pmix_host_server.job_control(&pmix_globals.myid, cb->procs, cb->nprocs,
-                                      cb->info, cb->ninfo, acb, (void*)cb);
+                                      cb->info, cb->ninfo, jctrl_hostcb, (void*)cb);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        /* the host completed the operation and will not call back */
+        rc = PMIX_SUCCESS;
+        if (NULL != cb->cbfunc.infofn) {
+            cb->cbfunc.infofn(rc, NULL, 0, cb->cbdata, relcbfunc, (void*)cb);
+        } else {
+            PMIX_RELEASE(cb);
+        }
+        return;
+    }
     if (PMIX_SUCCESS != rc) {
         if (NULL != cb->cbfunc.infofn) {
             cb->cbfunc.infofn(rc, NULL, 0, cb->cbdata, relcbfunc, (void*)cb);

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -201,6 +201,11 @@ PMIX_EXPORT pmix_status_t PMIx_Data_pack(const pmix_proc_t *target, pmix_data_bu
             return rc;
         }
         peer = scd.peer;
+        /* the caddy only borrowed the peer - it belongs to the
+         * server's client array - so clear the field before
+         * destructing or the destructor releases a reference we
+         * never took and we go on to pack against freed memory */
+        scd.peer = NULL;
         PMIX_DESTRUCT(&scd);
     } else {
         // if I am a client or tool, then we can only talk to the
@@ -278,6 +283,9 @@ PMIX_EXPORT pmix_status_t PMIx_Data_unpack(const pmix_proc_t *target, pmix_data_
             return rc;
         }
         peer = scd.peer;
+        /* the caddy only borrowed the peer - see the note in
+         * PMIx_Data_pack */
+        scd.peer = NULL;
         PMIX_DESTRUCT(&scd);
     } else {
         // if I am a client or tool, then we can only talk to the
@@ -350,6 +358,10 @@ PMIX_EXPORT pmix_status_t PMIx_Data_copy_payload(pmix_data_buffer_t *dest, pmix_
 
     if (NULL == src) {
         return PMIX_SUCCESS;
+    }
+
+    if (NULL == dest) {
+        return PMIX_ERR_BAD_PARAM;
     }
 
     /* setup the hosts */

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -173,6 +173,12 @@ PMIX_EXPORT pmix_status_t PMIx_Data_pack(const pmix_proc_t *target, pmix_data_bu
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* the buffer is embedded (and its pointers rewritten) below, so
+     * there has to be one */
+    if (NULL == buffer) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     // if the target is a member of my own nspace, then use our own peer
     if (NULL == target ||
         PMIx_Check_nspace(target->nspace, pmix_globals.myid.nspace)) {
@@ -253,6 +259,12 @@ PMIX_EXPORT pmix_status_t PMIx_Data_unpack(const pmix_proc_t *target, pmix_data_
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* the buffer is embedded (and its pointers rewritten) below, so
+     * there has to be one */
+    if (NULL == buffer) {
+        return PMIX_ERR_BAD_PARAM;
     }
 
     // if the target is a member of my own nspace, then use our own peer

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -57,6 +57,14 @@ static void myregcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
 
     PMIX_ACQUIRE_OBJECT(req);
 
+    /* a zero-byte buffer indicates that this recv is being completed
+     * due to a lost connection - say so, rather than reporting the
+     * unpack failure that reading an empty buffer produces */
+    if (PMIX_BUFFER_IS_EMPTY(buf)) {
+        req->status = PMIX_ERR_COMM_FAILURE;
+        goto report;
+    }
+
     /* unpack the return status */
     m = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &req->status, &m, PMIX_STATUS);
@@ -82,6 +90,22 @@ static void myregcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         }
     }
 
+report:
+    if (PMIX_SUCCESS != req->status) {
+        /* the registration did not take, so it must not be left in our
+         * array where it would go on matching incoming IO. myreg's own
+         * error paths do the same, and leave the release to whichever
+         * side owns the request from here */
+        pmix_pointer_array_set_item(&pmix_globals.iof_requests, req->local_id, NULL);
+        if (NULL != req->regcbfunc) {
+            req->regcbfunc(req->status, req->local_id, req->cbdata);
+            PMIX_RELEASE(req);
+        } else {
+            PMIX_WAKEUP_THREAD(&req->lock);
+        }
+        return;
+    }
+
     if (NULL == req->regcbfunc) {
         PMIX_WAKEUP_THREAD(&req->lock);
     } else {
@@ -99,6 +123,14 @@ static void process_cache(int sd, short args, void *cbdata)
     pmix_status_t rc;
     pmix_buffer_t *msg;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    /* a request registered by a client or a launcher that has an
+     * upstream server carries no requestor peer - its IO is delivered
+     * through its own callback when the message arrives, not by
+     * packing one here - so there is nothing for us to forward */
+    if (NULL == req->requestor) {
+        return;
+    }
 
     PMIX_LIST_FOREACH_SAFE (iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
         /* if the channels don't match, then ignore it */
@@ -307,6 +339,12 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
+    /* the sources are copied wholesale below, so there has to be an
+     * array to copy from */
+    if (0 == nprocs || NULL == procs) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     req = PMIX_NEW(pmix_iof_req_t);
     if (NULL == req) {
         return PMIX_ERR_NOMEM;
@@ -370,6 +408,14 @@ static void deregcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
 
     PMIX_ACQUIRE_OBJECT(cd);
 
+    /* a zero-byte buffer indicates that this recv is being completed
+     * due to a lost connection - the local removal already happened in
+     * mydereg, but say what actually became of the request */
+    if (PMIX_BUFFER_IS_EMPTY(buf)) {
+        cd->status = PMIX_ERR_COMM_FAILURE;
+        goto report;
+    }
+
     /* unpack the return status */
     m = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->status, &m, PMIX_STATUS);
@@ -381,6 +427,8 @@ static void deregcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
             cd->status = rc;
         }
     }
+
+report:
 
     pmix_output_verbose(2, pmix_client_globals.iof_output,
                         "pmix:iof_deregister returned status %s",
@@ -1181,16 +1229,23 @@ void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags)
         flags->set = true;
     } else if (PMIX_CHECK_KEY(info, PMIX_IOF_OUTPUT_TO_FILE) ||
                PMIX_CHECK_KEY(info, PMIX_OUTPUT_TO_FILE)) {
-        flags->file = strdup(info->value.data.string);
-        flags->set = true;
-        flags->local_output = true;
-        flags->local_output_given = true;
+        /* the value's type is under the caller's control - a name that
+         * is not a string must be ignored rather than strdup'd from
+         * whatever else shares the union */
+        if (PMIX_STRING == info->value.type && NULL != info->value.data.string) {
+            flags->file = strdup(info->value.data.string);
+            flags->set = true;
+            flags->local_output = true;
+            flags->local_output_given = true;
+        }
     } else if (PMIX_CHECK_KEY(info, PMIX_IOF_OUTPUT_TO_DIRECTORY) ||
                PMIX_CHECK_KEY(info, PMIX_OUTPUT_TO_DIRECTORY)) {
-        flags->directory = strdup(info->value.data.string);
-        flags->set = true;
-        flags->local_output = true;
-        flags->local_output_given = true;
+        if (PMIX_STRING == info->value.type && NULL != info->value.data.string) {
+            flags->directory = strdup(info->value.data.string);
+            flags->set = true;
+            flags->local_output = true;
+            flags->local_output_given = true;
+        }
     } else if (PMIX_CHECK_KEY(info, PMIX_IOF_FILE_ONLY) ||
                PMIX_CHECK_KEY(info, PMIX_OUTPUT_NOCOPY)) {
         flags->nocopy = PMIX_INFO_TRUE(info);
@@ -1234,6 +1289,13 @@ pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels, const pmix_proc_
         }
     }
     if (!match) {
+        return PMIX_SUCCESS;
+    }
+    /* a request registered locally by a client - or by a launcher that
+     * has an upstream server of its own - has no requestor peer to send
+     * to; its IO reaches it through its own callback instead. The
+     * server's request array holds both kinds */
+    if (NULL == req->requestor) {
         return PMIX_SUCCESS;
     }
     /* never forward back to the source! This can happen if the source
@@ -1322,6 +1384,7 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
     pmix_byte_object_t *output;
     size_t offset, j, n, m, bufsize;
     char *buffer, qprint[15], *cptr;
+    unsigned char uc;
     const char *usestring;
     bool bufcopy;
     pmix_cb_t cb2;
@@ -1600,12 +1663,17 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
     if (myflags->xml) {
         bufsize = bo->size;
         for (n = 0; n < bo->size; n++) {
-            if ('&' == bo->bytes[n]) {
+            /* the payload is arbitrary bytes, so it must be read as
+             * unsigned: isprint() is undefined for a negative argument
+             * other than EOF, and a signed byte would be escaped as a
+             * negative character reference that is not valid XML */
+            uc = (unsigned char) bo->bytes[n];
+            if ('&' == uc) {
                 bufsize += 5;
-            } else if ('<' == bo->bytes[n] || '>' == bo->bytes[n]) {
+            } else if ('<' == uc || '>' == uc) {
                 bufsize += 4;
-            } else if (!isprint(bo->bytes[n])) {
-                pmix_snprintf(qprint, 10, "&#%03d;", (int) bo->bytes[n]);
+            } else if (!isprint(uc)) {
+                pmix_snprintf(qprint, sizeof(qprint), "&#%03u;", (unsigned int) uc);
                 bufsize += strlen(qprint);
             }
         }
@@ -1618,29 +1686,31 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
             bufcopy = true;
             m = 0;
             for (n = 0; n < bo->size; n++) {
-                if ('&' == bo->bytes[n]) {
+                /* read unsigned, exactly as the sizing pass above did */
+                uc = (unsigned char) bo->bytes[n];
+                if ('&' == uc) {
                     buffer[m++] = '&';
                     buffer[m++] = 'a';
                     buffer[m++] = 'm';
                     buffer[m++] = 'p';
                     buffer[m++] = ';';
-                } else if ('<' == bo->bytes[n]) {
+                } else if ('<' == uc) {
                     buffer[m++] = '&';
                     buffer[m++] = 'l';
                     buffer[m++] = 't';
                     buffer[m++] = ';';
-                } else if ('>' == bo->bytes[n]) {
+                } else if ('>' == uc) {
                     buffer[m++] = '&';
                     buffer[m++] = 'g';
                     buffer[m++] = 't';
                     buffer[m++] = ';';
-                } else if (!isprint(bo->bytes[n])) {
-                    pmix_snprintf(qprint, 10, "&#%03d;", (int) bo->bytes[n]);
+                } else if (!isprint(uc)) {
+                    pmix_snprintf(qprint, sizeof(qprint), "&#%03u;", (unsigned int) uc);
                     for (j = 0; j < strlen(qprint); j++) {
                         buffer[m++] = qprint[j];
                     }
                 } else {
-                    buffer[m++] = bo->bytes[n];
+                    buffer[m++] = (char) uc;
                 }
             }
             /* the initial bufsize was a worst-case over-estimate used to
@@ -2014,11 +2084,16 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
 void pmix_iof_flush_residuals(void)
 {
     pmix_status_t rc;
-    pmix_iof_residual_t *res;
+    pmix_iof_residual_t *res, *next;
 
-    PMIX_LIST_FOREACH(res, &pmix_server_globals.iof_residuals, pmix_iof_residual_t) {
+    /* drain the list as we go, the way flush_sink_residuals does: a
+     * residual that has been written must not be written again if this
+     * is ever reached twice */
+    PMIX_LIST_FOREACH_SAFE(res, next, &pmix_server_globals.iof_residuals, pmix_iof_residual_t) {
         rc = write_output_line(&res->name, res->channel, &res->flags,
                                res->stream, res->copystdout, res->copystderr, &res->bo);
+        pmix_list_remove_item(&pmix_server_globals.iof_residuals, &res->super);
+        PMIX_RELEASE(res);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             return;

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -190,6 +190,13 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
                     timestamp = time(NULL);
                 }
             } else if (0 == strncmp(directives[n].key, PMIX_LOG_SOURCE, PMIX_MAX_KEYLEN)) {
+                /* the value's type is under the caller's control, so
+                 * confirm it before reading the union as a proc */
+                if (PMIX_PROC != directives[n].value.type ||
+                    NULL == directives[n].value.data.proc) {
+                    PMIX_PROC_FREE(source, 1);
+                    return PMIX_ERR_BAD_PARAM;
+                }
                 memcpy(source, directives[n].value.data.proc, sizeof(pmix_proc_t));
                 found = true;
             }
@@ -223,8 +230,7 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
+            goto senderr;
         }
         if (!PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, PMIX_MINOR_WILDCARD,
                                   PMIX_RELEASE_WILDCARD)) {
@@ -234,8 +240,7 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
-                PMIX_RELEASE(cd);
-                return rc;
+                goto senderr;
             }
         }
         /* pack the number of data entries */
@@ -243,32 +248,28 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
+            goto senderr;
         }
         if (0 < ndata) {
             PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, data, ndata, PMIX_INFO);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
-                PMIX_RELEASE(cd);
-                return rc;
+                goto senderr;
             }
         }
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ndirs, 1, PMIX_SIZE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
+            goto senderr;
         }
         if (0 < ndirs) {
             PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, directives, ndirs, PMIX_INFO);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
-                PMIX_RELEASE(cd);
-                return rc;
+                goto senderr;
             }
         }
 
@@ -277,8 +278,15 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, log_cbfunc, (void *) cd);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(cd);
+            goto senderr;
         }
+        return rc;
+
+senderr:
+        /* the caddy destructor does not free the proc we handed it,
+         * so it must be released explicitly on every error path */
+        PMIX_PROC_FREE(cd->proc, 1);
+        PMIX_RELEASE(cd);
         return rc;
     }
 
@@ -309,7 +317,11 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
             PMIX_RELEASE(cb);
             return PMIX_ERR_NOT_SUPPORTED;
         } else {
-            // no choice but to process locally
+            /* no choice but to process locally - the caddy we built
+             * for the host was never handed to anyone, so release it
+             * (the source proc lives on into the local path) */
+            cb->proc = NULL;
+            PMIX_RELEASE(cb);
             goto local;
         }
         return PMIX_SUCCESS;

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -55,6 +55,15 @@ static void log_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
 
     pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
                         "pmix:log log_cbfunc called");
+
+    /* a zero-byte buffer indicates that this recv is being completed
+     * due to a lost connection - say so, rather than reporting the
+     * unpack failure that reading an empty buffer produces */
+    if (PMIX_BUFFER_IS_EMPTY(buf)) {
+        status = PMIX_ERR_COMM_FAILURE;
+        goto report;
+    }
+
     /* unpack the return status */
     m = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &status, &m, PMIX_STATUS);
@@ -66,6 +75,8 @@ static void log_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         /* call down to process the request */
         status = pmix_plog.log(cd->proc, cd->info, cd->ninfo, cd->directives, cd->ndirs);
     }
+
+report:
     if (NULL != cd->cbfunc.opcbfn) {
         cd->cbfunc.opcbfn(status, cd->cbdata);
     }

--- a/src/common/pmix_monitor.c
+++ b/src/common/pmix_monitor.c
@@ -127,6 +127,35 @@ pmix_status_t PMIx_Process_monitor(const pmix_info_t *monitor, pmix_status_t err
     return rc;
 }
 
+/* The value carried by a target directive comes straight from the
+ * caller, so its type must be confirmed before the union is read as a
+ * data array - a mismatched type would otherwise be dereferenced as a
+ * pointer. An absent array is legal and means "everywhere"; a value
+ * that is not an array of the expected type is a bad parameter. */
+static pmix_status_t target_array(const pmix_info_t *dir,
+                                  pmix_data_type_t type,
+                                  void **array, size_t *sz)
+{
+    *array = NULL;
+    *sz = 0;
+
+    if (PMIX_DATA_ARRAY != dir->value.type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (NULL == dir->value.data.darray ||
+        NULL == dir->value.data.darray->array ||
+        0 == dir->value.data.darray->size) {
+        /* nothing specified - the request covers everything */
+        return PMIX_SUCCESS;
+    }
+    if (type != dir->value.data.darray->type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    *array = dir->value.data.darray->array;
+    *sz = dir->value.data.darray->size;
+    return PMIX_SUCCESS;
+}
+
 static void hostprocess(int sd, short args, void *cbdata)
 {
     pmix_shift_caddy_t *scd = (pmix_shift_caddy_t*)cbdata;
@@ -258,16 +287,18 @@ void pmix_monitor_processing(int sd, short args, void *cbdata)
         }
 
         if (PMIx_Check_key(cb->directives[n].key, PMIX_MONITOR_TARGET_PROCS)) {
+            cb->status = target_array(&cb->directives[n], PMIX_PROC,
+                                      (void**)&procs, &sz);
+            if (PMIX_SUCCESS != cb->status) {
+                goto complete;
+            }
             // if there are no procs specified, then it is all procs everywhere
-            if (NULL == cb->directives[n].value.data.darray ||
-                NULL == cb->directives[n].value.data.darray->array) {
+            if (NULL == procs) {
                 local = true;
                 remote = true;
                 continue;
             }
             // are any of the procs local?
-            procs = (pmix_proc_t*)cb->directives[n].value.data.darray->array;
-            sz = cb->directives[n].value.data.darray->size;
             for (m=0; (!local || !remote) && m < sz; m++) {
                 for (k=0; (!local || !remote) && k < pmix_server_globals.clients.size; k++) {
                     ptr = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, k);
@@ -289,18 +320,23 @@ void pmix_monitor_processing(int sd, short args, void *cbdata)
         }
 
         if (PMIx_Check_key(cb->directives[n].key, PMIX_MONITOR_TARGET_NODES)) {
+            cb->status = target_array(&cb->directives[n], PMIX_STRING,
+                                      (void**)&hostnames, &sz);
+            if (PMIX_SUCCESS != cb->status) {
+                goto complete;
+            }
             // if there are no hosts specified, then it is all hosts everywhere
-            if (NULL == cb->directives[n].value.data.darray ||
-                NULL == cb->directives[n].value.data.darray->array) {
+            if (NULL == hostnames) {
                 local = true;
                 remote = true;
                 continue;
             }
             // is our node included?
-            hostnames = (char**)cb->directives[n].value.data.darray->array;
-            sz = cb->directives[n].value.data.darray->size;
             for (m=0; (!local || !remote) && m < sz; m++) {
                 // see if this node is us
+                if (NULL == hostnames[m]) {
+                    continue;
+                }
                 if (0 == strcmp(hostnames[m], pmix_globals.hostname)) {
                     local = true;
                 } else {
@@ -314,16 +350,18 @@ void pmix_monitor_processing(int sd, short args, void *cbdata)
         }
 
         if (PMIx_Check_key(cb->directives[n].key, PMIX_MONITOR_TARGET_NODEIDS)) {
+            cb->status = target_array(&cb->directives[n], PMIX_UINT32,
+                                      (void**)&nids, &sz);
+            if (PMIX_SUCCESS != cb->status) {
+                goto complete;
+            }
             // if there are no nodeIDs specified, then it is all hosts everywhere
-            if (NULL == cb->directives[n].value.data.darray ||
-                NULL == cb->directives[n].value.data.darray->array) {
+            if (NULL == nids) {
                 local = true;
                 remote = true;
                 continue;
             }
             // is our node included?
-            nids = (uint32_t*)cb->directives[n].value.data.darray->array;
-            sz = cb->directives[n].value.data.darray->size;
             for (m=0; (!local || !remote) && m < sz; m++) {
                 // see if this node is us
                 if (nids[m] == pmix_globals.nodeid) {
@@ -339,20 +377,23 @@ void pmix_monitor_processing(int sd, short args, void *cbdata)
         }
 
         if (PMIx_Check_key(cb->directives[n].key, PMIX_MONITOR_TARGET_PIDS)) {
+            cb->status = target_array(&cb->directives[n], PMIX_NODE_PID,
+                                      (void**)&ppid, &sz);
+            if (PMIX_SUCCESS != cb->status) {
+                goto complete;
+            }
             // if there are no host/pids specified, then it is all host/pids everywhere
-            if (NULL == cb->directives[n].value.data.darray ||
-                NULL == cb->directives[n].value.data.darray->array) {
+            if (NULL == ppid) {
                 local = true;
                 remote = true;
                 continue;
             }
             // is our node included?
-            ppid = (pmix_node_pid_t*)cb->directives[n].value.data.darray->array;
-            sz = cb->directives[n].value.data.darray->size;
             for (m=0; (!local || !remote) && m < sz; m++) {
                 // see if this node is us
                 if (ppid[m].nodeid == pmix_globals.nodeid ||
-                    0 == strcmp(ppid[m].hostname, pmix_globals.hostname)) {
+                    (NULL != ppid[m].hostname &&
+                     0 == strcmp(ppid[m].hostname, pmix_globals.hostname))) {
                     local = true;
                 } else {
                     remote = true;
@@ -400,7 +441,9 @@ void pmix_monitor_processing(int sd, short args, void *cbdata)
         cb->info = results;
         cb->ninfo = sz;
         if (NULL != cb->cbfunc.infofn) {
-            PMIX_RETAIN(cb);
+            /* relcbfunc holds the caddy's only reference and releases
+             * it - retaining here as well would leave the count at one
+             * and leak the caddy along with the results it carries */
             cb->cbfunc.infofn(cb->status, cb->info, cb->ninfo, cb->cbdata,
                               relcbfunc, (void*)cb);
         } else {
@@ -529,6 +572,14 @@ pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pmix_status_t 
         proxy = false;
         for (n=0; n < ndirs; n++) {
             if (PMIx_Check_key(directives[n].key, PMIX_MONITOR_PROXY)) {
+                /* the value's type is under the caller's control, so
+                 * confirm it before reading the union as a proc */
+                if (PMIX_PROC != directives[n].value.type ||
+                    NULL == directives[n].value.data.proc) {
+                    PMIX_PROC_FREE(cb->proc, 1);
+                    PMIX_RELEASE(cb);
+                    return PMIX_ERR_BAD_PARAM;
+                }
                 memcpy(&cb->proc[0], directives[n].value.data.proc, sizeof(pmix_proc_t));
                 proxy = true;
                 break;
@@ -561,9 +612,15 @@ pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pmix_status_t 
         return PMIX_ERR_UNREACH;
     }
 
-    /* if the monitor is PMIX_SEND_HEARTBEAT, then send it */
+    /* if the monitor is PMIX_SEND_HEARTBEAT, then send it. This
+     * completes immediately, but the _nb contract still requires that
+     * we report completion through the callback - without it a
+     * blocking caller waits forever for a wakeup nobody will deliver */
     if (PMIX_CHECK_KEY(monitor, PMIX_SEND_HEARTBEAT)) {
         PMIx_Heartbeat();
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_SUCCESS, NULL, 0, cbdata, NULL, NULL);
+        }
         return PMIX_SUCCESS;
     }
 
@@ -714,6 +771,8 @@ static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     PMIX_BFROPS_UNPACK(rc, peer, buf, &results->ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
         PMIX_ERROR_LOG(rc);
+        results->status = rc;
+        results->ninfo = 0;
         goto complete;
     }
     if (0 < results->ninfo) {
@@ -723,6 +782,7 @@ static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         PMIX_BFROPS_UNPACK(rc, peer, buf, results->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            results->status = rc;
             goto complete;
         }
     }
@@ -760,7 +820,12 @@ static void acb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbd
             PMIX_INFO_XFER(&cb->info[n], &info[n]);
         }
     } else {
+        /* the caddy's info array is the caller's monitor argument, so
+         * both the pointer AND the count must be cleared - dropping
+         * only the pointer hands the caller a NULL array with a
+         * non-zero length */
         cb->info = NULL;
+        cb->ninfo = 0;
     }
 
     if (NULL != release_fn) {

--- a/src/common/pmix_monitor.c
+++ b/src/common/pmix_monitor.c
@@ -96,7 +96,11 @@ pmix_status_t PMIx_Process_monitor(const pmix_info_t *monitor, pmix_status_t err
                         "%s pmix:monitor called",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
-    // init return values
+    // init return values - screen the caller's pointers first, since
+    // this is where we write through them
+    if (NULL == results || NULL == nresults) {
+        return PMIX_ERR_BAD_PARAM;
+    }
     *results = NULL;
     *nresults = 0;
 

--- a/src/common/pmix_pfexec.c
+++ b/src/common/pmix_pfexec.c
@@ -277,7 +277,9 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
     size_t m, k;
     pmix_status_t rc;
     char **argv = NULL, **env = NULL;
-    pmix_nspace_t nspace;
+    /* the completion callback below reports this even on the error
+     * paths that jump there before a namespace has been composed */
+    pmix_nspace_t nspace = {0};
     char basedir[MAXPATHLEN], sock[10];
     pmix_pfexec_child_t *child;
     pmix_rank_info_t *info;
@@ -350,8 +352,24 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
             for (k = 0; k < app->ninfo; k++) {
                 if (PMIX_CHECK_KEY(&app->info[k], PMIX_FORKEXEC_AGENT)) {
                     /* we were given a fork agent - use it. We have to put its
-                     * argv at the beginning of the app argv array */
+                     * argv at the beginning of the app argv array. The value
+                     * comes from the caller, so confirm it really is a string
+                     * before splitting it, and that the split produced
+                     * something - an empty agent leaves us nothing to exec */
+                    if (PMIX_STRING != app->info[k].value.type ||
+                        NULL == app->info[k].value.data.string) {
+                        rc = PMIX_ERR_BAD_PARAM;
+                        goto complete;
+                    }
                     argv = PMIx_Argv_split(app->info[k].value.data.string, ' ');
+                    if (NULL == argv || NULL == argv[0]) {
+                        if (NULL != argv) {
+                            PMIx_Argv_free(argv);
+                            argv = NULL;
+                        }
+                        rc = PMIX_ERR_BAD_PARAM;
+                        goto complete;
+                    }
                     /* add in the argv from the app */
                     for (i = 0; NULL != argv[i]; i++) {
                         PMIx_Argv_prepend_nosize(&app->argv, argv[i]);
@@ -471,6 +489,7 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
 
             rc = fork_proc(app, child, env);
             PMIx_Argv_free(env);
+            env = NULL;
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
@@ -484,6 +503,12 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
     rc = PMIX_SUCCESS;
 
 complete:
+    /* the copy of the app's environment is made per proc and freed once
+     * the fork is done with it - the error paths in between jump here
+     * with it still live */
+    if (NULL != env) {
+        PMIx_Argv_free(env);
+    }
     /* ensure we reset our working directory back to our default location  */
     if (0 != chdir(basedir)) {
         PMIX_ERROR_LOG(PMIX_ERROR);
@@ -609,24 +634,33 @@ static void kill_stage2(int sd, short args, void *cbdata)
                          PMIX_NAME_PRINT(&pmix_globals.myid));
     scd->lock->status = sigproc(scd->child->pid, SIGTERM);
 
-    if (0 != scd->lock->status) {
-        /* wait a little again, then escalate to SIGKILL */
-        kill_pause(scd, kill_stage3);
-        return;
-    }
-
-    kill_finish(scd);
+    /* Wait a little to give the proc a chance to exit cleanly, then
+     * escalate to SIGKILL. The escalation must NOT be conditional on
+     * the SIGTERM having failed to be delivered: the case the sequence
+     * exists for is a child that RECEIVES SIGTERM and ignores it, and
+     * such a child was previously left running forever - and, having
+     * already been taken off the children list here, never reaped
+     * either. A proc that did exit on the SIGTERM simply makes the
+     * SIGKILL a no-op, since sigproc tolerates ESRCH. */
+    kill_pause(scd, kill_stage3);
 }
 
 static void kill_stage3(int sd, short args, void *cbdata)
 {
     pmix_pfexec_signal_caddy_t *scd = (pmix_pfexec_signal_caddy_t *) cbdata;
+    pmix_status_t rc;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     /* issue a SIGKILL */
     pmix_output_verbose(5, pmix_client_globals.spawn_output, "%s SENDING SIGKILL",
                          PMIX_NAME_PRINT(&pmix_globals.myid));
-    scd->lock->status = sigproc(scd->child->pid, SIGKILL);
+    rc = sigproc(scd->child->pid, SIGKILL);
+
+    /* a SIGKILL that lands rescues a SIGTERM that did not, so only
+     * report a failure when neither signal could be delivered */
+    if (0 != scd->lock->status) {
+        scd->lock->status = rc;
+    }
 
     kill_finish(scd);
 }
@@ -914,6 +948,10 @@ static pmix_status_t register_nspace(char *nspace, pmix_setup_caddy_t *fcd)
         }
         str = PMIx_Argv_join(fcd->apps[n].argv, ' ');
         PMIX_INFO_LIST_ADD(rc, tmpinfo, PMIX_APP_ARGV, str, PMIX_STRING);
+        /* the list took its own copy */
+        if (NULL != str) {
+            free(str);
+        }
         /* convert the list into an array */
         PMIX_INFO_LIST_CONVERT(rc, tmpinfo, &darray);
         /* release the list */
@@ -1104,6 +1142,10 @@ static pmix_status_t do_parent(pmix_app_t *app, pmix_pfexec_child_t *child, int 
     }
     if (0 <= child->keepalive[1]) {
         close(child->keepalive[1]);
+        /* mark it closed - the child destructor closes this end too, and
+         * a double close in a multithreaded process can take down an
+         * unrelated descriptor that was opened in between */
+        child->keepalive[1] = -1;
     }
 
     /* Read the child's failure record. A pipe that closes with no data
@@ -1295,6 +1337,10 @@ static void chcon(pmix_pfexec_child_t *p)
     PMIX_LOAD_PROCID(&p->proc, NULL, PMIX_RANK_UNDEF);
     p->pid = 0;
     p->completed = false;
+    /* objects are malloc'd, not calloc'd - a child that completes
+     * through a path that never records an exit status must report
+     * zero, not whatever was on the heap */
+    p->exitcode = 0;
     p->keepalive[0] = -1;
     p->keepalive[1] = -1;
     memset(&p->opts, 0, sizeof(pmix_pfexec_base_io_conf_t));

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -64,8 +64,15 @@ static void query_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
                         "pmix:query cback from server");
 
     /* a zero-byte buffer indicates that this recv is being
-     * completed due to a lost connection */
+     * completed due to a lost connection - report the failure to
+     * the caller and release the caddy. A bare return here both
+     * leaks the caddy and leaves a blocking caller waiting forever
+     * on a wakeup that will never come */
     if (PMIX_BUFFER_IS_EMPTY(buf)) {
+        if (NULL != cd->cbfunc) {
+            cd->cbfunc(PMIX_ERR_COMM_FAILURE, NULL, 0, cd->cbdata, NULL, NULL);
+        }
+        PMIX_RELEASE(cd);
         return;
     }
 
@@ -353,6 +360,12 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
             /* check for request to scan the local node for available
              * servers the caller could connect to */
             } else if (0 == strcmp(queries[n].keys[p], PMIX_QUERY_AVAIL_SERVERS)) {
+                /* that handler takes the caddy from here - discard the
+                 * scratch state we built before handing it off, or the
+                 * fetched values and unresolved queries are leaked */
+                cb.key = NULL;
+                PMIX_DESTRUCT(&cb);
+                PMIX_LIST_DESTRUCT(&unresolved);
                 PMIX_THREADSHIFT(cd, pmix_ptl_base_query_servers);
                 return;
 
@@ -409,6 +422,10 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
 
         if (NULL != cd->cbfunc) {
             cd->cbfunc(cd->status, cd->info, cd->ninfo, cd->cbdata, _local_relcb, cd);
+        } else {
+            /* nobody to hand the answer to - the release-fn only runs
+             * when there is a cbfunc, so clean up here instead */
+            _local_relcb(cd);
         }
         return;
     }
@@ -456,11 +473,15 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
             }
             if (NULL != cd->cbfunc) {
                 cd->cbfunc(rc, cd->info, cd->ninfo, cd->cbdata, _local_relcb, cd);
+            } else {
+                _local_relcb(cd);
             }
         } else {
             /* we have to return the error to the caller */
             if (NULL != cd->cbfunc) {
                 cd->cbfunc(rc, NULL, 0, cd->cbdata, _local_relcb, cd);
+            } else {
+                _local_relcb(cd);
             }
         }
     }
@@ -536,9 +557,15 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
-    /* do a quick check of the qualifiers arrays to ensure
-     * the nqual field has been set */
+    /* check that each query is well-formed before we accept it: the
+     * parser walks the keys array to its NULL terminator, and reads
+     * the procid/nspace/rank qualifiers through the matching member
+     * of the value union - neither is safe on a malformed query */
     for (n = 0; n < nqueries; n++) {
+        if (NULL == queries[n].keys || NULL == queries[n].keys[0]) {
+            /* a query that asks for nothing */
+            return PMIX_ERR_BAD_PARAM;
+        }
         if (NULL != queries[n].qualifiers && 0 == queries[n].nqual) {
             /* look for the info marked as "end" */
             p = 0;
@@ -550,6 +577,23 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
                 return PMIX_ERR_BAD_PARAM;
             }
             queries[n].nqual = p;
+        }
+        for (p = 0; p < queries[n].nqual; p++) {
+            if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_PROCID)) {
+                if (PMIX_PROC != queries[n].qualifiers[p].value.type ||
+                    NULL == queries[n].qualifiers[p].value.data.proc) {
+                    return PMIX_ERR_BAD_PARAM;
+                }
+            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_NSPACE)) {
+                if (PMIX_STRING != queries[n].qualifiers[p].value.type ||
+                    NULL == queries[n].qualifiers[p].value.data.string) {
+                    return PMIX_ERR_BAD_PARAM;
+                }
+            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_RANK)) {
+                if (PMIX_PROC_RANK != queries[n].qualifiers[p].value.type) {
+                    return PMIX_ERR_BAD_PARAM;
+                }
+            }
         }
     }
 

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -498,7 +498,11 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info(pmix_query_t queries[], size_t nquerie
     pmix_query_caddy_t *cd;
     pmix_status_t rc;
 
-    // setup default response
+    // setup default response - screen the caller's pointers first,
+    // since this is where we write through them
+    if (NULL == results || NULL == nresults) {
+        return PMIX_ERR_BAD_PARAM;
+    }
     *results = NULL;
     *nresults = 0;
 

--- a/src/common/pmix_security.c
+++ b/src/common/pmix_security.c
@@ -374,12 +374,20 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cre
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* set the default response */
+    if (NULL != results) {
+        *results = NULL;
+    }
+    if (NULL != nresults) {
+        *nresults = 0;
+    }
+
     PMIX_CONSTRUCT(&cb, pmix_query_caddy_t);
     rc = PMIx_Validate_credential_nb(cred, directives, ndirs, myvalcb, &cb);
     if (PMIX_SUCCESS == rc) {
         PMIX_WAIT_THREAD(&cb.lock);
         rc = cb.status;
-        if (NULL != cb.info) {
+        if (NULL != cb.info && NULL != results && NULL != nresults) {
             *results = cb.info;
             *nresults = cb.ninfo;
             cb.info = NULL;

--- a/src/common/pmix_security.c
+++ b/src/common/pmix_security.c
@@ -143,6 +143,12 @@ PMIX_EXPORT pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t n
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* the credential is written through below, so it has to be there */
+    if (NULL == credential) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    PMIX_BYTE_OBJECT_CONSTRUCT(credential);
+
     PMIX_CONSTRUCT(&cb, pmix_query_caddy_t);
     rc = PMIx_Get_credential_nb(info, ninfo, mycdcb, &cb);
     if (PMIX_SUCCESS == rc) {

--- a/src/common/pmix_session.c
+++ b/src/common/pmix_session.c
@@ -97,6 +97,9 @@ static void ssnctrlcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     PMIX_BFROPS_UNPACK(rc, peer, buf, &results->status, &cnt, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        /* the unpack left the status field untouched, so report the
+         * failure rather than telling the caller it all worked */
+        results->status = rc;
         goto complete;
     }
     if (PMIX_SUCCESS != results->status) {
@@ -108,6 +111,8 @@ static void ssnctrlcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     PMIX_BFROPS_UNPACK(rc, peer, buf, &results->ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
         PMIX_ERROR_LOG(rc);
+        results->status = rc;
+        results->ninfo = 0;
         goto complete;
     }
     if (0 < results->ninfo) {
@@ -116,6 +121,7 @@ static void ssnctrlcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         PMIX_BFROPS_UNPACK(rc, peer, buf, results->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            results->status = rc;
             goto complete;
         }
     }

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -179,6 +179,9 @@ PMIX_EXPORT char *PMIx_Info_directives_string(pmix_info_directives_t directives)
         if (PMIX_INFO_ARRAY_END & directives) {
             PMIx_Argv_append_nosize(&tmp, "END");
         }
+        if (PMIX_INFO_PERSISTENT & directives) {
+            PMIx_Argv_append_nosize(&tmp, "PERSISTENT");
+        }
     }
     if (NULL != tmp) {
         ret = PMIx_Argv_join(tmp, ':');

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -353,6 +353,10 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_iof_req_t, pmix_object_t, iofreqcon, iofreq
 static void scon(pmix_shift_caddy_t *p)
 {
     PMIX_CONSTRUCT_LOCK(&p->lock);
+    /* objects are malloc'd, not calloc'd, so every field must be
+     * given a value here - a caddy whose status is never explicitly
+     * set is otherwise reported to the caller as random garbage */
+    p->status = PMIX_SUCCESS;
     p->codes = NULL;
     p->ncodes = 0;
     p->sessionid = UINT32_MAX;
@@ -532,6 +536,9 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_querylist_t,
 static void qcon(pmix_query_caddy_t *p)
 {
     PMIX_CONSTRUCT_LOCK(&p->lock);
+    /* objects are malloc'd, not calloc'd, so every field must be
+     * given a value here - see the note in scon() */
+    p->status = PMIX_SUCCESS;
     p->host_called = false;
     p->queries = NULL;
     p->nqueries = 0;
@@ -539,6 +546,8 @@ static void qcon(pmix_query_caddy_t *p)
     p->ntargets = 0;
     p->info = NULL;
     p->ninfo = 0;
+    p->dirs = NULL;
+    p->ndirs = 0;
     PMIX_BYTE_OBJECT_CONSTRUCT(&p->bo);
     PMIX_CONSTRUCT(&p->results, pmix_list_t);
     p->nreplies = 0;

--- a/test/simple/simpmonitor.c
+++ b/test/simple/simpmonitor.c
@@ -188,6 +188,36 @@ static int run_monitored(void)
     return 0;
 }
 
+/* The blocking form of PMIx_Process_monitor with PMIX_SEND_HEARTBEAT
+ * used to hang forever: the _nb entry point fired the beat and returned
+ * success without ever invoking the callback, so the blocking wrapper
+ * waited on a lock nobody would wake. This has to run on a connected
+ * client - a singleton is turned away at the "am I connected?" check
+ * long before it reaches the heartbeat branch - and it has to run on the
+ * observer, since the monitored rank must stay silent for the alert to
+ * fire. Returns 0 if the call came back at all. */
+static int send_one_heartbeat(void)
+{
+    pmix_status_t rc;
+    pmix_info_t monitor;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+
+    PMIX_INFO_LOAD(&monitor, PMIX_SEND_HEARTBEAT, NULL, PMIX_POINTER);
+    rc = PMIx_Process_monitor(&monitor, PMIX_SUCCESS, NULL, 0, &results, &nresults);
+    PMIX_INFO_DESTRUCT(&monitor);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(stderr, "Observer %s:%d: HEARTBEAT TEST FAILED - %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        return 1;
+    }
+    fprintf(stderr, "Observer %s:%d: HEARTBEAT TEST PASSED\n", myproc.nspace, myproc.rank);
+    return 0;
+}
+
 /* rank 1: watch for the alert the server raises about rank 0 */
 static int run_observer(void)
 {
@@ -244,6 +274,12 @@ int main(int argc, char **argv)
     if (MONITORED_RANK == (int) myproc.rank) {
         result = run_monitored();
     } else if (OBSERVER_RANK == (int) myproc.rank) {
+        /* the blocking heartbeat call must return before we go on to
+         * wait for the alert - if it hangs, this whole test hangs and
+         * the driver's time limit reports it */
+        if (0 != send_one_heartbeat()) {
+            result = 1;
+        }
         if (0 == wait_for_alert(&alertlock, 30) && alert_source_ok) {
             fprintf(stderr, "Observer %s:%d: MONITOR TEST PASSED\n", myproc.nspace, myproc.rank);
             result = 0;

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -106,6 +106,45 @@ pointers had survived in them:
   library and proves nothing. Both forms are in the test so the
   distinction stays visible.
 
+### `common_api` — the `src/common` regression test
+
+[`common_api.c`](common_api.c) is the same idea one directory over: the
+singleton-side regression suite for [`src/common`](../../src/common), the
+role-shared public API layer. Every case corresponds to a defect from the
+August 2026 review of that directory (see
+[`src/common/AGENTS.md`](../../src/common/AGENTS.md)), and three of them
+**segfault** rather than merely failing against an unfixed library — the
+malformed `PMIX_LOG_SOURCE`, `PMIx_IOF_pull` with a source count and no
+array, and printing the attributes of a function registered under a long
+name. Those run early on purpose: a crash there means the rest never runs,
+which is exactly the signal wanted.
+
+- Malformed directive values, which is the recurring defect in that
+  directory: `PMIX_LOG_SOURCE` read as a proc, the
+  `PMIX_PROCID`/`PMIX_NSPACE`/`PMIX_RANK` query qualifiers read the same
+  way, `PMIX_IOF_OUTPUT_TO_FILE`/`_TO_DIRECTORY` read as strings.
+- `PMIx_Query_info` with no keys at all, and the locally-resolved queries
+  repeated 200 times — including a run with a NULL callback, because the
+  query caddy is released through several different paths depending on
+  how the request was answered and that one used to release it through
+  none.
+- `PMIx_Data_copy_payload` with a NULL destination, and
+  `PMIx_Info_directives_string` for `PMIX_INFO_PERSISTENT`.
+- The IOF XML escaper, fed two high-bit bytes: it asserts they come back
+  as `&#128;`/`&#255;` **and** that no `&#-` appears, so the test states
+  what was actually wrong with the old signed-char output rather than
+  just what the new output happens to be.
+- `PMIx_Register_attributes` with a NULL name, with an over-long name
+  (the stack-overflow case), and the two public attribute lookups with
+  NULL.
+
+The heartbeat hang from that same review is **not** here, because it
+cannot be: a singleton is turned away at the "am I connected?" check long
+before `PMIx_Process_monitor` reaches its heartbeat branch. It lives in
+[`../simple/simpmonitor.c`](../simple/simpmonitor.c) on the observer rank
+instead, driven by `run_monitor.pl`, where a regression is an unbounded
+hang the driver's time limit catches.
+
 **What it cannot cover, and why.** A singleton has no server, so every
 path that round-trips — which is most of `src/client` — short-circuits
 before it starts. `PMIx_Fence` and `PMIx_Commit` return success without
@@ -113,9 +152,10 @@ sending; `PMIx_Get` never leaves the local datastore;
 publish/lookup/spawn/connect all stop at the "am I connected?" check.
 That half of the directory is covered by
 `contrib/dockerswarm/run-client-tests.sh`, which puts the ranks behind
-different PMIx servers. Do not try to grow `client_api.c` into it: a
-test that needs a server belongs in the swarm suite or in a `run_*.pl`
-against `test/simple`.
+different PMIx servers — and, for `src/common`, by
+`contrib/dockerswarm/run-common-tests.sh`. Do not try to grow
+`client_api.c` or `common_api.c` into them: a test that needs a server
+belongs in the swarm suite or in a `run_*.pl` against `test/simple`.
 
 The same short-circuit is why the *parameter* coverage here is uneven,
 and the unevenness is not an oversight. Most entry points run

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,14 +55,20 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
 
-TESTS = client_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
 
 client_api_SOURCES = \
         client_api.c
 client_api_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 client_api_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+common_api_SOURCES = \
+        common_api.c
+common_api_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+common_api_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 compress_SOURCES =  \

--- a/test/unit/common_api.c
+++ b/test/unit/common_api.c
@@ -66,10 +66,36 @@ static void check(int ok, const char *what)
     }
 }
 
+static volatile int opcbcount = 0;
+
 static void opcb(pmix_status_t status, void *cbdata)
 {
     (void) status;
     (void) cbdata;
+    opcbcount++;
+}
+
+/* Spin until the operation's callback has fired.
+ *
+ * This is NOT optional politeness. A caddy holds POINTERS to the
+ * caller's info arrays rather than copies - that is the no-copy rule in
+ * src/common/AGENTS.md, and the contract it rests on is that the caller
+ * keeps its inputs alive until the callback comes back. An accepted
+ * PMIx_Log_nb is thread-shifted, so returning from the calling function
+ * before the callback fires destroys the stack the progress thread is
+ * still reading. It happens to survive on some platforms and does not
+ * on others; ASan calls it what it is, a stack-use-after-return. */
+static int wait_for_op(int target)
+{
+    int spins;
+
+    for (spins = 0; spins < 5000; spins++) {
+        if (opcbcount >= target) {
+            return 1;
+        }
+        usleep(1000);
+    }
+    return 0;
 }
 
 static void infocb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
@@ -109,12 +135,20 @@ static void test_log_bad_source(void)
     check(PMIX_ERR_BAD_PARAM == rc, "bool-valued PMIX_LOG_SOURCE rejected");
     PMIX_INFO_DESTRUCT(&dir);
 
-    /* a well-formed source must still be accepted - the check must not
-     * have made the good case unreachable */
+    /* A well-formed source must still be accepted - the check must not
+     * have made the good case unreachable. This one is ACCEPTED, which
+     * means it is thread-shifted and the library is holding a pointer
+     * to our stack until it calls back, so we have to wait for that
+     * before letting "data" go out of scope. The rejected cases above
+     * need no wait: they never reach a caddy. */
     PMIX_INFO_DESTRUCT(&data);
     PMIX_INFO_LOAD(&data, PMIX_LOG_STDERR, "regression", PMIX_STRING);
+    opcbcount = 0;
     rc = PMIx_Log_nb(&data, 1, NULL, 0, opcb, NULL);
     check(PMIX_ERR_BAD_PARAM != rc, "log with no directives still accepted");
+    if (PMIX_SUCCESS == rc) {
+        check(wait_for_op(1), "accepted log completed its callback");
+    }
     PMIX_INFO_DESTRUCT(&data);
 
     /* an empty data array is a bad parameter, and must be caught before

--- a/test/unit/common_api.c
+++ b/test/unit/common_api.c
@@ -45,6 +45,7 @@
 #include "include/pmix.h"
 #include "src/common/pmix_iof.h"
 #include "src/include/pmix_globals.h"
+#include "src/common/pmix_attributes.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -425,6 +426,11 @@ static void test_register_attributes(void)
 {
     pmix_status_t rc;
     char *attrs[] = {"PMIX_TESTATTR", NULL};
+    /* the printer only reaches the line-building code for attributes it
+     * can find in the dictionary, so this one has to be a real name */
+    char *realattrs[] = {"PMIX_HOSTNAME", NULL};
+    char longname[400];
+    char **lines;
 
     fprintf(stdout, "\n-- PMIx_Register_attributes --\n");
 
@@ -438,6 +444,31 @@ static void test_register_attributes(void)
     check(PMIX_SUCCESS == rc, "named function registered");
     rc = PMIx_Register_attributes("common_api_test_fn", attrs);
     check(PMIX_ERR_REPEAT_ATTR_REGISTRATION == rc, "duplicate registration refused");
+
+    /* A name longer than the printer's fixed line. The printer copied
+     * it into a 141-byte stack buffer with no bound at all, so listing
+     * the host attributes smashed the stack. */
+    memset(longname, 'x', sizeof(longname) - 1);
+    longname[sizeof(longname) - 1] = '\0';
+    rc = PMIx_Register_attributes(longname, realattrs);
+    check(PMIX_SUCCESS == rc, "over-long function name registered");
+
+    lines = pmix_attributes_print_attr(PMIX_HOST_ATTRIBUTES, longname);
+    check(NULL != lines, "over-long function name printed without smashing the stack");
+    if (NULL != lines) {
+        PMIx_Argv_free(lines);
+    }
+
+    /* an empty function list splits to nothing */
+    lines = pmix_attributes_print_attr(PMIX_HOST_ATTRIBUTES, "");
+    check(NULL == lines || NULL != lines, "empty function list survived");
+    if (NULL != lines) {
+        PMIx_Argv_free(lines);
+    }
+
+    /* the public lookups take whatever the caller passed */
+    check(NULL == PMIx_Get_attribute_string(NULL), "PMIx_Get_attribute_string(NULL) safe");
+    check(NULL == PMIx_Get_attribute_name(NULL), "PMIx_Get_attribute_name(NULL) safe");
 }
 
 int main(int argc, char **argv)

--- a/test/unit/common_api.c
+++ b/test/unit/common_api.c
@@ -418,6 +418,28 @@ static void test_iof_xml_escaping(void)
     PMIx_Byte_object_free(out, 1);
 }
 
+/* ------------------------------------------------------------------ */
+/* PMIx_Register_attributes: a function name that is not there         */
+/* ------------------------------------------------------------------ */
+static void test_register_attributes(void)
+{
+    pmix_status_t rc;
+    char *attrs[] = {"PMIX_TESTATTR", NULL};
+
+    fprintf(stdout, "\n-- PMIx_Register_attributes --\n");
+
+    /* the name is compared against and then duplicated on the progress
+     * thread, so a NULL used to reach strdup() */
+    rc = PMIx_Register_attributes(NULL, attrs);
+    check(PMIX_ERR_BAD_PARAM == rc, "NULL function name rejected");
+
+    /* a real registration still works, and is still refused twice */
+    rc = PMIx_Register_attributes("common_api_test_fn", attrs);
+    check(PMIX_SUCCESS == rc, "named function registered");
+    rc = PMIx_Register_attributes("common_api_test_fn", attrs);
+    check(PMIX_ERR_REPEAT_ATTR_REGISTRATION == rc, "duplicate registration refused");
+}
+
 int main(int argc, char **argv)
 {
     pmix_proc_t myproc;
@@ -454,6 +476,7 @@ int main(int argc, char **argv)
     test_iof_bad_params();
     test_iof_flags();
     test_iof_xml_escaping();
+    test_register_attributes();
 
     rc = PMIx_Finalize(NULL, 0);
     if (PMIX_SUCCESS != rc) {

--- a/test/unit/common_api.c
+++ b/test/unit/common_api.c
@@ -420,6 +420,50 @@ static void test_iof_xml_escaping(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* OUT parameters that were written through unchecked                  */
+/* ------------------------------------------------------------------ */
+static void test_out_parameters(void)
+{
+    pmix_status_t rc;
+    pmix_query_t query;
+    pmix_info_t monitor;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    int32_t val = 7;
+
+    fprintf(stdout, "\n-- OUT parameters --\n");
+
+    /* every one of these writes a default through the caller's pointer
+     * as its first act, ahead of any other validation */
+    rc = PMIx_Allocation_request(PMIX_ALLOC_NEW, NULL, 0, NULL, &nresults);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Allocation_request(NULL results) rejected");
+    rc = PMIx_Allocation_request(PMIX_ALLOC_NEW, NULL, 0, &results, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Allocation_request(NULL nresults) rejected");
+
+    PMIX_QUERY_CONSTRUCT(&query);
+    PMIx_Argv_append_nosize(&query.keys, PMIX_QUERY_STABLE_ABI_VERSION);
+    rc = PMIx_Query_info(&query, 1, NULL, &nresults);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Query_info(NULL results) rejected");
+    rc = PMIx_Query_info(&query, 1, &results, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Query_info(NULL nresults) rejected");
+    PMIX_QUERY_DESTRUCT(&query);
+
+    PMIX_INFO_LOAD(&monitor, PMIX_MONITOR_HEARTBEAT, NULL, PMIX_POINTER);
+    rc = PMIx_Process_monitor(&monitor, PMIX_SUCCESS, NULL, 0, NULL, &nresults);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Process_monitor(NULL results) rejected");
+    PMIX_INFO_DESTRUCT(&monitor);
+
+    rc = PMIx_Get_credential(NULL, 0, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Get_credential(NULL credential) rejected");
+
+    /* the data buffer is embedded, and its pointers rewritten, in place */
+    rc = PMIx_Data_pack(NULL, NULL, &val, 1, PMIX_INT32);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Data_pack(NULL buffer) rejected");
+    rc = PMIx_Data_unpack(NULL, NULL, &val, NULL, PMIX_INT32);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Data_unpack(NULL buffer) rejected");
+}
+
+/* ------------------------------------------------------------------ */
 /* PMIx_Register_attributes: a function name that is not there         */
 /* ------------------------------------------------------------------ */
 static void test_register_attributes(void)
@@ -507,6 +551,7 @@ int main(int argc, char **argv)
     test_iof_bad_params();
     test_iof_flags();
     test_iof_xml_escaping();
+    test_out_parameters();
     test_register_attributes();
 
     rc = PMIx_Finalize(NULL, 0);

--- a/test/unit/common_api.c
+++ b/test/unit/common_api.c
@@ -43,6 +43,8 @@
 #include "src/include/pmix_config.h"
 
 #include "include/pmix.h"
+#include "src/common/pmix_iof.h"
+#include "src/include/pmix_globals.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -296,6 +298,126 @@ static void test_directives_string(void)
     free(str);
 }
 
+/* ------------------------------------------------------------------ */
+/* IOF: sources, flags, and the XML escaper                            */
+/* ------------------------------------------------------------------ */
+static void iofcb(size_t iofhdlr, pmix_iof_channel_t channel, pmix_proc_t *source,
+                  pmix_byte_object_t *payload, pmix_info_t info[], size_t ninfo)
+{
+    (void) iofhdlr;
+    (void) channel;
+    (void) source;
+    (void) payload;
+    (void) info;
+    (void) ninfo;
+}
+
+static void test_iof_bad_params(void)
+{
+    pmix_status_t rc;
+    pmix_proc_t proc;
+
+    fprintf(stdout, "\n-- PMIx_IOF_pull, malformed sources --\n");
+
+    /* the sources are copied wholesale into the request, so a count
+     * with no array behind it used to be a memcpy from NULL */
+    rc = PMIx_IOF_pull(NULL, 1, NULL, 0, PMIX_FWD_STDOUT_CHANNEL, iofcb, NULL, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_IOF_pull(NULL sources, 1) rejected");
+
+    rc = PMIx_IOF_pull(NULL, 0, NULL, 0, PMIX_FWD_STDOUT_CHANNEL, iofcb, NULL, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_IOF_pull(no sources) rejected");
+
+    /* stdin is still refused for its own reason, ahead of the above */
+    PMIX_LOAD_PROCID(&proc, "nspace", PMIX_RANK_WILDCARD);
+    rc = PMIx_IOF_pull(&proc, 1, NULL, 0, PMIX_FWD_STDIN_CHANNEL, iofcb, NULL, NULL);
+    check(PMIX_ERR_NOT_SUPPORTED == rc, "PMIx_IOF_pull(stdin) still refused");
+}
+
+static void test_iof_flags(void)
+{
+    pmix_iof_flags_t flags;
+    pmix_info_t info;
+
+    fprintf(stdout, "\n-- pmix_iof_check_flags, malformed output names --\n");
+
+    /* a name that is not a string used to be strdup'd from whatever
+     * else shared the value union */
+    pmix_iof_init_flags(&flags);
+    PMIX_INFO_LOAD(&info, PMIX_IOF_OUTPUT_TO_FILE, NULL, PMIX_BOOL);
+    pmix_iof_check_flags(&info, &flags);
+    check(NULL == flags.file, "bool-valued PMIX_IOF_OUTPUT_TO_FILE ignored");
+    PMIX_INFO_DESTRUCT(&info);
+
+    pmix_iof_init_flags(&flags);
+    PMIX_INFO_LOAD(&info, PMIX_IOF_OUTPUT_TO_DIRECTORY, NULL, PMIX_BOOL);
+    pmix_iof_check_flags(&info, &flags);
+    check(NULL == flags.directory, "bool-valued PMIX_IOF_OUTPUT_TO_DIRECTORY ignored");
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* and a well-formed one is still taken */
+    pmix_iof_init_flags(&flags);
+    PMIX_INFO_LOAD(&info, PMIX_IOF_OUTPUT_TO_FILE, "out", PMIX_STRING);
+    pmix_iof_check_flags(&info, &flags);
+    check(NULL != flags.file && 0 == strcmp(flags.file, "out"),
+          "string-valued PMIX_IOF_OUTPUT_TO_FILE taken");
+    if (NULL != flags.file) {
+        free(flags.file);
+    }
+    PMIX_INFO_DESTRUCT(&info);
+}
+
+static void test_iof_xml_escaping(void)
+{
+    pmix_iof_flags_t flags;
+    pmix_byte_object_t bo, *out;
+    pmix_proc_t name;
+    char payload[6];
+    char *text;
+    int ok;
+
+    fprintf(stdout, "\n-- pmix_iof_prep_output, XML escaping --\n");
+
+    /* '<', '&', '>' are escaped by name; the two high-bit bytes are not
+     * printable and become numeric character references. Reading them
+     * through a signed char - which is what the escaper used to do -
+     * is undefined for isprint() and renders "&#-01;" style references
+     * that are not valid XML at all */
+    payload[0] = '<';
+    payload[1] = '&';
+    payload[2] = '>';
+    payload[3] = (char) 0x80;
+    payload[4] = (char) 0xFF;
+    payload[5] = '\n';
+    bo.bytes = payload;
+    bo.size = sizeof(payload);
+
+    PMIX_LOAD_PROCID(&name, "nspace", 0);
+    pmix_iof_init_flags(&flags);
+    flags.set = true;
+    flags.xml = true;
+
+    out = pmix_iof_prep_output(&name, &flags, PMIX_FWD_STDOUT_CHANNEL, &bo);
+    check(NULL != out && NULL != out->bytes, "prep_output produced XML output");
+    if (NULL == out || NULL == out->bytes) {
+        return;
+    }
+    /* prep_output returns a counted buffer, not a C string */
+    text = (char *) malloc(out->size + 1);
+    memcpy(text, out->bytes, out->size);
+    text[out->size] = '\0';
+
+    check(NULL != strstr(text, "&lt;"), "'<' escaped as &lt;");
+    check(NULL != strstr(text, "&amp;"), "'&' escaped as &amp;");
+    check(NULL != strstr(text, "&gt;"), "'>' escaped as &gt;");
+    check(NULL != strstr(text, "&#128;"), "0x80 escaped as &#128;");
+    check(NULL != strstr(text, "&#255;"), "0xFF escaped as &#255;");
+    ok = (NULL == strstr(text, "&#-"));
+    check(ok, "no negative character references emitted");
+
+    free(text);
+    PMIx_Byte_object_free(out, 1);
+}
+
 int main(int argc, char **argv)
 {
     pmix_proc_t myproc;
@@ -329,6 +451,9 @@ int main(int argc, char **argv)
     test_query_local();
     test_data_bad_params();
     test_directives_string();
+    test_iof_bad_params();
+    test_iof_flags();
+    test_iof_xml_escaping();
 
     rc = PMIx_Finalize(NULL, 0);
     if (PMIX_SUCCESS != rc) {

--- a/test/unit/common_api.c
+++ b/test/unit/common_api.c
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression coverage for defects found reviewing src/common.
+ *
+ * Like test/unit/client_api.c, everything here runs as a singleton - no
+ * server, no launcher - so the whole file is safe under "make check".
+ * That bounds what can be covered to the paths src/common resolves
+ * locally or rejects up front, which is where this round's defects were:
+ *
+ *   1. PMIx_Log_nb read the value of a PMIX_LOG_SOURCE directive through
+ *      the "proc" member of the union without ever checking that the
+ *      caller had actually stored a proc there. Any other type - a
+ *      string, an int - was dereferenced as a pointer.
+ *
+ *   2. PMIx_Query_info_nb accepted a query carrying no keys. The parser
+ *      that runs on the progress thread walks keys[] to its NULL
+ *      terminator, so a NULL array was dereferenced immediately.
+ *
+ *   3. The same parser read the PMIX_PROCID / PMIX_NSPACE / PMIX_RANK
+ *      qualifiers through the matching member of the value union with no
+ *      type check - the same wild dereference as (1).
+ *
+ *   4. PMIx_Data_copy_payload checked its source for NULL but not its
+ *      destination, then embedded the destination buffer regardless.
+ *
+ *   5. PMIx_Info_directives_string never learned about
+ *      PMIX_INFO_PERSISTENT, so a persistent info printed as though the
+ *      flag were not set at all.
+ *
+ * The locally-resolved queries are repeated enough times that a caddy
+ * leak or a reference-count error shows up as growth or a crash rather
+ * than passing quietly - the query caddy is released through several
+ * different paths depending on whether the request was answered locally,
+ * and one of them (a NULL cbfunc) used to release it through none.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define REPEAT 200
+
+static int nfail = 0;
+
+static void check(int ok, const char *what)
+{
+    if (ok) {
+        fprintf(stdout, "  ok    : %s\n", what);
+    } else {
+        fprintf(stdout, "  FAILED: %s\n", what);
+        nfail++;
+    }
+}
+
+static void opcb(pmix_status_t status, void *cbdata)
+{
+    (void) status;
+    (void) cbdata;
+}
+
+static void infocb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
+                   pmix_release_cbfunc_t release_fn, void *release_cbdata)
+{
+    (void) status;
+    (void) info;
+    (void) ninfo;
+    (void) cbdata;
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIx_Log: a PMIX_LOG_SOURCE whose value is not a proc               */
+/* ------------------------------------------------------------------ */
+static void test_log_bad_source(void)
+{
+    pmix_status_t rc;
+    pmix_info_t data, dir;
+
+    fprintf(stdout, "\n-- PMIx_Log_nb, malformed PMIX_LOG_SOURCE --\n");
+
+    PMIX_INFO_LOAD(&data, PMIX_LOG_STDERR, "regression", PMIX_STRING);
+
+    /* a string where a proc belongs: the old code memcpy'd sizeof(proc)
+     * bytes from the string pointer */
+    PMIX_INFO_LOAD(&dir, PMIX_LOG_SOURCE, "not-a-proc", PMIX_STRING);
+    rc = PMIx_Log_nb(&data, 1, &dir, 1, opcb, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "string-valued PMIX_LOG_SOURCE rejected");
+    PMIX_INFO_DESTRUCT(&dir);
+
+    /* an int is just as wrong, and lands on a small non-pointer value */
+    PMIX_INFO_LOAD(&dir, PMIX_LOG_SOURCE, NULL, PMIX_BOOL);
+    rc = PMIx_Log_nb(&data, 1, &dir, 1, opcb, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "bool-valued PMIX_LOG_SOURCE rejected");
+    PMIX_INFO_DESTRUCT(&dir);
+
+    /* a well-formed source must still be accepted - the check must not
+     * have made the good case unreachable */
+    PMIX_INFO_DESTRUCT(&data);
+    PMIX_INFO_LOAD(&data, PMIX_LOG_STDERR, "regression", PMIX_STRING);
+    rc = PMIx_Log_nb(&data, 1, NULL, 0, opcb, NULL);
+    check(PMIX_ERR_BAD_PARAM != rc, "log with no directives still accepted");
+    PMIX_INFO_DESTRUCT(&data);
+
+    /* an empty data array is a bad parameter, and must be caught before
+     * anything is allocated on its behalf */
+    rc = PMIx_Log_nb(NULL, 0, NULL, 0, opcb, NULL);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Log_nb(NULL data) rejected");
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIx_Query_info: malformed queries                                  */
+/* ------------------------------------------------------------------ */
+static void test_query_bad_params(void)
+{
+    pmix_status_t rc;
+    pmix_query_t query;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    char *nokeys[] = {NULL};
+
+    fprintf(stdout, "\n-- PMIx_Query_info, malformed queries --\n");
+
+    /* a query with no keys array at all */
+    PMIX_QUERY_CONSTRUCT(&query);
+    rc = PMIx_Query_info(&query, 1, &results, &nresults);
+    check(PMIX_ERR_BAD_PARAM == rc, "query with NULL keys rejected");
+    PMIX_QUERY_DESTRUCT(&query);
+
+    /* a keys array that is present but empty */
+    PMIX_QUERY_CONSTRUCT(&query);
+    query.keys = nokeys;
+    rc = PMIx_Query_info(&query, 1, &results, &nresults);
+    check(PMIX_ERR_BAD_PARAM == rc, "query with empty keys rejected");
+    query.keys = NULL;
+    PMIX_QUERY_DESTRUCT(&query);
+
+    /* PMIX_PROCID carrying something that is not a proc */
+    PMIX_QUERY_CONSTRUCT(&query);
+    PMIx_Argv_append_nosize(&query.keys, PMIX_QUERY_STABLE_ABI_VERSION);
+    query.nqual = 1;
+    PMIX_INFO_CREATE(query.qualifiers, 1);
+    PMIX_INFO_LOAD(&query.qualifiers[0], PMIX_PROCID, "not-a-proc", PMIX_STRING);
+    rc = PMIx_Query_info(&query, 1, &results, &nresults);
+    check(PMIX_ERR_BAD_PARAM == rc, "string-valued PMIX_PROCID qualifier rejected");
+    PMIX_QUERY_DESTRUCT(&query);
+
+    /* PMIX_NSPACE carrying something that is not a string */
+    PMIX_QUERY_CONSTRUCT(&query);
+    PMIx_Argv_append_nosize(&query.keys, PMIX_QUERY_STABLE_ABI_VERSION);
+    query.nqual = 1;
+    PMIX_INFO_CREATE(query.qualifiers, 1);
+    PMIX_INFO_LOAD(&query.qualifiers[0], PMIX_NSPACE, NULL, PMIX_BOOL);
+    rc = PMIx_Query_info(&query, 1, &results, &nresults);
+    check(PMIX_ERR_BAD_PARAM == rc, "bool-valued PMIX_NSPACE qualifier rejected");
+    PMIX_QUERY_DESTRUCT(&query);
+
+    /* PMIX_RANK carrying something that is not a rank */
+    PMIX_QUERY_CONSTRUCT(&query);
+    PMIx_Argv_append_nosize(&query.keys, PMIX_QUERY_STABLE_ABI_VERSION);
+    query.nqual = 1;
+    PMIX_INFO_CREATE(query.qualifiers, 1);
+    PMIX_INFO_LOAD(&query.qualifiers[0], PMIX_RANK, "not-a-rank", PMIX_STRING);
+    rc = PMIx_Query_info(&query, 1, &results, &nresults);
+    check(PMIX_ERR_BAD_PARAM == rc, "string-valued PMIX_RANK qualifier rejected");
+    PMIX_QUERY_DESTRUCT(&query);
+
+    /* zero queries is still a bad parameter */
+    rc = PMIx_Query_info(NULL, 0, &results, &nresults);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIx_Query_info(NULL queries) rejected");
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIx_Query_info: the locally-resolved path, repeatedly              */
+/* ------------------------------------------------------------------ */
+static void test_query_local(void)
+{
+    pmix_status_t rc;
+    pmix_query_t query;
+    pmix_info_t *results;
+    size_t nresults;
+    int i, good = 0;
+
+    fprintf(stdout, "\n-- PMIx_Query_info, locally resolved --\n");
+
+    for (i = 0; i < REPEAT; i++) {
+        PMIX_QUERY_CONSTRUCT(&query);
+        PMIx_Argv_append_nosize(&query.keys, PMIX_QUERY_STABLE_ABI_VERSION);
+        results = NULL;
+        nresults = 0;
+        rc = PMIx_Query_info(&query, 1, &results, &nresults);
+        if (PMIX_SUCCESS == rc && 0 < nresults && NULL != results) {
+            good++;
+        }
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+        }
+        PMIX_QUERY_DESTRUCT(&query);
+    }
+    check(REPEAT == good, "ABI-version query answered locally every time");
+
+    /* the same request with no callback at all: the caddy and everything
+     * it built have to be released by the handler itself, since the
+     * release function only ever runs by way of a callback */
+    for (i = 0; i < REPEAT; i++) {
+        PMIX_QUERY_CONSTRUCT(&query);
+        PMIx_Argv_append_nosize(&query.keys, PMIX_QUERY_PROVISIONAL_ABI_VERSION);
+        rc = PMIx_Query_info_nb(&query, 1, NULL, NULL);
+        PMIX_QUERY_DESTRUCT(&query);
+        if (PMIX_SUCCESS != rc) {
+            break;
+        }
+    }
+    check(PMIX_SUCCESS == rc, "locally-resolved query with a NULL cbfunc accepted");
+    /* let the progress thread drain those before we tear down */
+    usleep(200000);
+
+    /* and with a callback, to keep the ordinary path exercised too */
+    PMIX_QUERY_CONSTRUCT(&query);
+    PMIx_Argv_append_nosize(&query.keys, PMIX_QUERY_STABLE_ABI_VERSION);
+    rc = PMIx_Query_info_nb(&query, 1, infocb, NULL);
+    check(PMIX_SUCCESS == rc, "locally-resolved query with a cbfunc accepted");
+    PMIX_QUERY_DESTRUCT(&query);
+    usleep(200000);
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIx_Data_copy_payload: a NULL destination                          */
+/* ------------------------------------------------------------------ */
+static void test_data_bad_params(void)
+{
+    pmix_status_t rc;
+    pmix_data_buffer_t src, dst;
+    int32_t val = 42;
+
+    fprintf(stdout, "\n-- PMIx_Data_copy_payload, missing buffers --\n");
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&src);
+    rc = PMIx_Data_pack(NULL, &src, &val, 1, PMIX_INT32);
+    check(PMIX_SUCCESS == rc, "packed a value for our own peer");
+
+    /* a NULL source is defined to be a no-op */
+    rc = PMIx_Data_copy_payload(&src, NULL);
+    check(PMIX_SUCCESS == rc, "NULL source is a no-op");
+
+    /* a NULL destination used to be embedded anyway */
+    rc = PMIx_Data_copy_payload(NULL, &src);
+    check(PMIX_ERR_BAD_PARAM == rc, "NULL destination rejected");
+
+    /* and the real thing still works */
+    PMIX_DATA_BUFFER_CONSTRUCT(&dst);
+    rc = PMIx_Data_copy_payload(&dst, &src);
+    check(PMIX_SUCCESS == rc, "payload copied between two buffers");
+    PMIX_DATA_BUFFER_DESTRUCT(&dst);
+    PMIX_DATA_BUFFER_DESTRUCT(&src);
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIx_Info_directives_string: every flag it is asked to render       */
+/* ------------------------------------------------------------------ */
+static void test_directives_string(void)
+{
+    char *str;
+
+    fprintf(stdout, "\n-- PMIx_Info_directives_string --\n");
+
+    str = PMIx_Info_directives_string(PMIX_INFO_REQD);
+    check(NULL != str && NULL != strstr(str, "REQUIRED"), "REQD renders as REQUIRED");
+    free(str);
+
+    str = PMIx_Info_directives_string(PMIX_INFO_QUALIFIER);
+    check(NULL != str && NULL != strstr(str, "QUALIFIER"), "QUALIFIER renders");
+    free(str);
+
+    /* PMIX_INFO_PERSISTENT was added to the header without being added
+     * here, so a persistent info printed as a plain optional one */
+    str = PMIx_Info_directives_string(PMIX_INFO_PERSISTENT);
+    check(NULL != str && NULL != strstr(str, "PERSISTENT"), "PERSISTENT renders");
+    free(str);
+
+    str = PMIx_Info_directives_string(PMIX_INFO_REQD | PMIX_INFO_PERSISTENT);
+    check(NULL != str && NULL != strstr(str, "REQUIRED") && NULL != strstr(str, "PERSISTENT"),
+          "REQD|PERSISTENT renders both");
+    free(str);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc;
+    pmix_status_t rc;
+    (void) argc;
+    (void) argv;
+
+    /* force the singleton path - nothing to connect to, so each API call
+     * either resolves locally or is rejected up front */
+    unsetenv("PMIX_NAMESPACE");
+    unsetenv("PMIX_RANK");
+    unsetenv("PMIX_SERVER_URI");
+    unsetenv("PMIX_SERVER_URI2");
+    unsetenv("PMIX_SERVER_URI3");
+    unsetenv("PMIX_SERVER_URI21");
+    unsetenv("PMIX_SERVER_URI41");
+    unsetenv("PMIX_SERVER_URI51");
+
+    fprintf(stdout, "\n=== src/common API regression test ===\n");
+
+    /* a singleton reports PMIX_ERR_UNREACH from init - it is fully
+     * initialized, it just has no server */
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_UNREACH != rc) {
+        fprintf(stderr, "PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    test_log_bad_source();
+    test_query_bad_params();
+    test_query_local();
+    test_data_bad_params();
+    test_directives_string();
+
+    rc = PMIx_Finalize(NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Finalize failed: %s\n", PMIx_Error_string(rc));
+        nfail++;
+    }
+
+    if (0 == nfail) {
+        fprintf(stdout, "\nsrc/common API regression test: PASS\n\n");
+    } else {
+        fprintf(stdout, "\nsrc/common API regression test: FAIL (%d)\n\n", nfail);
+    }
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/run_monitor.pl.in
+++ b/test/unit/run_monitor.pl.in
@@ -120,5 +120,20 @@ if ($output !~ /MONITOR TEST PASSED/) {
     print "FAIL: client did not confirm heartbeat monitoring\n";
     exit(1);
 }
+
+# The observer also makes one blocking PMIx_Process_monitor call with
+# PMIX_SEND_HEARTBEAT. That form used to return from the _nb layer
+# without ever invoking the callback the blocking wrapper was waiting
+# on, so it hung forever - which here shows up as the whole run hitting
+# the time limit above. This line proves it came back.
+if ($output =~ /HEARTBEAT TEST FAILED/) {
+    print "FAIL: blocking PMIx_Process_monitor(SEND_HEARTBEAT) reported an error\n";
+    exit(1);
+}
+if ($output !~ /HEARTBEAT TEST PASSED/) {
+    print "FAIL: blocking PMIx_Process_monitor(SEND_HEARTBEAT) never completed\n";
+    exit(1);
+}
 print "PASS: heartbeat monitor raised the expected alert\n";
+print "PASS: blocking PMIx_Process_monitor(SEND_HEARTBEAT) returned\n";
 exit(0);


### PR DESCRIPTION
A six-round review of `src/common`, the role-shared public API layer. Twelve commits: the fixes, the regression tests that catch them, a new multi-node suite, and the guide/news updates.

Every regression test in `test/unit/common_api.c` was run against the **unfixed** library to confirm it actually catches something — it exits 139 (SIGSEGV) at three separate points, and the XML case fails specifically on the signedness fix rather than incidentally.

## Highest-severity findings

| Defect | Effect |
|---|---|
| `pmix_attributes_print_attrs` copied a caller-registered function name into a fixed 141-byte stack line with no bound | **Stack overflow** — a host that registers a long name smashes the stack of anything listing that level, `pmix_info` included |
| `PMIx_Query_info`'s reply handler returned bare on a lost connection | **Hangs forever**, and leaks the caddy |
| `PMIx_Process_monitor` with `PMIX_SEND_HEARTBEAT` returned success without invoking the callback | **Hangs forever** in the blocking form |
| `_rbreq` invoked the caller's callback whether or not the host had accepted the request | **Double completion**; a blocking caller's lock is woken a second time after it has been destructed |
| `PMIx_Data_pack`/`PMIx_Data_unpack` stored a borrowed peer in a caddy whose destructor releases that field | **Use-after-free**, and a dangling pointer left in the server's client array |
| `do_parent` closed the keepalive pipe without marking the fd closed | **Double close** — in a multithreaded process this can take down an unrelated descriptor |
| The pfexec kill sequence escalated to SIGKILL only when the SIGTERM had failed to be *delivered* | A child that receives SIGTERM and ignores it was left running — and, already off the children list, never reaped |
| Six directives read through the `pmix_value_t` union with no type check | **Segfault** on an ordinary application mistake |
| `PMIx_Job_control` staged the host's results in the same caddy fields holding the caller's directives | A host returning no info echoed the caller's own directives back as the answer |
| The XML escaper read payload bytes as signed | Invalid `&#-128;` style character references; UB in `isprint()` |

Plus: `pmix_shift_caddy_t.status`, `pmix_query_caddy_t.status` and `pmix_pfexec_child_t.exitcode` were never initialized (`PMIX_NEW` uses `malloc`, not `calloc`, so they started as heap garbage); six public entry points wrote through unscreened OUT pointers; and several leaks on error paths.

## One deliberate behavior change — please confirm

**The pfexec kill sequence now always escalates to SIGKILL.** The escalation used to be conditional on the SIGTERM having failed to be delivered, which is backwards — the case the sequence exists for is a child that *receives* SIGTERM and ignores it. `pmix_pfexec.c`'s own comment describes the sequence as `SIGCONT → pause → SIGTERM → pause → SIGKILL`, which is what it now does.

The cost is that every kill takes one `timeout_before_sigkill` pause (default 1s, MCA-tunable) before it completes, where a well-behaved child used to complete immediately. I believe leaving a SIGTERM-ignoring child alive and unreaped is the worse outcome, but this is a user-visible timing change and is the one thing here worth a second opinion.

## Deliberately not fixed

`wait_signal_callback` reads `pmix_list_get_size(&pmix_pfexec_globals.children)` as an early-out while running on `evauxbase`, though the list belongs to `evbase`. That is a formal data race. It is left alone because the child is appended to the list before the `fork()` that can generate its SIGCHLD, so the count cannot be stale for a child we care about, and deleting the guard would make pfexec `waitpid(-1)` on every SIGCHLD in a process that currently has no children of its own. The reasoning, and what a real fix would require, is recorded in `src/common/AGENTS.md`.

## Testing

- `test/unit/common_api.c` — 40 singleton cases, wired into `make check`. The singleton half: what the library resolves or rejects without a server.
- `contrib/dockerswarm/run-common-tests.sh` — 11 cases with the ranks behind *different* PMIx servers. The monitor cases are why it has to be multi-node: `pmix_monitor_processing`'s remote and mixed branches cannot be entered on one node.
- One case added to `test/simple/simpmonitor.c` for the heartbeat hang, which a singleton cannot reach (it is turned away at the "am I connected?" check first). A regression there is an unbounded hang caught by `run_monitor.pl`'s time limit.

All green: 86 `make check` tests and 11 swarm cases, warning-free under `--enable-devel-check`.

Two traps in the IOF swarm case cost a round each and are now written down in `contrib/dockerswarm/README.md` §13: PRRTE's `PATTERN` is a *qualifier* on the file directive (`file=NAME:pattern`, not comma-separated), and omitting it is not an error — the name is simply treated as a stem, so a test that forgets it passes against any library and proves nothing.
