### PR TITLE
Drop the unused deprecated-argument attribute check

### DIFF
--- a/config/pmix_check_attributes.m4
+++ b/config/pmix_check_attributes.m4
@@ -136,7 +136,6 @@ AC_DEFUN([PMIX_CHECK_ATTRIBUTES], [
     pmix_cv___attribute__cold=0
     pmix_cv___attribute__const=0
     pmix_cv___attribute__deprecated=0
-    pmix_cv___attribute__deprecated_argument=0
     pmix_cv___attribute__format=0
     pmix_cv___attribute__format_funcptr=0
     pmix_cv___attribute__hot=0
@@ -190,14 +189,6 @@ AC_DEFUN([PMIX_CHECK_ATTRIBUTES], [
     _PMIX_CHECK_SPECIFIC_ATTRIBUTE([deprecated],
         [
          int foo(int arg1, int arg2) __attribute__ ((__deprecated__));
-         int foo(int arg1, int arg2) { return arg1 * arg2 + arg1; }
-        ],
-        [],
-        [])
-
-    _PMIX_CHECK_SPECIFIC_ATTRIBUTE([deprecated_argument],
-        [
-         int foo(int arg1, int arg2) __attribute__ ((__deprecated__("compiler allows argument")));
          int foo(int arg1, int arg2) { return arg1 * arg2 + arg1; }
         ],
         [],
@@ -500,8 +491,6 @@ AC_DEFUN([PMIX_CHECK_ATTRIBUTES], [
                      [Whether your compiler has __attribute__ const or not])
   AC_DEFINE_UNQUOTED(PMIX_HAVE_ATTRIBUTE_DEPRECATED, [$pmix_cv___attribute__deprecated],
                      [Whether your compiler has __attribute__ deprecated or not])
-  AC_DEFINE_UNQUOTED(PMIX_HAVE_ATTRIBUTE_DEPRECATED_ARGUMENT, [$pmix_cv___attribute__deprecated_argument],
-                     [Whether your compiler has __attribute__ deprecated with optional argument])
   AC_DEFINE_UNQUOTED(PMIX_HAVE_ATTRIBUTE_FORMAT, [$pmix_cv___attribute__format],
                      [Whether your compiler has __attribute__ format or not])
   AC_DEFINE_UNQUOTED(PMIX_HAVE_ATTRIBUTE_FORMAT_FUNCPTR, [$pmix_cv___attribute__format_funcptr],


### PR DESCRIPTION
Configure probed whether the compiler accepts an optional message argument to `__attribute__((__deprecated__))` and exported the answer as `PMIX_HAVE_ATTRIBUTE_DEPRECATED_ARGUMENT`. Nothing ever read that macro: `pmix_config_bottom.h` defines `__pmix_attribute_deprecated__` from `PMIX_HAVE_ATTRIBUTE_DEPRECATED` alone, and no source file or document references the argument variant.

This removes the probe, its zero-initializer in the no-`__attribute__` branch, and the `AC_DEFINE`, so configure stops paying for a test whose result cannot influence the build.

Verified with the full regeneration cycle (`./autogen.pl`, `./configure` with the tree's original options, `make -j8`): configure and build both succeed warning-free, and the generated `src/include/pmix_config.h` now carries only `PMIX_HAVE_ATTRIBUTE_DEPRECATED`.