### PR TITLE
Clear the Coverity findings in the test tree

### DIFF
--- a/test/pmix_regex.c
+++ b/test/pmix_regex.c
@@ -60,7 +60,11 @@ int main(int argc, char **argv)
 
     TEST_VERBOSE(("Testing version %s", PMIx_Get_version()));
 
-    PMIx_server_init(&mymodule, NULL, 0);
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        TEST_ERROR(("PMIx_server_init failed: %s", PMIx_Error_string(rc)));
+        exit(1);
+    }
 
     TEST_VERBOSE(("Start PMIx regex smoke test"));
 

--- a/test/simple/doubleget.c
+++ b/test/simple/doubleget.c
@@ -135,6 +135,7 @@ static int pmix_create_group(void) {
                                      &results, &nresults))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
+        PMIX_INFO_FREE(directives, ndirs);
         return rc;
     }
 
@@ -142,9 +143,9 @@ static int pmix_create_group(void) {
         fprintf(stdout, "%s-%d: %s\n", myproc.nspace, myproc.rank, PMIx_Info_string(&results[k]));
     }
 
-    if (directives != NULL) {
-        PMIX_INFO_FREE(directives, ndirs);
-    }
+    /* the directives were created above and have been used since, so
+     * they are known to be there */
+    PMIX_INFO_FREE(directives, ndirs);
     if (results != NULL) {
         PMIX_INFO_FREE(results, nresults);
     }
@@ -161,9 +162,8 @@ static int pmix_destruct_group(void) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace,
                 myproc.rank, PMIx_Error_string(rc));
     }
-    if (directives != NULL) {
-        PMIX_INFO_FREE(directives, ndirs);
-    }
+    /* created just above, so it is known to be there */
+    PMIX_INFO_FREE(directives, ndirs);
     return rc;
 }
 

--- a/test/simple/get_put_example.c
+++ b/test/simple/get_put_example.c
@@ -40,12 +40,18 @@ int main(int argc, char **argv)
         }
     }
 
-    PMIx_Commit();
+    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        fprintf(stderr, "Commit failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
 
     bool tvalue = 1;
     strcpy(info.key, PMIX_COLLECT_DATA);
     PMIX_VALUE_LOAD(&(info.value), &tvalue, PMIX_BOOL);
-    PMIx_Fence(NULL, 0, &info, 1);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, &info, 1))) {
+        fprintf(stderr, "Fence failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
 
     fprintf(stderr, "[%s:%u]: Fence complete\n", myproc.nspace, myproc.rank);
 

--- a/test/simple/gwtest.c
+++ b/test/simple/gwtest.c
@@ -114,12 +114,15 @@ typedef struct {
     pmix_status_t status;
 } mylock_t;
 
+/* set the fields under the mutex - see the note in simptest.h */
 #define DEBUG_CONSTRUCT_LOCK(l)                \
     do {                                       \
         pthread_mutex_init(&(l)->mutex, NULL); \
+        pthread_mutex_lock(&(l)->mutex);       \
         pthread_cond_init(&(l)->cond, NULL);   \
         (l)->active = true;                    \
         (l)->status = PMIX_SUCCESS;            \
+        pthread_mutex_unlock(&(l)->mutex);     \
     } while (0)
 
 #define DEBUG_DESTRUCT_LOCK(l)              \

--- a/test/simple/gwtest.c
+++ b/test/simple/gwtest.c
@@ -952,6 +952,8 @@ static pmix_status_t query_fn(pmix_proc_t *proct, pmix_query_t *queries, size_t 
         pmix_strncpy(info[n].key, queries[n].keys[0], PMIX_MAX_KEYLEN);
         info[n].value.type = PMIX_STRING;
         if (0 > asprintf(&info[n].value.data.string, "%d", (int) n)) {
+            /* the callback never runs, so this array is ours to release */
+            PMIX_INFO_FREE(info, nqueries);
             return PMIX_ERROR;
         }
     }

--- a/test/simple/refresh.c
+++ b/test/simple/refresh.c
@@ -12,8 +12,33 @@ static void fence_collect(const char *nspace)
     bool collect = true;
     PMIx_Info_load(&info, PMIX_COLLECT_DATA, &collect, PMIX_BOOL);
 
-    PMIx_Fence(&wildcard, 1, &info, 1);
+    pmix_status_t rc = PMIx_Fence(&wildcard, 1, &info, 1);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Fence failed: %s\n", PMIx_Error_string(rc));
+    }
     PMIx_Info_destruct(&info);
+}
+
+/* the point of this test is what a subsequent get returns, so a put or
+ * commit that fails has to be reported - it would otherwise show up as
+ * an unexplained wrong value further down */
+static int put_value(const char *key, const char *val)
+{
+    pmix_value_t v;
+    pmix_status_t rc;
+
+    PMIx_Value_load(&v, (void *) val, PMIX_STRING);
+    rc = PMIx_Put(PMIX_GLOBAL, key, &v);
+    PMIx_Value_destruct(&v);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Put of '%s' failed: %s\n", val, PMIx_Error_string(rc));
+        return rc;
+    }
+    rc = PMIx_Commit();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Commit of '%s' failed: %s\n", val, PMIx_Error_string(rc));
+    }
+    return rc;
 }
 
 int main(int argc, char **argv)
@@ -35,11 +60,10 @@ int main(int argc, char **argv)
 
     // Round 0: Rank 0 puts "A"
     if (me.rank == 0) {
-        pmix_value_t v;
-        PMIx_Value_load(&v, "A", PMIX_STRING);
-        PMIx_Put(PMIX_GLOBAL, key, &v);
-        PMIx_Commit();
-        PMIx_Value_destruct(&v);
+        if (PMIX_SUCCESS != put_value(key, "A")) {
+            PMIx_Finalize(NULL, 0);
+            return 1;
+        }
         printf("rank0: PUT 'A'\n");
     }
     fence_collect(me.nspace);
@@ -56,11 +80,10 @@ int main(int argc, char **argv)
 
     // Round 1: Rank 0 overwrites with "B"
     if (me.rank == 0) {
-        pmix_value_t v;
-        PMIx_Value_load(&v, "B", PMIX_STRING);
-        PMIx_Put(PMIX_GLOBAL, key, &v);
-        PMIx_Commit();
-        PMIx_Value_destruct(&v);
+        if (PMIX_SUCCESS != put_value(key, "B")) {
+            PMIx_Finalize(NULL, 0);
+            return 1;
+        }
         printf("rank0: PUT 'B' (overwrite)\n");
     }
     fence_collect(me.nspace);

--- a/test/simple/simpdmodex.c
+++ b/test/simple/simpdmodex.c
@@ -221,8 +221,8 @@ int main(int argc, char **argv)
     /* commit the data to the server */
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
         pmix_output(0, "Rank %d[msg=%d]: PMIx_Commit failed: %d", myproc.rank, msgnum, rc);
-        goto done;
         ++msgnum;
+        goto done;
     }
 
     if (dofence) {

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -1287,7 +1287,6 @@ static void wait_signal_callback(int sd, short args, void *arg)
             }
         }
     }
-    fprintf(stderr, "ENDLOOP\n");
 }
 
 static void relcbfunc(void *cbdata)

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -1148,6 +1148,9 @@ static pmix_status_t query_fn(pmix_proc_t *proct, pmix_query_t *queries, size_t 
         pmix_strncpy(info[n].key, queries[n].keys[0], PMIX_MAX_KEYLEN);
         info[n].value.type = PMIX_STRING;
         if (0 > asprintf(&info[n].value.data.string, "%d", (int) n)) {
+            /* nobody downstream will ever see this array, so it is
+             * ours to release */
+            PMIX_INFO_FREE(info, nqueries);
             return PMIX_ERROR;
         }
     }

--- a/test/simple/simptest.h
+++ b/test/simple/simptest.h
@@ -22,12 +22,19 @@ typedef struct {
     pmix_status_t status;
 } mylock_t;
 
+/* the fields are set under the mutex, exactly as the wakeup does it:
+ * a lock is routinely constructed for a second operation while the
+ * thread that serviced the first one is still on its way out, so an
+ * unlocked store to "active" leaves the two threads disagreeing about
+ * it - see examples/examples.h, which does the same */
 #define DEBUG_CONSTRUCT_LOCK(l)                \
     do {                                       \
         pthread_mutex_init(&(l)->mutex, NULL); \
+        pthread_mutex_lock(&(l)->mutex);       \
         pthread_cond_init(&(l)->cond, NULL);   \
         (l)->active = true;                    \
         (l)->status = PMIX_SUCCESS;            \
+        pthread_mutex_unlock(&(l)->mutex);     \
     } while (0)
 
 #define DEBUG_DESTRUCT_LOCK(l)              \

--- a/test/simple/simptoolcycle.c
+++ b/test/simple/simptoolcycle.c
@@ -61,9 +61,26 @@
 
 #define DEFAULT_CYCLES 50
 
+/* the cycle count is taken from the command line and then used as a loop
+ * bound, so cap it - a typo must not turn into a test that never ends */
+#define MAX_CYCLES 10000
+
 /* a phase may leave at most this many live peers behind while its final
  * socket-close is still settling; a per-cycle leak blows past it */
 #define PEER_LEAK_BOUND 5
+
+static long parse_cycles(const char *str)
+{
+    long ncycles = strtol(str, NULL, 10);
+
+    if (0 >= ncycles) {
+        return DEFAULT_CYCLES;
+    }
+    if (MAX_CYCLES < ncycles) {
+        return MAX_CYCLES;
+    }
+    return ncycles;
+}
 
 static volatile int regdone;
 static void reg_cbfunc(pmix_status_t status, void *cbdata)
@@ -335,18 +352,12 @@ int main(int argc, char **argv)
     long ncycles = DEFAULT_CYCLES;
 
     if (3 < argc && 0 == strcmp(argv[1], "--tool-child")) {
-        ncycles = strtol(argv[3], NULL, 10);
-        if (0 >= ncycles) {
-            ncycles = DEFAULT_CYCLES;
-        }
+        ncycles = parse_cycles(argv[3]);
         return run_tool_child(argv[2], ncycles);
     }
 
     if (1 < argc) {
-        ncycles = strtol(argv[1], NULL, 10);
-        if (0 >= ncycles) {
-            ncycles = DEFAULT_CYCLES;
-        }
+        ncycles = parse_cycles(argv[1]);
     }
     return run_server(argv[0], ncycles);
 }

--- a/test/simple/simpvni.c
+++ b/test/simple/simpvni.c
@@ -28,12 +28,15 @@ typedef struct {
     size_t ninfo;
 } myxfer_t;
 
+/* set the fields under the mutex - see the note in simptest.h */
 #define DEBUG_CONSTRUCT_LOCK(l)                \
     do {                                       \
         pthread_mutex_init(&(l)->mutex, NULL); \
+        pthread_mutex_lock(&(l)->mutex);       \
         pthread_cond_init(&(l)->cond, NULL);   \
         (l)->active = true;                    \
         (l)->status = PMIX_SUCCESS;            \
+        pthread_mutex_unlock(&(l)->mutex);     \
     } while (0)
 
 #define DEBUG_DESTRUCT_LOCK(l)              \

--- a/test/simple/simpvni.c
+++ b/test/simple/simpvni.c
@@ -89,7 +89,7 @@ static void setup_cbfunc(pmix_status_t status, pmix_info_t info[], size_t ninfo,
 
 int main(int argc, char **argv)
 {
-    pmix_status_t rc=0;
+    pmix_status_t rc=0, ret;
     myxfer_t x;
     pmix_proc_t myproc;
     pmix_info_t *info;
@@ -143,6 +143,11 @@ int main(int argc, char **argv)
     fprintf(stderr, "VNI: %s\n", (NULL == myvni) ? "NULL" : myvni);
 
 done:
-    rc = PMIx_tool_finalize();
+    /* whatever brought us here is what the test failed on - the
+     * finalize status only matters if everything else went well */
+    ret = PMIx_tool_finalize();
+    if (PMIX_SUCCESS == rc) {
+        rc = ret;
+    }
     return rc;
 }

--- a/test/simple/stability.c
+++ b/test/simple/stability.c
@@ -988,6 +988,8 @@ static pmix_status_t query_fn(pmix_proc_t *proct, pmix_query_t *queries, size_t 
         pmix_strncpy(info[n].key, queries[n].keys[0], PMIX_MAX_KEYLEN);
         info[n].value.type = PMIX_STRING;
         if (0 > asprintf(&info[n].value.data.string, "%d", (int) n)) {
+            /* the callback never runs, so this array is ours to release */
+            PMIX_INFO_FREE(info, nqueries);
             return PMIX_ERROR;
         }
     }

--- a/test/simple/test_pmix.c
+++ b/test/simple/test_pmix.c
@@ -1,6 +1,5 @@
 
 #include "include/pmix.h"
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -17,6 +16,17 @@ static void hide_unused_params(int x, ...)
     va_end(ap);
 }
 
+/* these were assert()s, which a build that defines NDEBUG compiles out
+ * entirely - the calls then had their status silently discarded */
+#define CHECK_RC(fn)                                                 \
+    do {                                                             \
+        if (PMIX_SUCCESS != rc) {                                    \
+            fprintf(stderr, "%s failed: %s\n", (fn),                 \
+                    PMIx_Error_string(rc));                          \
+            exit(1);                                                 \
+        }                                                            \
+    } while (0)
+
 int main(int argc, char **argv)
 {
     pmix_proc_t myproc;
@@ -25,17 +35,18 @@ int main(int argc, char **argv)
     hide_unused_params(rc, argc, argv);
 
     rc = PMIx_Init(&myproc, NULL, 0);
-    assert(PMIX_SUCCESS == rc);
+    CHECK_RC("PMIx_Init");
 
-    {
-        pmix_value_t *value;
-        rc = PMIx_Get(&myproc, PMIX_RANK, NULL, 0, &value);
-        assert(PMIX_SUCCESS == rc);
-        printf("%d\n", value->type);
-        assert(value->type == PMIX_INT);
-        rank = value->data.uint32;
-        PMIX_VALUE_RELEASE(value);
-    }
+    /* PMIx_Init already handed us our identity. This used to ask for
+     * it back with PMIx_Get(&myproc, PMIX_RANK), which cannot work and
+     * is not meant to: naming the proc to ask about requires supplying
+     * the very rank being asked for. PMIX_RANK inside a proc-data array
+     * identifies which process the array describes, so it is consumed
+     * as the index rather than stored as a retrievable key. The library
+     * does serve the one form of the question that carries information
+     * - "what is my own rank", asked with PMIX_RANK_INVALID in the rank
+     * field - but there is nothing here that needs it. */
+    rank = myproc.rank;
 
     if (rank == 0) {
         pmix_info_t *info;
@@ -44,7 +55,7 @@ int main(int argc, char **argv)
         info[0].value.type = PMIX_STRING;
         info[0].value.data.string = "yes";
         rc = PMIx_Publish(info, 1);
-        assert(PMIX_SUCCESS == rc);
+        CHECK_RC("PMIx_Publish");
     }
 
     printf("I am rank %d\n", rank);
@@ -56,7 +67,7 @@ int main(int argc, char **argv)
         flag = true;
         PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
         rc = PMIx_Fence(&myproc, 1, info, 1);
-        assert(PMIX_SUCCESS == rc);
+        CHECK_RC("PMIx_Fence");
         PMIX_INFO_FREE(info, 1);
     }
 
@@ -67,15 +78,20 @@ int main(int argc, char **argv)
         snprintf(pdata[0].key, PMIX_MAX_KEYLEN, "magic-found");
         snprintf(pdata[1].key, PMIX_MAX_KEYLEN, "magic-not-found");
         rc = PMIx_Lookup(&pdata[0], 2, NULL, 0);
-        assert((PMIX_SUCCESS == rc) || (PMIX_ERR_NOT_FOUND == rc));
+        if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
+            fprintf(stderr, "PMIx_Lookup failed: %s\n", PMIx_Error_string(rc));
+            exit(1);
+        }
         for (i = 0; i < 2; i++)
             if (pdata[i].value.type == PMIX_STRING)
                 printf("Found[%d] %d %s\n", i, pdata[i].value.type, pdata[i].value.data.string);
             else
                 printf("Found[%d] %d\n", i, pdata[i].value.type);
-        PMIX_PDATA_FREE(pdata, 1);
+        /* two were created, so two have to be released */
+        PMIX_PDATA_FREE(pdata, 2);
     }
 
     rc = PMIx_Finalize(NULL, 0);
-    assert(PMIX_SUCCESS == rc);
+    CHECK_RC("PMIx_Finalize");
+    return 0;
 }

--- a/test/simple/tool_server_switch.c
+++ b/test/simple/tool_server_switch.c
@@ -61,9 +61,26 @@
 
 #define DEFAULT_CYCLES 30
 
+/* the cycle count is taken from the command line and then used as a loop
+ * bound, so cap it - a typo must not turn into a test that never ends */
+#define MAX_CYCLES 10000
+
 /* ------------------------------------------------------------------ */
 /* shared helpers                                                     */
 /* ------------------------------------------------------------------ */
+
+static long parse_cycles(const char *str)
+{
+    long ncycles = strtol(str, NULL, 10);
+
+    if (0 >= ncycles) {
+        return DEFAULT_CYCLES;
+    }
+    if (MAX_CYCLES < ncycles) {
+        return MAX_CYCLES;
+    }
+    return ncycles;
+}
 
 /* hand every connecting tool a fresh identity so repeated attaches across
  * cycles never collide on the server side */
@@ -514,10 +531,7 @@ int main(int argc, char **argv)
 
     if (2 < argc && 0 == strcmp(argv[1], "--tool-child")) {
         char *burl = getenv("PMIX_TEST_SERVERB_URI");
-        ncycles = strtol(argv[2], NULL, 10);
-        if (0 >= ncycles) {
-            ncycles = DEFAULT_CYCLES;
-        }
+        ncycles = parse_cycles(argv[2]);
         if (NULL == burl) {
             fprintf(stderr, "tool child: PMIX_TEST_SERVERB_URI not set\n");
             return 1;
@@ -530,10 +544,7 @@ int main(int argc, char **argv)
     }
 
     if (1 < argc) {
-        ncycles = strtol(argv[1], NULL, 10);
-        if (0 >= ncycles) {
-            ncycles = DEFAULT_CYCLES;
-        }
+        ncycles = parse_cycles(argv[1]);
     }
     return run_orchestrator(argv[0], ncycles);
 }

--- a/test/sshot/testcoord.c
+++ b/test/sshot/testcoord.c
@@ -49,12 +49,15 @@ typedef struct {
     pmix_status_t status;
 } mylock_t;
 
+/* set the fields under the mutex - see the note in test/simple/simptest.h */
 #define DEBUG_CONSTRUCT_LOCK(l)                \
     do {                                       \
         pthread_mutex_init(&(l)->mutex, NULL); \
+        pthread_mutex_lock(&(l)->mutex);       \
         pthread_cond_init(&(l)->cond, NULL);   \
         (l)->active = true;                    \
         (l)->status = PMIX_SUCCESS;            \
+        pthread_mutex_unlock(&(l)->mutex);     \
     } while (0)
 
 #define DEBUG_DESTRUCT_LOCK(l)              \


### PR DESCRIPTION
Coverity's latest scan reported 17 defects, all of them in the test
programs under `test/` rather than in the library. Most of the files
are long-standing — `simpdmodex.c` and `stability.c` were last touched
in 2024, `simpsched.c` and `simpfabric.c` in 2022 — so this looks like
the scan newly covering the test tree rather than a regression from
any recent change.

One commit per defect class:

| Commit | Checker | Files |
|---|---|---|
| Set the test debug lock's fields under its own mutex | LOCK_EVASION | `simptest.h`, `simpvni.c`, `gwtest.c`, `testcoord.c` |
| Release the query results the test servers never hand off | RESOURCE_LEAK | `simptest.c`, `gwtest.c`, `stability.c` |
| Bound the cycle count the tool tests take from the command line | TAINTED_SCALAR | `simptoolcycle.c`, `tool_server_switch.c` |
| Check the status of the PMIx calls these tests discard it from | CHECKED_RETURN | `pmix_regex.c`, `get_put_example.c`, `refresh.c` |
| Clear the leftover Coverity findings in the test programs | REVERSE_INULL, UNREACHABLE, UNUSED_VALUE | `doubleget.c`, `simpdmodex.c`, `simpvni.c`, `simptest.c` |
| Stop test_pmix from checking its statuses only under assert | UNUSED_VALUE | `test_pmix.c` |

Notes on the two that are more than mechanical:

**The lock fix is a real one, not a suppression.** `DEBUG_CONSTRUCT_LOCK`
stored `active` outside the mutex while `DEBUG_WAKEUP_THREAD` flips the
same field under it. The tests routinely construct a lock for a second
operation right after waiting on the first, so the thread that serviced
the earlier call can still be on its way out when the unsynchronized
store lands. `examples/examples.h` already takes the mutex across the
whole initialization; the four copies under `test/` had drifted from it.
That one macro accounted for all five reported CIDs.

**`test_pmix` was hiding a broken call behind `assert()`.** Its statuses
were only checked via `assert()`, which a build defining NDEBUG compiles
out, so a failed `PMIx_Get` fell straight into dereferencing the value it
never returned — the original binary exits 139 (SIGSEGV).

The failing call was the `PMIx_Get` the test used to fetch its own rank,
and it cannot work by construction: it passed the proc `PMIx_Init` had
just filled in and asked for `PMIX_RANK`, which requires supplying the
very rank being asked for. `PMIX_RANK` inside a proc-data array
identifies *which* process the array describes — see the
`PMIX_PROC_INFO_ARRAY` description in `pmix_common.h.in` — so all three
GDS store loops consume it as the array index and never store it as a
retrievable key. Confirmed empirically: simptest supplies `PMIX_RANK`
alongside `PMIX_GLOBAL_RANK`, `PMIX_LOCAL_RANK` and `PMIX_NODE_RANK` in
the same blob, and those three are retrievable while `PMIX_RANK` is not.
The library does serve the one form of the question that carries
information — "what is my own rank", asked with `PMIX_RANK_INVALID` in
the rank field (`pmix_client_get.c:294`, added in 992c56ff) — but the
test has no need of it, since `PMIx_Init` already handed it its
identity. It now uses that.

No library change is needed here; the test was simply asking a circular
question. The same commit drops an assertion that the value came back as
`PMIX_INT`, which was also wrong — `PMIX_RANK` is a `PMIX_PROC_RANK`,
and the test read `data.uint32` where the union member is `data.rank`.
It only appeared to work because both are `uint32_t` at the same offset.

Two incidental leaks are fixed alongside and called out in their commit
bodies: `doubleget`'s construct-error path abandoned `directives`, and
`test_pmix` created two pdata entries but freed one.

No news entry — these are test-only changes with no user-visible
behavior change.

Verified: warning-free build under the tree's default
`--enable-devel-check`, and `make check` passes 85/85 under a clean
`$TMPDIR`. `test_pmix`, which is not part of `make check`, now runs
clean too.