### PR TITLE
Accept every documented identifier of a proc info array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,6 +273,7 @@ test/unit/info_support
 test/unit/rndz_stale
 test/unit/singleton_register
 test/unit/iof_pattern
+test/unit/proc_array_id
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -164,8 +164,9 @@ available:
 * ``PMIX_NSPACE`` (char*) |mdash| namespace of the process's job.
 * ``PMIX_JOBID`` (char*) |mdash| job identifier assigned by the scheduler.
 * ``PMIX_PROCID`` (pmix_proc_t\*) |mdash| process identifier (namespace and
-  rank).
+  rank). Self-referential: see below.
 * ``PMIX_RANK`` (pmix_rank_t) |mdash| rank of the process within its job.
+  Self-referential: see below.
 * ``PMIX_GLOBAL_RANK`` (pmix_rank_t) |mdash| rank of the process spanning across
   all jobs in this session.
 * ``PMIX_APP_RANK`` (pmix_rank_t) |mdash| rank of the process within its
@@ -186,6 +187,34 @@ available:
 * ``PMIX_SESSION_ID`` (uint32_t) |mdash| session identifier.
 * ``PMIX_PROC_PID`` (pid_t) |mdash| operating-system process identifier (pid) of
   the specified process.
+
+.. note::
+
+   ``PMIX_RANK`` and ``PMIX_PROCID`` are *self-referential* |mdash| they name
+   the very thing the ``proc`` parameter must already supply, so asking for
+   them about a process identified in ``proc`` conveys no information and is
+   not supported. Each is instead retrieved by leaving the corresponding part
+   of ``proc`` unspecified, which asks "who am I?":
+
+   * ``PMIX_RANK`` |mdash| pass a ``proc`` whose namespace is the caller's own
+     and whose rank is ``PMIX_RANK_INVALID``. The caller's own rank is
+     returned, as a ``PMIX_PROC_RANK`` value.
+   * ``PMIX_PROCID`` |mdash| pass ``NULL`` for ``proc``. The caller's own
+     process identifier is returned.
+
+   Passing a fully specified ``proc`` with either key returns
+   ``PMIX_ERR_NOT_FOUND``. Note in particular that ``PMIX_RANK`` is not
+   retrievable for *another* process: it serves as the identifier of the
+   process-realm information supplied by the host (see
+   ``PMIX_PROC_INFO_ARRAY``) rather than as a stored value. A process's rank
+   is already known to any caller able to name it. The remaining rank keys in
+   this section |mdash| ``PMIX_GLOBAL_RANK``, ``PMIX_APP_RANK``,
+   ``PMIX_LOCAL_RANK``, ``PMIX_NODE_RANK`` and ``PMIX_PACKAGE_RANK`` |mdash|
+   are ordinary stored values and are retrieved for the process identified in
+   ``proc`` in the usual way.
+
+   In the same vein, ``PMIX_VERSION_NUMERIC`` reports the version of the
+   library the caller is linked against and ignores ``proc`` entirely.
 
 **Node and host information**
 

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -16,6 +16,12 @@ Detailed changes since v6.1.0:
    permits, or that simply ordered the array differently, could not
    register its job. PMIX_RANK and PMIX_PROCID are now both accepted, in
    any position; PMIX_RANK is preferred when both are present
+ - Documented the self-referential reserved keys on the PMIx_Get man
+   page. PMIX_RANK and PMIX_PROCID name the very thing the proc
+   parameter has to supply, so they are retrieved by leaving that part
+   of proc unspecified - a rank of PMIX_RANK_INVALID for PMIX_RANK, a
+   NULL proc for PMIX_PROCID - rather than for the process identified in
+   proc as the surrounding text implied
  - A PMIx_Query_info that is outstanding when the connection to the
    server is lost now returns PMIX_ERR_COMM_FAILURE instead of hanging.
    The reply handler treated a zero-byte buffer with a bare return, so

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,15 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - A process-realm info array (PMIX_PROC_INFO_ARRAY, also known by its
+   deprecated name PMIX_PROC_DATA) may now identify the process it
+   describes with any of the forms its definition allows. The datastore
+   accepted only PMIX_RANK, and only as the very first element,
+   rejecting anything else with PMIX_ERR_TYPE_MISMATCH - so a host that
+   identified the array with PMIX_PROCID, as the attribute expressly
+   permits, or that simply ordered the array differently, could not
+   register its job. PMIX_RANK and PMIX_PROCID are now both accepted, in
+   any position; PMIX_RANK is preferred when both are present
  - A PMIx_Query_info that is outstanding when the connection to the
    server is lost now returns PMIX_ERR_COMM_FAILURE instead of hanging.
    The reply handler treated a zero-byte buffer with a bare return, so

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -130,6 +130,32 @@ PMIX_EXPORT pmix_status_t pmix_gds_base_store_modex(pmix_buffer_t *buff,
                                                     pmix_gds_base_store_modex_cb_fn_t cb_fn,
                                                     void *cbdata);
 
+/**
+ * Find the process identifier carried by a process-realm info array.
+ *
+ * PMIX_PROC_INFO_ARRAY requires the array to identify the process it
+ * describes, and allows the host to do so with either PMIX_RANK (plus
+ * PMIX_NSPACE where the job would otherwise be ambiguous) or
+ * PMIX_PROCID. It places no requirement on where in the array that
+ * identifier appears. Scan for whichever the host used rather than
+ * demanding one particular key in the first position.
+ *
+ * PMIX_RANK is preferred when both are present. The array position
+ * that carried the identifier is returned in idpos so the caller can
+ * skip it when storing the remaining values - it names the array
+ * rather than being data belonging to the process.
+ *
+ * @param array   the array of info describing the process
+ * @param size    number of elements in the array
+ * @param rank    OUT - the rank the array describes
+ * @param idpos   OUT - index of the element that identified it
+ *
+ * @return PMIX_SUCCESS, or PMIX_ERR_TYPE_MISMATCH if no usable
+ *         identifier is present.
+ */
+PMIX_EXPORT pmix_status_t pmix_gds_base_proc_array_id(const pmix_info_t *array, size_t size,
+                                                      pmix_rank_t *rank, size_t *idpos);
+
 END_C_DECLS
 
 #endif

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -310,3 +310,46 @@ exit:
     PMIX_LIST_DESTRUCT(&nspaces);
     return rc;
 }
+
+pmix_status_t pmix_gds_base_proc_array_id(const pmix_info_t *array, size_t size,
+                                          pmix_rank_t *rank, size_t *idpos)
+{
+    size_t n;
+    bool haveproc = false;
+    size_t procpos = 0;
+
+    if (NULL == array || 0 == size || NULL == rank || NULL == idpos) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    for (n = 0; n < size; n++) {
+        /* an explicit rank is the preferred identifier, so take it
+         * as soon as we see one no matter where it sits */
+        if (PMIX_CHECK_KEY(&array[n], PMIX_RANK)) {
+            if (PMIX_PROC_RANK != array[n].value.type) {
+                return PMIX_ERR_TYPE_MISMATCH;
+            }
+            *rank = array[n].value.data.rank;
+            *idpos = n;
+            return PMIX_SUCCESS;
+        }
+        /* remember the first procid in case no rank turns up */
+        if (!haveproc && PMIX_CHECK_KEY(&array[n], PMIX_PROCID)) {
+            if (PMIX_PROC != array[n].value.type ||
+                NULL == array[n].value.data.proc) {
+                return PMIX_ERR_TYPE_MISMATCH;
+            }
+            haveproc = true;
+            procpos = n;
+        }
+    }
+
+    if (haveproc) {
+        *rank = array[procpos].value.data.proc->rank;
+        *idpos = procpos;
+        return PMIX_SUCCESS;
+    }
+
+    /* the array does not say who it describes */
+    return PMIX_ERR_TYPE_MISMATCH;
+}

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -168,7 +168,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
     uint32_t sid = UINT32_MAX;
     pmix_rank_t rank;
     pmix_status_t rc = PMIX_SUCCESS;
-    size_t n, j, size;
+    size_t n, j, size, idpos;
     uint32_t flags = 0;
     pmix_nodeinfo_t *nd;
     pmix_apptrkr_t *apptr;
@@ -313,15 +313,19 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
             }
             size = info[n].value.data.darray->size;
             iptr = (pmix_info_t *) info[n].value.data.darray->array;
-            /* first element of the array must be the rank */
-            if (0 != strcmp(iptr[0].key, PMIX_RANK) || PMIX_PROC_RANK != iptr[0].value.type) {
-                rc = PMIX_ERR_TYPE_MISMATCH;
-                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+            /* the array has to say which proc it describes - the host
+             * may do that with a rank or a procid, in any position */
+            rc = pmix_gds_base_proc_array_id(iptr, size, &rank, &idpos);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
                 goto release;
             }
-            rank = iptr[0].value.data.rank;
-            /* cycle thru the values for this rank and store them */
-            for (j = 1; j < size; j++) {
+            /* cycle thru the values for this rank and store them,
+             * skipping the entry that identified the array */
+            for (j = 0; j < size; j++) {
+                if (j == idpos) {
+                    continue;
+                }
                 /* if the key is PMIX_QUALIFIED_VALUE, then the value
                  * consists of a data array that starts with the key-value
                  * itself followed by the qualifiers */
@@ -777,7 +781,7 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
     pmix_kval_t kptr, kp2, *kp3, *kp4, kv, kv2;
     pmix_value_t val;
     int32_t cnt;
-    size_t nnodes, n, sz;
+    size_t nnodes, n, sz, idpos;
     uint32_t i, j, sid = UINT32_MAX;
     char **procs = NULL;
     pmix_byte_object_t *bo;
@@ -1119,15 +1123,18 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
         } else if (PMIX_CHECK_KEY(&kptr, PMIX_PROC_DATA)) {
             iptr = (pmix_info_t*)kptr.value->data.darray->array;
             sz = kptr.value->data.darray->size;
-            /* the first position is the rank */
-            if (PMIX_CHECK_KEY(&iptr[0], PMIX_RANK)) {
-                rank = iptr[0].value.data.rank;
-            } else {
-                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+            /* the array has to say which proc it describes - the host
+             * may do that with a rank or a procid, in any position */
+            rc = pmix_gds_base_proc_array_id(iptr, sz, &rank, &idpos);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
                 PMIX_DESTRUCT(&kptr);
                 return rc;
             }
-            for (n=1; n < sz; n++) {
+            for (n=0; n < sz; n++) {
+                if (n == idpos) {
+                    continue;
+                }
                 PMIX_CONSTRUCT(&kv, pmix_kval_t);
                 kv.key = iptr[n].key;
                 kv.value = &iptr[n].value;
@@ -1186,7 +1193,7 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
     pmix_status_t rc;
     pmix_kval_t kp;
     pmix_rank_t rank;
-    size_t j, size;
+    size_t j, size, idpos;
     pmix_info_t *iptr;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
@@ -1255,16 +1262,19 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
             }
             size = kv->value->data.darray->size;
             iptr = (pmix_info_t *) kv->value->data.darray->array;
-            /* first element of the array must be the rank */
-            if (0 != strcmp(iptr[0].key, PMIX_RANK) ||
-                PMIX_PROC_RANK != iptr[0].value.type) {
-                rc = PMIX_ERR_TYPE_MISMATCH;
+            /* the array has to say which proc it describes - the host
+             * may do that with a rank or a procid, in any position */
+            rc = pmix_gds_base_proc_array_id(iptr, size, &rank, &idpos);
+            if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 return rc;
             }
-            rank = iptr[0].value.data.rank;
-            /* cycle thru the values for this rank and store them */
-            for (j = 1; j < size; j++) {
+            /* cycle thru the values for this rank and store them,
+             * skipping the entry that identified the array */
+            for (j = 0; j < size; j++) {
+                if (j == idpos) {
+                    continue;
+                }
                 if (PMIX_CHECK_KEY(&iptr[j], PMIX_QUALIFIED_VALUE)) {
                     rc = pmix_gds_hash_store_qualified(&trk->internal, rank, &iptr[j].value);
                     if (PMIX_SUCCESS != rc) {

--- a/src/mca/gds/shmem3/gds_shmem3_store.c
+++ b/src/mca/gds/shmem3/gds_shmem3_store.c
@@ -392,10 +392,13 @@ store_proc_data(
     }
 
     pmix_info_t *const info = (pmix_info_t *)kval->value->data.darray->array;
-    // First element of the array must be the rank.
-    if (PMIX_UNLIKELY(!PMIX_CHECK_KEY(&info[0], PMIX_RANK)) ||
-        info[0].value.type != PMIX_PROC_RANK) {
-        rc = PMIX_ERR_TYPE_MISMATCH;
+    const size_t size = kval->value->data.darray->size;
+    // The array has to say which proc it describes - the host may do
+    // that with a rank or a procid, in any position.
+    pmix_rank_t rank;
+    size_t idpos;
+    rc = pmix_gds_base_proc_array_id(info, size, &rank, &idpos);
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -403,10 +406,12 @@ store_proc_data(
     pmix_hash_table_t *const ht = job->smdata->local_hashtab;
     pmix_tma_t *const tma = pmix_obj_get_tma(&ht->super);
 
-    const pmix_rank_t rank = info[0].value.data.rank;
-    const size_t size = kval->value->data.darray->size;
-    // Cycle through the values for this rank and store them.
-    for (size_t j = 1; j < size; j++) {
+    // Cycle through the values for this rank and store them, skipping
+    // the entry that identified the array.
+    for (size_t j = 0; j < size; j++) {
+        if (j == idpos) {
+            continue;
+        }
         pmix_kval_t *kv = PMIX_NEW(pmix_kval_t, tma);
         kv->key = info[j].key;
         kv->value = &info[j].value;

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
 
-TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
 
 client_api_SOURCES = \
         client_api.c
@@ -93,6 +93,12 @@ bfrops_alloc_inherit_SOURCES = \
         bfrops_alloc_inherit.c
 bfrops_alloc_inherit_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 bfrops_alloc_inherit_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+proc_array_id_SOURCES = \
+        proc_array_id.c
+proc_array_id_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+proc_array_id_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 nested_darray_SOURCES = \
@@ -193,4 +199,4 @@ iof_pattern_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 clean-local:
-	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern
+	rm -f compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id

--- a/test/unit/proc_array_id.c
+++ b/test/unit/proc_array_id.c
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the identifier of a process-realm info array.
+ *
+ * PMIX_PROC_INFO_ARRAY lets the host identify the process an array
+ * describes with either PMIX_RANK (plus PMIX_NSPACE) or PMIX_PROCID,
+ * and places no requirement on where in the array that identifier
+ * appears. The datastore used to accept only PMIX_RANK, and only in
+ * the first position, rejecting anything else with
+ * PMIX_ERR_TYPE_MISMATCH - so a host that followed the documented
+ * attribute could not register its job.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/gds/base/base.h"
+#include "src/mca/gds/gds.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* the identifier scan itself                                          */
+/* ------------------------------------------------------------------ */
+static void test_scan(void)
+{
+    pmix_info_t array[3];
+    pmix_proc_t p;
+    pmix_status_t rc;
+    pmix_rank_t rank = PMIX_RANK_UNDEF;
+    size_t idpos = SIZE_MAX;
+
+    fprintf(stdout, "\n-- identifier scan --\n");
+
+    /* the classic form: a rank in the first position */
+    PMIX_INFO_LOAD(&array[0], PMIX_RANK, &(pmix_rank_t){3}, PMIX_PROC_RANK);
+    PMIX_INFO_LOAD(&array[1], PMIX_LOCAL_RANK, &(uint16_t){1}, PMIX_UINT16);
+    rc = pmix_gds_base_proc_array_id(array, 2, &rank, &idpos);
+    report("rank in the first position is found",
+           PMIX_SUCCESS == rc && 3 == rank && 0 == idpos);
+    PMIX_INFO_DESTRUCT(&array[0]);
+    PMIX_INFO_DESTRUCT(&array[1]);
+
+    /* the same identifier, further down the array */
+    PMIX_INFO_LOAD(&array[0], PMIX_LOCAL_RANK, &(uint16_t){1}, PMIX_UINT16);
+    PMIX_INFO_LOAD(&array[1], PMIX_NODEID, &(uint32_t){0}, PMIX_UINT32);
+    PMIX_INFO_LOAD(&array[2], PMIX_RANK, &(pmix_rank_t){7}, PMIX_PROC_RANK);
+    rc = pmix_gds_base_proc_array_id(array, 3, &rank, &idpos);
+    report("rank in a later position is found",
+           PMIX_SUCCESS == rc && 7 == rank && 2 == idpos);
+    PMIX_INFO_DESTRUCT(&array[0]);
+    PMIX_INFO_DESTRUCT(&array[1]);
+    PMIX_INFO_DESTRUCT(&array[2]);
+
+    /* identified by procid instead of rank */
+    PMIX_LOAD_PROCID(&p, "myjob", 5);
+    PMIX_INFO_LOAD(&array[0], PMIX_LOCAL_RANK, &(uint16_t){1}, PMIX_UINT16);
+    PMIX_INFO_LOAD(&array[1], PMIX_PROCID, &p, PMIX_PROC);
+    rc = pmix_gds_base_proc_array_id(array, 2, &rank, &idpos);
+    report("procid is accepted as the identifier",
+           PMIX_SUCCESS == rc && 5 == rank && 1 == idpos);
+    PMIX_INFO_DESTRUCT(&array[0]);
+    PMIX_INFO_DESTRUCT(&array[1]);
+
+    /* both present - the explicit rank is the one to use */
+    PMIX_LOAD_PROCID(&p, "myjob", 5);
+    PMIX_INFO_LOAD(&array[0], PMIX_PROCID, &p, PMIX_PROC);
+    PMIX_INFO_LOAD(&array[1], PMIX_RANK, &(pmix_rank_t){9}, PMIX_PROC_RANK);
+    rc = pmix_gds_base_proc_array_id(array, 2, &rank, &idpos);
+    report("an explicit rank wins over a procid",
+           PMIX_SUCCESS == rc && 9 == rank && 1 == idpos);
+    PMIX_INFO_DESTRUCT(&array[0]);
+    PMIX_INFO_DESTRUCT(&array[1]);
+
+    /* nothing that says who this is */
+    PMIX_INFO_LOAD(&array[0], PMIX_LOCAL_RANK, &(uint16_t){1}, PMIX_UINT16);
+    PMIX_INFO_LOAD(&array[1], PMIX_NODEID, &(uint32_t){0}, PMIX_UINT32);
+    rc = pmix_gds_base_proc_array_id(array, 2, &rank, &idpos);
+    report("an unidentified array is rejected", PMIX_ERR_TYPE_MISMATCH == rc);
+    PMIX_INFO_DESTRUCT(&array[0]);
+    PMIX_INFO_DESTRUCT(&array[1]);
+
+    /* the right key carrying the wrong type */
+    PMIX_INFO_LOAD(&array[0], PMIX_RANK, &(uint16_t){2}, PMIX_UINT16);
+    rc = pmix_gds_base_proc_array_id(array, 1, &rank, &idpos);
+    report("a rank of the wrong type is rejected", PMIX_ERR_TYPE_MISMATCH == rc);
+    PMIX_INFO_DESTRUCT(&array[0]);
+
+    /* nothing to scan */
+    rc = pmix_gds_base_proc_array_id(NULL, 0, &rank, &idpos);
+    report("a missing array is rejected", PMIX_ERR_BAD_PARAM == rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* the same thing through a real namespace registration                */
+/* ------------------------------------------------------------------ */
+
+/* Build a job whose per-proc arrays are identified the way the
+ * attribute allows but the datastore used to refuse: by PMIX_PROCID,
+ * and not in the first position. */
+static pmix_status_t register_job(const char *nspace, int nprocs)
+{
+    char *regex = NULL, *ppn = NULL, *rks, **agg = NULL;
+    char tmp[64];
+    pmix_info_t *info, *iptr, *pdata;
+    pmix_data_array_t *array;
+    pmix_proc_t p;
+    size_t ninfo, n;
+    int m, k, nnodes = 1;
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+
+    PMIx_generate_regex(pmix_globals.hostname, &regex);
+    for (m = 0; m < nprocs; m++) {
+        snprintf(tmp, sizeof(tmp), "%d", m);
+        PMIx_Argv_append_nosize(&agg, tmp);
+    }
+    rks = PMIx_Argv_join(agg, ',');
+    PMIx_Argv_free(agg);
+    PMIx_generate_ppn(rks, &ppn);
+    free(rks);
+
+    ninfo = 1 + (size_t) nnodes + (size_t) nprocs;
+    PMIX_INFO_CREATE(info, ninfo);
+
+    n = 0;
+    pmix_strncpy(info[n].key, PMIX_JOB_INFO_ARRAY, PMIX_MAX_KEYLEN);
+    info[n].value.type = PMIX_DATA_ARRAY;
+    PMIX_DATA_ARRAY_CREATE(info[n].value.data.darray, 8, PMIX_INFO);
+    iptr = (pmix_info_t *) info[n].value.data.darray->array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_NODE_MAP, regex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&iptr[1], PMIX_PROC_MAP, ppn, PMIX_REGEX);
+    PMIX_INFO_LOAD(&iptr[2], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[3], PMIX_JOBID, "1234", PMIX_STRING);
+    PMIX_INFO_LOAD(&iptr[4], PMIX_UNIV_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[5], PMIX_MAX_PROCS, &nprocs, PMIX_UINT32);
+    m = 1;
+    PMIX_INFO_LOAD(&iptr[6], PMIX_JOB_NUM_APPS, &m, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[7], PMIX_NUM_NODES, &nnodes, PMIX_UINT32);
+    free(regex);
+    free(ppn);
+    ++n;
+
+    pmix_strncpy(info[n].key, PMIX_NODE_INFO_ARRAY, PMIX_MAX_KEYLEN);
+    info[n].value.type = PMIX_DATA_ARRAY;
+    PMIX_DATA_ARRAY_CREATE(info[n].value.data.darray, 3, PMIX_INFO);
+    iptr = (pmix_info_t *) info[n].value.data.darray->array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_HOSTNAME, pmix_globals.hostname, PMIX_STRING);
+    m = 0;
+    PMIX_INFO_LOAD(&iptr[1], PMIX_NODEID, &m, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[2], PMIX_NODE_SIZE, &nprocs, PMIX_UINT32);
+    ++n;
+
+    /* per-proc data, identified by a procid that is deliberately not
+     * the first element */
+    for (m = 0; m < nprocs; m++) {
+        pmix_strncpy(info[n].key, PMIX_PROC_DATA, PMIX_MAX_KEYLEN);
+        info[n].value.type = PMIX_DATA_ARRAY;
+        PMIX_DATA_ARRAY_CREATE(array, 3, PMIX_INFO);
+        info[n].value.data.darray = array;
+        pdata = (pmix_info_t *) array->array;
+        k = 0;
+        pmix_strncpy(pdata[k].key, PMIX_LOCAL_RANK, PMIX_MAX_KEYLEN);
+        pdata[k].value.type = PMIX_UINT16;
+        pdata[k].value.data.uint16 = (uint16_t) (100 + m);
+        ++k;
+        PMIX_LOAD_PROCID(&p, nspace, (pmix_rank_t) m);
+        PMIX_INFO_LOAD(&pdata[k], PMIX_PROCID, &p, PMIX_PROC);
+        ++k;
+        pmix_strncpy(pdata[k].key, PMIX_NODEID, PMIX_MAX_KEYLEN);
+        pdata[k].value.type = PMIX_UINT32;
+        pdata[k].value.data.uint32 = 0;
+        ++n;
+    }
+
+    PMIX_LOAD_NSPACE(ns, nspace);
+    rc = PMIx_server_register_nspace(ns, nprocs, info, ninfo, NULL, NULL);
+    PMIX_INFO_FREE(info, ninfo);
+    return rc;
+}
+
+/* fetch one key for one rank out of the local datastore */
+static pmix_status_t fetch_one(const char *nspace, pmix_rank_t rank,
+                               const char *key, pmix_value_t *result)
+{
+    pmix_cb_t cb;
+    pmix_proc_t proc;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    PMIX_LOAD_PROCID(&proc, nspace, rank);
+    cb.proc = &proc;
+    cb.key = (char *) key;
+    cb.scope = PMIX_INTERNAL;
+    cb.copy = false;
+    cb.info = NULL;
+    cb.ninfo = 0;
+
+    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+    if (PMIX_SUCCESS == rc && NULL != result) {
+        kv = (pmix_kval_t *) pmix_list_get_first(&cb.kvs);
+        if (NULL != kv && NULL != kv->value) {
+            PMIX_VALUE_XFER_DIRECT(rc, result, kv->value);
+        } else {
+            rc = PMIX_ERR_NOT_FOUND;
+        }
+    }
+    cb.proc = NULL;
+    cb.key = NULL;
+    PMIX_DESTRUCT(&cb);
+    return rc;
+}
+
+static void test_registration(void)
+{
+    const char *nspace = "procid-identified";
+    pmix_status_t rc;
+    pmix_value_t val;
+
+    fprintf(stdout, "\n-- namespace registration --\n");
+
+    rc = register_job(nspace, 2);
+    report("a procid-identified proc array registers",
+           PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(stdout, "    register_nspace said: %s\n", PMIx_Error_string(rc));
+        return;
+    }
+
+    /* the values either side of the identifier must have been stored,
+     * and attributed to the rank the procid named */
+    PMIX_VALUE_CONSTRUCT(&val);
+    rc = fetch_one(nspace, 1, PMIX_LOCAL_RANK, &val);
+    report("a value ahead of the identifier is stored for the right rank",
+           PMIX_SUCCESS == rc && PMIX_UINT16 == val.type && 101 == val.data.uint16);
+    PMIX_VALUE_DESTRUCT(&val);
+
+    PMIX_VALUE_CONSTRUCT(&val);
+    rc = fetch_one(nspace, 0, PMIX_LOCAL_RANK, &val);
+    report("the other rank got its own value",
+           PMIX_SUCCESS == rc && PMIX_UINT16 == val.type && 100 == val.data.uint16);
+    PMIX_VALUE_DESTRUCT(&val);
+
+    /* the identifier names the array rather than being data belonging
+     * to the process, so it is consumed rather than stored */
+    rc = fetch_one(nspace, 1, PMIX_PROCID, NULL);
+    report("the identifier itself is not stored as a key", PMIX_SUCCESS != rc);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    static pmix_server_module_t mymodule = {0};
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== proc-array identifier unit tests ===\n");
+
+    test_scan();
+    test_registration();
+
+    fprintf(stdout, "\n=== %d passed, %d failed ===\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+    return (0 == nfail) ? 0 : 1;
+}


### PR DESCRIPTION
Follow-up to the `PMIX_RANK` question raised in #4073. Investigating why
`PMIx_Get(&myproc, PMIX_RANK)` returned `PMIX_ERR_NOT_FOUND` turned up two
real gaps — one in the datastore, one in the documentation.

## The datastore was stricter than the attribute it implements

`PMIX_PROC_INFO_ARRAY` (`"pmix.pdata"`, also reachable by its deprecated
name `PMIX_PROC_DATA`) says the array is identified by the `PMIX_RANK` and
`PMIX_NSPACE` attributes, **or** by `PMIX_PROCID`, and places no
requirement on where in the array that identifier appears.

Every site that expands one of these arrays instead required `PMIX_RANK`,
of type `PMIX_PROC_RANK`, as the *very first element*, rejecting anything
else with `PMIX_ERR_TYPE_MISMATCH`, then walked from index 1 — conflating
"first element" with "the identifier". A host that identified its arrays
with `PMIX_PROCID`, exactly as the attribute permits, could not register
its job at all; neither could one that merely ordered the array
differently.

A new base helper, `pmix_gds_base_proc_array_id()`, scans for whichever
form the host used and returns both the rank and the position that carried
it, so the store loops skip that one entry wherever it sits and store all
the rest. `PMIX_RANK` is preferred when both are present. The four
expansion sites — three in `gds/hash`, one in `gds/shmem3` — now share it.

The identifier is still consumed rather than stored: it names the array
rather than being data belonging to the process. That is precisely why
`PMIX_RANK` has never been retrievable through `PMIx_Get` for a named
process, which leads to the second half.

One incidental fix falls out of the shared helper: `hash_store_job_info`
reported a missing identifier by logging `PMIX_ERR_BAD_PARAM` and then
returning `rc`, which at that point still held `PMIX_SUCCESS` — a
malformed array was announced and then silently accepted.

## The man page described a contract that does not hold

`PMIx_Get(3)` introduces its RESERVED KEYS list with "unless otherwise
noted, are retrieved for the process identified in `proc`", then lists
`PMIX_RANK` and `PMIX_PROCID` without noting otherwise. For those two the
statement cannot be true — they name the very thing `proc` has to supply.
Both are retrieved by leaving the corresponding part of `proc`
unspecified: rank `PMIX_RANK_INVALID` for `PMIX_RANK`, a `NULL` proc for
`PMIX_PROCID`. Neither sentinel was written down anywhere. A note now
covers both, says what a fully specified `proc` returns instead, and
separates these two from the neighbouring rank keys (`PMIX_GLOBAL_RANK`,
`PMIX_APP_RANK`, `PMIX_LOCAL_RANK`, `PMIX_NODE_RANK`,
`PMIX_PACKAGE_RANK`), which really are ordinary stored values.

No library behavior was changed to make `PMIx_Get(&myproc, PMIX_RANK)`
work — the request is circular and the current behavior is correct.

## Testing

New `test/unit/proc_array_id`, wired into `make check`: seven cases over
the identifier scan (rank first, rank later, procid-identified, both
present, unidentified, wrong type, missing array) plus four that go
through a real `PMIx_server_register_nspace` with a procid-identified
array whose identifier is deliberately not first, checking the values
either side of it land against the right rank and that the identifier is
not itself stored.

Confirmed the test catches the old behavior: reverting only `gds_hash.c`
fails it with `register_nspace said: PMIX_ERR_TYPE_MISMATCH`.

Verified on both platforms, since `gds/shmem3` does not build on macOS and
so would otherwise have gone entirely uncompiled:

* macOS, `--enable-devel-check` — warning-free, `make check` 87/87.
* Linux (container), `--enable-devel-check` — warning-free,
  `make check` 87/87, with `Shared-Memory: yes` so `gds_shmem3_store.c` is
  both compiled and, being the preferred module there, actually exercised.