### PR TITLE
Deep review of src/mca/base: fixes, tests, and AGENTS.md

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -352,6 +352,7 @@ AC_CONFIG_FILES(pmix_config_prefix[contrib/Makefile]
                 pmix_config_prefix[test/unit/Makefile]
                 pmix_config_prefix[test/unit/util/Makefile]
                 pmix_config_prefix[test/unit/class/Makefile]
+                pmix_config_prefix[test/unit/mca/Makefile]
                 pmix_config_prefix[test/util/Makefile]
                 pmix_config_prefix[docs/Makefile]
                 pmix_config_prefix[maint/pmix.pc])

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -24,6 +24,7 @@ two disagree, the README wins, and please fix this file.
 | `run-class-tests.sh` | The `src/class` unit suite, in the two configurations nobody develops in (README §11) |
 | `run-client-tests.sh` | The `src/client` API suite with ranks behind different servers (README §12) |
 | `run-common-tests.sh` | The `src/common` role-shared API suite — query/log/job-control/allocation/monitor/IOF across separate servers (README §13) |
+| `run-mca-tests.sh` | The `src/mca/base` unit suite plus hostile MCA parameters, in the `--enable-mca-dso` configuration where the component repository is actually exercised (README §14) |
 | `swarm-common.sh` | **Sourced, never executed.** `$PMIX_SWARM` naming and the one copy of `cleanup_swarm` |
 
 ## Things that will bite you

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -706,3 +706,104 @@ in-tree library and runs them under a single local `prterun`. The
 connected query/log/job-control paths are real, but with one server the
 monitor's local/remote split collapses to "all local", so this is a
 regression smoke pass rather than the multi-server case above.
+
+## 14. The `src/mca/base` unit suite (`run-mca-tests.sh`)
+
+```
+./run-mca-tests.sh linux    # in the containers: static and --enable-mca-dso
+./run-mca-tests.sh macos    # natively: in-tree, plus an --enable-mca-dso build
+```
+
+[`src/mca/base`](../../src/mca/base) is the MCA implementation itself —
+the MCA variable registry, the component repository, and the framework
+register/open/select/close lifecycle. Its unit suite lives in
+[`test/unit/mca`](../../test/unit/mca) and runs under an ordinary
+`make check`.
+
+### This is not a multi-node test, and does not pretend to be
+
+Everything in `src/mca/base` is process-local: it reads the environment
+and parameter files, registers variables, loads plugins, and opens
+frameworks. Nothing in it crosses a node boundary. The ten-node stage at
+the end of the Linux run is a contention and load pass — ten independent
+copies against one kernel and one CPU set — and confirms the staged
+binaries work under the same runtime as the rest of the harness. It is
+not a distributed test.
+
+### What the swarm actually buys
+
+**`--enable-mca-dso`, which is the whole reason this runner exists.**
+Roughly half of `src/mca/base` is compiled but never executed in an
+ordinary build:
+[`pmix_mca_base_component_repository.c`](../../src/mca/base/pmix_mca_base_component_repository.c)
+is entirely `#if PMIX_HAVE_PDL_SUPPORT`, and `find_dyn_components()` in
+[`pmix_mca_base_component_find.c`](../../src/mca/base/pmix_mca_base_component_find.c)
+does nothing at all when there are no DSOs to find. A static build walks
+`framework_static_components` and stops — so the `project@path` parser,
+the repository hash, the `dlopen`/`dlsym`/version-check sequence, the
+per-file refcount, and the `show_load_errors` reporting wrapped around
+them get **zero** coverage from `make check` on a normal tree. Two of the
+memory errors the August 2026 review of that directory found were in
+exactly that code.
+
+Secondarily: Linux (the primary development host here is macOS, and this
+directory reaches `getcwd`, `geteuid`, the home directory, `syslog` and
+`dlopen`), and an optimized `--disable-debug` build, since
+`register_variable()` and its neighbours guard developer errors behind
+`assert()` and `#if PMIX_ENABLE_DEBUG`.
+
+### The stages
+
+1. **Static build, unit suite.** Against the tree `build.sh` already
+   configured, as a baseline.
+2. **`--enable-mca-dso` build, unit suite.** A separate prefix and VPATH
+   directory, so this library never displaces the one the rest of the
+   harness runs against.
+3. **"The repository actually loaded components."** With DSOs, the only
+   way `pmix_info --all` can name a component is by having `dlopen`ed
+   it, so a count near zero means the dynamic path silently found
+   nothing — precisely the failure a static build hides. The stage fails
+   below ten.
+4. **Malformed MCA parameters must not be memory errors.** Each case
+   runs `pmix_info --all` with one hostile value and asserts the process
+   **survives** — an exit status above 128 is a signal and fails. What it
+   prints is deliberately not checked: a malformed MCA parameter is an
+   ordinary user mistake, and the only contract is that it may not take
+   the library down. The cases include an
+   `mca_base_component_path` entry with no `@` delimiter and one with an
+   over-long project name (both were a stack buffer overflow),
+   `mca_base_verbose=syslogid:<str>` (a use-after-free), every accepted
+   shape of `mca_base_component_show_load_errors` including the bare
+   framework and `^` forms (a `NULL` dereference), and a deprecated
+   synonym.
+5. **Ten-node contention pass**, as described above.
+
+The unit suite the first two stages run includes `mca_base_framework`,
+whose subject is the register/open/close reference count. That one is
+worth having in the DSO configuration specifically: a framework whose
+open fails there has real components to tear down, where in the static
+build the lists are empty.
+
+### Things to know
+
+**The build volume outlives your branch.** `test/unit/mca` is newer than
+some trees sitting in `pmix-build`, and a `config.status` that predates a
+directory has never heard of its `Makefile` — `make` then dies with
+`test/unit/mca: No such file or directory`. The runner detects the
+missing Makefile and re-runs `config.status --recheck` rather than
+failing with a message that points nowhere. The same shape of problem,
+from the other direction, is the `aclocal.m4` trap described in §8.
+
+**`pmix_info` is used on purpose** for stages 3 and 4: it is the one
+installed program that opens every framework, so a single run exercises
+the repository across all of them rather than only the ones some client
+happens to need.
+
+### macOS mode
+
+`./run-mca-tests.sh macos` runs the in-tree suite and then builds a
+second, `--enable-mca-dso` tree out of tree and repeats stages 2–4
+against it. It skips the second half if the source directory is
+configured in place, because autoconf refuses a VPATH build alongside a
+`config.status` in the srcdir — and a test script has no business running
+`make distclean` on a working tree to get around that.

--- a/contrib/dockerswarm/run-mca-tests.sh
+++ b/contrib/dockerswarm/run-mca-tests.sh
@@ -1,0 +1,426 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Run the src/mca/base unit suite (test/unit/mca) against your live openpmix
+# tree, in the configuration a developer's own `make check` does not give
+# them: a Linux build with --enable-mca-dso, where every MCA component is a
+# real dlopen'd plugin.
+#
+#   ./run-mca-tests.sh linux    # in the swarm's containers
+#   ./run-mca-tests.sh macos    # natively, in-tree plus a --enable-mca-dso build
+#
+# WHY THIS IS NOT A MULTI-NODE TEST
+#
+# src/mca/base is process-local by construction.  It registers MCA variables,
+# reads parameter files and the environment, finds and loads components, and
+# runs the framework register/open/select/close lifecycle.  None of that
+# crosses a node boundary, so spreading it over ten containers would tell you
+# nothing that running it once does not.  The ten-node stage below is a
+# contention and load pass -- ten independent copies against one kernel and
+# one CPU set -- and is not claimed to be more.
+#
+# WHAT THE SWARM DOES BUY -- AND IT IS THE WHOLE POINT
+#
+#  1. --enable-mca-dso.  Roughly half of this directory is compiled but never
+#     executed in an ordinary build.  pmix_mca_base_component_repository.c is
+#     entirely #if PMIX_HAVE_PDL_SUPPORT, and find_dyn_components() in
+#     pmix_mca_base_component_find.c only does anything when there are DSOs to
+#     find.  A static build walks framework_static_components and stops.  So
+#     the component-path parser, the repository hash, the dlopen/dlsym/version
+#     checks, the retain/release refcount on a repository item and the
+#     show_load_errors reporting around them all get zero coverage from
+#     `make check` on a normal tree.  Two of the defects the August 2026
+#     review of this directory found were in exactly that code.
+#
+#  2. Linux.  The primary development host here is macOS.  This directory
+#     reaches getcwd, geteuid, the home directory, syslog and dlopen, and the
+#     container is the nearest Linux userspace.
+#
+#  3. An OPTIMIZED build.  register_variable() and several other routines
+#     guard developer errors behind assert() and #if PMIX_ENABLE_DEBUG.  A
+#     --disable-debug tree is the one users get and the one nobody tests.
+#
+# Beyond the unit suite, the stages below drive the parameter forms that only
+# reach live code once components are loadable, plus the three malformed-input
+# cases that used to be memory errors: an mca_base_component_path entry with
+# no "@" delimiter, an over-long project name in one, and
+# mca_base_verbose=syslogid:<str>.  Those assert survival, not output.
+#
+# Prints PASS/FAIL per stage and exits non-zero if anything failed.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+. "$(dirname "$0")/swarm-common.sh"
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+# The program list comes out of the Makefile.am rather than being repeated
+# here, so adding an mca_base_* test to the suite does not silently leave it
+# out of this run.
+mca_programs() {
+    sed -n '/^check_PROGRAMS[[:space:]]*=/,/[^\\]$/p' \
+        "$root/test/unit/mca/Makefile.am" \
+        | sed 's/^check_PROGRAMS[[:space:]]*=//; s/\\$//' \
+        | tr -s ' \t\n' ' '
+}
+
+# The hostile-input cases, as one shell fragment so the linux and macos halves
+# cannot drift.  $1 is the directory holding an installed pmix_info.  Every
+# case asserts that the process SURVIVES -- what it prints is not the subject,
+# and a malformed MCA parameter is an ordinary user mistake, not something
+# that may take the library down.  A crash shows up as a signal exit status
+# (>128), which is why each case tests for that rather than for zero.
+#
+# Note the deliberate use of pmix_info: it is the one installed program that
+# opens every framework, so it exercises the repository across all of them.
+BAD_INPUT_CASES='
+# Refuse to run at all if the binary is not there.  Without this the cases
+# below "pass" against a missing program -- env(1) exits 127, which is not a
+# signal, so every case reports ok and the whole stage proves nothing.  That
+# is precisely how a build failure two stages earlier turned into fourteen
+# green lines the first time this script was run.
+if [ ! -x "$INFO/pmix_info" ]; then
+    echo "PREFLIGHT no-pmix_info-at-$INFO"
+    exit 0
+fi
+survives() {   # $1 = label, rest = env assignments; prints "label verdict"
+    local label="$1"; shift
+    local rc
+    env "$@" "$INFO/pmix_info" --all >/dev/null 2>&1
+    rc=$?
+    # What is being asserted is "not a MEMORY error", not "exit zero".
+    #
+    # Rejecting a malformed value is legitimate, and PMIx rejects some of
+    # these loudly: an unparseable mca_base_component_show_load_errors makes
+    # pmix_mca_base_open() fail, which pmix_info reports through show_help
+    # and then abort()s on.  That is a diagnosed refusal, and SIGABRT is how
+    # it arrives -- so treating every signal as failure would flag correct
+    # behavior.  SIGSEGV/SIGBUS/SIGILL/SIGFPE have no such reading: they are
+    # the library walking off the end of something, which is the entire
+    # subject of this stage.
+    #
+    # 127 means the program never ran, which is a broken harness rather than
+    # a passing case.
+    case "$rc" in
+        139|138|132|136) echo "$label CRASH(signal $((rc-128)))" ;;
+        127)             echo "$label NOT-RUN" ;;
+        *)               echo "$label ok" ;;
+    esac
+}
+# Rejecting bad input is fine; accepting it silently is not.  This asserts
+# that the one value the parser is documented to refuse actually is refused,
+# and says so -- otherwise "survives" above would be satisfied by a library
+# that quietly ignored it.
+rejects() {    # $1 = label, rest = env assignments
+    local label="$1"; shift
+    if env "$@" "$INFO/pmix_info" --all 2>&1 >/dev/null \
+         | grep -q "more than one"; then
+        echo "$label ok"
+    else
+        echo "$label NOT-DIAGNOSED"
+    fi
+}
+survives no-at-delimiter        PMIX_MCA_mca_base_component_path=/no/at/sign/here
+survives overlong-project       PMIX_MCA_mca_base_component_path=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@/tmp
+survives empty-component-path   PMIX_MCA_mca_base_component_path=
+survives syslogid               PMIX_MCA_mca_base_verbose=syslogid:pmixtest,stderr
+survives sle-bare-framework     PMIX_MCA_mca_base_component_show_load_errors=ptl
+survives sle-negated-framework  PMIX_MCA_mca_base_component_show_load_errors=^ptl
+survives sle-fw-component       PMIX_MCA_mca_base_component_show_load_errors=ptl/tcp
+survives sle-mixed              PMIX_MCA_mca_base_component_show_load_errors=ptl/tcp,gds,psec
+survives sle-empty-entries      PMIX_MCA_mca_base_component_show_load_errors=ptl,,gds,
+survives sle-too-many-slashes   PMIX_MCA_mca_base_component_show_load_errors=ptl/tcp/extra
+rejects  sle-too-many-slashes-diagnosed \
+                                PMIX_MCA_mca_base_component_show_load_errors=ptl/tcp/extra
+survives sle-none               PMIX_MCA_mca_base_component_show_load_errors=none
+survives paramfiles-none        PMIX_MCA_mca_base_param_files=none
+survives missing-param-file     PMIX_MCA_mca_base_param_files=/nonexistent/mca-params.conf
+survives deprecated-synonym     PMIX_MCA_mca_param_files=none
+'
+
+# Did the repository actually load anything?  With --enable-mca-dso the only
+# way pmix_info can name a component is by having dlopen'd it, so a low count
+# means the dynamic path silently found nothing -- which is exactly the
+# failure mode a static build hides.
+COUNT_COMPONENTS='
+n=$("$INFO/pmix_info" --all 2>/dev/null \
+      | grep -cE "^ *MCA [a-z0-9_]+: .+ \(MCA v")
+echo "components:$n"
+'
+
+# An out-of-tree build cannot coexist with a config.status in the srcdir --
+# autoconf refuses with "source directory already configured".  Every VPATH
+# build below reads this clone through a read-only mount, so a configured-in-
+# place tree stops them all.  Say so once, plainly, instead of letting three
+# stages fail with an autoconf error that names no way out.  ./build.sh runs
+# "make distclean" for exactly this reason; a test script has no business
+# doing that to a working tree.
+srcdir_blocks_vpath() {
+    [ -f "$root/config.status" ] || return 1
+    echo "     $root holds a config.status, so autoconf will refuse every" >&2
+    echo "     VPATH build this script needs.  Either:" >&2
+    echo "         make -C $root distclean && $0 $mode" >&2
+    echo "     or run ./build.sh, which distcleans the tree for you." >&2
+    return 0
+}
+
+########################################################################
+# Linux: build the DSO configuration in a builder container, run the
+# suite and the hostile-input cases against it, then a contention pass.
+########################################################################
+
+test_linux() {
+    local progs rc out
+
+    progs="$(mca_programs)"
+    if [ -z "${progs// /}" ]; then
+        bad "could not read check_PROGRAMS from test/unit/mca/Makefile.am"
+        return
+    fi
+    echo "    suite: $progs"
+
+    swarm_up_or_die
+
+    if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+        bad "build volume $VOLUME missing -- run ./build.sh first"
+        return
+    fi
+
+    if srcdir_blocks_vpath; then
+        skp "srcdir is configured in place -- no VPATH build can be made from it"
+        return
+    fi
+
+    banner "unit suite in the tree build.sh configured (static components)"
+    # Reuse the tree build.sh already configured; if it is not there, say so
+    # rather than configuring a third one behind the user's back.
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e PROGS="$progs" \
+        "$IMAGE" bash -euo pipefail -c '
+            cd /opt/prte/vpath-pmix 2>/dev/null || {
+                echo "no /opt/prte/vpath-pmix -- run ./build.sh first" >&2; exit 2; }
+            # The build volume outlives your branch, so this tree may have
+            # been configured before test/unit/mca existed -- its
+            # config.status has never heard of that Makefile and make dies
+            # with "test/unit/mca: No such file or directory".  Re-running
+            # config.status --recheck re-runs configure (with the original
+            # arguments) against the current source, and the plain
+            # config.status then instantiates the new Makefile.
+            if [ ! -f test/unit/mca/Makefile ]; then
+                echo "reconfiguring: this tree predates test/unit/mca"
+                ./config.status --recheck
+                ./config.status
+                make -j"$(nproc)"
+            fi
+            make -j"$(nproc)" -C test/unit/mca check
+            mkdir -p /opt/prte/tests-mca/static
+            for p in $PROGS; do
+                # Stage the real ELF binary, not the libtool wrapper.  An
+                # uninstalled libtool target leaves a /bin/sh wrapper at
+                # test/unit/mca/$p and puts the executable under .libs/;
+                # copying the wrapper gives a script that says .libs/$p does
+                # not exist and exits 1.
+                cp "test/unit/mca/.libs/$p" /opt/prte/tests-mca/static/ 2>/dev/null \
+                    || cp "test/unit/mca/$p" /opt/prte/tests-mca/static/ 2>/dev/null || true
+            done
+        '
+    rc=$?
+    [ "$rc" = 0 ] && ok "static build: unit suite green in the container" \
+                  || bad "static build: unit suite failed (rc=$rc)"
+
+    banner "--enable-mca-dso build (the configuration that exercises this code)"
+    # A separate prefix and a separate VPATH directory: this library must not
+    # displace the one the rest of the harness runs against.
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e PROGS="$progs" \
+        "$IMAGE" bash -euo pipefail -c '
+            mkdir -p /opt/prte/vpath-pmix-dso && cd /opt/prte/vpath-pmix-dso
+            [ -f config.status ] || /pmix-src/configure \
+                --prefix=/opt/prte/pmix-dso --enable-mca-dso \
+                --disable-debug --disable-devel-check
+            # Two statements, not "make && make install": set -e does not fire
+            # for a failing command in a non-final position of an && list, so
+            # the joined form reports success over a stale install.
+            make -j"$(nproc)"
+            make install
+            make -j"$(nproc)" -C test/unit/mca check
+            mkdir -p /opt/prte/tests-mca/dso
+            for p in $PROGS; do
+                cp "test/unit/mca/.libs/$p" /opt/prte/tests-mca/dso/ 2>/dev/null \
+                    || cp "test/unit/mca/$p" /opt/prte/tests-mca/dso/ 2>/dev/null || true
+            done
+        '
+    rc=$?
+    [ "$rc" = 0 ] && ok "mca-dso build: unit suite green in the container" \
+                  || bad "mca-dso build: unit suite failed (rc=$rc)"
+
+    banner "the repository actually loaded components"
+    out=$(docker run --rm -v "$VOLUME":/opt/prte \
+              -e INFO=/opt/prte/pmix-dso/bin \
+              "$IMAGE" bash -c "export LD_LIBRARY_PATH=/opt/prte/pmix-dso/lib; $COUNT_COMPONENTS" \
+              2>/dev/null | tr -d '\r')
+    case "$out" in
+        components:0|components:|"")
+            bad "pmix_info named no components -- the dynamic path found nothing ($out)" ;;
+        components:*)
+            # A real tree has dozens; anything above a handful means dlopen,
+            # dlsym and the version check all worked for many frameworks.
+            if [ "${out#components:}" -ge 10 ] 2>/dev/null; then
+                ok "pmix_info named ${out#components:} components out of the repository"
+            else
+                bad "pmix_info named only ${out#components:} components -- suspiciously few"
+            fi ;;
+        *) bad "unexpected output from the component count: $out" ;;
+    esac
+
+    banner "malformed MCA parameters must not be memory errors (dso build)"
+    out=$(docker run --rm -v "$VOLUME":/opt/prte \
+              -e INFO=/opt/prte/pmix-dso/bin \
+              "$IMAGE" bash -c "export LD_LIBRARY_PATH=/opt/prte/pmix-dso/lib; $BAD_INPUT_CASES" \
+              2>/dev/null | tr -d '\r')
+    case "$out" in
+        ""|*PREFLIGHT*)
+            bad "the hostile-input stage never ran: ${out:-no output at all}" ;;
+        *)
+            while read -r label verdict; do
+                [ -n "$label" ] || continue
+                [ "$verdict" = ok ] && ok "survived: $label" \
+                                    || bad "survived: $label -- $verdict"
+            done <<< "$out" ;;
+    esac
+
+    # Ten containers on one host share a kernel and a set of CPUs, so this is
+    # a load and contention pass, not a distributed one.  It is worth the
+    # minute it costs because it confirms the staged binaries work under the
+    # same runtime the rest of the harness uses.  It is not claimed to be
+    # more than that.
+    banner "concurrent run across all ten nodes (contention pass)"
+    for cfg in static dso; do
+        if ! ON 1 "test -d /opt/prte/tests-mca/$cfg"; then
+            skp "$cfg binaries not staged"
+            continue
+        fi
+        local lib="/opt/prte/pmix/lib"
+        [ "$cfg" = dso ] && lib="/opt/prte/pmix-dso/lib"
+
+        local pids="" n bad_nodes=""
+        rm -f /tmp/swarm-mca-$cfg-*.out
+        for n in $(seq 1 10); do
+            ( docker exec "$NODE$n" bash -lc \
+                "export LD_LIBRARY_PATH=$lib; \
+                 cd /opt/prte/tests-mca/$cfg && \
+                 for p in $progs; do ./\$p >/dev/null 2>&1 || exit 1; done" \
+              >/dev/null 2>&1; echo "$?" > "/tmp/swarm-mca-$cfg-$n.out" ) &
+            pids="$pids $!"
+        done
+        for p in $pids; do wait "$p"; done
+        for n in $(seq 1 10); do
+            [ "$(cat "/tmp/swarm-mca-$cfg-$n.out" 2>/dev/null)" = 0 ] \
+                || bad_nodes="$bad_nodes node$n"
+        done
+        rm -f /tmp/swarm-mca-$cfg-*.out
+        [ -z "$bad_nodes" ] && ok "$cfg: suite green on all ten nodes at once" \
+                            || bad "$cfg: failed on$bad_nodes"
+    done
+}
+
+########################################################################
+# macOS: the in-tree build, plus an --enable-mca-dso VPATH build.  No
+# containers -- the point here is still the DSO configuration, which the
+# developer's own tree does not provide either.
+########################################################################
+
+test_macos() {
+    local progs rc jobs out dso="$root/vpath-macos-pmix-dso"
+
+    progs="$(mca_programs)"
+    echo "    suite: $progs"
+    jobs="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+
+    banner "in-tree build (whatever it is configured as)"
+    if [ ! -f "$root/config.status" ]; then
+        skp "no configured tree at $root -- run ./configure there first"
+    else
+        ( cd "$root" && make -j"$jobs" && make -C test/unit/mca check ) \
+            >/tmp/mca-intree.$$ 2>&1
+        rc=$?
+        [ "$rc" = 0 ] && ok "in-tree: unit suite green" \
+                      || { bad "in-tree: unit suite failed (rc=$rc)"; tail -30 /tmp/mca-intree.$$; }
+        rm -f /tmp/mca-intree.$$
+    fi
+
+    banner "--enable-mca-dso VPATH build"
+    if srcdir_blocks_vpath; then
+        skp "srcdir is configured in place -- an out-of-tree build cannot coexist"
+        return
+    fi
+
+    mkdir -p "$dso"
+    ( cd "$dso" \
+        && { [ -f config.status ] || "$root/configure" --prefix="$dso/install" \
+                 --enable-mca-dso --disable-debug --disable-devel-check; } \
+        && make -j"$jobs" \
+        && make install \
+        && make -C test/unit/mca check ) >/tmp/mca-dso.$$ 2>&1
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        bad "mca-dso: build or unit suite failed (rc=$rc)"
+        tail -30 /tmp/mca-dso.$$
+        rm -f /tmp/mca-dso.$$
+        return
+    fi
+    ok "mca-dso: unit suite green"
+    rm -f /tmp/mca-dso.$$
+
+    banner "the repository actually loaded components"
+    out=$(INFO="$dso/install/bin" \
+          DYLD_LIBRARY_PATH="$dso/install/lib" bash -c "$COUNT_COMPONENTS" 2>/dev/null)
+    if [ "${out#components:}" -ge 10 ] 2>/dev/null; then
+        ok "pmix_info named ${out#components:} components out of the repository"
+    else
+        bad "pmix_info named too few components ($out)"
+    fi
+
+    banner "malformed MCA parameters must not be memory errors (dso build)"
+    out=$(INFO="$dso/install/bin" \
+          DYLD_LIBRARY_PATH="$dso/install/lib" bash -c "$BAD_INPUT_CASES" 2>/dev/null)
+    case "$out" in
+        ""|*PREFLIGHT*)
+            bad "the hostile-input stage never ran: ${out:-no output at all}" ;;
+        *)
+            while read -r label verdict; do
+                [ -n "$label" ] || continue
+                [ "$verdict" = ok ] && ok "survived: $label" \
+                                    || bad "survived: $label -- $verdict"
+            done <<< "$out" ;;
+    esac
+}
+
+########################################################################
+
+case "$mode" in
+    linux) test_linux ;;
+    macos) test_macos ;;
+    *) echo "usage: $0 [linux|macos]" >&2; exit 2 ;;
+esac
+
+printf '\n=== summary: %d passed, %d failed, %d skipped ===\n' "$pass" "$fail" "$skip"
+[ "$fail" -eq 0 ]

--- a/src/mca/AGENTS.md
+++ b/src/mca/AGENTS.md
@@ -1,0 +1,202 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The MCA tree
+
+This document orients AI agents and human contributors working anywhere
+under `src/mca`. Read the top-level [`AGENTS.md`](../../AGENTS.md) first
+— the golden rules, prefix conventions, thread-safety model and the MCA
+vocabulary (project → framework → component → module) all come from
+there and are not repeated here. This file covers what is true of the
+*tree*: the two files that live at this level, the directory shape every
+framework must follow, and where to look next.
+
+Nearly every framework subdirectory carries its own `AGENTS.md`, and so
+do most component subdirectories. Those are the authoritative documents
+for the thing they describe; this one only gets you to them.
+
+## What lives at this level
+
+Only three things:
+
+| Path | Role |
+|------|------|
+| [`mca.h`](mca.h) | the component and module ABI — what every component struct starts with |
+| [`Makefile.include`](Makefile.include) | one line, included from `src/Makefile.am`, that installs `mca.h` |
+| [`base/`](base/) | **not a framework** — the MCA implementation itself. See [`base/AGENTS.md`](base/AGENTS.md) |
+
+Everything else is a framework directory.
+
+### `mca.h` — the component ABI
+
+`pmix_mca_base_component_t` (versioned as
+`pmix_mca_base_component_2_1_0_t`) is the struct every component's public
+symbol begins with. It carries three sets of names and versions — MCA,
+project, framework, component — and four optional function pointers:
+
+| Field | When it runs | Notes |
+|-------|--------------|-------|
+| `pmix_mca_register_component_params` | during framework *register* | the right place for `pmix_mca_base_component_var_register()` |
+| `pmix_mca_open_component` | during framework *open* | allocate resources; **not** the place to register variables |
+| `pmix_mca_query_component` | during *select* | return a module and a priority |
+| `pmix_mca_close_component` | during framework *close* | release resources |
+
+All four may be `NULL`, which the base treats as "called it, it returned
+`PMIX_SUCCESS`".
+
+**`PMIX_ERR_NOT_AVAILABLE` from register or open means "silently ignore
+me".** It is how a component says "not on this machine" without
+producing a user-visible error. Any *other* failure is reported (subject
+to `mca_base_component_show_load_errors`) and the component is dropped.
+**`PMIX_ERR_FATAL` from a query stops selection entirely** — a component
+uses it to say "the user asked for something I cannot provide, do not
+quietly pick someone else instead."
+
+The struct ends with `char reserved[32]`. That is the ABI escape hatch:
+new fields come out of `reserved`, never by inserting into the middle,
+because host environments and dynamically-loaded components built
+against an older release must keep working. The same reasoning as the
+top-level backward-compatibility rules — treat this layout as
+append-only.
+
+Three name-length limits are fixed here and used to size fields all over
+the tree: project 15, framework 31, component 63 (each `+1` for the
+terminator).
+
+A component struct is opened with its framework's version macro, which
+expands through `PMIX_MCA_BASE_VERSION_1_0_0()` in this header:
+
+```c
+pmix_gds_base_component_t pmix_mca_gds_hash_component = {
+    PMIX_GDS_BASE_VERSION_1_0_0,
+    .pmix_mca_component_name = "hash",
+    ...
+};
+```
+
+The public symbol must be named
+`<project>_mca_<framework>_<component>_component`, because that is the
+string
+[`base/pmix_mca_base_component_repository.c`](base/pmix_mca_base_component_repository.c)
+builds and looks up with `dlsym` when the component is a DSO. Get it
+wrong and the component works statically and silently disappears from a
+`--enable-mca-dso` build.
+
+## Directory shape
+
+The layout is strict — nothing under `src/mca` may deviate:
+
+```
+src/mca/<framework>/
+├── <framework>.h            the framework's public API: module struct + version macro
+├── base/                    framework infrastructure, NOT a component
+│   ├── base.h
+│   ├── <framework>_base_frame.c     PMIX_MCA_BASE_FRAMEWORK_DECLARE
+│   ├── <framework>_base_select.c
+│   └── ...
+└── <component>/             one directory per component
+    ├── Makefile.am
+    ├── configure.m4         only if the component has build prerequisites
+    └── <framework>_<component>_*.c
+```
+
+`base/` is the one name that is not a component. Everything else at that
+level is.
+
+Naming follows from the prefix rule: files are
+`<framework>_<component>_*.c`, framework-scoped symbols are
+`pmix_<framework>_*`, component-scoped symbols are
+`pmix_<framework>_<component>_*`.
+
+## Frameworks in this tree
+
+| Framework | Select | Purpose |
+|-----------|--------|---------|
+| [`bfrops`](bfrops/) | multi | pack/unpack/copy/print/compare — one component per wire-format version |
+| [`gds`](gds/) | multi (assign-on-demand per peer) | the datastore behind `PMIx_Put`/`PMIx_Get` |
+| [`pcompress`](pcompress/) | single | compression of large data objects |
+| [`pdl`](pdl/) | single | `dlopen` abstraction — used *by* `base/` itself |
+| [`pgpu`](pgpu/) | multi | GPU resource discovery |
+| [`pif`](pif/) | multi | network interface discovery |
+| [`pinstalldirs`](pinstalldirs/) | multi | installation directory resolution |
+| [`plog`](plog/) | multi | logging of user-provided alerts |
+| [`pmdl`](pmdl/) | multi | programming-model (MPI, OpenMP, …) env and parameter setup |
+| [`pnet`](pnet/) | multi | network support and "instant on" endpoint computation |
+| [`preg`](preg/) | multi | node/proc-map regular expression generation and parsing |
+| [`psec`](psec/) | multi | connection security handshakes |
+| [`psensor`](psensor/) | multi | process monitoring and health checks |
+| [`pstat`](pstat/) | single | process/node/disk statistics |
+| [`ptl`](ptl/) | single | client/server and tool/server transport |
+
+Note that the top-level [`AGENTS.md`](../../AGENTS.md) also lists `prm`
+and `psquash`. Neither directory exists in this tree any more; the table
+above is what is actually here. Trust `ls` over either document, and
+each framework's own `AGENTS.md` over this table's one-word
+select column.
+
+**`pdl` is special: it is opened by the MCA base itself**, in
+`pmix_mca_base_component_repository_init()`, before any other framework
+exists. It therefore cannot depend on anything the rest of the MCA
+provides.
+
+## Adding a framework or component
+
+The full procedure is in the top-level guide; the parts specific to this
+tree:
+
+1. Create `src/mca/<framework>/<component>/` with a `Makefile.am`, and a
+   `configure.m4` **only** if the component can fail to be buildable.
+2. Give the component struct the exactly-correct public symbol name (see
+   `mca.h` above) and open it with the framework's version macro.
+3. Register MCA variables from the component's *register* function, not
+   its open function.
+4. **Regenerate the build system.** Adding or removing a component
+   directory, or touching a `configure.m4`, changes wiring that a plain
+   `make` cannot pick up:
+
+   ```sh
+   ./autogen.pl
+   ./configure <same options as before>   # ./config.status --config
+   make -j
+   ```
+
+   Until you do, the component is simply not built — and it will look
+   like your code is being ignored.
+5. Add the build products to the appropriate `.gitignore`, and check
+   `git status` after a clean build.
+
+Editing a `Makefile.am` alone needs only a plain `make`.
+
+## Two things that bite
+
+- **A renamed or deleted component directory wedges existing build
+  trees.** Automake records each component's `configure.m4` as a
+  prerequisite of `aclocal.m4`; when one disappears, `make` decides
+  `aclocal.m4` is stale and shells out to `aclocal`. The error names
+  `aclocal`, never the component. Delete `config.status` and re-run
+  `configure`. See
+  [`contrib/dockerswarm/AGENTS.md`](../../contrib/dockerswarm/AGENTS.md),
+  where this is a recurring problem.
+- **A component that only builds when some hardware or third-party
+  library is present gets no compiler coverage on a machine that lacks
+  it.** Gate its `configure.m4` with `|| test "$pmix_testbuild" = "1"`
+  and guard its third-party include with `#if PMIX_TESTBUILD` against a
+  shim header, so `--enable-test-build` can compile-check it. A
+  test-build tree is for compiling only — never run the functional tests
+  against one.
+
+## Where to go next
+
+- [`base/AGENTS.md`](base/AGENTS.md) — the MCA implementation: variables,
+  component discovery and loading, the framework lifecycle.
+- `<framework>/AGENTS.md` — one per framework, and the authoritative
+  document for it.
+- [`docs/developers/terminology.rst`](../../docs/developers/terminology.rst)
+  — the project's own MCA vocabulary.

--- a/src/mca/CLAUDE.md
+++ b/src/mca/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/base/AGENTS.md
+++ b/src/mca/base/AGENTS.md
@@ -1,0 +1,662 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The MCA base
+
+This document orients AI agents and human contributors working in
+`src/mca/base` — the machinery that *is* the Modular Component
+Architecture. Read the top-level [`AGENTS.md`](../../../AGENTS.md) first;
+the golden rules, prefix conventions, and MCA vocabulary described there
+apply here and are not repeated. [`../AGENTS.md`](../AGENTS.md) covers
+the `src/mca` tree as a whole.
+
+This directory is **not a framework**. There is no `src/mca/base/base/`,
+no components, no `mca_base` module interface. It is the library that
+every *other* framework's `base/` is written against: it registers MCA
+variables, finds and opens components (statically linked or `dlopen`ed),
+drives the register/open/select/close lifecycle, and hands frameworks
+their verbosity streams. Nothing in `src/mca/base` knows what any
+framework does.
+
+## The two halves
+
+Almost everything here belongs to one of two subsystems that only touch
+at the edges:
+
+| Subsystem | Files | What it owns |
+|-----------|-------|--------------|
+| **MCA variables** | `pmix_mca_base_var*.c/h`, `pmix_mca_base_parse_paramfile.c` | the `name -> value` registry behind `PMIX_MCA_*` env vars, `mca-params.conf`, and `pmix_info` |
+| **Components** | `pmix_mca_base_component_*.c`, `pmix_mca_base_components_*.c`, `pmix_mca_base_framework.c`, `pmix_mca_base_alias.c` | finding, loading, registering, opening, selecting and closing plugins |
+
+`pmix_mca_base_open.c` / `_close.c` bring both up and down and own the
+handful of `mca_base_*` parameters the base registers for itself.
+
+## Part 1: the MCA variable system
+
+### Registration is the API
+
+A variable is a **name plus a pointer to the caller's storage**. The
+caller declares the storage, seeds it with the default, and registers it:
+
+```c
+static int my_param = 5;
+(void) pmix_mca_base_var_register("pmix", "ptl", "tcp", "my_param",
+                                  "what this does",
+                                  PMIX_MCA_BASE_VAR_TYPE_INT, &my_param);
+```
+
+Registration **immediately resolves the value** and writes it through
+that pointer, so `my_param` is correct the moment the call returns —
+there is no separate "look it up" step. The storage must outlive the
+registration; every caller in the tree uses a file-scope static.
+
+`pmix_mca_base_var_get_value()` exists for the case where you have an
+index but not the storage, and it does **not** copy: it hands back a
+*pointer to* the registered storage, so the argument is the address of
+a pointer and the value is read by dereferencing what comes back.
+
+```c
+int *val;
+pmix_mca_base_var_get_value(idx, &val, NULL, NULL);   /* &val, not &myint */
+printf("%d\n", *val);
+```
+
+Passing the address of an `int` writes a pointer through it. The header
+described a copy-out interface with a `value_size` parameter for years;
+no such parameter has ever existed.
+
+Three conveniences wrap the same call:
+`pmix_mca_base_component_var_register()` (takes the names out of a
+component struct, so the variable is dropped when the component closes)
+and `pmix_mca_base_framework_var_register()` (component name `"base"`).
+
+**`pmix_mca_base_var_register()` returns the variable's index, not a
+status.** Index 0 is a perfectly good index and happens to equal
+`PMIX_SUCCESS`, which makes `if (PMIX_SUCCESS != ret)` look like it
+works. Test the sign — `if (0 > ret)` — as the rest of this directory
+does.
+
+### Where a value comes from, and in what order
+
+`var_set_initial()` resolves each variable through, in increasing
+precedence:
+
+1. the default already in the caller's storage,
+2. the **override file** (`$sysconfdir/pmix-mca-params-override.conf`),
+3. a **`PMIX_MCA_<name>`** environment variable,
+4. an ordinary **parameter file** (`~/.pmix/mca-params.conf`,
+   `$sysconfdir/pmix-mca-params.conf`, or whatever
+   `mca_base_param_files` names).
+
+That ordering is enforced by the `mbv_source` each stage records, and
+`var_set_from_file()` cannot tell which of the two lists it was handed —
+it always records `SOURCE_FILE`. `var_set_initial()` is what promotes an
+override-file hit to `SOURCE_OVERRIDE`, and it has to do so on **both**
+the name that matched and the variable that name stands for. Marking
+only the former is invisible for an ordinary variable (they are the same
+object) and wrong for a synonym: the environment check that runs next
+tests the *original's* source, so an override file that used a
+deprecated spelling was silently beaten by a user's environment.
+
+Two names are accepted for every variable: the **full name**
+(`framework_component_variable`) and the **long name**
+(`project_framework_component_variable`), each with the project's
+upper-cased prefix — `PMIX_MCA_ptl_tcp_if_include` and
+`PMIX_MCA_pmix_ptl_tcp_if_include` both work. A companion
+`PMIX_MCA_SOURCE_<name>` variable records where a value came from when
+it is forwarded between processes.
+
+**Parameter files are read once, at `pmix_mca_base_var_init()`**, into
+`pmix_mca_base_var_file_values` / `..._override_values`; registration
+then searches those lists. So a variable registered before the files are
+read would silently miss a user's setting — which is why
+`pmix_mca_base_var_cache_files()` registers the two
+`suppress_*_warning` parameters *after* the read, with a comment saying
+so. Keep that ordering.
+
+**`PMIX_PARAM_FILE_PASSED` short-circuits the whole file stage.** The
+`pmdl` framework sets it in every child's environment (see
+`src/mca/pmdl/base/pmdl_base_stubs.c`) to say "your parent already
+resolved the files and put the results in your environment." In such a
+process `pmix_mca_base_var_cache_files()` returns early, so
+`pmix_mca_base_var_override_file` and friends stay `NULL` while
+`PMIX_MCA_SOURCE_*` variables are still present in the environment.
+Anything comparing against those file names has to tolerate `NULL`.
+
+### Synonyms
+
+`pmix_mca_base_var_register_synonym()` creates a second name for an
+existing variable, normally flagged `..._SYN_FLAG_DEPRECATED` so setting
+it prints a warning. **A synonym has no storage of its own** — reads and
+writes resolve to the original through `var_get(..., original=true)`.
+That is the single most common source of NULL dereferences in this file:
+code that walks `pmix_mca_base_vars` directly and touches
+`var->mbv_storage` must skip synonyms (`PMIX_VAR_IS_SYNONYM`) and
+deregistered variables (`!PMIX_VAR_IS_VALID`, storage dropped), because
+neither has any. `pmix_mca_base_var_build_env()` carries exactly that
+guard, and a comment saying why.
+
+A synonym's name must not collide with its original's full name.
+`register_variable()` catches that and raises the `var-name-conflict`
+`show_help` topic; under `--enable-debug` it also `assert(0)`s.
+
+### Deregistration is not deletion
+
+`pmix_mca_base_var_deregister()` clears `PMIX_MCA_BASE_VAR_FLAG_VALID`,
+frees a string value, drops the enumerator, and sets `mbv_storage` to
+`NULL` — but keeps the entry and its index. Re-registering the same name
+**revives the same index**. Nothing is actually freed until
+`pmix_mca_base_var_finalize()`. Indices are therefore stable for the life
+of the process, which is what lets `pmix_mca_base_var_group_t` hold
+plain `int` lists of its members.
+
+### Groups
+
+[`pmix_mca_base_var_group.c`](pmix_mca_base_var_group.c) is a parallel
+registry of `(project, framework, component)` tuples, each holding the
+indices of its variables and its subgroups. It exists so that closing a
+component can deregister everything that component registered in one
+call (`pmix_mca_base_var_group_deregister()`), and so `pmix_info` can
+present variables grouped by owner. Lookups go through a hash of the
+generated full name, except when any name component is `"*"`, which
+forces the linear scan in `group_find_linear()`.
+
+**`pmix_mca_base_var_group_find()` returns the group's index, not a
+status** — same trap as `pmix_mca_base_var_register()`, and the header
+said `PMIX_SUCCESS` for years while every caller in the tree correctly
+treated the result as an index. Test the sign.
+
+Note that `group_register()` builds a group's name by calling
+`pmix_mca_base_var_generate_full_name4(NULL, project, framework,
+component, ...)` — the arguments are shifted one slot to the left of
+what the parameter names suggest. It works because that function only
+joins its non-`NULL` arguments with `_` and attaches no meaning to the
+slots, and it produces the same string `group_find()` looks up. Don't
+"fix" one side without the other.
+
+### Enumerators
+
+An enumerator maps strings to integers, and is what `pmix_info` prints
+as "Valid values".
+
+**No variable in this tree actually has one.** `pmix_mca_base_var_t`
+carries an `mbv_enumerator` field, `pmix_mca_base_var.c` has five
+branches that use it, and the header used to document an `enumerator`
+parameter — but `pmix_mca_base_var_register()` takes no such parameter
+and nothing ever assigns that field. Those branches are dead code, and
+the enumerators are reachable only by calling their vtable directly.
+Know that before "fixing" the variable-side enumerator paths against
+behavior you cannot reproduce, and before assuming a variable you
+register can validate its own values.
+
+Two enumerators are built in and statically
+allocated — `pmix_mca_base_var_enum_bool` and
+`pmix_mca_base_var_enum_verbose` — and **must never be `PMIX_RELEASE`d**;
+`enum_is_static` guards that, and `PMIX_MCA_VAR_MBV_ENUMERATOR_FREE()`
+in `pmix_mca_base_var.c` honours it. Dynamic ones come from
+`pmix_mca_base_var_enum_create()` (value list) or
+`pmix_mca_base_var_enum_create_flag()` (bitmask list, with conflict
+declarations).
+
+Two ownership rules in that vtable pull in opposite directions, and
+getting them backwards leaks or double-frees:
+
+- **`string_from_value()` returns a string the caller owns** and must
+  `free()`.
+- **`get_value()` returns a string the caller *borrows*** from the
+  enumerator. It cannot be otherwise: the boolean enumerator's
+  `get_value()` returns a string literal, so no caller could safely free
+  what this slot hands back.
+
+The flag enumerator's `value_from_string()` parses a **comma-delimited
+list**, which means two unrelated index spaces in one nest of loops: the
+outer index walks the caller's tokens, the inner walks the enumerator's
+flag table. Confusing them matches the wrong flag *and* reads past the
+end of the table as soon as the caller passes more tokens than the
+enumerator has flags.
+
+Whatever an enumerator's `dump()` advertises has to be accepted by its
+`value_from_string()`. That text is what a user reads out of
+`pmix_info`, so a value listed there and then rejected is a bug, not a
+cosmetic mismatch. `test/unit/mca/mca_base_var_enum.c` feeds the bool
+enumerator's own dump back into it for exactly this reason.
+
+## Part 2: components and frameworks
+
+### The framework lifecycle
+
+A framework is a `pmix_mca_base_framework_t` declared by
+`PMIX_MCA_BASE_FRAMEWORK_DECLARE()` and driven through three entry
+points in [`pmix_mca_base_framework.c`](pmix_mca_base_framework.c):
+
+```
+pmix_mca_base_framework_register()   refcnt++, register MCA vars,
+                                     find components, call each
+                                     component's register function
+pmix_mca_base_framework_open()       register() first, then call the
+                                     framework's open (default:
+                                     open every component)
+pmix_mca_base_framework_close()      refcnt--, at zero deregister the
+                                     variable group and close/unload
+                                     every component
+```
+
+**`framework_refcnt` is the whole contract.** Register and open bump it;
+close decrements and only does real work at zero. Every failure path in
+`register()` and `open()` must **undo the registration it performed** —
+not merely decrement:
+
+- `register()` funnels its errors through a single `error:` label that
+  puts the count back before the `REGISTERED` bit is ever set.
+- `open()` registers on the way in, so its failure path calls
+  `pmix_mca_base_framework_close()`. That is the only thing that gets
+  both cases right: if someone else already held a reference it just
+  gives ours back, and if this call was the first one in it deregisters
+  the variable group and tears the component lists down.
+
+Getting this wrong does not merely leak. A framework left `REGISTERED`
+with a count of zero **wedges permanently**: the next `close()`
+decrements 0 to −1, finds that non-zero, and returns success without
+tearing anything down, so no later close can ever reach zero. The
+`assert(framework->framework_refcnt)` at the top of `close()` catches
+it — but only in a build with asserts enabled, which is not the one
+users get. `test/unit/mca/mca_base_framework.c` covers both failure
+paths and both holder cases.
+
+`framework_flags` carries `NOREGISTER` (skip the MCA variable stage
+entirely — used by frameworks that run before the variable system is
+ready) and `NO_DSO` (this framework has no loadable components, so don't
+scan). The `REGISTERED` and `OPEN` bits are internal state; do not set
+them from outside this file.
+
+### Finding components
+
+[`pmix_mca_base_component_find.c`](pmix_mca_base_component_find.c) builds
+`framework->framework_components` from two sources:
+
+- **Static components** — the `framework_static_components` array
+  generated into each framework's `base/static-components.h` at build
+  time.
+- **Dynamic components** — entries in the repository (below), opened
+  with `dlopen` unless `mca_base_component_disable_dlopen` is set or the
+  framework declared `NO_DSO`.
+
+Both are filtered by `use_component()` against the framework's selection
+parameter (`--mca <framework> a,b` or `--mca <framework> ^c`), parsed by
+`pmix_mca_base_component_parse_requested()`. The negate character is only
+legal at the very front of the value; anywhere else raises
+`framework-param:too-many-negates`. In include mode,
+`component_find_check()` then warns about every requested name that never
+turned up, and aborts if `mca_base_abort_on_load_error` is set.
+
+**Those last two are independent parameters, and the abort must not be
+nested inside the report.** `mca_base_component_show_load_errors`
+defaults to `"none"`, so gating the abort on "are we printing this?"
+makes `mca_base_abort_on_load_error` a silent no-op in the default
+configuration. The two used to be nested and got away with it only
+because the old test was on the raw parameter *string*, which is
+non-NULL even for `"none"` — fixing the spurious message without
+splitting the abort out reintroduces the no-op.
+
+### The component repository
+
+[`pmix_mca_base_component_repository.c`](pmix_mca_base_component_repository.c)
+is the catalogue of loadable plugins, built once at
+`pmix_mca_base_open()` and keyed by framework name. It only exists when
+`PMIX_HAVE_PDL_SUPPORT` is set — the entire file is `#if`'d, and the
+`#else` arms return `PMIX_ERR_NOT_SUPPORTED` or do nothing.
+
+Two things about it repay attention:
+
+- **`pmix_mca_base_component_path` is a `;`-delimited list of
+  `project@path` entries**, not a plain path. It is assembled in
+  `pmix_mca_base_open()` from `$pmixlibdir`, `~/.pmix/components`, the
+  `mca_base_component_path` MCA parameter, and whatever the caller passed
+  as `add_path` — so **its content is partly user-supplied** and the
+  parser may not assume the `@` is present or that the project name fits
+  any particular buffer.
+- **A repository item's `project` string belongs to the caller.**
+  `process_repository_item()` receives it as the `void *data` cookie of
+  `pmix_pdl_foreachfile()`, and `pmix_mca_base_component_repository_init()`
+  passes a **stack buffer**. It must be copied, never freed.
+
+`ri_constructor()` has to initialize every field of the item:
+`PMIX_NEW` malloc's without zeroing, and the destructor `free()`s
+`ri_project` and `ri_base`.
+
+**Frameworks can be opened before the repository exists.**
+`pmix_init_util()` opens `pinstalldirs` *before* it calls
+`pmix_mca_base_open()`, and the repository hash table is constructed by
+the latter. The only thing that keeps that first framework from reaching
+`pmix_mca_base_component_repository_get_components()` with an
+unconstructed table is the `NO_DSO` flag on its declaration — remove
+that flag, or add another framework opened that early without it, and
+the ordering matters again. `get_components()` therefore checks its own
+`initialized` flag rather than relying on how `pmix_hash_table_t`
+happens to treat a zero capacity.
+
+`pmix_mca_base_component_repository_retain_component()` is exported and
+has no callers anywhere in the tree.
+
+Reference counting here is per-*file*: `ri_refcnt` goes to 1 when the
+component is `dlopen`ed and back to 0 through
+`pmix_mca_base_component_repository_release()`, at which point the
+variable group is deregistered and the handle closed. Note the warning in
+`ri_destructor()` — after `dlclose`, the `pmix_mca_base_component_t`
+pointer is dangling.
+
+### Opening, selecting, closing
+
+- [`pmix_mca_base_components_register.c`](pmix_mca_base_components_register.c)
+  calls each component's `pmix_mca_register_component_params`, dropping
+  any that fail. `PMIX_ERR_NOT_AVAILABLE` means "silently ignore me" and
+  is not reported.
+- [`pmix_mca_base_components_open.c`](pmix_mca_base_components_open.c)
+  does the same for `pmix_mca_open_component`, with the same
+  `NOT_AVAILABLE` convention, and also owns the
+  `mca_base_component_show_load_errors` parser (below).
+- [`pmix_mca_base_components_select.c`](pmix_mca_base_components_select.c)
+  is the generic single-select helper: query every component, keep the
+  highest priority, close the rest. A component returning
+  `PMIX_ERR_FATAL` stops selection dead — that is how a component says
+  "the user asked for something I cannot provide, do not paper over it
+  by picking someone else."
+
+  **It consumes the list.** On success it closes, unloads and releases
+  every component except the winner; on `PMIX_ERR_NOT_FOUND` it empties
+  the list entirely; on `PMIX_ERR_FATAL` it closes nothing at all. That
+  last asymmetry is safe only because every caller passes its own
+  `framework_components`, so the framework's close mops up. A caller
+  that passed a list it owned separately would be left holding it.
+  `pmix_base.h` now spells this out.
+- [`pmix_mca_base_components_close.c`](pmix_mca_base_components_close.c)
+  closes and unloads, with an optional `skip` for the component that was
+  just selected.
+
+### `show_load_errors`
+
+`mca_base_component_show_load_errors` accepts `"all"`, `"none"`, any
+boolean spelling, or a comma-delimited list of `framework` /
+`framework/component` items optionally prefixed with `^` to negate the
+list. `pmix_mca_base_show_load_errors_init()` parses it once into two
+lists and `pmix_mca_base_show_load_errors(framework, component)` answers
+per call site.
+
+**A list entry naming a bare framework leaves its `component_name`
+`NULL`**, and a caller may pass a `NULL` component to ask about the
+framework as a whole. Both are ordinary, documented inputs, so the
+matcher has to handle a `NULL` on either side rather than handing it to
+`strcmp`.
+
+Use the **function**, never the raw
+`pmix_mca_base_component_show_load_errors` string: the string is
+non-`NULL` whenever the parameter has any value at all, including
+`"none"` and lists naming some other framework.
+
+### Aliases
+
+[`pmix_mca_base_alias.c`](pmix_mca_base_alias.c) maps an old component
+name to a new one so that `--mca btl vader` and `--mca btl sm` select the
+same thing and variables registered under one name get synonyms under
+the other. It is a hash of `project_framework_component` to a list of
+alias strings, torn down by `pmix_mca_base_alias_cleanup()`. Nothing in
+PMIx registers an alias today; the machinery is here because the MCA
+base is shared lineage with Open MPI and PRRTE.
+
+## Directory layout
+
+```
+src/mca/base/
+├── pmix_base.h                        the public face of this directory
+├── pmix_mca_base_open.c / _close.c    bring-up/tear-down + the base's own MCA params
+│
+│   -- variables --
+├── pmix_mca_base_var.h / .c           registration, resolution, dump, build_env
+├── pmix_mca_base_vari.h               internal declarations (flags, file values)
+├── pmix_mca_base_var_group.h / .c     (project, framework, component) groups
+├── pmix_mca_base_var_enum.h / .c      value and flag enumerators
+├── pmix_mca_base_parse_paramfile.c    thin wrapper over the keyval parser
+│
+│   -- components --
+├── pmix_mca_base_framework.h / .c     framework register/open/close + refcount
+├── pmix_mca_base_component_find.c     static + dynamic discovery, selection filter
+├── pmix_mca_base_component_repository.h / .c   the dlopen catalogue (PDL-gated)
+├── pmix_mca_base_components_register.c
+├── pmix_mca_base_components_open.c    + the show_load_errors parser
+├── pmix_mca_base_components_select.c  generic single-select
+├── pmix_mca_base_components_close.c
+├── pmix_mca_base_component_compare.c  ordering + version compatibility
+├── pmix_mca_base_alias.h / .c         component name aliases
+├── pmix_mca_base_list.c               the two list-item classes
+│
+└── help-pmix-mca-base.txt, help-pmix-mca-var.txt
+```
+
+## Threading
+
+**There is no thread-shifting here and no caddies.** The MCA base runs
+during library start-up and shutdown, before the progress thread matters
+and after it is gone, and its state — the variable pointer array, the
+group array, the repository hash, the `show_load_errors` lists — is
+guarded by nothing at all. That is safe only because everything that
+touches it runs on the initializing thread inside `pmix_init_util()` /
+`pmix_finalize_util()`, or from `pmix_info`.
+
+Do not call `pmix_mca_base_var_register()` (or any framework
+open/close) from the progress thread or from a user thread after
+init. A component's `register`/`open`/`close` functions are the
+sanctioned places to touch this machinery, and they are already called
+on the right thread.
+
+## Building
+
+`src/mca/base` builds into `libpmix_mca_base.la`, which is linked into
+`libpmix`. Its headers are **installed** (`pmix_HEADERS`) because
+`pmix_info` and companion projects build against them. It has no
+`configure.m4` and no components, so an edit here needs only a plain
+`make` from the top of the tree — the `autogen.pl` + `configure` cycle
+is not required unless you touch `Makefile.am`'s file lists in a way
+that adds a new source, and even then `make` regenerates the `Makefile`.
+
+The one build-system dependency worth knowing is `PMIX_HAVE_PDL_SUPPORT`,
+which gates all of `pmix_mca_base_component_repository.c` and the
+dynamic half of `pmix_mca_base_component_find.c`. A build without it
+still works — every component is statically linked — so a change in
+those files has to compile and behave in both configurations.
+
+**Both `help-*.txt` files in this directory are `show_help` content.**
+Per the top-level golden rule, after any edit to them:
+
+```sh
+rm src/util/pmix_show_help_content.*
+make
+```
+
+## Testing
+
+The unit suite for this directory is
+[`test/unit/mca`](../../../test/unit/mca), wired into `make check`:
+
+| Program | Covers |
+|---------|--------|
+| `mca_base_var` | name generation, register/find/get (including the aliasing contract of `get_value`), env-sourced values, synonyms, all three dump formats, `build_env`, deregister, `check_exclusive`, and the group registry |
+| `mca_base_var_enum` | the bool and verbose enumerators, `_enum_create`, `_enum_create_flag`, and the dump-vs-accept agreement |
+| `mca_base_component` | `component_compare` / `_compatible` / `_to_string`, `parse_requested`, and aliases |
+| `mca_base_show_load_errors` | every accepted form of the parameter, including the bare-framework and `^` list forms |
+| `mca_base_select` | `pmix_mca_base_select()` over fabricated components — priority order, the three ways a component is skipped, `PMIX_ERR_FATAL`, the empty list — and every include/exclude form of `pmix_mca_base_components_filter()` |
+| `mca_base_paramfile` | the parameter-file path end to end: values read from a file, the file-list ordering, `~/` expansion, the `K`/`M`/`G` suffixes, and every precedence pair between file, override file and environment — including when the override names a synonym |
+| `mca_base_framework` | register/open/close, the reference count, the `REGISTERED`/`OPEN` bits, the variables a registration creates, repeated cycling, and the `NOREGISTER`/`NO_DSO` flags. Its subject is a framework declared in the test itself with no components, so nothing a real framework's components do can colour the result |
+
+`mca_base_var` comes up through `pmix_init_util()` — the lightest init
+that establishes the install dirs and the MCA; a full `PMIx_Init` would
+need a server. It sets `PMIX_MCA_mca_base_param_files=none` before that
+call so the results do not depend on whatever is in the developer's
+`~/.pmix`. **Keep that**: without it the suite passes or fails according
+to the machine it runs on.
+
+For the configurations a developer's own `make check` cannot produce —
+notably a Linux tree built `--enable-mca-dso`, where every component is
+a real `dlopen`ed plugin and the repository code path in this directory
+is actually exercised — use
+[`contrib/dockerswarm/run-mca-tests.sh`](../../../contrib/dockerswarm/run-mca-tests.sh).
+On macOS with the default static build, the whole repository/`dlopen`
+half of this directory never runs.
+
+## Issues found in the August 2026 review
+
+Recorded so a future change does not reintroduce them, and so the tests
+above are read as regression tests rather than decoration:
+
+- **`pmix_mca_base_show_load_errors()` dereferenced a `NULL` component
+  name.** A list entry naming a bare framework (`^ptl`) plus any load
+  error in one of its components was a segfault.
+- **`pmix_mca_base_var_build_env()` dereferenced storage that synonyms
+  and deregistered variables do not have.** Any deprecated STRING
+  synonym with a non-default source — `PMIX_MCA_mca_base_param_files` is
+  one — crashed the walk. Found by the new unit test.
+- **The flag enumerator's `value_from_string()` indexed its flag table
+  with the caller's token index**, matching the wrong flag and reading
+  out of bounds for a list longer than the table.
+- **`pmix_mca_base_component_repository_init()` parsed `project@path`
+  with an unbounded copy loop** and no check that the `@` existed —
+  a stack buffer overflow driven by a user-settable MCA parameter.
+- **`process_repository_item()` `free()`d its caller's project string**
+  on the out-of-memory path; the caller passes a stack buffer.
+- **`ri_constructor()` left `ri_project`, `ri_base`, `ri_name` and
+  `ri_refcnt` uninitialized** over a non-zeroing `PMIX_NEW`.
+- **`parse_verbose()` pointed `lds_syslog_ident` into a buffer it then
+  freed**, so `mca_base_verbose=syslogid:foo` used freed memory.
+- **`var_set_from_env()` compared against `pmix_mca_base_var_override_file`
+  without a `NULL` check**, which a process launched with
+  `PMIX_PARAM_FILE_PASSED` can reach.
+- **`pmix_mca_base_framework_register()` leaked its refcount** on every
+  error path, leaving the framework permanently un-closeable.
+- **`pmix_mca_base_show_load_errors_init()` leaked the `argv` vector of
+  every list entry** and both vectors on each early return, and returned
+  error codes through a `pmix_boolean_t`.
+- **The enumerator `get_value()` slots `strdup`'d into a `const char **`
+  out-parameter** whose other implementation returns a literal — an
+  unfreeable allocation, i.e. a guaranteed leak in
+  `pmix_mca_base_var_dump()`.
+- **The bool enumerator's `dump()` advertised `y` and `n`**, which its
+  `value_from_string()` rejected, and matched its other names
+  case-sensitively while the non-enumerated bool path did not.
+- **`component_find_check()` tested the raw
+  `pmix_mca_base_component_show_load_errors` pointer**, so it reported
+  even under `"none"`.
+- Smaller items: `resolve_relative_paths()` freeing an indeterminate
+  `asprintf` output, a leaked `getcwd` buffer, unchecked allocations in
+  `register_variable()`, `err_msg` leaks in
+  `pmix_mca_base_component_repository_open()`, the enumerator
+  constructors leaking on a failed name `strdup`, a missing
+  `<ctype.h>`, and `set_defaults()` still identifying itself to syslog
+  as `"ompi"`.
+
+A fifth sweep covered component selection and filtering and found **no
+defect** — `pmix_mca_base_select()` and `pmix_mca_base_components_filter()`
+behave as documented in all 32 cases now in `mca_base_select`. The only
+change it produced was documentation: `pmix_mca_base_select()` is
+exported and had a one-line comment saying "A generic select function",
+which said nothing about the list ownership described above.
+
+A fourth sweep, over the parameter-file and value-parsing path, found:
+
+- **The override file could be defeated by the environment.** When the
+  override file named a variable by a **deprecated synonym**, the
+  promotion to `SOURCE_OVERRIDE` landed only on the synonym, so the
+  environment check that follows saw an ordinary file value and let a
+  user's `PMIX_MCA_*` setting win. A site administrator's "this is not
+  negotiable" file was therefore enforced or not depending on which
+  spelling of the name they happened to write — and the reported source
+  said `FILE` either way. Covered now by
+  `test/unit/mca/mca_base_paramfile.c`, which drives real files through
+  a private temporary directory.
+
+A third sweep, aimed at the lifecycle and re-entrancy paths, found:
+
+- **A failed `pmix_mca_base_framework_register()` orphaned whatever
+  components it had already found.** Discovery runs inside `register()`,
+  so `framework_components` is populated by the time
+  `component_find_check()` rejects a selection naming a component that
+  does not exist — and nothing ever drains it, because
+  `pmix_mca_base_framework_close()` returns immediately when neither
+  `REGISTERED` nor `OPEN` is set, which is exactly the state a failed
+  register leaves. Reachable from ordinary user input
+  (`mca_base_abort_on_load_error` plus a bad `--mca <framework>` value),
+  not just from an allocation failure. The `error:` label now unwinds
+  the way the not-open branch of `close()` does.
+- **`mca_base_abort_on_load_error` was gated on
+  `mca_base_component_show_load_errors`**, which defaults to `"none"` —
+  so the abort silently did nothing unless the user had *also* asked to
+  see load-error messages. See the note under "Finding components".
+- **`pmix_mca_base_framework_open()`'s failure path wedged the
+  framework.** It decremented the reference count but left `REGISTERED`
+  set, so a framework whose open failed reported itself registered with
+  nobody holding it, and the next `close()` underflowed to −1 and
+  silently did nothing. Every later close was then a no-op too. Found by
+  the new `mca_base_framework` test.
+- The `--disable-dlopen` configuration (`PMIX_HAVE_PDL_SUPPORT` 0) was
+  compile-checked and is clean; the `#else` arms behave, and the
+  ordering coupling with `pinstalldirs` described above is now explicit
+  in the code rather than implied by another subsystem's guard.
+
+A second sweep found that the **installed headers documented interfaces
+that do not exist**, in ways that would make a caller write wrong code
+rather than merely be confused:
+
+- **`pmix_mca_base_var_get_value()` was documented as copying the value
+  out**, through a `value_size` parameter that has never been in the
+  signature. It returns a pointer to the registered storage. A caller
+  following the comment would pass `&myint` and get a pointer written
+  through it. `test/unit/mca/mca_base_var.c` now pins the aliasing
+  contract.
+- **`pmix_mca_base_var_register()` was documented with five parameters
+  it does not take** — `enumerator`, `bind`, `flags`, `info_lvl`,
+  `scope` — plus several paragraphs about how they behave. The
+  enumerator paragraphs in particular describe a capability the library
+  does not have (see Enumerators above).
+- **`pmix_mca_base_var_group_find()` was documented as returning
+  `PMIX_SUCCESS`**; it returns the group index, which is what all four
+  callers rely on.
+- **`pmix_mca_base_var_group_t::group_index` was never assigned**, so
+  every group reported index 0 to anyone reading the field out of the
+  installed header. It is now set alongside the pointer-array add, the
+  way `mbv_index` already was.
+- **`pmix_mca_base_open()`'s `add_path` had no documentation at all**,
+  and is not a directory: it is spliced into a `;`-delimited list of
+  `project@path` entries. Every in-tree caller passes `NULL`, so the
+  requirement was invisible, and an entry without an `@` is silently
+  skipped (before the fix above, it was a buffer overrun).
+- The colour strings in `pmix_var_dump_color[]` are only populated by
+  `pmix_register_params()`, which `pmix_init_util()` does not call —
+  so a `..._DUMP_READABLE_COLOR` dump reached before that fed `NULL` to
+  a `"%s"`. The dump sites now fall back to the uncoloured default,
+  which is what the surrounding code already intended.
+
+## When working in this directory
+
+- **Nothing here may assume the variable system is initialized.**
+  `var_get()` and friends check `pmix_mca_base_var_initialized` and
+  return `PMIX_ERROR`; keep new entry points doing the same.
+- **Walking `pmix_mca_base_vars` directly means handling synonyms and
+  deregistered entries.** Neither has storage. Prefer
+  `pmix_mca_base_var_get_value()`, which resolves through.
+- **Test the sign of a `_register()` return, never `!= PMIX_SUCCESS`.**
+- **Every MCA parameter value is attacker-adjacent input.** They arrive
+  from the environment, from files under the user's control, and from
+  command lines. Parse them defensively — the two buffer bugs above were
+  both in parameter parsing.
+- **Preserve the "no thread-shifting" property.** If a new code path
+  needs MCA state at run time, cache the value at registration instead of
+  reaching into the variable system from the progress thread.
+- **Add the regression test in [`test/unit/mca`](../../../test/unit/mca)
+  in the same commit.** This directory has no server dependency and no
+  hardware dependency, so there is essentially never a reason a fix here
+  cannot be covered.

--- a/src/mca/base/CLAUDE.md
+++ b/src/mca/base/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/base/pmix_base.h
+++ b/src/mca/base/pmix_base.h
@@ -107,6 +107,7 @@ enum {
 /**
  * First function called in the MCA.
  *
+ * @param[in] add_path Additional component search path, or NULL.
  * @return PMIX_SUCCESS Upon success
  * @return PMIX_ERROR Upon failure
  *
@@ -117,6 +118,18 @@ enum {
  * It must be the first MCA function invoked.  It is normally
  * invoked during the initialization stage and specifically
  * invoked in the special case of the *_info command.
+ *
+ * IMPORTANT: {add_path} is NOT a plain directory. The component search
+ * path is a ';'-delimited list of "project@path" entries, where "path"
+ * is itself a PMIX_ENV_SEP-delimited list of directories, and
+ * {add_path} is spliced into the front of that list verbatim. An entry
+ * with no '@' names no project, cannot be matched against any
+ * component file name, and is skipped with a verbose message. So pass
+ * e.g. "pmix@/opt/site/lib/pmix", not "/opt/site/lib/pmix".
+ *
+ * Calling this more than once is a reference count, not a re-init: the
+ * second and later calls only prepend {add_path} and bump the count.
+ * Each must be matched by a pmix_mca_base_close().
  */
 PMIX_EXPORT int pmix_mca_base_open(const char *add_path);
 
@@ -135,8 +148,37 @@ PMIX_EXPORT int pmix_mca_base_open(const char *add_path);
 PMIX_EXPORT int pmix_mca_base_close(void);
 
 /**
- * A generic select function
+ * A generic select function: query every available component and keep
+ * the one that bids the highest priority.
  *
+ * @param[in] type_name Framework name, used only in verbose output.
+ * @param[in] output_id Verbose output stream for the messages.
+ * @param[in,out] components_available List of
+ * pmix_mca_base_component_list_item_t to choose among. See the
+ * ownership note below -- this list is modified.
+ * @param[out] best_module Module returned by the winning query.
+ * @param[out] best_component The winning component.
+ * @param[out] priority_out The winning priority. May be NULL.
+ *
+ * @retval PMIX_SUCCESS A component was selected.
+ * @retval PMIX_ERR_NOT_FOUND No component bid successfully.
+ * @retval PMIX_ERR_FATAL A component reported that it cannot provide
+ * something the user explicitly asked for. Selection stops there and no
+ * component is chosen -- deliberately, since silently falling back to a
+ * different component would do something the user did not ask for.
+ *
+ * A component is skipped if it has no query function, if its query
+ * returns anything but PMIX_SUCCESS, or if its query succeeds but hands
+ * back no module (whatever priority it claimed).
+ *
+ * OWNERSHIP: on PMIX_SUCCESS and on PMIX_ERR_NOT_FOUND this function
+ * **closes, unloads and releases every component it did not select**,
+ * removing them from {components_available} -- so a successful call
+ * leaves exactly the winner on the list, and a PMIX_ERR_NOT_FOUND call
+ * leaves it empty. On PMIX_ERR_FATAL it closes nothing and the list is
+ * untouched. Callers in this tree all pass their framework's own
+ * framework_components, so the framework's close handles the remainder
+ * in the fatal case.
  */
 PMIX_EXPORT int pmix_mca_base_select(const char *type_name, int output_id,
                                      pmix_list_t *components_available,

--- a/src/mca/base/pmix_mca_base_component_find.c
+++ b/src/mca/base/pmix_mca_base_component_find.c
@@ -323,11 +323,26 @@ static int component_find_check(pmix_mca_base_framework_t *framework,
             }
         }
 
-        if (!found && pmix_mca_base_component_show_load_errors) {
-            char h[PMIX_MAXHOSTNAMELEN] = {0};
-            gethostname(h, sizeof(h) - 1);
-            pmix_show_help("help-pmix-mca-base.txt", "find-available:not-valid", true, h,
-                           framework->framework_name, requested_component_names[i]);
+        if (!found) {
+            /* Whether to *report* this is one question... NOTE:
+             * pmix_mca_base_component_show_load_errors is the raw string
+             * form of the MCA parameter, and is non-NULL for every
+             * value including "none" (which is the default), so testing
+             * it directly reports even when the user asked for silence
+             * or listed some *other* framework. Ask the parsed form. */
+            if (pmix_mca_base_show_load_errors(framework->framework_name,
+                                               requested_component_names[i])) {
+                char h[PMIX_MAXHOSTNAMELEN] = {0};
+                gethostname(h, sizeof(h) - 1);
+                pmix_show_help("help-pmix-mca-base.txt", "find-available:not-valid", true, h,
+                               framework->framework_name, requested_component_names[i]);
+            }
+
+            /* ...and whether to *abort* is a different one. These are
+             * two independent MCA parameters, so the abort must not sit
+             * inside the reporting test: a user who asked to abort on a
+             * missing component means it whether or not they also asked
+             * to see the message, and the default is not to show it. */
             if (pmix_mca_base_component_abort_on_load_error) {
                 return PMIX_ERR_NOT_FOUND;
             }

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -94,7 +94,10 @@ static pmix_hash_table_t pmix_mca_base_component_repository;
 
 static int process_repository_item(const char *filename, void *data)
 {
-    char *project = (char*)data;
+    /* the project name belongs to our caller (it can even be a stack
+     * buffer - see pmix_mca_base_component_repository_init) so it must
+     * never be freed here */
+    const char *project = (const char *) data;
     char *name;
     char *type;
     pmix_mca_base_component_repository_item_t *ri;
@@ -172,7 +175,6 @@ static int process_repository_item(const char *filename, void *data)
     ri = PMIX_NEW(pmix_mca_base_component_repository_item_t);
     if (NULL == ri) {
         free(base);
-        free(project);
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
@@ -185,11 +187,11 @@ static int process_repository_item(const char *filename, void *data)
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
-    /* pmix_strncpy does not guarantee a \0 */
-    ri->ri_type[PMIX_MCA_BASE_MAX_TYPE_NAME_LEN] = '\0';
+    /* pmix_strncpy always terminates: it copies at most "len" chars and
+     * then writes dest[len] = '\0', so each of these needs one byte more
+     * than the length it is given -- which is exactly how ri_type and
+     * ri_name are sized */
     pmix_strncpy(ri->ri_type, type, PMIX_MCA_BASE_MAX_TYPE_NAME_LEN);
-
-    ri->ri_name[PMIX_MCA_BASE_MAX_TYPE_NAME_LEN] = '\0';
     pmix_strncpy(ri->ri_name, name, PMIX_MCA_BASE_MAX_COMPONENT_NAME_LEN);
 
     pmix_list_append(component_list, &ri->super);
@@ -260,9 +262,9 @@ int pmix_mca_base_component_repository_init(void)
     /* Setup internal structures */
 
 #if PMIX_HAVE_PDL_SUPPORT
-    char **projects = NULL, *pathstr;
-    char project[PMIX_MCA_BASE_MAX_TYPE_NAME_LEN + 1];
-    int m, n;
+    char **projects = NULL, *pathstr, *delim;
+    char project[PMIX_MCA_BASE_MAX_PROJECT_NAME_LEN + 1];
+    int n;
     int ret;
 
     if (!initialized) {
@@ -287,16 +289,29 @@ int pmix_mca_base_component_repository_init(void)
         }
         initialized = true;
     }
-    /* split on semi-colons to find projects */
+    /* split on semi-colons to find projects. Note that
+     * pmix_mca_base_component_path is settable by the user (it is built
+     * from the mca_base_component_path MCA parameter plus whatever a
+     * caller handed to pmix_mca_base_open), so nothing here may assume
+     * the "project@path" form is actually present or that the project
+     * name fits in our buffer. */
     projects = PMIx_Argv_split(pmix_mca_base_component_path, ';');
+    if (NULL == projects) {
+        return PMIX_SUCCESS;
+    }
     for (n=0; NULL != projects[n]; n++) {
         /* look for the '@' to delimit the project name */
-        for (m=0; '@' != projects[n][m]; m++) {
-            project[m] = projects[n][m];
+        delim = strchr(projects[n], '@');
+        if (NULL == delim || (size_t)(delim - projects[n]) > sizeof(project) - 1) {
+            /* not of the expected form, or the project name is too long
+             * to be a legal MCA project name - ignore this entry */
+            pmix_output_verbose(PMIX_MCA_BASE_VERBOSE_INFO, 0,
+                                "mca:base:component_repository_init: ignoring malformed "
+                                "component path entry \"%s\"", projects[n]);
+            continue;
         }
-        project[m] = '\0';
-        ++m;
-        pathstr = &projects[n][m];
+        pmix_strncpy(project, projects[n], (size_t)(delim - projects[n]));
+        pathstr = delim + 1;
         ret = pmix_mca_base_component_repository_add(project, pathstr);
         if (PMIX_SUCCESS != ret) {
             PMIX_DESTRUCT(&pmix_mca_base_component_repository);
@@ -319,6 +334,17 @@ int pmix_mca_base_component_repository_get_components(pmix_mca_base_framework_t 
 {
     *framework_components = NULL;
 #if PMIX_HAVE_PDL_SUPPORT
+    /* The repository hash table is only constructed by
+     * pmix_mca_base_component_repository_init(), which runs inside
+     * pmix_mca_base_open() -- and frameworks can legitimately be opened
+     * before that. pmix_init_util() opens pinstalldirs first, and the
+     * only reason that does not reach this function with an
+     * unconstructed table is the NO_DSO flag on its declaration. Answer
+     * "no dynamic components" from our own state rather than depending
+     * on how pmix_hash_table_t happens to treat a zero capacity. */
+    if (!initialized) {
+        return PMIX_ERR_NOT_FOUND;
+    }
     return pmix_hash_table_get_value_ptr(&pmix_mca_base_component_repository,
                                          framework->framework_name,
                                          strlen(framework->framework_name),
@@ -481,7 +507,13 @@ int pmix_mca_base_component_repository_open(pmix_mca_base_framework_t *framework
             pmix_asprintf(&tmp,
                           "\n    dlopen error: %s\n    Perhaps a missing symbol, or compiled for a different version of %s?",
                           err_msg, framework->framework_project);
-            err_msg = tmp;
+            /* pmix_asprintf sets tmp to NULL if it fails - keep the
+             * original message in that case rather than reporting
+             * nothing and then feeding NULL to a "%s" */
+            if (NULL != tmp) {
+                free(err_msg);
+                err_msg = tmp;
+            }
         }
         pmix_output_verbose(
             vl, 0, "pmix_mca_base_component_repository_open: unable to open %s: %s (ignored)",
@@ -518,15 +550,16 @@ int pmix_mca_base_component_repository_open(pmix_mca_base_framework_t *framework
         err_msg = NULL;
         ret = pmix_pdl_lookup(ri->ri_dlhandle, struct_name, (void **) &component_struct, &err_msg);
         if (PMIX_SUCCESS != ret || NULL == component_struct) {
-            if (NULL == err_msg) {
-                err_msg = "pmix_dl_lookup() error message was NULL!";
-            }
             pmix_output_verbose(
                 vl, 0,
                 "pmix_mca_base_component_repository_open: \"%s\" does not appear to be a valid "
                 "%s MCA dynamic component (ignored):\n    %s (ret %d)",
-                ri->ri_base, ri->ri_type, err_msg, ret);
+                ri->ri_base, ri->ri_type,
+                (NULL == err_msg) ? "pmix_dl_lookup() error message was NULL!" : err_msg, ret);
 
+            /* the message is ours to release - it must not be replaced
+             * by a literal first, or we would leak it */
+            free(err_msg);
             ret = PMIX_ERR_BAD_PARAM;
             break;
         }
@@ -636,10 +669,19 @@ void pmix_mca_base_component_repository_finalize(void)
  */
 static void ri_constructor(pmix_mca_base_component_repository_item_t *ri)
 {
+    /* PMIX_NEW does not zero the allocation, so every field has to be
+     * set here. Leaving ri_project/ri_base unset left the destructor
+     * free()ing indeterminate pointers, and leaving ri_refcnt unset
+     * meant retain/release worked from garbage for any component that
+     * was scanned but never opened through this repository. */
     memset(ri->ri_type, 0, sizeof(ri->ri_type));
+    memset(ri->ri_name, 0, sizeof(ri->ri_name));
+    ri->ri_project = NULL;
     ri->ri_dlhandle = NULL;
     ri->ri_component_struct = NULL;
     ri->ri_path = NULL;
+    ri->ri_base = NULL;
+    ri->ri_refcnt = 0;
 }
 
 /*

--- a/src/mca/base/pmix_mca_base_components_open.c
+++ b/src/mca/base/pmix_mca_base_components_open.c
@@ -100,8 +100,15 @@ PMIX_CLASS_INSTANCE(fc_pair_t, pmix_list_item_t,
  */
 int pmix_mca_base_show_load_errors_init(void)
 {
+    int rc = PMIX_SUCCESS;
+
     PMIX_CONSTRUCT(&show_load_errors_include, pmix_list_t);
     PMIX_CONSTRUCT(&show_load_errors_exclude, pmix_list_t);
+
+    if (NULL == pmix_mca_base_component_show_load_errors) {
+        show_load_errors = SHOW_LOAD_ERRORS_ALL;
+        return PMIX_SUCCESS;
+    }
 
     // Check to see if mca_base_component_show_load_errors is a
     // boolean value
@@ -140,13 +147,13 @@ int pmix_mca_base_show_load_errors_init(void)
             char **values = PMIx_Argv_split(pmix_mca_base_component_show_load_errors + pos,
                                             ',');
             if (values == NULL) {
-                ret = PMIX_ERROR;
+                rc = PMIX_ERROR;
                 pmix_show_help("help-pmix-mca-base.txt",
                                "internal error during init", true,
                                __func__, __FILE__, __LINE__,
-                               ret,
+                               rc,
                                "Failed to argv split pmix_mca_base_component_show_load_errors");
-                return ret;
+                return rc;
             }
 
             char **split;
@@ -155,64 +162,73 @@ int pmix_mca_base_show_load_errors_init(void)
             for (int i = 0; values[i] != NULL; ++i) {
                 split = PMIx_Argv_split(values[i], '/');
                 if (NULL == split) {
-                    ret = PMIX_ERROR;
+                    rc = PMIX_ERROR;
                     pmix_show_help("help-pmix-mca-base.txt",
                                    "internal error during init", true,
                                    __func__, __FILE__, __LINE__,
-                                   ret,
+                                   rc,
                                    "Failed to argv split pmix_mca_base_component_show_load_errors value");
-                    return ret;
+                    goto done;
                 }
 
                 argc = PMIx_Argv_count(split);
                 if (0 == argc) {
                     // This should never happen
-                    ret = PMIX_ERROR;
+                    rc = PMIX_ERROR;
                     pmix_show_help("help-pmix-mca-base.txt",
                                    "internal error during init", true,
                                    __func__, __FILE__, __LINE__,
-                                   ret,
+                                   rc,
                                    "Argv split resulted in 0 tokens");
-                    return ret;
+                    PMIx_Argv_free(split);
+                    goto done;
                 }
 
                 if (0 == strlen(split[0])) {
                     // Empty entry (e.g., consecutive commas); silently
                     // skip it
+                    PMIx_Argv_free(split);
                     continue;
                 }
 
                 if (argc > 2) {
-                    ret = PMIX_ERR_BAD_PARAM;
+                    rc = PMIX_ERR_BAD_PARAM;
                     pmix_show_help("help-pmix-mca-base.txt",
                                    "show_load_errors: too many /", true,
                                    values[i]);
-                    return ret;
+                    PMIx_Argv_free(split);
+                    goto done;
                 }
 
                 fcp = PMIX_NEW(fc_pair_t);
                 if (NULL == fcp) {
-                    ret = PMIX_ERR_OUT_OF_RESOURCE;
+                    rc = PMIX_ERR_OUT_OF_RESOURCE;
                     pmix_show_help("help-pmix-mca-base.txt",
                                    "internal error during init", true,
                                    __func__, __FILE__, __LINE__,
-                                   ret,
+                                   rc,
                                    "Failed to alloc new fc_pair_t");
-                    return ret;
+                    PMIx_Argv_free(split);
+                    goto done;
                 }
 
+                /* the fc_pair takes ownership of the individual strings,
+                 * so release only the vector that held them */
                 fcp->framework_name = split[0];
                 if (2 == argc) {
                     fcp->component_name = split[1];
                 }
+                free(split);
 
                 pmix_list_append(list, &fcp->li);
             }
+
+        done:
             PMIx_Argv_free(values);
         }
     }
 
-    return PMIX_SUCCESS;
+    return rc;
 }
 
 
@@ -247,9 +263,11 @@ bool pmix_mca_base_show_load_errors(const char *framework_name,
     fc_pair_t *item;
     PMIX_LIST_FOREACH(item, list, fc_pair_t) {
         if (0 == strcmp(framework_name, item->framework_name)) {
-            if (NULL == component_name) {
-                // If there's no component name, then we're matching
-                // all components in this framework.
+            if (NULL == item->component_name || NULL == component_name) {
+                // The list entry named a bare framework (no
+                // "/component"), or the caller did not name a
+                // component: either way we are matching all
+                // components in this framework.
                 return value_if_match_found;
             } else if (0 == strcmp(component_name, item->component_name)) {
                 // We matched both the framework *and* component name.

--- a/src/mca/base/pmix_mca_base_framework.c
+++ b/src/mca/base/pmix_mca_base_framework.c
@@ -74,12 +74,18 @@ int pmix_mca_base_framework_register(struct pmix_mca_base_framework_t *framework
     }
 
     if (!(PMIX_MCA_BASE_FRAMEWORK_FLAG_NOREGISTER & framework->framework_flags)) {
+        /* NOTE: every failure below must undo the refcnt bump above, or
+         * the framework can never reach zero in
+         * pmix_mca_base_framework_close() and its components are never
+         * closed. pmix_mca_base_framework_open() does the same on its
+         * own failure path. */
+
         /* register this framework with the MCA variable system */
         ret = pmix_mca_base_var_group_register(framework->framework_project,
                                                framework->framework_name, NULL,
                                                framework->framework_description);
         if (0 > ret) {
-            return ret;
+            goto error;
         }
 
         ret = asprintf(&desc,
@@ -87,7 +93,8 @@ int pmix_mca_base_framework_register(struct pmix_mca_base_framework_t *framework
                        " means use all components that can be found)",
                        framework->framework_name);
         if (0 > ret) {
-            return PMIX_ERR_OUT_OF_RESOURCE;
+            ret = PMIX_ERR_OUT_OF_RESOURCE;
+            goto error;
         }
 
         ret = pmix_mca_base_var_register(framework->framework_project, framework->framework_name,
@@ -95,14 +102,15 @@ int pmix_mca_base_framework_register(struct pmix_mca_base_framework_t *framework
                                          &framework->framework_selection);
         free(desc);
         if (0 > ret) {
-            return ret;
+            goto error;
         }
 
         /* register a verbosity variable for this framework */
         ret = asprintf(&desc, "Verbosity level for the %s framework (default: 0)",
                        framework->framework_name);
         if (0 > ret) {
-            return PMIX_ERR_OUT_OF_RESOURCE;
+            ret = PMIX_ERR_OUT_OF_RESOURCE;
+            goto error;
         }
 
         framework->framework_verbose = PMIX_MCA_BASE_VERBOSE_ERROR;
@@ -111,7 +119,7 @@ int pmix_mca_base_framework_register(struct pmix_mca_base_framework_t *framework
                                                    &framework->framework_verbose);
         free(desc);
         if (0 > ret) {
-            return ret;
+            goto error;
         }
 
         /* check the initial verbosity and open the output if necessary. we
@@ -122,14 +130,14 @@ int pmix_mca_base_framework_register(struct pmix_mca_base_framework_t *framework
         if (NULL != framework->framework_register) {
             ret = framework->framework_register(flags);
             if (PMIX_SUCCESS != ret) {
-                return ret;
+                goto error;
             }
         }
 
         /* register components variables */
         ret = pmix_mca_base_framework_components_register(framework, flags);
         if (PMIX_SUCCESS != ret) {
-            return ret;
+            goto error;
         }
     }
 
@@ -137,6 +145,45 @@ int pmix_mca_base_framework_register(struct pmix_mca_base_framework_t *framework
 
     /* framework did not provide a register function */
     return PMIX_SUCCESS;
+
+error:
+    /* Undo everything this call built, not just the reference count.
+     *
+     * Nothing else can do it for us: with neither REGISTERED nor OPEN
+     * set, pmix_mca_base_framework_close() returns immediately, so
+     * whatever is left on framework_components here is orphaned for
+     * good. And that list can be non-empty on a plain user error rather
+     * than only on an allocation failure -- component_find() appends
+     * every component that matched the selection and only afterwards
+     * does component_find_check() reject the run over a requested name
+     * that matched nothing (which it does when the user asked for
+     * mca_base_abort_on_load_error).
+     *
+     * This mirrors the not-open branch of
+     * pmix_mca_base_framework_close(), which is what would have run had
+     * the registration got far enough to be closeable. */
+    if (0 == --framework->framework_refcnt) {
+        pmix_list_item_t *item;
+        int group_id;
+
+        group_id = pmix_mca_base_var_group_find(framework->framework_project,
+                                                framework->framework_name, NULL);
+        if (0 <= group_id) {
+            (void) pmix_mca_base_var_group_deregister(group_id);
+        }
+
+        while (NULL != (item = pmix_list_remove_first(&framework->framework_components))) {
+            pmix_mca_base_component_list_item_t *cli;
+            cli = (pmix_mca_base_component_list_item_t *) item;
+            pmix_mca_base_component_unload(cli->cli_component, framework->framework_output);
+            PMIX_RELEASE(item);
+        }
+
+        PMIX_DESTRUCT(&framework->framework_components);
+        PMIX_LIST_DESTRUCT(&framework->framework_failed_components);
+        framework_close_output(framework);
+    }
+    return ret;
 }
 
 int pmix_mca_base_framework_open(struct pmix_mca_base_framework_t *framework,
@@ -175,7 +222,24 @@ int pmix_mca_base_framework_open(struct pmix_mca_base_framework_t *framework,
     }
 
     if (PMIX_SUCCESS != ret) {
-        framework->framework_refcnt--;
+        /* Undo the registration this call performed at the top. A bare
+         * refcnt-- is not enough: when this call was the one that
+         * registered the framework, dropping the count back to zero
+         * while REGISTERED stays set leaves a framework that reports
+         * itself registered with nobody holding it -- and the next
+         * pmix_mca_base_framework_close() then decrements 0 to -1,
+         * finds that non-zero, returns success without tearing
+         * anything down, and wedges the framework permanently. (The
+         * assert() at the top of close() catches it, but only in a
+         * build with asserts enabled, which is not the one users get.)
+         *
+         * Closing here does exactly the right thing in both cases: if
+         * someone else already held a reference, close() just gives
+         * ours back; if we were the only holder, it deregisters the
+         * variable group and tears the component lists down. It does
+         * not call the framework's own close function, because OPEN was
+         * never set -- which is correct, since its open failed. */
+        (void) pmix_mca_base_framework_close(framework);
     } else {
         framework->framework_flags |= PMIX_MCA_BASE_FRAMEWORK_FLAG_OPEN;
     }

--- a/src/mca/base/pmix_mca_base_open.c
+++ b/src/mca/base/pmix_mca_base_open.c
@@ -57,6 +57,10 @@ bool pmix_mca_base_component_disable_dlopen = false;
 
 static char *pmix_mca_base_verbose = NULL;
 static char *path_from_param = NULL;
+/* our own copy of any "syslogid:" value parsed out of
+ * mca_base_verbose - pmix_output_reopen() duplicates whatever it is
+ * handed, so this only has to stay alive across that one call */
+static char *syslog_ident = NULL;
 
 /*
  * Private functions
@@ -197,12 +201,26 @@ int pmix_mca_base_open(const char *add_path)
         if (NULL != lds.lds_file_suffix) {
             free(lds.lds_file_suffix);
         }
+        if (NULL != syslog_ident) {
+            free(syslog_ident);
+            syslog_ident = NULL;
+        }
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
     pmix_output_reopen(0, &lds);
     pmix_output_verbose(PMIX_MCA_BASE_VERBOSE_COMPONENT, 0, "mca: base: opening components at %s",
                         pmix_mca_base_component_path);
+    /* pmix_output_reopen() duplicated everything it needed out of lds,
+     * so release the strings we built for it */
     free(lds.lds_prefix);
+    if (NULL != lds.lds_file_suffix) {
+        free(lds.lds_file_suffix);
+        lds.lds_file_suffix = NULL;
+    }
+    if (NULL != syslog_ident) {
+        free(syslog_ident);
+        syslog_ident = NULL;
+    }
 
     /* Open up the component repository */
 
@@ -221,7 +239,7 @@ static void set_defaults(pmix_output_stream_t *lds)
 #if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
     lds->lds_syslog_priority = LOG_INFO;
 #endif /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
-    lds->lds_syslog_ident = "ompi";
+    lds->lds_syslog_ident = "pmix";
     lds->lds_want_stderr = true;
 }
 
@@ -272,7 +290,12 @@ static void parse_verbose(char *e, pmix_output_stream_t *lds)
         } else if (strncasecmp(ptr, "syslogid:", 9) == 0) {
 #if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
-            lds->lds_syslog_ident = ptr + 9;
+            /* "ptr" points into our local copy of the value, which is
+             * freed before this function returns - the caller uses the
+             * stream description afterwards, so it needs its own copy */
+            free(syslog_ident);
+            syslog_ident = strdup(ptr + 9);
+            lds->lds_syslog_ident = syslog_ident;
 #else
             pmix_output(0, "syslog support requested but not available on this system");
 #endif /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -27,6 +27,7 @@
 
 #include "src/include/pmix_config.h"
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -282,11 +283,12 @@ static void resolve_relative_paths(char **file_prefix, char *file_path, bool rel
         ;
 #endif
     } else {
-        /* Prepend the files to the search list */
+        /* Prepend the files to the search list. NOTE: asprintf leaves
+         * its output pointer indeterminate on failure, so it must not
+         * be freed here */
         if (0 > asprintf(&tmp_str, "%s%c%s", *file_prefix, sep, *files)) {
             pmix_output(0, "OUT OF MEM");
             free(*files);
-            free(tmp_str);
             *files = NULL;
             return;
         }
@@ -304,10 +306,19 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
     home = (char *) pmix_home_directory(geteuid());
 
     if (NULL == cwd) {
-        cwd = (char *) malloc(sizeof(char) * MAXPATHLEN);
-        if (NULL == (cwd = getcwd(cwd, MAXPATHLEN))) {
+        char *buf = (char *) malloc(sizeof(char) * MAXPATHLEN);
+        if (NULL == buf) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        /* getcwd returns NULL on failure without freeing our buffer */
+        cwd = getcwd(buf, MAXPATHLEN);
+        if (NULL == cwd) {
+            free(buf);
             pmix_output(0, "Error: Unable to get the current working directory\n");
             cwd = strdup(".");
+            if (NULL == cwd) {
+                return PMIX_ERR_OUT_OF_RESOURCE;
+            }
         }
     }
 
@@ -338,7 +349,10 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
                                      &pmix_mca_base_var_files);
     free(tmp);
-    if (PMIX_SUCCESS != ret) {
+    /* register returns the variable index on success, which is only
+     * equal to PMIX_SUCCESS when it happens to be zero - test the sign,
+     * as every other registration in this file does */
+    if (0 > ret) {
         return ret;
     }
 
@@ -902,6 +916,21 @@ int pmix_mca_base_var_build_env(char ***env, int *num_env)
             continue;
         }
 
+        /* Skip synonyms: a synonym has no storage of its own, and
+         * whatever set it also marked the variable it stands for as
+         * non-default, so the real name is emitted below anyway. Naming
+         * the synonym as well would only make the child warn about a
+         * deprecated parameter it never set. */
+        if (PMIX_VAR_IS_SYNONYM(var[0])) {
+            continue;
+        }
+
+        /* Skip anything that has been deregistered - its storage has
+         * been dropped, so there is no value left to report */
+        if (!PMIX_VAR_IS_VALID(var[0]) || NULL == var->mbv_storage) {
+            continue;
+        }
+
         if ((PMIX_MCA_BASE_VAR_TYPE_STRING == var->mbv_type
              || PMIX_MCA_BASE_VAR_TYPE_VERSION_STRING == var->mbv_type)
             && NULL == var->mbv_storage->stringval) {
@@ -1221,9 +1250,23 @@ static int register_variable(const char *project_name, const char *framework_nam
         }
 
         var = PMIX_NEW(pmix_mca_base_var_t);
-        ntmp = (char*)malloc(strlen(project_name)+1);
-        for (n=0; '\0' != project_name[n]; n++) {
-            ntmp[n] = toupper(project_name[n]);
+        if (NULL == var) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        /* the environment variable prefix is the upper-cased project
+         * name. The header documents project_name as optional "for
+         * legacy reasons", so fall back to this library's own project
+         * rather than dereferencing NULL */
+        if (NULL == project_name) {
+            project_name = "pmix";
+        }
+        ntmp = (char *) malloc(strlen(project_name) + 1);
+        if (NULL == ntmp) {
+            PMIX_RELEASE(var);
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        for (n = 0; '\0' != project_name[n]; n++) {
+            ntmp[n] = (char) toupper((unsigned char) project_name[n]);
         }
         ntmp[n] = '\0';
         pmix_asprintf(&var->mbv_prefix, "%s_MCA_", ntmp);
@@ -1461,7 +1504,14 @@ static int var_set_from_env(pmix_mca_base_var_t *var, pmix_mca_base_var_t *origi
     if (NULL != source_env) {
         if (0 == strncasecmp(source_env, "file:", 5)) {
             original->mbv_source_file = append_filename_to_list(source_env + 5);
-            if (0 == strcmp(original->mbv_source_file, pmix_mca_base_var_override_file)) {
+            /* the override file name is only established by
+             * pmix_mca_base_var_cache_files(), which returns early when
+             * PMIX_PARAM_FILE_PASSED is set in our environment -- so in
+             * a process launched by a PMIx-aware RM it can legitimately
+             * be NULL while this SOURCE_ envar is present */
+            if (NULL != original->mbv_source_file &&
+                NULL != pmix_mca_base_var_override_file &&
+                0 == strcmp(original->mbv_source_file, pmix_mca_base_var_override_file)) {
                 original->mbv_source = PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE;
             } else {
                 original->mbv_source = PMIX_MCA_BASE_VAR_SOURCE_FILE;
@@ -1583,7 +1633,20 @@ static int var_set_initial(pmix_mca_base_var_t *var, pmix_mca_base_var_t *origin
        file. */
     ret = var_set_from_file(var, original, &pmix_mca_base_var_override_values);
     if (PMIX_SUCCESS == ret) {
+        /* var_set_from_file() records SOURCE_FILE, because it cannot
+         * tell which of the two lists it was handed. Promote that to
+         * SOURCE_OVERRIDE on *both* the name that matched and the
+         * variable it stands for.
+         *
+         * Marking only "var" is enough when the two are the same
+         * object, but not when the override file named a synonym: the
+         * environment check immediately below tests
+         * original->mbv_source, so leaving the original saying FILE
+         * meant a user's environment could beat a site administrator's
+         * override file -- silently, and only when the administrator
+         * wrote the deprecated spelling of the name. */
         var->mbv_source = PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE;
+        original->mbv_source = PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE;
     }
 
     ret = var_set_from_env(var, original);
@@ -1954,7 +2017,12 @@ int pmix_mca_base_var_dump(int vari, char ***out, pmix_mca_base_var_dump_type_t 
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
 
-        if (PMIX_MCA_BASE_VAR_DUMP_READABLE_COLOR == output_type) {
+        if (PMIX_MCA_BASE_VAR_DUMP_READABLE_COLOR == output_type
+            && NULL != pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VAR_NAME]
+            && NULL != pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VAR_VALUE]) {
+            /* the array is only populated by pmix_register_params(); an
+             * entry can still be NULL if a caller reached this dump
+             * before that ran, and NULL is not a valid "%s" argument */
             color_name = pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VAR_NAME];
             color_value = pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VAR_VALUE];
             color_reset = "\033[0m";

--- a/src/mca/base/pmix_mca_base_var.h
+++ b/src/mca/base/pmix_mca_base_var.h
@@ -284,14 +284,12 @@ PMIX_EXPORT int pmix_mca_base_var_init(void);
  * @param[in] description A string describing the use and valid
  * values of the variable (string).
  * @param[in] type The type of this variable (string, int, bool).
- * @param[in] enumerator Enumerator describing valid values.
- * @param[in] bind Hint for MPIT to specify type of binding (0 = none)
- * @param[in] flags Flags for this variable.
- * @param[in] info_lvl Info level of this variable
- * @param[in] scope Indicates the scope of this variable
  * @param[in,out] storage Pointer to the value's location.
  *
- * @retval index Index value representing this variable.
+ * @retval index Index value representing this variable. NOTE: this is
+ * an index, not a status -- a successful registration returns a value
+ * >= 0, and index 0 is a perfectly ordinary result that happens to
+ * equal PMIX_SUCCESS. Test the sign (0 > rc), never (PMIX_SUCCESS != rc).
  * @retval PMIX_ERR_OUT_OF_RESOURCE Upon failure to allocate memory.
  * @retval PMIX_ERROR Upon failure to register the variable.
  *
@@ -301,61 +299,33 @@ PMIX_EXPORT int pmix_mca_base_var_init(void);
  * {description} is a string of arbitrary length (verbose is good!)
  * for explaining what the variable is for and what its valid values
  * are.  This message is used in help messages, such as the output
- * from the ompi_info executable.  The {description} string is copied
+ * from the pmix_info executable.  The {description} string is copied
  * internally; the caller can free {description} upon successful
  * return.
- *
- * {enumerator} is either NULL or a handle that was created via
- * pmix_mca_base_var_enum_create(), and describes the valid values of an
- * integer variable (i.e., one with type MCA_BASE_VAR_TYPE_INT).  When
- * a non-NULL {enumerator} is used, the value set for this variable by
- * the user will be compared against the values in the enumerator.
- * The MCA variable system will allow the parameter to be set to
- * either one of the enumerator values (0, 1, 2, etc) or a string
- * representing one of those values.  {enumerator} is retained until
- * either the variable is deregistered using
- * pmix_mca_base_var_deregister(), pmix_mca_base_var_group_deregister(), or
- * pmix_mca_base_var_finalize().  {enumerator} should be NULL for
- * parameters that do not support enumerated values.
- *
- * {flags} indicate attributes of this variable (internal, settable,
- * default only, etc.), as listed below.
- *
- * If MCA_BASE_VAR_FLAG_INTERNAL is set in {flags}, this variable
- * is not shown by default in the output of ompi_info.  That is,
- * this variable is considered internal to the PMIX implementation
- * and is not supposed to be viewed / changed by the user.
- *
- * If MCA_BASE_VAR_FLAG_DEFAULT_ONLY is set in {flags}, then the value
- * provided in storage will not be modified by the MCA variable system
- * (i.e., users cannot set the value of this variable via CLI
- * parameter, environment variable, file, etc.). It is up to the
- * caller to specify (using the scope) if this value may change
- * (MCA_BASE_VAR_SCOPE_READONLY) or remain constant
- * (MCA_BASE_VAR_SCOPE_CONSTANT).  MCA_BASE_VAR_FLAG_DEFAULT_ONLY must
- * not be specified with MCA_BASE_VAR_FLAG_SETTABLE.
- *
- * Set MCA_BASE_VAR_FLAG_DEPRECATED in {flags} to indicate that
- * this variable name is deprecated. The user will get a warning
- * if they set this variable.
- *
- * {scope} is for informational purposes to indicate how this variable
- * can be set, or if it is considered constant or readonly (which, by
- * MPI_T's definitions, are different things).  See the comments in
- * the description of pmix_mca_base_var_scope_t for information about the
- * different scope meanings.
  *
  * {storage} points to a (char *), (int), or (bool) where the value of
  * this variable is stored ({type} indicates the type of this
  * pointer).  The location pointed to by {storage} must exist until
- * the variable is deregistered.  Note that the initial value in
- * {storage} may be overwritten if the MCA_BASE_VAR_FLAG_DEFAULT_ONLY
- * flag is not set (e.g., if the user sets this variable via CLI
- * option, environment variable, or file value).  If input value of
+ * the variable is deregistered.  The registration itself resolves the
+ * value and writes it through {storage}, so the caller's variable is
+ * correct as soon as this function returns -- there is no separate
+ * "look it up" step.  Note that the initial value in {storage} is
+ * therefore overwritten whenever the user set this variable through
+ * the environment or a parameter file.  If the input value of
  * {storage} points to a (char *), the pointed-to string will be
  * duplicated and maintained internally by the MCA variable system;
  * the caller may free the original string after this function returns
  * successfully.
+ *
+ * NOTE: this interface takes no flags, scope, info level, binding hint
+ * or enumerator. Earlier revisions of this comment described all five,
+ * and none of them has ever been a parameter of this function. The
+ * corresponding pmix_mca_base_var_t fields (mbv_flags beyond the
+ * internal bits, mbv_bind, mbv_enumerator) are consequently never set
+ * by any caller in this tree -- the enumerator machinery in
+ * pmix_mca_base_var_enum.h is reachable only by calling it directly.
+ * Do not write a call against the removed parameters; it will not
+ * compile.
  */
 PMIX_EXPORT int pmix_mca_base_var_register(const char *project_name, const char *framework_name,
                                            const char *component_name, const char *variable_name,
@@ -443,21 +413,34 @@ PMIX_EXPORT int pmix_mca_base_var_deregister(int vari);
  * Get the current value of an MCA variable.
  *
  * @param[in] vari Index of variable
- * @param[in,out] value Pointer to copy the value to. Can be NULL.
- * @param[in,out] value_size Size of memory pointed to by value.
- * copied size will be returned in value_size.
+ * @param[out] value Address of a pointer that will be made to point at
+ * the variable's backing store. Can be NULL.
  * @param[out] source Source of current value. Can be NULL.
  * @param[out] source_file Source file for the current value if
  * it was set from a file.
  *
  * @return PMIX_ERROR Upon failure.  The contents of value are
  * undefined.
- * @return PMIX_SUCCESS Upon success. value (if not NULL) will be filled
- * with the variable's current value. value_size will contain the size
- * copied. source (if not NULL) will contain the source of the variable.
+ * @return PMIX_SUCCESS Upon success.
  *
- * Note: The value can be changed by the registering code without using
- * the pmix_mca_base_var_* interface so the source may be incorrect.
+ * IMPORTANT: {value} does NOT receive a copy of the value. It receives
+ * a *pointer to the storage the caller supplied at registration* --
+ * that is, the argument must be the address of a pointer of the
+ * variable's type, and the value is read by dereferencing what comes
+ * back:
+ *
+ *   int *val;
+ *   pmix_mca_base_var_get_value(idx, &val, NULL, NULL);
+ *   printf("%d\n", *val);
+ *
+ * Passing the address of an int (rather than of an int *) writes a
+ * pointer through it. An earlier revision of this comment described a
+ * copy-out interface with a {value_size} parameter; no such parameter
+ * has ever existed, and no copy is made.
+ *
+ * Because what comes back aliases the registering code's own storage,
+ * it also tracks any change that code makes directly -- so {source}
+ * may not reflect where the current contents actually came from.
  */
 PMIX_EXPORT int pmix_mca_base_var_get_value(int vari, void *value,
                                             pmix_mca_base_var_source_t *source,
@@ -607,7 +590,7 @@ typedef enum {
     PMIX_VAR_DUMP_COLOR_KEY_COUNT
 } pmix_var_dump_color_key_t;
 
-extern char *pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_KEY_COUNT];
+PMIX_EXPORT extern char *pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_KEY_COUNT];
 
 
 /**

--- a/src/mca/base/pmix_mca_base_var_enum.c
+++ b/src/mca/base/pmix_mca_base_var_enum.c
@@ -85,11 +85,20 @@ static int pmix_mca_base_var_enum_bool_vfs(pmix_mca_base_var_enum_t *self, const
 
     v = strtol(string_value, &tmp, 10);
     if (*tmp != '\0') {
-        if (0 == strcmp(string_value, "true") || 0 == strcmp(string_value, "t")
-            || 0 == strcmp(string_value, "enabled") || 0 == strcmp(string_value, "yes")) {
+        /* NOTE: this list must stay in step with what
+         * pmix_mca_base_var_enum_bool_dump() advertises as valid - that
+         * dump is what a user sees from "pmix_info --all", so anything
+         * it names has to actually be accepted here. Matching is
+         * case-insensitive because the non-enumerated bool path in
+         * pmix_mca_base_var.c is. */
+        if (0 == strcasecmp(string_value, "true") || 0 == strcasecmp(string_value, "t")
+            || 0 == strcasecmp(string_value, "enabled") || 0 == strcasecmp(string_value, "yes")
+            || 0 == strcasecmp(string_value, "y")) {
             v = 1;
-        } else if (0 == strcmp(string_value, "false") || 0 == strcmp(string_value, "f")
-                   || 0 == strcmp(string_value, "disabled") || 0 == strcmp(string_value, "no")) {
+        } else if (0 == strcasecmp(string_value, "false") || 0 == strcasecmp(string_value, "f")
+                   || 0 == strcasecmp(string_value, "disabled")
+                   || 0 == strcasecmp(string_value, "no")
+                   || 0 == strcasecmp(string_value, "n")) {
             v = 0;
         } else {
             return PMIX_ERR_VALUE_OUT_OF_BOUNDS;
@@ -121,8 +130,13 @@ static int pmix_mca_base_var_enum_bool_dump(pmix_mca_base_var_enum_t *self, char
     char *color_vv = "", *color_reset = "";
 
     if (PMIX_MCA_BASE_VAR_ENUM_DUMP_READABLE_COLOR == output_type) {
-        color_vv = pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES];
-        color_reset = "\033[0m";
+        /* the array is only populated by pmix_register_params(); an
+         * entry can still be NULL if a caller reached this dump
+         * before that ran, and NULL is not a valid "%s" argument */
+        if (NULL != pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES]) {
+            color_vv = pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES];
+            color_reset = "\033[0m";
+        }
     }
 
     ret = pmix_asprintf(out, "%s0%s|%sf%s|%sfalse%s|%sdisabled%s|%sno%s|%sn%s, "
@@ -212,7 +226,11 @@ static int pmix_mca_base_var_enum_verbose_sfv(pmix_mca_base_var_enum_t *self, co
 
     for (int i = 0; verbose_values[i].string; ++i) {
         if (verbose_values[i].value == value) {
-            *string_value = strdup(verbose_values[i].string);
+            /* string_value is documented as optional - honor that here
+             * too, not just on the fall-through path below */
+            if (NULL != string_value) {
+                *string_value = strdup(verbose_values[i].string);
+            }
             return PMIX_SUCCESS;
         }
     }
@@ -241,8 +259,13 @@ static int pmix_mca_base_var_enum_verbose_dump(pmix_mca_base_var_enum_t *self, c
     }
 
     if (PMIX_MCA_BASE_VAR_ENUM_DUMP_READABLE_COLOR == output_type) {
-        color_vv = pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES];
-        color_reset = "\033[0m";
+        /* the array is only populated by pmix_register_params(); an
+         * entry can still be NULL if a caller reached this dump
+         * before that ran, and NULL is not a valid "%s" argument */
+        if (NULL != pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES]) {
+            color_vv = pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES];
+            color_reset = "\033[0m";
+        }
     }
 
     ret = pmix_asprintf(&tmp, "%s, %s0%s-%s100%s", *out,
@@ -287,6 +310,7 @@ int pmix_mca_base_var_enum_create(const char *name, const pmix_mca_base_var_enum
 
     new_enum->enum_name = strdup(name);
     if (NULL == new_enum->enum_name) {
+        PMIX_RELEASE(new_enum);
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
@@ -327,6 +351,7 @@ int pmix_mca_base_var_enum_create_flag(const char *name,
 
     new_enum->super.enum_name = strdup(name);
     if (NULL == new_enum->super.enum_name) {
+        PMIX_RELEASE(new_enum);
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
@@ -383,8 +408,13 @@ static int enum_dump(pmix_mca_base_var_enum_t *self, char **out,
     }
 
     if (PMIX_MCA_BASE_VAR_ENUM_DUMP_READABLE_COLOR == output_type) {
-        color_vv = pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES];
-        color_reset = "\033[0m";
+        /* the array is only populated by pmix_register_params(); an
+         * entry can still be NULL if a caller reached this dump
+         * before that ran, and NULL is not a valid "%s" argument */
+        if (NULL != pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES]) {
+            color_vv = pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES];
+            color_reset = "\033[0m";
+        }
     }
 
     tmp = NULL;
@@ -421,7 +451,7 @@ static int enum_get_value(pmix_mca_base_var_enum_t *self, int index, int *value,
         return ret;
     }
 
-    if (index >= count) {
+    if (index < 0 || index >= count) {
         return PMIX_ERR_VALUE_OUT_OF_BOUNDS;
     }
 
@@ -429,8 +459,12 @@ static int enum_get_value(pmix_mca_base_var_enum_t *self, int index, int *value,
         *value = self->enum_values[index].value;
     }
 
+    /* the returned string is borrowed from the enumerator, not owned by
+     * the caller - see the get_value contract in pmix_mca_base_var_enum.h.
+     * The bool enumerator's get_value returns a string literal, so a
+     * caller cannot be asked to free what it gets back from this slot. */
     if (string_value) {
-        *string_value = strdup(self->enum_values[index].string);
+        *string_value = self->enum_values[index].string;
     }
 
     return PMIX_SUCCESS;
@@ -535,7 +569,7 @@ static int enum_get_value_flag(pmix_mca_base_var_enum_t *self, int index, int *v
         return ret;
     }
 
-    if (index >= count) {
+    if (index < 0 || index >= count) {
         return PMIX_ERR_VALUE_OUT_OF_BOUNDS;
     }
 
@@ -543,8 +577,9 @@ static int enum_get_value_flag(pmix_mca_base_var_enum_t *self, int index, int *v
         *value = flag_enum->enum_flags[index].flag;
     }
 
+    /* borrowed, not owned - see the note in enum_get_value() */
     if (string_value) {
-        *string_value = strdup(flag_enum->enum_flags[index].string);
+        *string_value = flag_enum->enum_flags[index].string;
     }
 
     return PMIX_SUCCESS;
@@ -576,15 +611,21 @@ static int enum_value_from_string_flag(pmix_mca_base_var_enum_t *self, const cha
         is_int = tmp[0] == '\0';
 
         bool found = false, conflict = false;
+        /* NOTE: "i" indexes the caller's comma-delimited token list,
+         * while "j" indexes this enumerator's flag table -- they are
+         * unrelated, so every reference to the table below must use
+         * "j". Using "i" both matched the wrong entry and read past
+         * the end of the table whenever the caller passed more tokens
+         * than the enumerator has flags. */
         for (int j = 0; j < count; ++j) {
-            if ((is_int && (value == flag_enum->enum_flags[i].flag))
-                || 0 == strcasecmp(flags[i], flag_enum->enum_flags[i].string)) {
+            if ((is_int && (value == flag_enum->enum_flags[j].flag))
+                || 0 == strcasecmp(flags[i], flag_enum->enum_flags[j].string)) {
                 found = true;
 
-                if (flag & flag_enum->enum_flags[i].conflicting_flag) {
+                if (flag & flag_enum->enum_flags[j].conflicting_flag) {
                     conflict = true;
                 } else {
-                    flag |= flag_enum->enum_flags[i].flag;
+                    flag |= flag_enum->enum_flags[j].flag;
                 }
 
                 break;
@@ -668,8 +709,13 @@ static int enum_dump_flag(pmix_mca_base_var_enum_t *self, char **out,
     }
 
     if (PMIX_MCA_BASE_VAR_ENUM_DUMP_READABLE_COLOR == output_type) {
-        color_vv = pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES];
-        color_reset = "\033[0m";
+        /* the array is only populated by pmix_register_params(); an
+         * entry can still be NULL if a caller reached this dump
+         * before that ran, and NULL is not a valid "%s" argument */
+        if (NULL != pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES]) {
+            color_vv = pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES];
+            color_reset = "\033[0m";
+        }
     }
 
     *out = strdup("Comma-delimited list of: ");

--- a/src/mca/base/pmix_mca_base_var_enum.h
+++ b/src/mca/base/pmix_mca_base_var_enum.h
@@ -62,6 +62,14 @@ typedef int (*pmix_mca_base_var_enum_get_count_fn_t)(pmix_mca_base_var_enum_t *s
  * @param[in] index the index to get the value of
  * @param[out] value integer value
  * @param[out] string_value string value
+ *
+ * @long The string returned in {string_value} is *borrowed* from the
+ * enumerator - the caller must not free it, and must not use it after
+ * the enumerator has been released. This differs from string_from_value(),
+ * which hands back a string the caller owns. The distinction is not
+ * cosmetic: the boolean enumerator's get_value() returns a string
+ * literal, so there is no implementation of this slot whose result can
+ * safely be freed.
  */
 typedef int (*pmix_mca_base_var_enum_get_value_fn_t)(pmix_mca_base_var_enum_t *self, int index,
                                                      int *value, const char **string_value);
@@ -214,8 +222,9 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_var_enum_t);
  * strings passed in values[] after pmix_mca_base_var_enum_create()
  * returns.
  */
-int pmix_mca_base_var_enum_create(const char *name, const pmix_mca_base_var_enum_value_t values[],
-                                  pmix_mca_base_var_enum_t **enumerator);
+PMIX_EXPORT int pmix_mca_base_var_enum_create(const char *name,
+                                              const pmix_mca_base_var_enum_value_t values[],
+                                              pmix_mca_base_var_enum_t **enumerator);
 
 /**
  * Create a new default flag enumerator
@@ -241,23 +250,23 @@ int pmix_mca_base_var_enum_create(const char *name, const pmix_mca_base_var_enum
  * strings passed in values[] after pmix_mca_base_var_enum_create()
  * returns.
  */
-int pmix_mca_base_var_enum_create_flag(const char *name,
-                                       const pmix_mca_base_var_enum_value_flag_t flags[],
-                                       pmix_mca_base_var_enum_flag_t **enumerator);
+PMIX_EXPORT int pmix_mca_base_var_enum_create_flag(const char *name,
+                                                   const pmix_mca_base_var_enum_value_flag_t flags[],
+                                                   pmix_mca_base_var_enum_flag_t **enumerator);
 
 /* standard enumerators. it is invalid to call OBJ_RELEASE on any of these enumerators */
 /**
  * Boolean enumerator
  *
- * This enumerator maps:
- *   positive integer, true, yes, enabled, t -> 1
- *   0, false, no, disabled, f -> 0
+ * This enumerator maps (case-insensitively):
+ *   non-zero integer, true, t, yes, y, enabled -> 1
+ *   0, false, f, no, n, disabled -> 0
  */
-extern pmix_mca_base_var_enum_t pmix_mca_base_var_enum_bool;
+PMIX_EXPORT extern pmix_mca_base_var_enum_t pmix_mca_base_var_enum_bool;
 
 /**
  * Verbosity level enumerator
  */
-extern pmix_mca_base_var_enum_t pmix_mca_base_var_enum_verbose;
+PMIX_EXPORT extern pmix_mca_base_var_enum_t pmix_mca_base_var_enum_verbose;
 
 #endif /* !defined(MCA_BASE_VAR_ENUM_H) */

--- a/src/mca/base/pmix_mca_base_var_group.c
+++ b/src/mca/base/pmix_mca_base_var_group.c
@@ -289,6 +289,11 @@ static int group_register(const char *project_name, const char *framework_name,
         PMIX_RELEASE(group);
         return PMIX_ERROR;
     }
+    /* record the group's own index, the way register_variable() records
+     * mbv_index. group_index is declared in the installed header and was
+     * left at the constructor's zero for every group, so anything that
+     * read it back got 0 for all of them. */
+    group->group_index = group_id;
 
     pmix_hash_table_set_value_ptr(&pmix_mca_base_var_group_index_hash, group->group_full_name,
                                   strlen(group->group_full_name), (void *) (uintptr_t) group_id);

--- a/src/mca/base/pmix_mca_base_var_group.h
+++ b/src/mca/base/pmix_mca_base_var_group.h
@@ -110,8 +110,14 @@ PMIX_EXPORT int pmix_mca_base_var_group_deregister(int group_index);
  * @param[in] framework_name Framework name
  * @param[in] component_name Component name
  *
- * @returns PMIX_SUCCESS if found
+ * @returns index The group's index if found -- NOT PMIX_SUCCESS. Any
+ * name may be "*" to wildcard that component of the name.
  * @returns PMIX_ERR_NOT_FOUND if not found
+ *
+ * Test the sign of the result and pass it on as an index, the way
+ * pmix_mca_base_framework_close() and pmix_mca_base_component_unload()
+ * do; a group whose index happens to be 0 is not distinguishable from
+ * PMIX_SUCCESS.
  */
 PMIX_EXPORT int pmix_mca_base_var_group_find(const char *project_name, const char *framework_name,
                                              const char *component_name);

--- a/src/tools/pmix_info/help-pmix_info.txt
+++ b/src/tools/pmix_info/help-pmix_info.txt
@@ -155,7 +155,7 @@ parameters: "unsigned_int", "unsigned_long", "unsigned_long_long", "size_t",
 #
 [lib-call-fail]
 A library call unexpectedly failed.  This is a terminal error; please
-show this message to an ORTE wizard:
+show this message to a PMIx wizard:
 
         Library call: %s
          Source file: %s

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -19,12 +19,41 @@ force: nearly every program here exists because a specific defect got
 past review, and weakening one hides exactly the regression it was
 written to catch.
 
-Two subdirectories carry their own suites and their own guidance:
+Three subdirectories carry their own suites:
 
 - [`class/`](class/) — the `src/class` object model and containers. See
   [`class/AGENTS.md`](class/AGENTS.md); it documents a build-configuration
   trap that let several real defects survive having a test suite.
 - [`util/`](util/) — the `src/util` helpers.
+- [`mca/`](mca/) — [`src/mca/base`](../../src/mca/base): the MCA variable
+  system, the enumerators, the component comparison/selection helpers,
+  the `show_load_errors` parser and the framework register/open/close
+  lifecycle. Every case there corresponds to a defect
+  from the August 2026 review of that directory, listed in
+  [`src/mca/base/AGENTS.md`](../../src/mca/base/AGENTS.md).
+
+  Two things about that suite are load-bearing. Every program that
+  brings the variable system up does so through `pmix_init_util()` — the
+  lightest init that establishes the install dirs and the MCA — and
+  settles what the parameter files will say **before** that call,
+  because the variable system reads them exactly once during init and
+  there is no second chance. `mca_base_var` sets
+  `PMIX_MCA_mca_base_param_files=none` so its results do not depend on
+  the developer's `~/.pmix`; `mca_base_paramfile` instead writes real
+  files into a private temporary directory and points
+  `mca_base_param_files` and `mca_base_override_param_file` at them,
+  which is the only way to reach the precedence rules at all.
+  `mca_base_var_enum` feeds the boolean enumerator's own `dump()` output
+  back into its `value_from_string()`, on the principle that a value
+  `pmix_info` advertises and the library then rejects is a bug rather
+  than a cosmetic mismatch.
+
+  What that suite cannot cover is the `dlopen` half of `src/mca/base`:
+  the component repository is `#if PMIX_HAVE_PDL_SUPPORT` and does
+  nothing at all in a statically-linked build, which is what a developer
+  on macOS has. That half belongs to
+  `contrib/dockerswarm/run-mca-tests.sh`, which builds an
+  `--enable-mca-dso` tree.
 
 ## What lives here
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -21,7 +21,7 @@
 # $HEADER$
 #
 
-SUBDIRS = util class
+SUBDIRS = util class mca
 
 # Point the tests at the components in the build tree so that "make
 # check" does not require a prior "make install". See the comments in

--- a/test/unit/mca/.gitignore
+++ b/test/unit/mca/.gitignore
@@ -1,0 +1,7 @@
+mca_base_var
+mca_base_var_enum
+mca_base_component
+mca_base_show_load_errors
+mca_base_framework
+mca_base_paramfile
+mca_base_select

--- a/test/unit/mca/Makefile.am
+++ b/test/unit/mca/Makefile.am
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# Point the tests at the components in the build tree so that "make
+# check" does not require a prior "make install". See the comments in
+# test/pmix_test_env.sh.in.
+AM_TESTS_ENVIRONMENT = . $(abs_top_builddir)/test/pmix_test_env.sh;
+
+check_PROGRAMS = mca_base_var mca_base_var_enum mca_base_component \
+    mca_base_show_load_errors mca_base_framework mca_base_paramfile \
+    mca_base_select
+
+TESTS = mca_base_var mca_base_var_enum mca_base_component \
+    mca_base_show_load_errors mca_base_framework mca_base_paramfile \
+    mca_base_select
+
+mca_base_var_SOURCES = mca_base_var.c
+mca_base_var_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+mca_base_var_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+mca_base_var_enum_SOURCES = mca_base_var_enum.c
+mca_base_var_enum_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+mca_base_var_enum_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+mca_base_component_SOURCES = mca_base_component.c
+mca_base_component_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+mca_base_component_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+mca_base_show_load_errors_SOURCES = mca_base_show_load_errors.c
+mca_base_show_load_errors_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+mca_base_show_load_errors_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+mca_base_framework_SOURCES = mca_base_framework.c
+mca_base_framework_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+mca_base_framework_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+mca_base_paramfile_SOURCES = mca_base_paramfile.c
+mca_base_paramfile_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+mca_base_paramfile_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+mca_base_select_SOURCES = mca_base_select.c
+mca_base_select_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+mca_base_select_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+clean-local:
+	rm -f mca_base_var mca_base_var_enum mca_base_component \
+	    mca_base_show_load_errors mca_base_framework mca_base_paramfile \
+    mca_base_select

--- a/test/unit/mca/mca_base_component.c
+++ b/test/unit/mca/mca_base_component.c
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the component-level helpers in src/mca/base:
+ * the comparison/rendering routines in
+ * pmix_mca_base_component_compare.c, the "--mca <framework> a,b,^c"
+ * parser in pmix_mca_base_component_find.c, and the component name
+ * aliasing in pmix_mca_base_alias.c.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pmix_common.h"
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/base/pmix_mca_base_alias.h"
+#include "src/mca/mca.h"
+#include "src/util/pmix_argv.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* component compare                                                   */
+/* ------------------------------------------------------------------ */
+
+static void fill(pmix_mca_base_component_t *c, const char *type, const char *name, int major,
+                 int minor, int release)
+{
+    memset(c, 0, sizeof(*c));
+    pmix_strncpy(c->pmix_mca_project_name, "pmix", PMIX_MCA_BASE_MAX_PROJECT_NAME_LEN);
+    pmix_strncpy(c->pmix_mca_type_name, type, PMIX_MCA_BASE_MAX_TYPE_NAME_LEN);
+    pmix_strncpy(c->pmix_mca_component_name, name, PMIX_MCA_BASE_MAX_COMPONENT_NAME_LEN);
+    c->pmix_mca_component_major_version = major;
+    c->pmix_mca_component_minor_version = minor;
+    c->pmix_mca_component_release_version = release;
+}
+
+/* compare() is an *inverse* ordering: it returns a negative number for
+ * the entry that should sort to the head of a list. */
+static void test_compare(void)
+{
+    pmix_mca_base_component_t a, b;
+
+    fill(&a, "ptl", "tcp", 1, 0, 0);
+    fill(&b, "ptl", "tcp", 1, 0, 0);
+    report("compare: identical components are equal", 0 == pmix_mca_base_component_compare(&a, &b));
+    report("compatible: identical components are compatible",
+           0 == pmix_mca_base_component_compatible(&a, &b));
+
+    fill(&b, "ptl", "tcp", 2, 0, 0);
+    report("compare: higher major sorts first", 0 < pmix_mca_base_component_compare(&a, &b));
+    report("compare: is antisymmetric in major", 0 > pmix_mca_base_component_compare(&b, &a));
+    report("compatible: differing major is not compatible",
+           0 != pmix_mca_base_component_compatible(&a, &b));
+
+    fill(&b, "ptl", "tcp", 1, 3, 0);
+    report("compare: higher minor sorts first", 0 < pmix_mca_base_component_compare(&a, &b));
+    report("compatible: differing minor is not compatible",
+           0 != pmix_mca_base_component_compatible(&a, &b));
+
+    /* release version separates compare() from compatible() */
+    fill(&b, "ptl", "tcp", 1, 0, 9);
+    report("compare: release version is significant",
+           0 != pmix_mca_base_component_compare(&a, &b));
+    report("compatible: release version is ignored",
+           0 == pmix_mca_base_component_compatible(&a, &b));
+
+    fill(&b, "ptl", "server", 1, 0, 0);
+    report("compare: different component names differ",
+           0 != pmix_mca_base_component_compare(&a, &b));
+
+    fill(&b, "gds", "tcp", 1, 0, 0);
+    report("compare: different framework names differ",
+           0 != pmix_mca_base_component_compare(&a, &b));
+}
+
+static void test_to_string(void)
+{
+    pmix_mca_base_component_t a;
+    char *str;
+
+    fill(&a, "ptl", "tcp", 6, 1, 4);
+    str = pmix_mca_base_component_to_string(&a);
+    report("to_string renders type.name.major.minor",
+           NULL != str && 0 == strcmp(str, "ptl.tcp.6.1"));
+    free(str);
+}
+
+/* ------------------------------------------------------------------ */
+/* parse_requested                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_requested(void)
+{
+    char **names = NULL;
+    bool include_mode = false;
+    int rc;
+
+    /* NULL and empty select everything */
+    rc = pmix_mca_base_component_parse_requested(NULL, &include_mode, &names);
+    report("parse: NULL selects everything",
+           PMIX_SUCCESS == rc && NULL == names && include_mode);
+
+    rc = pmix_mca_base_component_parse_requested("", &include_mode, &names);
+    report("parse: empty selects everything", PMIX_SUCCESS == rc && NULL == names && include_mode);
+
+    /* plain include list */
+    rc = pmix_mca_base_component_parse_requested("tcp,server", &include_mode, &names);
+    report("parse: include list", PMIX_SUCCESS == rc && NULL != names && include_mode);
+    if (NULL != names) {
+        report("parse: include list has both names",
+               2 == PMIx_Argv_count(names) && 0 == strcmp(names[0], "tcp")
+                   && 0 == strcmp(names[1], "server"));
+        PMIx_Argv_free(names);
+        names = NULL;
+    }
+
+    /* exclude list */
+    rc = pmix_mca_base_component_parse_requested("^tcp", &include_mode, &names);
+    report("parse: exclude list flips include_mode",
+           PMIX_SUCCESS == rc && NULL != names && !include_mode);
+    if (NULL != names) {
+        report("parse: exclude list drops the negate character",
+               1 == PMIx_Argv_count(names) && 0 == strcmp(names[0], "tcp"));
+        PMIx_Argv_free(names);
+        names = NULL;
+    }
+
+    /* several leading negates are tolerated */
+    rc = pmix_mca_base_component_parse_requested("^^^tcp", &include_mode, &names);
+    report("parse: repeated leading negates tolerated",
+           PMIX_SUCCESS == rc && NULL != names && !include_mode);
+    if (NULL != names) {
+        report("parse: repeated negates all stripped",
+               1 == PMIx_Argv_count(names) && 0 == strcmp(names[0], "tcp"));
+        PMIx_Argv_free(names);
+        names = NULL;
+    }
+
+    /* a negate anywhere but the front is an error */
+    rc = pmix_mca_base_component_parse_requested("tcp,^server", &include_mode, &names);
+    report("parse: embedded negate is refused", PMIX_SUCCESS != rc);
+    if (NULL != names) {
+        PMIx_Argv_free(names);
+        names = NULL;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* aliases                                                             */
+/* ------------------------------------------------------------------ */
+
+static void test_alias(void)
+{
+    const pmix_mca_base_alias_t *alias;
+    pmix_mca_base_alias_item_t *item;
+    int nfound;
+    int rc;
+
+    report("alias: lookup of an unregistered name returns NULL",
+           NULL == pmix_mca_base_alias_lookup("pmix", "utest", "nothing"));
+
+    rc = pmix_mca_base_alias_register("pmix", "utest", "real", "nickname", 0);
+    report("alias: register succeeds", PMIX_SUCCESS == rc);
+
+    alias = pmix_mca_base_alias_lookup("pmix", "utest", "real");
+    report("alias: lookup finds it", NULL != alias);
+    if (NULL != alias) {
+        nfound = 0;
+        PMIX_LIST_FOREACH (item, (pmix_list_t *) &alias->component_aliases,
+                           pmix_mca_base_alias_item_t) {
+            if (0 == strcmp(item->component_alias, "nickname")) {
+                nfound++;
+            }
+        }
+        report("alias: the registered name is on the list", 1 == nfound);
+    }
+
+    /* a second alias for the same component joins the same list */
+    rc = pmix_mca_base_alias_register("pmix", "utest", "real", "othername", 0);
+    report("alias: second register succeeds", PMIX_SUCCESS == rc);
+    alias = pmix_mca_base_alias_lookup("pmix", "utest", "real");
+    if (NULL != alias) {
+        nfound = 0;
+        PMIX_LIST_FOREACH (item, (pmix_list_t *) &alias->component_aliases,
+                           pmix_mca_base_alias_item_t) {
+            nfound++;
+        }
+        report("alias: both aliases are on one list", 2 == nfound);
+    }
+
+    /* the project and framework are part of the key */
+    report("alias: a different framework does not match",
+           NULL == pmix_mca_base_alias_lookup("pmix", "other", "real"));
+
+    /* NULL project/framework is a distinct, legal key */
+    rc = pmix_mca_base_alias_register(NULL, NULL, "bare", "barealias", 0);
+    report("alias: register with no project/framework", PMIX_SUCCESS == rc);
+    report("alias: lookup with no project/framework",
+           NULL != pmix_mca_base_alias_lookup(NULL, NULL, "bare"));
+
+    /* a NULL component name is a programming error, not a crash */
+    report("alias: register with a NULL component is refused",
+           PMIX_ERR_BAD_PARAM == pmix_mca_base_alias_register("pmix", "utest", NULL, "x", 0));
+    report("alias: lookup with a NULL component returns NULL",
+           NULL == pmix_mca_base_alias_lookup("pmix", "utest", NULL));
+
+    pmix_mca_base_alias_cleanup();
+    report("alias: lookup after cleanup returns NULL",
+           NULL == pmix_mca_base_alias_lookup("pmix", "utest", "real"));
+}
+
+int main(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "\n=== mca_base component helper unit tests ===\n\n");
+
+    test_compare();
+    test_to_string();
+    test_parse_requested();
+    test_alias();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/mca/mca_base_framework.c
+++ b/test/unit/mca/mca_base_framework.c
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the framework lifecycle in
+ * src/mca/base/pmix_mca_base_framework.c: register / open / close, the
+ * reference count that ties them together, the REGISTERED and OPEN
+ * state bits, the MCA variables a registration creates, and the
+ * NOREGISTER and NO_DSO flags.
+ *
+ * The subject is a framework declared right here with no components at
+ * all. That is deliberate: driving one of the library's real frameworks
+ * would drag in whatever its components do, and the behavior under test
+ * belongs entirely to the base.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pmix_common.h"
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/base/pmix_mca_base_framework.h"
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/runtime/pmix_init_util.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* the framework under test                                            */
+/* ------------------------------------------------------------------ */
+
+static int n_register_calls = 0;
+static int n_open_calls = 0;
+static int n_close_calls = 0;
+static int register_result = PMIX_SUCCESS;
+static int open_result = PMIX_SUCCESS;
+
+static int utestfw_register(pmix_mca_base_register_flag_t flags)
+{
+    (void) flags;
+    n_register_calls++;
+    return register_result;
+}
+
+static int utestfw_open(pmix_mca_base_open_flag_t flags)
+{
+    (void) flags;
+    n_open_calls++;
+    return open_result;
+}
+
+static int utestfw_close(void)
+{
+    n_close_calls++;
+    return PMIX_SUCCESS;
+}
+
+PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, utestfw, "a framework with no components",
+                                utestfw_register, utestfw_open, utestfw_close,
+                                NULL, PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
+
+/* a second one that opts out of the MCA variable stage entirely */
+PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, utestnoreg, "a NOREGISTER framework",
+                                NULL, NULL, NULL, NULL,
+                                PMIX_MCA_BASE_FRAMEWORK_FLAG_NOREGISTER
+                                    | PMIX_MCA_BASE_FRAMEWORK_FLAG_NO_DSO);
+
+/* A third framework, this one with a real static component, so that a
+ * registration can fail *after* component discovery has already put
+ * something on framework_components. See
+ * test_failed_register_unwinds_components(). */
+static pmix_mca_base_component_t utestreg_alpha = {
+    PMIX_MCA_BASE_VERSION_1_0_0("utestreg", 1, 0, 0),
+    .pmix_mca_component_name = "alpha",
+    .pmix_mca_component_major_version = 1,
+    .pmix_mca_component_minor_version = 0,
+    .pmix_mca_component_release_version = 0,
+};
+
+static const pmix_mca_base_component_t *utestreg_components[] = {&utestreg_alpha, NULL};
+static const pmix_mca_base_component_t **utestreg_static_components[] = {utestreg_components,
+                                                                         NULL};
+
+PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, utestreg, "a framework with one static component",
+                                NULL, NULL, NULL,
+                                (const pmix_mca_base_component_t ***) utestreg_static_components,
+                                PMIX_MCA_BASE_FRAMEWORK_FLAG_NO_DSO);
+
+static void reset_counters(void)
+{
+    n_register_calls = 0;
+    n_open_calls = 0;
+    n_close_calls = 0;
+    register_result = PMIX_SUCCESS;
+    open_result = PMIX_SUCCESS;
+}
+
+/* ------------------------------------------------------------------ */
+/* register / open / close and the reference count                     */
+/* ------------------------------------------------------------------ */
+
+static void test_register_open_close(void)
+{
+    pmix_mca_base_framework_t *fw = &pmix_utestfw_base_framework;
+    int rc;
+
+    reset_counters();
+
+    report("starts unregistered", !pmix_mca_base_framework_is_registered(fw));
+    report("starts closed", !pmix_mca_base_framework_is_open(fw));
+    report("starts with refcnt 0", 0 == fw->framework_refcnt);
+
+    rc = pmix_mca_base_framework_register(fw, PMIX_MCA_BASE_REGISTER_DEFAULT);
+    report("register succeeds", PMIX_SUCCESS == rc);
+    report("register called the framework's register function", 1 == n_register_calls);
+    report("register sets REGISTERED", pmix_mca_base_framework_is_registered(fw));
+    report("register does not set OPEN", !pmix_mca_base_framework_is_open(fw));
+    report("register takes a reference", 1 == fw->framework_refcnt);
+
+    /* registering creates the framework's selection variable and its
+     * verbosity variable */
+    report("register created the selection variable",
+           0 <= pmix_mca_base_var_find("pmix", "utestfw", NULL, NULL));
+    report("register created the verbosity variable",
+           0 <= pmix_mca_base_var_find("pmix", "utestfw", "base", "verbose"));
+
+    /* a second register is just a reference */
+    rc = pmix_mca_base_framework_register(fw, PMIX_MCA_BASE_REGISTER_DEFAULT);
+    report("re-register succeeds", PMIX_SUCCESS == rc);
+    report("re-register does not call the register function again", 1 == n_register_calls);
+    report("re-register takes another reference", 2 == fw->framework_refcnt);
+
+    rc = pmix_mca_base_framework_close(fw);
+    report("close drops the extra reference", PMIX_SUCCESS == rc && 1 == fw->framework_refcnt);
+    report("framework still registered after the extra reference went",
+           pmix_mca_base_framework_is_registered(fw));
+
+    rc = pmix_mca_base_framework_open(fw, PMIX_MCA_BASE_OPEN_DEFAULT);
+    report("open succeeds", PMIX_SUCCESS == rc);
+    report("open called the framework's open function", 1 == n_open_calls);
+    report("open sets OPEN", pmix_mca_base_framework_is_open(fw));
+    report("open registered again, so it took a reference", 2 == fw->framework_refcnt);
+
+    rc = pmix_mca_base_framework_close(fw);
+    report("first close does not tear down", PMIX_SUCCESS == rc && 0 == n_close_calls);
+    report("first close leaves it open", pmix_mca_base_framework_is_open(fw));
+    report("first close drops one reference", 1 == fw->framework_refcnt);
+
+    rc = pmix_mca_base_framework_close(fw);
+    report("last close succeeds", PMIX_SUCCESS == rc);
+    report("last close called the framework's close function", 1 == n_close_calls);
+    report("last close clears OPEN", !pmix_mca_base_framework_is_open(fw));
+    report("last close clears REGISTERED", !pmix_mca_base_framework_is_registered(fw));
+    report("last close returns to refcnt 0", 0 == fw->framework_refcnt);
+
+    /* closing an already-closed framework is a no-op, not an underflow */
+    rc = pmix_mca_base_framework_close(fw);
+    report("close on a closed framework is a no-op",
+           PMIX_SUCCESS == rc && 0 == fw->framework_refcnt && 1 == n_close_calls);
+}
+
+/* A failed registration must put the reference count back. If it does
+ * not, the framework can never reach zero again: the next close drops
+ * the leaked reference instead of tearing down, so the close function
+ * never runs and every component the framework holds is leaked. */
+static void test_failed_register_restores_refcount(void)
+{
+    pmix_mca_base_framework_t *fw = &pmix_utestfw_base_framework;
+    int rc;
+
+    reset_counters();
+    register_result = PMIX_ERR_BAD_PARAM;
+
+    rc = pmix_mca_base_framework_register(fw, PMIX_MCA_BASE_REGISTER_DEFAULT);
+    report("failed register reports the failure", PMIX_SUCCESS != rc);
+    report("failed register did call the register function", 1 == n_register_calls);
+    report("failed register leaves REGISTERED clear",
+           !pmix_mca_base_framework_is_registered(fw));
+    report("failed register restores refcnt to 0", 0 == fw->framework_refcnt);
+
+    /* and the framework must still be usable afterwards */
+    reset_counters();
+    rc = pmix_mca_base_framework_register(fw, PMIX_MCA_BASE_REGISTER_DEFAULT);
+    report("register after a failed register succeeds", PMIX_SUCCESS == rc);
+    report("register after a failed register takes exactly one reference",
+           1 == fw->framework_refcnt);
+
+    rc = pmix_mca_base_framework_close(fw);
+    report("close after the recovery tears down", PMIX_SUCCESS == rc);
+    report("close after the recovery returns to refcnt 0", 0 == fw->framework_refcnt);
+    report("close after the recovery clears REGISTERED",
+           !pmix_mca_base_framework_is_registered(fw));
+}
+
+/* A failed registration must also give back everything it built, not
+ * only the reference count.
+ *
+ * This is the case a bare "refcnt--" misses. Component discovery runs
+ * inside register(), appending every component that matched the
+ * selection, and component_find_check() only afterwards rejects the run
+ * over a requested name that matched nothing -- so by the time the
+ * failure surfaces, framework_components is already populated. Nothing
+ * else will ever drain it: pmix_mca_base_framework_close() returns
+ * immediately when neither REGISTERED nor OPEN is set, which is exactly
+ * the state a failed register leaves behind.
+ *
+ * main() arranges the failure with mca_base_abort_on_load_error and a
+ * selection naming this framework's one real component plus one that
+ * does not exist -- ordinary user input, no allocation failure. */
+static void test_failed_register_unwinds_components(void)
+{
+    pmix_mca_base_framework_t *fw = &pmix_utestreg_base_framework;
+    int rc;
+
+    rc = pmix_mca_base_framework_register(fw, PMIX_MCA_BASE_REGISTER_DEFAULT);
+    report("register fails on a selection naming a missing component",
+           PMIX_ERR_NOT_FOUND == rc);
+    report("the failed register restores refcnt to 0", 0 == fw->framework_refcnt);
+    report("the failed register leaves REGISTERED clear",
+           !pmix_mca_base_framework_is_registered(fw));
+    report("the failed register drained the components it had found",
+           0 == pmix_list_get_size(&fw->framework_components));
+    report("the failed register drained the failed-component list",
+           0 == pmix_list_get_size(&fw->framework_failed_components));
+
+    /* and close on the wreckage is still a clean no-op */
+    rc = pmix_mca_base_framework_close(fw);
+    report("close after a failed register is a no-op",
+           PMIX_SUCCESS == rc && 0 == fw->framework_refcnt);
+}
+
+/* A failed open has to undo the registration it performed on the way in.
+ *
+ * Merely decrementing is not enough. pmix_mca_base_framework_open()
+ * registers first, so when the caller is the first one in, the failure
+ * path has to put REGISTERED back as well -- otherwise the framework
+ * reports itself registered with a reference count of zero, and the
+ * next close() decrements 0 to -1, finds that non-zero, and returns
+ * success without tearing anything down. The framework is then wedged:
+ * no later close can ever reach zero. */
+static void test_failed_open_when_sole_holder(void)
+{
+    pmix_mca_base_framework_t *fw = &pmix_utestfw_base_framework;
+    int rc;
+
+    reset_counters();
+    open_result = PMIX_ERR_NOT_SUPPORTED;
+
+    report("precondition: framework starts idle",
+           0 == fw->framework_refcnt && !pmix_mca_base_framework_is_registered(fw));
+
+    rc = pmix_mca_base_framework_open(fw, PMIX_MCA_BASE_OPEN_DEFAULT);
+    report("failed open reports the failure", PMIX_SUCCESS != rc);
+    report("failed open leaves OPEN clear", !pmix_mca_base_framework_is_open(fw));
+    report("failed open restores refcnt to 0", 0 == fw->framework_refcnt);
+    report("failed open also clears REGISTERED it had just set",
+           !pmix_mca_base_framework_is_registered(fw));
+    report("failed open did not run the close function", 0 == n_close_calls);
+
+    /* the framework must be usable afterwards -- in particular the next
+     * close must be able to reach zero */
+    reset_counters();
+    rc = pmix_mca_base_framework_open(fw, PMIX_MCA_BASE_OPEN_DEFAULT);
+    report("open after a failed open succeeds", PMIX_SUCCESS == rc);
+    report("open after a failed open takes exactly one reference",
+           1 == fw->framework_refcnt);
+    rc = pmix_mca_base_framework_close(fw);
+    report("close after the recovery tears down",
+           PMIX_SUCCESS == rc && 1 == n_close_calls);
+    report("close after the recovery returns to refcnt 0", 0 == fw->framework_refcnt);
+}
+
+/* The other half of that contract: when somebody else already holds a
+ * reference, a failed open must give back only its own -- it must not
+ * tear down a framework that is still in use. */
+static void test_failed_open_when_not_sole_holder(void)
+{
+    pmix_mca_base_framework_t *fw = &pmix_utestfw_base_framework;
+    int rc;
+
+    reset_counters();
+
+    rc = pmix_mca_base_framework_register(fw, PMIX_MCA_BASE_REGISTER_DEFAULT);
+    report("holder registers the framework",
+           PMIX_SUCCESS == rc && 1 == fw->framework_refcnt);
+
+    open_result = PMIX_ERR_NOT_SUPPORTED;
+    rc = pmix_mca_base_framework_open(fw, PMIX_MCA_BASE_OPEN_DEFAULT);
+    report("failed open still reports the failure", PMIX_SUCCESS != rc);
+    report("failed open gave back only its own reference", 1 == fw->framework_refcnt);
+    report("failed open left the other holder's registration intact",
+           pmix_mca_base_framework_is_registered(fw));
+    report("failed open did not run the close function", 0 == n_close_calls);
+
+    /* and the holder's own close still tears down */
+    rc = pmix_mca_base_framework_close(fw);
+    report("the holder's close tears down",
+           PMIX_SUCCESS == rc && 0 == fw->framework_refcnt
+               && !pmix_mca_base_framework_is_registered(fw));
+}
+
+/* Repeated open/close cycles have to be idempotent: the variables are
+ * deregistered and re-registered, the component lists are destroyed and
+ * reconstructed, and the state bits have to come back to where they
+ * started every time. */
+static void test_cycling(void)
+{
+    pmix_mca_base_framework_t *fw = &pmix_utestfw_base_framework;
+    int i, rc;
+    bool ok = true;
+
+    reset_counters();
+
+    for (i = 0; i < 5; ++i) {
+        rc = pmix_mca_base_framework_open(fw, PMIX_MCA_BASE_OPEN_DEFAULT);
+        if (PMIX_SUCCESS != rc || !pmix_mca_base_framework_is_open(fw)) {
+            ok = false;
+            break;
+        }
+        /* while the framework is open its variables are registered */
+        if (0 > pmix_mca_base_var_find("pmix", "utestfw", NULL, NULL)
+            || 0 > pmix_mca_base_var_find("pmix", "utestfw", "base", "verbose")) {
+            ok = false;
+            break;
+        }
+        rc = pmix_mca_base_framework_close(fw);
+        if (PMIX_SUCCESS != rc || pmix_mca_base_framework_is_open(fw)
+            || 0 != fw->framework_refcnt) {
+            ok = false;
+            break;
+        }
+        /* and closing deregisters the whole variable group with it --
+         * that is the point of grouping them by owner */
+        if (0 <= pmix_mca_base_var_find("pmix", "utestfw", NULL, NULL)) {
+            ok = false;
+            break;
+        }
+    }
+    report("five open/close cycles leave the framework where it started", ok);
+    report("each cycle ran the open function", 5 == n_open_calls);
+    report("each cycle ran the close function", 5 == n_close_calls);
+
+    /* one more open, to show the deregistered variables come back rather
+     * than the group staying dead after the first cycle */
+    rc = pmix_mca_base_framework_open(fw, PMIX_MCA_BASE_OPEN_DEFAULT);
+    report("the variable group is revived by a later open",
+           PMIX_SUCCESS == rc && 0 <= pmix_mca_base_var_find("pmix", "utestfw", NULL, NULL));
+    (void) pmix_mca_base_framework_close(fw);
+    report("framework left idle for the next test",
+           0 == fw->framework_refcnt && !pmix_mca_base_framework_is_registered(fw));
+}
+
+/* A NOREGISTER framework skips the MCA variable stage entirely, but
+ * still opens and closes. */
+static void test_noregister(void)
+{
+    pmix_mca_base_framework_t *fw = &pmix_utestnoreg_base_framework;
+    int rc;
+
+    rc = pmix_mca_base_framework_open(fw, PMIX_MCA_BASE_OPEN_DEFAULT);
+    report("NOREGISTER framework opens", PMIX_SUCCESS == rc);
+    report("NOREGISTER framework reports open", pmix_mca_base_framework_is_open(fw));
+    report("NOREGISTER framework registered no selection variable",
+           0 > pmix_mca_base_var_find("pmix", "utestnoreg", NULL, NULL));
+    report("NOREGISTER framework registered no verbosity variable",
+           0 > pmix_mca_base_var_find("pmix", "utestnoreg", "base", "verbose"));
+
+    rc = pmix_mca_base_framework_close(fw);
+    report("NOREGISTER framework closes", PMIX_SUCCESS == rc);
+    report("NOREGISTER framework returns to refcnt 0", 0 == fw->framework_refcnt);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+
+    (void) argc;
+    (void) argv;
+
+    /* Keep the caller's MCA parameter files out of the results, exactly
+     * as mca_base_var.c does. */
+    setenv("PMIX_MCA_mca_base_param_files", "none", 1);
+    /* make component_find_check() reject a selection that names a
+     * component this framework does not have -- see
+     * test_failed_register_unwinds_components() */
+    setenv("PMIX_MCA_mca_base_abort_on_load_error", "1", 1);
+    setenv("PMIX_MCA_utestreg", "alpha,nosuchcomponent", 1);
+
+    /* pmix_init_util() establishes the install dirs, the variable
+     * system and the component repository. The last of those matters
+     * here: registering a framework that permits DSO components reaches
+     * pmix_mca_base_component_repository_get_components(), which reads a
+     * hash table that only pmix_mca_base_open() constructs. */
+    rc = pmix_init_util(NULL, 0, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "pmix_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== pmix_mca_base_framework unit tests ===\n\n");
+
+    test_register_open_close();
+    test_failed_register_restores_refcount();
+    test_failed_register_unwinds_components();
+    test_failed_open_when_sole_holder();
+    test_failed_open_when_not_sole_holder();
+    test_cycling();
+    test_noregister();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    pmix_finalize_util();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/mca/mca_base_paramfile.c
+++ b/test/unit/mca/mca_base_paramfile.c
@@ -1,0 +1,454 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the MCA parameter *file* path in src/mca/base:
+ * pmix_mca_base_parse_paramfile.c, the read_files()/append_filename_to_list()
+ * machinery in pmix_mca_base_var.c, and -- the point of the exercise --
+ * the precedence rules between a value in an ordinary parameter file, a
+ * value in the override file, and a value in the environment.
+ *
+ * Everything here is driven through real files that main() writes into a
+ * private temporary directory and names through the MCA parameters that
+ * select them, because those parameters are read exactly once during
+ * pmix_mca_base_var_init() and there is no other way in.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "pmix_common.h"
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/mca/base/pmix_mca_base_vari.h"
+#include "src/runtime/pmix_init_util.h"
+
+static int npass = 0;
+static int nfail = 0;
+static char tmpdir[512];
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* a plain value out of an ordinary parameter file                     */
+/* ------------------------------------------------------------------ */
+
+static int file_int = 0;
+static char *file_string = NULL;
+
+static void test_value_from_file(void)
+{
+    pmix_mca_base_var_source_t source = PMIX_MCA_BASE_VAR_SOURCE_MAX;
+    const char *source_file = NULL;
+    int *ip = NULL;
+    char **sp = NULL;
+    int idx, rc;
+
+    file_int = 1;
+    idx = pmix_mca_base_var_register("pmix", "utest", "file", "an_int", "from a parameter file",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &file_int);
+    report("file int registered", 0 <= idx);
+    rc = pmix_mca_base_var_get_value(idx, &ip, &source, &source_file);
+    report("file int took the file's value", PMIX_SUCCESS == rc && NULL != ip && 77 == *ip);
+    report("file int reports FILE as its source", PMIX_MCA_BASE_VAR_SOURCE_FILE == source);
+    report("file int names the file it came from",
+           NULL != source_file && NULL != strstr(source_file, "params.conf"));
+
+    file_string = NULL;
+    idx = pmix_mca_base_var_register("pmix", "utest", "file", "a_string", "from a parameter file",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING, &file_string);
+    report("file string registered", 0 <= idx);
+    rc = pmix_mca_base_var_get_value(idx, &sp, NULL, NULL);
+    report("file string took the file's value",
+           PMIX_SUCCESS == rc && NULL != sp && NULL != *sp && 0 == strcmp(*sp, "from-the-file"));
+}
+
+/* A variable named in neither file nor environment keeps its default,
+ * even though the files were read. */
+static int untouched_int = 0;
+
+static void test_default_survives(void)
+{
+    pmix_mca_base_var_source_t source = PMIX_MCA_BASE_VAR_SOURCE_MAX;
+    int *ip = NULL;
+    int idx, rc;
+
+    untouched_int = 5;
+    idx = pmix_mca_base_var_register("pmix", "utest", "file", "untouched", "never set anywhere",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &untouched_int);
+    rc = pmix_mca_base_var_get_value(idx, &ip, &source, NULL);
+    report("unmentioned variable keeps its default",
+           PMIX_SUCCESS == rc && NULL != ip && 5 == *ip);
+    report("unmentioned variable reports DEFAULT",
+           PMIX_MCA_BASE_VAR_SOURCE_DEFAULT == source);
+}
+
+/* ------------------------------------------------------------------ */
+/* precedence                                                          */
+/* ------------------------------------------------------------------ */
+
+/* The environment beats an ordinary parameter file. */
+static int env_beats_file = 0;
+
+static void test_env_beats_file(void)
+{
+    pmix_mca_base_var_source_t source = PMIX_MCA_BASE_VAR_SOURCE_MAX;
+    int *ip = NULL;
+    int idx, rc;
+
+    env_beats_file = 0;
+    idx = pmix_mca_base_var_register("pmix", "utest", "prec", "env_wins",
+                                     "in both the file and the environment",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &env_beats_file);
+    rc = pmix_mca_base_var_get_value(idx, &ip, &source, NULL);
+    report("environment beats an ordinary parameter file",
+           PMIX_SUCCESS == rc && NULL != ip && 22 == *ip);
+    report("and reports ENV as the source", PMIX_MCA_BASE_VAR_SOURCE_ENV == source);
+}
+
+/* The override file beats the environment -- that is the whole reason
+ * the override file exists. A site administrator writes it to say "this
+ * value is not negotiable", and a user's environment must not win. */
+static int override_wins = 0;
+
+static void test_override_beats_env(void)
+{
+    pmix_mca_base_var_source_t source = PMIX_MCA_BASE_VAR_SOURCE_MAX;
+    int *ip = NULL;
+    int idx, rc;
+
+    override_wins = 0;
+    idx = pmix_mca_base_var_register("pmix", "utest", "prec", "override_wins",
+                                     "in both the override file and the environment",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &override_wins);
+    rc = pmix_mca_base_var_get_value(idx, &ip, &source, NULL);
+    report("override file beats the environment",
+           PMIX_SUCCESS == rc && NULL != ip && 33 == *ip);
+    report("and reports OVERRIDE as the source",
+           PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE == source);
+}
+
+/* The override file beats an ordinary parameter file too. */
+static int override_beats_file = 0;
+
+static void test_override_beats_file(void)
+{
+    int *ip = NULL;
+    int idx, rc;
+
+    override_beats_file = 0;
+    idx = pmix_mca_base_var_register("pmix", "utest", "prec", "override_file",
+                                     "in both files", PMIX_MCA_BASE_VAR_TYPE_INT,
+                                     &override_beats_file);
+    rc = pmix_mca_base_var_get_value(idx, &ip, NULL, NULL);
+    report("override file beats an ordinary parameter file",
+           PMIX_SUCCESS == rc && NULL != ip && 44 == *ip);
+}
+
+/* ...and it has to keep beating the environment when the name the
+ * override file used was a *synonym*.
+ *
+ * This is the case that separates "the override is enforced" from "the
+ * override is enforced as long as the site administrator happened to
+ * write the modern spelling". var_set_from_file() records the source on
+ * the variable a synonym stands for, and var_set_initial() has to make
+ * that say OVERRIDE -- not just FILE -- or the environment check that
+ * follows sees no override to protect and lets the user's value through. */
+static int syn_override = 0;
+
+static void test_override_via_synonym_beats_env(void)
+{
+    pmix_mca_base_var_source_t source = PMIX_MCA_BASE_VAR_SOURCE_MAX;
+    int *ip = NULL;
+    int idx, syn, rc;
+
+    syn_override = 0;
+    idx = pmix_mca_base_var_register("pmix", "utest", "syn", "new_name",
+                                     "reachable under two names",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &syn_override);
+    report("synonym target registered", 0 <= idx);
+
+    /* the override file names "utest_old_name", which is this synonym */
+    syn = pmix_mca_base_var_register_synonym(idx, "pmix", "utest", NULL, "old_name",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    report("synonym registered", 0 <= syn);
+
+    rc = pmix_mca_base_var_get_value(idx, &ip, &source, NULL);
+    report("override file naming a synonym still beats the environment",
+           PMIX_SUCCESS == rc && NULL != ip && 55 == *ip);
+    report("and still reports OVERRIDE as the source",
+           PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE == source);
+}
+
+/* The sharper form of the same case: the override file names the
+ * synonym AND the environment names the synonym too.
+ *
+ * Above, the environment used the modern name, so the environment
+ * lookup for the synonym found nothing and the override survived by
+ * luck. Here both sides use the deprecated name, so the environment
+ * check actually runs against a variable whose recorded source decides
+ * whether it is protected -- and if reading the override file only
+ * marked the synonym, not the variable it stands for, the check sees an
+ * ordinary file value and lets the user's environment win. A site
+ * administrator's override would then be defeated by spelling. */
+static int syn2_override = 0;
+
+static void test_override_via_synonym_beats_synonym_env(void)
+{
+    pmix_mca_base_var_source_t source = PMIX_MCA_BASE_VAR_SOURCE_MAX;
+    int *ip = NULL;
+    int idx, syn, rc;
+
+    syn2_override = 0;
+    idx = pmix_mca_base_var_register("pmix", "utest", "syn2", "new_name",
+                                     "reachable under two names",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &syn2_override);
+    report("second synonym target registered", 0 <= idx);
+
+    syn = pmix_mca_base_var_register_synonym(idx, "pmix", "utest", NULL, "old2_name",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    report("second synonym registered", 0 <= syn);
+
+    rc = pmix_mca_base_var_get_value(idx, &ip, &source, NULL);
+    report("override beats the environment even when both name the synonym",
+           PMIX_SUCCESS == rc && NULL != ip && 66 == *ip);
+    report("and that case reports OVERRIDE as the source",
+           PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE == source);
+}
+
+/* ------------------------------------------------------------------ */
+/* value parsing out of a file                                         */
+/* ------------------------------------------------------------------ */
+
+static size_t suffix_k = 0;
+static size_t suffix_m = 0;
+static size_t suffix_g = 0;
+static bool file_bool_true = false;
+static bool file_bool_false = true;
+static int negative_int = 0;
+
+/* int_from_string() accepts a K/M/G suffix on the integral types. This
+ * is the only place that behavior is exercised. */
+static void test_value_parsing(void)
+{
+    size_t *zp = NULL;
+    bool *bp = NULL;
+    int *ip = NULL;
+    int idx, rc;
+
+    idx = pmix_mca_base_var_register("pmix", "utest", "parse", "k", "1k",
+                                     PMIX_MCA_BASE_VAR_TYPE_SIZE_T, &suffix_k);
+    rc = pmix_mca_base_var_get_value(idx, &zp, NULL, NULL);
+    report("\"1k\" parses as 1024", PMIX_SUCCESS == rc && NULL != zp && 1024 == *zp);
+
+    idx = pmix_mca_base_var_register("pmix", "utest", "parse", "m", "2M",
+                                     PMIX_MCA_BASE_VAR_TYPE_SIZE_T, &suffix_m);
+    rc = pmix_mca_base_var_get_value(idx, &zp, NULL, NULL);
+    report("\"2M\" parses as 2097152",
+           PMIX_SUCCESS == rc && NULL != zp && (2u << 20) == *zp);
+
+    idx = pmix_mca_base_var_register("pmix", "utest", "parse", "g", "1g",
+                                     PMIX_MCA_BASE_VAR_TYPE_SIZE_T, &suffix_g);
+    rc = pmix_mca_base_var_get_value(idx, &zp, NULL, NULL);
+    report("\"1g\" parses as 1073741824",
+           PMIX_SUCCESS == rc && NULL != zp && (1u << 30) == *zp);
+
+    idx = pmix_mca_base_var_register("pmix", "utest", "parse", "yes", "a true bool",
+                                     PMIX_MCA_BASE_VAR_TYPE_BOOL, &file_bool_true);
+    rc = pmix_mca_base_var_get_value(idx, &bp, NULL, NULL);
+    report("\"true\" in a file parses as true", PMIX_SUCCESS == rc && NULL != bp && *bp);
+
+    idx = pmix_mca_base_var_register("pmix", "utest", "parse", "no", "a false bool",
+                                     PMIX_MCA_BASE_VAR_TYPE_BOOL, &file_bool_false);
+    rc = pmix_mca_base_var_get_value(idx, &bp, NULL, NULL);
+    report("\"false\" in a file parses as false", PMIX_SUCCESS == rc && NULL != bp && !*bp);
+
+    idx = pmix_mca_base_var_register("pmix", "utest", "parse", "neg", "a negative int",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &negative_int);
+    rc = pmix_mca_base_var_get_value(idx, &ip, NULL, NULL);
+    report("a negative integer round-trips", PMIX_SUCCESS == rc && NULL != ip && -7 == *ip);
+}
+
+/* A "~/" prefix in a string value is expanded to the user's home
+ * directory; so is ":~/" anywhere in a path-style list. */
+static char *tilde_simple = NULL;
+static char *tilde_in_path = NULL;
+
+static void test_tilde_expansion(void)
+{
+    char **sp = NULL;
+    int idx, rc;
+
+    idx = pmix_mca_base_var_register("pmix", "utest", "tilde", "simple", "a ~/ value",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING, &tilde_simple);
+    rc = pmix_mca_base_var_get_value(idx, &sp, NULL, NULL);
+    report("leading \"~/\" is expanded",
+           PMIX_SUCCESS == rc && NULL != sp && NULL != *sp && '~' != (*sp)[0]
+               && NULL != strstr(*sp, "mydir"));
+
+    idx = pmix_mca_base_var_register("pmix", "utest", "tilde", "path", "a :~/ value",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING, &tilde_in_path);
+    rc = pmix_mca_base_var_get_value(idx, &sp, NULL, NULL);
+    report("\"~/\" after a colon is expanded",
+           PMIX_SUCCESS == rc && NULL != sp && NULL != *sp
+               && NULL == strstr(*sp, ":~/") && NULL != strstr(*sp, "second"));
+}
+
+/* ------------------------------------------------------------------ */
+/* the file list itself                                                */
+/* ------------------------------------------------------------------ */
+
+/* read_files() takes a comma-delimited list and reads it in reverse so
+ * that entries farthest to the LEFT take precedence. */
+static int from_first_file = 0;
+static int in_both_files = 0;
+
+static void test_file_list_precedence(void)
+{
+    int *ip = NULL;
+    int idx, rc;
+
+    idx = pmix_mca_base_var_register("pmix", "utest", "list", "only_second",
+                                     "only in the second file",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &from_first_file);
+    rc = pmix_mca_base_var_get_value(idx, &ip, NULL, NULL);
+    report("a value from the second file in the list is read",
+           PMIX_SUCCESS == rc && NULL != ip && 88 == *ip);
+
+    idx = pmix_mca_base_var_register("pmix", "utest", "list", "in_both",
+                                     "in both files of the list",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &in_both_files);
+    rc = pmix_mca_base_var_get_value(idx, &ip, NULL, NULL);
+    report("the leftmost file in the list wins",
+           PMIX_SUCCESS == rc && NULL != ip && 99 == *ip);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void write_file(const char *name, const char *contents)
+{
+    char path[1024];
+    FILE *fp;
+
+    snprintf(path, sizeof(path), "%s/%s", tmpdir, name);
+    fp = fopen(path, "w");
+    if (NULL == fp) {
+        fprintf(stderr, "cannot write %s\n", path);
+        exit(1);
+    }
+    fputs(contents, fp);
+    fclose(fp);
+}
+
+int main(int argc, char **argv)
+{
+    char params[1024], params2[1024], override[1024], list[2048];
+    char tmpl[] = "/tmp/pmix-mca-utest-XXXXXX";
+    int rc;
+
+    (void) argc;
+    (void) argv;
+
+    if (NULL == mkdtemp(tmpl)) {
+        fprintf(stderr, "cannot create a temporary directory\n");
+        return 1;
+    }
+    snprintf(tmpdir, sizeof(tmpdir), "%s", tmpl);
+
+    /* The first file in the list wins over the second, so put the
+     * "in_both" value here. */
+    write_file("params.conf",
+               "# an MCA parameter file\n"
+               "utest_file_an_int = 77\n"
+               "utest_file_a_string = from-the-file\n"
+               "utest_prec_env_wins = 11\n"
+               "utest_prec_override_file = 11\n"
+               "utest_parse_k = 1k\n"
+               "utest_parse_m = 2M\n"
+               "utest_parse_g = 1g\n"
+               "utest_parse_yes = true\n"
+               "utest_parse_no = false\n"
+               "utest_parse_neg = -7\n"
+               "utest_tilde_simple = ~/mydir\n"
+               "utest_tilde_path = /first:~/second\n"
+               "utest_list_in_both = 99\n");
+
+    write_file("params2.conf",
+               "utest_list_only_second = 88\n"
+               "utest_list_in_both = 11\n");
+
+    /* The override file names utest_prec_override_wins directly, and
+     * names the synonym utest_old_name for utest_syn_new_name. */
+    write_file("override.conf",
+               "utest_prec_override_wins = 33\n"
+               "utest_prec_override_file = 44\n"
+               "utest_old_name = 55\n"
+               "utest_old2_name = 66\n");
+
+    snprintf(params, sizeof(params), "%s/params.conf", tmpdir);
+    snprintf(params2, sizeof(params2), "%s/params2.conf", tmpdir);
+    snprintf(override, sizeof(override), "%s/override.conf", tmpdir);
+    snprintf(list, sizeof(list), "%s,%s", params, params2);
+
+    /* All of this has to be in place before pmix_init_util() runs: the
+     * variable system reads these files exactly once, during
+     * pmix_mca_base_var_init(). */
+    setenv("PMIX_MCA_mca_base_param_files", list, 1);
+    setenv("PMIX_MCA_mca_base_override_param_file", override, 1);
+
+    /* the environment side of the precedence cases */
+    setenv("PMIX_MCA_utest_prec_env_wins", "22", 1);
+    setenv("PMIX_MCA_utest_prec_override_wins", "2222", 1);
+    setenv("PMIX_MCA_utest_syn_new_name", "5555", 1);
+    setenv("PMIX_MCA_utest_old2_name", "6666", 1);
+
+    rc = pmix_init_util(NULL, 0, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "pmix_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== mca_base parameter file unit tests ===\n\n");
+
+    test_value_from_file();
+    test_default_survives();
+    test_env_beats_file();
+    test_override_beats_env();
+    test_override_beats_file();
+    test_override_via_synonym_beats_env();
+    test_override_via_synonym_beats_synonym_env();
+    test_value_parsing();
+    test_tilde_expansion();
+    test_file_list_precedence();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    pmix_finalize_util();
+
+    /* leave nothing behind in /tmp */
+    unlink(params);
+    unlink(params2);
+    unlink(override);
+    rmdir(tmpdir);
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/mca/mca_base_select.c
+++ b/test/unit/mca/mca_base_select.c
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the generic component selection and filtering in
+ * src/mca/base: pmix_mca_base_select() (query every component, keep the
+ * highest priority, close the rest) and
+ * pmix_mca_base_components_filter() (trim a framework's component list
+ * down to what its selection parameter asks for).
+ *
+ * The components here are fabricated in this file. They have names no
+ * framework uses, no MCA variables, and no repository entry, which is
+ * what makes it safe to let the base close and unload them: both of
+ * those look the component up by name and find nothing to do.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pmix_common.h"
+#include "src/class/pmix_list.h"
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/mca.h"
+#include "src/runtime/pmix_init_util.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* fabricated components                                               */
+/* ------------------------------------------------------------------ */
+
+/* one module object per component, so the caller can tell which
+ * component's module came back */
+static pmix_mca_base_module_t mod_low;
+static pmix_mca_base_module_t mod_high;
+static pmix_mca_base_module_t mod_mid;
+
+static int n_close_calls = 0;
+
+static int query_low(pmix_mca_base_module_t **module, int *priority)
+{
+    *module = &mod_low;
+    *priority = 10;
+    return PMIX_SUCCESS;
+}
+
+static int query_high(pmix_mca_base_module_t **module, int *priority)
+{
+    *module = &mod_high;
+    *priority = 90;
+    return PMIX_SUCCESS;
+}
+
+static int query_mid(pmix_mca_base_module_t **module, int *priority)
+{
+    *module = &mod_mid;
+    *priority = 50;
+    return PMIX_SUCCESS;
+}
+
+/* a component that declines by returning an error */
+static int query_declines(pmix_mca_base_module_t **module, int *priority)
+{
+    *module = NULL;
+    *priority = 0;
+    return PMIX_ERR_NOT_AVAILABLE;
+}
+
+/* a component that succeeds but hands back no module */
+static int query_no_module(pmix_mca_base_module_t **module, int *priority)
+{
+    *module = NULL;
+    *priority = 1000;
+    return PMIX_SUCCESS;
+}
+
+/* a component that says "stop -- do not pick anyone else" */
+static int query_fatal(pmix_mca_base_module_t **module, int *priority)
+{
+    *module = NULL;
+    *priority = 0;
+    return PMIX_ERR_FATAL;
+}
+
+static int count_close(void)
+{
+    n_close_calls++;
+    return PMIX_SUCCESS;
+}
+
+static pmix_mca_base_component_t *make_component(const char *name,
+                                                 pmix_mca_base_query_component_2_0_0_fn_t query)
+{
+    pmix_mca_base_component_t *c = calloc(1, sizeof(*c));
+    if (NULL == c) {
+        return NULL;
+    }
+    pmix_strncpy(c->pmix_mca_project_name, "pmix", PMIX_MCA_BASE_MAX_PROJECT_NAME_LEN);
+    pmix_strncpy(c->pmix_mca_type_name, "utestsel", PMIX_MCA_BASE_MAX_TYPE_NAME_LEN);
+    pmix_strncpy(c->pmix_mca_component_name, name, PMIX_MCA_BASE_MAX_COMPONENT_NAME_LEN);
+    c->pmix_mca_query_component = query;
+    c->pmix_mca_close_component = count_close;
+    return c;
+}
+
+/* Build a list of component list items. The caller owns the component
+ * structs; pmix_mca_base_select() releases the list items. */
+static void add_component(pmix_list_t *list, pmix_mca_base_component_t *c)
+{
+    pmix_mca_base_component_list_item_t *cli = PMIX_NEW(pmix_mca_base_component_list_item_t);
+    cli->cli_component = c;
+    pmix_list_append(list, &cli->super);
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_mca_base_select                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_select_highest_priority(void)
+{
+    pmix_list_t list;
+    pmix_mca_base_module_t *module = NULL;
+    pmix_mca_base_component_t *component = NULL;
+    pmix_mca_base_component_t *lo, *hi, *mid;
+    int priority = -1, rc;
+
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+    lo = make_component("lo", query_low);
+    hi = make_component("hi", query_high);
+    mid = make_component("mid", query_mid);
+    /* deliberately not in priority order */
+    add_component(&list, lo);
+    add_component(&list, hi);
+    add_component(&list, mid);
+
+    n_close_calls = 0;
+    rc = pmix_mca_base_select("utestsel", 0, &list, &module, &component, &priority);
+    report("select succeeds", PMIX_SUCCESS == rc);
+    report("select picks the highest priority module", &mod_high == module);
+    report("select reports the winning component", hi == component);
+    report("select reports the winning priority", 90 == priority);
+    report("select closed the two losers, not the winner", 2 == n_close_calls);
+    report("select left only the winner on the list", 1 == pmix_list_get_size(&list));
+
+    PMIX_LIST_DESTRUCT(&list);
+    free(lo);
+    free(hi);
+    free(mid);
+}
+
+/* A component with no query function at all is skipped, as is one whose
+ * query declines or returns no module. */
+static void test_select_skips(void)
+{
+    pmix_list_t list;
+    pmix_mca_base_module_t *module = NULL;
+    pmix_mca_base_component_t *component = NULL;
+    pmix_mca_base_component_t *none, *decl, *nomod, *lo;
+    int priority = -1, rc;
+
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+    none = make_component("noquery", NULL);
+    decl = make_component("declines", query_declines);
+    nomod = make_component("nomodule", query_no_module);
+    lo = make_component("lo", query_low);
+    add_component(&list, none);
+    add_component(&list, decl);
+    add_component(&list, nomod);
+    add_component(&list, lo);
+
+    rc = pmix_mca_base_select("utestsel", 0, &list, &module, &component, &priority);
+    report("select succeeds past the skipped components", PMIX_SUCCESS == rc);
+    report("a component with no query function is skipped", lo == component);
+    report("a declining component is skipped", &mod_low == module);
+    /* nomodule claimed priority 1000 but returned no module, so it must
+     * not have won despite outranking everyone */
+    report("a component that returns no module cannot win", 10 == priority);
+
+    PMIX_LIST_DESTRUCT(&list);
+    free(none);
+    free(decl);
+    free(nomod);
+    free(lo);
+}
+
+/* PMIX_ERR_FATAL from a query stops selection outright: the caller
+ * asked for something that cannot be provided, and quietly picking a
+ * different component would do the wrong thing silently. */
+static void test_select_fatal_stops(void)
+{
+    pmix_list_t list;
+    pmix_mca_base_module_t *module = NULL;
+    pmix_mca_base_component_t *component = NULL;
+    pmix_mca_base_component_t *fatal, *hi;
+    int priority = -1, rc;
+
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+    fatal = make_component("fatal", query_fatal);
+    hi = make_component("hi", query_high);
+    add_component(&list, fatal);
+    add_component(&list, hi);
+
+    n_close_calls = 0;
+    rc = pmix_mca_base_select("utestsel", 0, &list, &module, &component, &priority);
+    report("a fatal query aborts selection", PMIX_ERR_FATAL == rc);
+    report("a fatal query selects nothing", NULL == component && NULL == module);
+    report("a fatal query does not close the remaining components", 0 == n_close_calls);
+
+    PMIX_LIST_DESTRUCT(&list);
+    free(fatal);
+    free(hi);
+}
+
+static void test_select_nothing_available(void)
+{
+    pmix_list_t list;
+    pmix_mca_base_module_t *module = NULL;
+    pmix_mca_base_component_t *component = NULL;
+    pmix_mca_base_component_t *decl;
+    int priority = -1, rc;
+
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+    decl = make_component("declines", query_declines);
+    add_component(&list, decl);
+
+    n_close_calls = 0;
+    rc = pmix_mca_base_select("utestsel", 0, &list, &module, &component, &priority);
+    report("select with no viable component reports NOT_FOUND", PMIX_ERR_NOT_FOUND == rc);
+    report("select with no viable component returns no module",
+           NULL == module && NULL == component);
+    report("select closed the component it could not use", 1 == n_close_calls);
+    report("select emptied the list", 0 == pmix_list_get_size(&list));
+
+    PMIX_LIST_DESTRUCT(&list);
+    free(decl);
+}
+
+/* An empty list is not a crash. */
+static void test_select_empty_list(void)
+{
+    pmix_list_t list;
+    pmix_mca_base_module_t *module = NULL;
+    pmix_mca_base_component_t *component = NULL;
+    int rc;
+
+    PMIX_CONSTRUCT(&list, pmix_list_t);
+    /* priority_out is documented as optional */
+    rc = pmix_mca_base_select("utestsel", 0, &list, &module, &component, NULL);
+    report("select over an empty list reports NOT_FOUND", PMIX_ERR_NOT_FOUND == rc);
+    report("select over an empty list returns no module",
+           NULL == module && NULL == component);
+    PMIX_LIST_DESTRUCT(&list);
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_mca_base_components_filter                                     */
+/* ------------------------------------------------------------------ */
+
+static void filter_case(const char *selection, const char *expect_remaining, int expect_count)
+{
+    pmix_mca_base_framework_t fw;
+    pmix_mca_base_component_list_item_t *cli;
+    pmix_mca_base_component_t *a, *b, *c;
+    char label[256];
+    int rc, count;
+    bool found_expected = false;
+
+    memset(&fw, 0, sizeof(fw));
+    fw.framework_project = (char *) "pmix";
+    fw.framework_name = (char *) "utestsel";
+    fw.framework_output = 0;
+    fw.framework_selection = (char *) selection;
+    PMIX_CONSTRUCT(&fw.framework_components, pmix_list_t);
+
+    a = make_component("alpha", query_low);
+    b = make_component("beta", query_mid);
+    c = make_component("gamma", query_high);
+    add_component(&fw.framework_components, a);
+    add_component(&fw.framework_components, b);
+    add_component(&fw.framework_components, c);
+
+    rc = pmix_mca_base_components_filter(&fw);
+    count = (int) pmix_list_get_size(&fw.framework_components);
+
+    snprintf(label, sizeof(label), "filter \"%s\" keeps %d component(s)",
+             NULL == selection ? "(none)" : selection, expect_count);
+    report(label, PMIX_SUCCESS == rc && count == expect_count);
+
+    if (NULL != expect_remaining) {
+        PMIX_LIST_FOREACH (cli, &fw.framework_components,
+                           pmix_mca_base_component_list_item_t) {
+            if (0 == strcmp(cli->cli_component->pmix_mca_component_name, expect_remaining)) {
+                found_expected = true;
+            }
+        }
+        snprintf(label, sizeof(label), "filter \"%s\" keeps \"%s\"",
+                 NULL == selection ? "(none)" : selection, expect_remaining);
+        report(label, found_expected);
+    }
+
+    PMIX_LIST_DESTRUCT(&fw.framework_components);
+    free(a);
+    free(b);
+    free(c);
+}
+
+static void test_filter(void)
+{
+    /* no selection at all: everything stays */
+    filter_case(NULL, "alpha", 3);
+    /* an empty string is the same as no selection */
+    filter_case("", "alpha", 3);
+    /* include one */
+    filter_case("beta", "beta", 1);
+    /* include two */
+    filter_case("alpha,gamma", "gamma", 2);
+    /* exclude one */
+    filter_case("^beta", "alpha", 2);
+    /* exclude two */
+    filter_case("^alpha,gamma", "beta", 1);
+    /* a name that matches nothing leaves nothing, and is not an error
+     * (the warning about it is separate, and off by default) */
+    filter_case("nosuchcomponent", NULL, 0);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+
+    (void) argc;
+    (void) argv;
+
+    setenv("PMIX_MCA_mca_base_param_files", "none", 1);
+
+    rc = pmix_init_util(NULL, 0, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "pmix_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== mca_base component selection unit tests ===\n\n");
+
+    test_select_highest_priority();
+    test_select_skips();
+    test_select_fatal_stops();
+    test_select_nothing_available();
+    test_select_empty_list();
+    test_filter();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    pmix_finalize_util();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/mca/mca_base_show_load_errors.c
+++ b/test/unit/mca/mca_base_show_load_errors.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the mca_base_component_show_load_errors parser in
+ * src/mca/base/pmix_mca_base_components_open.c.
+ *
+ * The parameter accepts "all", "none", any boolean spelling, or a
+ * comma-delimited list of "framework" / "framework/component" items
+ * that may be prefixed with "^" to negate the sense of the list. Each
+ * form is driven here through pmix_mca_base_show_load_errors_init() and
+ * then queried with pmix_mca_base_show_load_errors().
+ *
+ * NOTE: a list entry naming a bare framework leaves the entry's
+ * component name NULL. Asking about a specific component of that
+ * framework used to compare against that NULL, which is why the
+ * bare-framework cases below matter more than they look.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pmix_common.h"
+#include "src/mca/base/pmix_base.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* Drive the parser over a value. The parser reads the global directly,
+ * so point it at our string for the duration. */
+static int setup(const char *value)
+{
+    pmix_mca_base_component_show_load_errors = (char *) value;
+    return pmix_mca_base_show_load_errors_init();
+}
+
+static void teardown(void)
+{
+    pmix_mca_base_show_load_errors_finalize();
+    pmix_mca_base_component_show_load_errors = NULL;
+}
+
+static void expect(const char *label, const char *framework, const char *component, bool want)
+{
+    char name[256];
+    bool got = pmix_mca_base_show_load_errors(framework, component);
+
+    snprintf(name, sizeof(name), "%s: (%s, %s) -> %s", label,
+             NULL == framework ? "NULL" : framework, NULL == component ? "NULL" : component,
+             want ? "true" : "false");
+    report(name, got == want);
+}
+
+static void test_all(void)
+{
+    report("\"all\" parses", PMIX_SUCCESS == setup("all"));
+    expect("all", "ptl", "tcp", true);
+    expect("all", "gds", NULL, true);
+    expect("all", NULL, NULL, true);
+    teardown();
+}
+
+static void test_none(void)
+{
+    report("\"none\" parses", PMIX_SUCCESS == setup("none"));
+    expect("none", "ptl", "tcp", false);
+    expect("none", "gds", NULL, false);
+    teardown();
+}
+
+static void test_boolean_synonyms(void)
+{
+    report("\"true\" parses", PMIX_SUCCESS == setup("true"));
+    expect("true", "ptl", "tcp", true);
+    teardown();
+
+    report("\"false\" parses", PMIX_SUCCESS == setup("false"));
+    expect("false", "ptl", "tcp", false);
+    teardown();
+
+    report("\"1\" parses", PMIX_SUCCESS == setup("1"));
+    expect("1", "ptl", "tcp", true);
+    teardown();
+
+    report("\"0\" parses", PMIX_SUCCESS == setup("0"));
+    expect("0", "ptl", "tcp", false);
+    teardown();
+}
+
+/* An include list naming only frameworks. Every component of a listed
+ * framework is included; anything else is not. */
+static void test_include_bare_framework(void)
+{
+    report("\"ptl,gds\" parses", PMIX_SUCCESS == setup("ptl,gds"));
+    expect("include-fw", "ptl", "tcp", true);
+    expect("include-fw", "ptl", "server", true);
+    expect("include-fw", "ptl", NULL, true);
+    expect("include-fw", "gds", "hash", true);
+    expect("include-fw", "psec", "native", false);
+    expect("include-fw", "psec", NULL, false);
+    teardown();
+}
+
+static void test_include_framework_component(void)
+{
+    report("\"ptl/tcp\" parses", PMIX_SUCCESS == setup("ptl/tcp"));
+    expect("include-fw/comp", "ptl", "tcp", true);
+    expect("include-fw/comp", "ptl", "server", false);
+    /* no component named: the caller is asking about the framework as a
+     * whole, which the list does mention */
+    expect("include-fw/comp", "ptl", NULL, true);
+    expect("include-fw/comp", "gds", "hash", false);
+    teardown();
+}
+
+static void test_include_mixed(void)
+{
+    report("\"ptl/tcp,gds\" parses", PMIX_SUCCESS == setup("ptl/tcp,gds"));
+    expect("include-mixed", "ptl", "tcp", true);
+    expect("include-mixed", "ptl", "server", false);
+    expect("include-mixed", "gds", "hash", true);
+    expect("include-mixed", "gds", "shmem3", true);
+    expect("include-mixed", "psec", "native", false);
+    teardown();
+}
+
+/* The "^" form inverts the sense of the list. */
+static void test_exclude_bare_framework(void)
+{
+    report("\"^ptl\" parses", PMIX_SUCCESS == setup("^ptl"));
+    expect("exclude-fw", "ptl", "tcp", false);
+    expect("exclude-fw", "ptl", NULL, false);
+    expect("exclude-fw", "gds", "hash", true);
+    teardown();
+}
+
+static void test_exclude_framework_component(void)
+{
+    report("\"^ptl/tcp\" parses", PMIX_SUCCESS == setup("^ptl/tcp"));
+    expect("exclude-fw/comp", "ptl", "tcp", false);
+    expect("exclude-fw/comp", "ptl", "server", true);
+    expect("exclude-fw/comp", "gds", "hash", true);
+    teardown();
+}
+
+/* Empty entries from consecutive commas are skipped, not treated as a
+ * framework named "". */
+static void test_empty_entries(void)
+{
+    report("\"ptl,,gds,\" parses", PMIX_SUCCESS == setup("ptl,,gds,"));
+    expect("empty-entries", "ptl", "tcp", true);
+    expect("empty-entries", "gds", "hash", true);
+    expect("empty-entries", "psec", "native", false);
+    teardown();
+}
+
+/* More than one "/" in an entry is a user error. */
+static void test_too_many_slashes(void)
+{
+    report("\"ptl/tcp/extra\" rejected", PMIX_SUCCESS != setup("ptl/tcp/extra"));
+    teardown();
+}
+
+/* A NULL value must not be dereferenced; treat it as the default. */
+static void test_null_value(void)
+{
+    report("NULL value parses", PMIX_SUCCESS == setup(NULL));
+    expect("null", "ptl", "tcp", true);
+    teardown();
+}
+
+int main(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "\n=== mca_base show_load_errors unit tests ===\n\n");
+
+    test_all();
+    test_none();
+    test_boolean_synonyms();
+    test_include_bare_framework();
+    test_include_framework_component();
+    test_include_mixed();
+    test_exclude_bare_framework();
+    test_exclude_framework_component();
+    test_empty_entries();
+    test_too_many_slashes();
+    test_null_value();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/mca/mca_base_var.c
+++ b/test/unit/mca/mca_base_var.c
@@ -1,0 +1,564 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the MCA variable system in
+ * src/mca/base/pmix_mca_base_var.c: name generation, registration and
+ * lookup, the value-resolution order (default vs. environment),
+ * synonyms, the several dump formats, and pmix_mca_base_var_build_env().
+ *
+ * The process is brought up with pmix_init_util(), which is the
+ * lightest init that establishes the install dirs and the MCA -- a
+ * full PMIx_Init would need a server. Reading of MCA parameter files
+ * is disabled from main() so the results do not depend on whatever
+ * happens to be in the caller's ~/.pmix or $sysconfdir.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pmix_common.h"
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/mca/base/pmix_mca_base_var_group.h"
+#include "src/mca/base/pmix_mca_base_vari.h"
+#include "src/runtime/pmix_init_util.h"
+#include "src/util/pmix_argv.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* full-name generation                                                */
+/* ------------------------------------------------------------------ */
+
+static void check_full_name(const char *project, const char *framework, const char *component,
+                            const char *variable, const char *expected)
+{
+    char label[256];
+    char *out = NULL;
+    int rc;
+
+    rc = pmix_mca_base_var_generate_full_name4(project, framework, component, variable, &out);
+    snprintf(label, sizeof(label), "full_name4 -> \"%s\"", expected);
+    report(label, PMIX_SUCCESS == rc && NULL != out && 0 == strcmp(out, expected));
+    free(out);
+}
+
+static void test_generate_full_name(void)
+{
+    check_full_name("pmix", "ptl", "tcp", "if_include", "pmix_ptl_tcp_if_include");
+    check_full_name(NULL, "ptl", "tcp", "if_include", "ptl_tcp_if_include");
+    check_full_name(NULL, "ptl", NULL, "verbose", "ptl_verbose");
+    check_full_name(NULL, NULL, NULL, "solo", "solo");
+    check_full_name("pmix", NULL, NULL, NULL, "pmix");
+    /* all-NULL yields an empty (but allocated and terminated) string */
+    check_full_name(NULL, NULL, NULL, NULL, "");
+}
+
+/* ------------------------------------------------------------------ */
+/* register / find / get                                               */
+/* ------------------------------------------------------------------ */
+
+static int int_var = -1;
+static bool bool_var = false;
+static char *string_var = NULL;
+static size_t size_var = 0;
+static double double_var = 0.0;
+
+static void test_register_and_find(void)
+{
+    const pmix_mca_base_var_t *var = NULL;
+    int *ip = NULL;
+    pmix_mca_base_var_source_t source = PMIX_MCA_BASE_VAR_SOURCE_MAX;
+    int idx, found, rc;
+
+    int_var = 42;
+    idx = pmix_mca_base_var_register("pmix", "utest", "vars", "an_int", "an integer variable",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &int_var);
+    report("register int returns an index", 0 <= idx);
+
+    found = pmix_mca_base_var_find("pmix", "utest", "vars", "an_int");
+    report("find by components returns the same index", found == idx);
+
+    found = -1;
+    rc = pmix_mca_base_var_find_by_name("utest_vars_an_int", &found);
+    report("find by full name", PMIX_SUCCESS == rc && found == idx);
+
+    rc = pmix_mca_base_var_find_by_name("utest_vars_no_such_thing", &found);
+    report("find by unknown name fails", PMIX_SUCCESS != rc);
+
+    rc = pmix_mca_base_var_get(idx, &var);
+    report("get returns the var", PMIX_SUCCESS == rc && NULL != var);
+    if (NULL != var) {
+        report("var records its full name", 0 == strcmp(var->mbv_full_name, "utest_vars_an_int"));
+        report("var records its long name",
+               0 == strcmp(var->mbv_long_name, "pmix_utest_vars_an_int"));
+        report("var records its type", PMIX_MCA_BASE_VAR_TYPE_INT == var->mbv_type);
+        report("var prefix is the upper-cased project",
+               0 == strcmp(var->mbv_prefix, "PMIX_MCA_"));
+    }
+
+    /* get_value hands back a POINTER TO the backing store, not a copy
+     * of the value -- the header used to document a copy-out interface
+     * with a value_size parameter that has never existed, so pin the
+     * real contract here */
+    rc = pmix_mca_base_var_get_value(idx, &ip, &source, NULL);
+    report("get_value succeeds", PMIX_SUCCESS == rc);
+    report("get_value points at the caller's storage", ip == &int_var);
+    report("get_value does not copy: writes through the pointer are seen",
+           NULL != ip && 42 == *ip);
+    int_var = 43;
+    report("get_value aliases, so a later direct write shows through",
+           NULL != ip && 43 == *ip);
+    int_var = 42;
+    report("unset variable reports the default as its source",
+           PMIX_MCA_BASE_VAR_SOURCE_DEFAULT == source);
+
+    /* re-registering the same name with a different type must be
+     * refused rather than silently reinterpreting the storage */
+    rc = pmix_mca_base_var_register("pmix", "utest", "vars", "an_int", "wrong type",
+                                    PMIX_MCA_BASE_VAR_TYPE_STRING, &string_var);
+    report("re-register with a different type is refused", 0 > rc);
+
+    /* bogus indices */
+    rc = pmix_mca_base_var_get_value(-1, &ip, NULL, NULL);
+    report("get_value(-1) is refused", PMIX_SUCCESS != rc);
+    rc = pmix_mca_base_var_get_value(1000000, &ip, NULL, NULL);
+    report("get_value(huge) is refused", PMIX_SUCCESS != rc);
+}
+
+static void test_register_types(void)
+{
+    int idx;
+
+    bool_var = false;
+    idx = pmix_mca_base_var_register("pmix", "utest", "vars", "a_bool", "a boolean variable",
+                                     PMIX_MCA_BASE_VAR_TYPE_BOOL, &bool_var);
+    report("register bool", 0 <= idx);
+
+    size_var = 7;
+    idx = pmix_mca_base_var_register("pmix", "utest", "vars", "a_size", "a size_t variable",
+                                     PMIX_MCA_BASE_VAR_TYPE_SIZE_T, &size_var);
+    report("register size_t", 0 <= idx);
+
+    double_var = 0.5;
+    idx = pmix_mca_base_var_register("pmix", "utest", "vars", "a_double", "a double variable",
+                                     PMIX_MCA_BASE_VAR_TYPE_DOUBLE, &double_var);
+    report("register double", 0 <= idx);
+
+    /* a string default is duplicated into the variable system, so the
+     * caller may keep passing a literal */
+    char *literal = (char *) "hello";
+    string_var = literal;
+    idx = pmix_mca_base_var_register("pmix", "utest", "vars", "a_string", "a string variable",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING, &string_var);
+    report("register string", 0 <= idx);
+    report("string default was duplicated",
+           NULL != string_var && 0 == strcmp(string_var, "hello") && string_var != literal);
+}
+
+/* ------------------------------------------------------------------ */
+/* values sourced from the environment                                 */
+/* ------------------------------------------------------------------ */
+
+static int env_int = 0;
+static bool env_bool = false;
+static char *env_string = NULL;
+
+/* The environment name is the project prefix plus either the full name
+ * (framework_component_variable) or the long name
+ * (project_framework_component_variable). Both must work. */
+static void test_env_sourced(void)
+{
+    pmix_mca_base_var_source_t source = PMIX_MCA_BASE_VAR_SOURCE_MAX;
+    int *ip = NULL;
+    bool *bp = NULL;
+    char **sp = NULL;
+    int idx, rc;
+
+    env_int = 1;
+    idx = pmix_mca_base_var_register("pmix", "utest", "env", "an_int", "from the environment",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &env_int);
+    report("env int registered", 0 <= idx);
+    rc = pmix_mca_base_var_get_value(idx, &ip, &source, NULL);
+    report("env int picked up the environment value",
+           PMIX_SUCCESS == rc && NULL != ip && 99 == *ip);
+    report("env int reports ENV as its source", PMIX_MCA_BASE_VAR_SOURCE_ENV == source);
+
+    env_bool = false;
+    idx = pmix_mca_base_var_register("pmix", "utest", "env", "a_bool", "from the environment",
+                                     PMIX_MCA_BASE_VAR_TYPE_BOOL, &env_bool);
+    report("env bool registered", 0 <= idx);
+    rc = pmix_mca_base_var_get_value(idx, &bp, NULL, NULL);
+    report("env bool parsed \"true\"", PMIX_SUCCESS == rc && NULL != bp && *bp);
+
+    env_string = NULL;
+    idx = pmix_mca_base_var_register("pmix", "utest", "env", "a_string", "from the environment",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING, &env_string);
+    report("env string registered (long-name form)", 0 <= idx);
+    rc = pmix_mca_base_var_get_value(idx, &sp, &source, NULL);
+    report("env string picked up the long-name environment value",
+           PMIX_SUCCESS == rc && NULL != sp && NULL != *sp && 0 == strcmp(*sp, "from-long-name"));
+    report("env string reports ENV as its source", PMIX_MCA_BASE_VAR_SOURCE_ENV == source);
+}
+
+/* ------------------------------------------------------------------ */
+/* synonyms                                                            */
+/* ------------------------------------------------------------------ */
+
+static int syn_var = 0;
+
+static void test_synonyms(void)
+{
+    int *ip = NULL;
+    int idx, syn, found, rc;
+
+    syn_var = 3;
+    idx = pmix_mca_base_var_register("pmix", "utest", "syn", "real_name", "the real variable",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &syn_var);
+    report("synonym target registered", 0 <= idx);
+
+    syn = pmix_mca_base_var_register_synonym(idx, "pmix", "utest", "syn", "old_name",
+                                             PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    report("synonym registered", 0 <= syn && syn != idx);
+
+    found = pmix_mca_base_var_find("pmix", "utest", "syn", "old_name");
+    report("synonym is findable under its own name", found == syn);
+
+    /* looking a synonym up resolves through to the original's storage */
+    rc = pmix_mca_base_var_get_value(syn, &ip, NULL, NULL);
+    report("synonym resolves to the original storage",
+           PMIX_SUCCESS == rc && ip == &syn_var && 3 == *ip);
+
+    /* a synonym of a synonym is not allowed */
+    rc = pmix_mca_base_var_register_synonym(syn, "pmix", "utest", "syn", "older_name",
+                                            PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    report("synonym of a synonym is refused", 0 > rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* dump                                                                */
+/* ------------------------------------------------------------------ */
+
+static int dump_var = 0;
+
+static void test_dump(void)
+{
+    char **out = NULL;
+    int idx, i, rc;
+
+    dump_var = 11;
+    idx = pmix_mca_base_var_register("pmix", "utest", "dump", "a_var", "a variable to dump",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &dump_var);
+    report("dump target registered", 0 <= idx);
+
+    rc = pmix_mca_base_var_dump(idx, &out, PMIX_MCA_BASE_VAR_DUMP_SIMPLE);
+    report("simple dump succeeds", PMIX_SUCCESS == rc && NULL != out && NULL != out[0]);
+    if (PMIX_SUCCESS == rc && NULL != out) {
+        report("simple dump shows name and value",
+               NULL != strstr(out[0], "utest_dump_a_var") && NULL != strstr(out[0], "11"));
+        for (i = 0; NULL != out[i]; ++i) {
+            free(out[i]);
+        }
+        free(out);
+        out = NULL;
+    }
+
+    rc = pmix_mca_base_var_dump(idx, &out, PMIX_MCA_BASE_VAR_DUMP_READABLE);
+    report("readable dump succeeds", PMIX_SUCCESS == rc && NULL != out && NULL != out[0]);
+    if (PMIX_SUCCESS == rc && NULL != out) {
+        report("readable dump carries the description",
+               NULL != out[1] && NULL != strstr(out[1], "a variable to dump"));
+        for (i = 0; NULL != out[i]; ++i) {
+            free(out[i]);
+        }
+        free(out);
+        out = NULL;
+    }
+
+    rc = pmix_mca_base_var_dump(idx, &out, PMIX_MCA_BASE_VAR_DUMP_PARSABLE);
+    report("parsable dump succeeds", PMIX_SUCCESS == rc && NULL != out && NULL != out[0]);
+    if (PMIX_SUCCESS == rc && NULL != out) {
+        bool saw_value = false, saw_type = false;
+        for (i = 0; NULL != out[i]; ++i) {
+            if (NULL != strstr(out[i], ":value:")) {
+                saw_value = true;
+            }
+            if (NULL != strstr(out[i], ":type:int")) {
+                saw_type = true;
+            }
+        }
+        report("parsable dump emits a value line", saw_value);
+        report("parsable dump emits a type line", saw_type);
+        for (i = 0; NULL != out[i]; ++i) {
+            free(out[i]);
+        }
+        free(out);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* build_env                                                           */
+/* ------------------------------------------------------------------ */
+
+/* build_env emits only variables whose value did not come from the
+ * default -- it is what gets forwarded to a child process.
+ *
+ * NOTE: the trickiest inputs here are variables that are *not* backed
+ * by storage of their own. A synonym has none (it borrows the
+ * variable it stands for) and a deregistered variable has had its
+ * storage dropped; walking either one as if it had a value dereferences
+ * NULL. A deprecated STRING synonym set from the environment -- which
+ * is exactly what "PMIX_MCA_mca_base_param_files" produces, and what
+ * this test's own main() sets up -- hits both conditions at once. */
+static void test_build_env(void)
+{
+    char **env = NULL;
+    int num_env = 0;
+    bool saw_env_int = false, saw_default = false, saw_synonym = false;
+    bool saw_string = false;
+    int i, rc;
+
+    /* a STRING variable set from the environment, with a deprecated
+     * synonym, and a deregistered non-default variable: all three shapes
+     * must survive the walk */
+    static char *syn_string = NULL;
+    static int dead_int = 0;
+    int sidx, didx;
+
+    /* main() put "PMIX_MCA_utest_benv_a_string" in the environment, so
+     * this variable -- and, through var_set_initial(), the synonym
+     * registered next -- carries a non-default source. That is what
+     * makes the synonym reach the storage dereference below. */
+    syn_string = NULL;
+    sidx = pmix_mca_base_var_register("pmix", "utest", "benv", "a_string", "string with a synonym",
+                                      PMIX_MCA_BASE_VAR_TYPE_STRING, &syn_string);
+    report("build_env: string target registered", 0 <= sidx);
+    rc = pmix_mca_base_var_register_synonym(sidx, "pmix", "utest", NULL, "old_string",
+                                            PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    report("build_env: string synonym registered", 0 <= rc);
+    report("build_env: string target took the environment value",
+           NULL != syn_string && 0 == strcmp(syn_string, "env-set"));
+
+    dead_int = 0;
+    didx = pmix_mca_base_var_register("pmix", "utest", "benv", "dead_int", "deregistered",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT, &dead_int);
+    report("build_env: deregistered-var target registered", 0 <= didx);
+    (void) pmix_mca_base_var_deregister(didx);
+
+    rc = pmix_mca_base_var_build_env(&env, &num_env);
+    report("build_env succeeds", PMIX_SUCCESS == rc);
+    if (PMIX_SUCCESS != rc || NULL == env) {
+        return;
+    }
+
+    for (i = 0; i < num_env; ++i) {
+        if (0 == strcmp(env[i], "PMIX_MCA_utest_env_an_int=99")) {
+            saw_env_int = true;
+        }
+        /* utest_vars_an_int was never set by anything, so it must not
+         * be forwarded */
+        if (0 == strncmp(env[i], "PMIX_MCA_utest_vars_an_int=", 27)) {
+            saw_default = true;
+        }
+        if (0 == strcmp(env[i], "PMIX_MCA_utest_benv_a_string=env-set")) {
+            saw_string = true;
+        }
+        /* "utest_old_string" is the deprecated synonym registered
+         * above, and "mca_param_files" is the library's own synonym of
+         * "mca_base_param_files" (which main() sets). Neither may be
+         * forwarded: only the real names are. */
+        if (0 == strncmp(env[i], "PMIX_MCA_utest_old_string=", 26)
+            || 0 == strncmp(env[i], "PMIX_MCA_mca_param_files=", 25)) {
+            saw_synonym = true;
+        }
+    }
+    report("build_env forwards an environment-sourced value", saw_env_int);
+    report("build_env forwards an environment-sourced string", saw_string);
+    report("build_env omits default-valued variables", !saw_default);
+    report("build_env omits deprecated synonyms", !saw_synonym);
+
+    PMIx_Argv_free(env);
+}
+
+/* ------------------------------------------------------------------ */
+/* deregister                                                          */
+/* ------------------------------------------------------------------ */
+
+static int dereg_var = 0;
+
+static void test_deregister(void)
+{
+    const pmix_mca_base_var_t *var = NULL;
+    int idx, rc;
+
+    dereg_var = 5;
+    idx = pmix_mca_base_var_register("pmix", "utest", "dereg", "a_var", "to be deregistered",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT, &dereg_var);
+    report("deregister target registered", 0 <= idx);
+
+    rc = pmix_mca_base_var_deregister(idx);
+    report("deregister succeeds", PMIX_SUCCESS == rc);
+
+    rc = pmix_mca_base_var_get(idx, &var);
+    report("deregistered var is no longer gettable", PMIX_SUCCESS != rc);
+
+    rc = pmix_mca_base_var_find("pmix", "utest", "dereg", "a_var");
+    report("deregistered var is no longer findable", 0 > rc);
+
+    /* deregistering twice is an error, not a crash */
+    rc = pmix_mca_base_var_deregister(idx);
+    report("double deregister is refused", PMIX_SUCCESS != rc);
+
+    /* re-registering revives the same index */
+    dereg_var = 6;
+    rc = pmix_mca_base_var_register("pmix", "utest", "dereg", "a_var", "to be deregistered",
+                                    PMIX_MCA_BASE_VAR_TYPE_INT, &dereg_var);
+    report("re-register reuses the original index", rc == idx);
+}
+
+/* ------------------------------------------------------------------ */
+/* check_exclusive                                                     */
+/* ------------------------------------------------------------------ */
+
+static int excl_a = 0;
+static int excl_b = 0;
+
+static void test_check_exclusive(void)
+{
+    int rc;
+
+    excl_a = 0;
+    (void) pmix_mca_base_var_register("pmix", "utest", "excl", "a", "exclusive a",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT, &excl_a);
+    excl_b = 0;
+    (void) pmix_mca_base_var_register("pmix", "utest", "excl", "b", "exclusive b",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT, &excl_b);
+
+    /* neither was set, so both are still at their defaults */
+    rc = pmix_mca_base_var_check_exclusive("pmix", "utest", "excl", "a", "utest", "excl", "b");
+    report("check_exclusive passes when both are defaults", PMIX_SUCCESS == rc);
+
+    rc = pmix_mca_base_var_check_exclusive("pmix", "utest", "excl", "a", "utest", "excl",
+                                           "no_such_var");
+    report("check_exclusive reports an unknown variable", PMIX_ERR_NOT_FOUND == rc);
+
+    /* utest_env_an_int and utest_env_a_bool were both set from the
+     * environment, so they collide */
+    rc = pmix_mca_base_var_check_exclusive("pmix", "utest", "env", "an_int", "utest", "env",
+                                           "a_bool");
+    report("check_exclusive catches two non-default values", PMIX_ERR_BAD_PARAM == rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* groups                                                              */
+/* ------------------------------------------------------------------ */
+
+static int grp_var = 0;
+
+static void test_groups(void)
+{
+    const pmix_mca_base_var_group_t *group = NULL;
+    int gidx, found, rc;
+
+    grp_var = 1;
+    (void) pmix_mca_base_var_register("pmix", "utest", "grp", "a_var", "in a group",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT, &grp_var);
+
+    /* find returns the group INDEX, not a status -- the header used to
+     * say PMIX_SUCCESS, and every caller in the tree relies on the
+     * index */
+    gidx = pmix_mca_base_var_group_find("pmix", "utest", "grp");
+    report("group_find returns an index", 0 <= gidx);
+
+    rc = pmix_mca_base_var_group_get(gidx, &group);
+    report("group_get succeeds", PMIX_SUCCESS == rc && NULL != group);
+    if (NULL != group) {
+        report("group records its own index", group->group_index == gidx);
+        report("group records its framework",
+               NULL != group->group_framework && 0 == strcmp(group->group_framework, "utest"));
+        report("group records its component",
+               NULL != group->group_component && 0 == strcmp(group->group_component, "grp"));
+        report("group holds the variable", 0 < pmix_value_array_get_size(
+                   (pmix_value_array_t *) &group->group_vars));
+    }
+
+    /* wildcards force the linear scan rather than the name hash */
+    found = pmix_mca_base_var_group_find("*", "utest", "grp");
+    report("group_find honors a wildcard project", found == gidx);
+
+    report("group_find on an unknown group fails",
+           0 > pmix_mca_base_var_group_find("pmix", "utest", "no_such_group"));
+
+    /* deregistering the group invalidates it and its variables */
+    rc = pmix_mca_base_var_group_deregister(gidx);
+    report("group_deregister succeeds", PMIX_SUCCESS == rc);
+    report("deregistered group is no longer found",
+           0 > pmix_mca_base_var_group_find("pmix", "utest", "grp"));
+    report("the group's variable went with it",
+           0 > pmix_mca_base_var_find("pmix", "utest", "grp", "a_var"));
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+
+    (void) argc;
+    (void) argv;
+
+    /* Do not let the caller's MCA parameter files influence the
+     * results, and pre-set the values the environment-sourced tests
+     * expect. All of this has to happen before pmix_init_util()
+     * initializes the variable system. */
+    setenv("PMIX_MCA_mca_base_param_files", "none", 1);
+    setenv("PMIX_MCA_utest_env_an_int", "99", 1);
+    setenv("PMIX_MCA_utest_env_a_bool", "true", 1);
+    setenv("PMIX_MCA_pmix_utest_env_a_string", "from-long-name", 1);
+    setenv("PMIX_MCA_utest_benv_a_string", "env-set", 1);
+
+    rc = pmix_init_util(NULL, 0, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "pmix_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== pmix_mca_base_var unit tests ===\n\n");
+
+    test_generate_full_name();
+    test_register_and_find();
+    test_register_types();
+    test_env_sourced();
+    test_synonyms();
+    test_dump();
+    test_build_env();
+    test_deregister();
+    test_check_exclusive();
+    test_groups();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    pmix_finalize_util();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/mca/mca_base_var_enum.c
+++ b/test/unit/mca/mca_base_var_enum.c
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the MCA variable enumerators in
+ * src/mca/base/pmix_mca_base_var_enum.c: the two shipped static
+ * enumerators (boolean and verbosity), the generic value enumerator
+ * built by pmix_mca_base_var_enum_create(), and the flag enumerator
+ * built by pmix_mca_base_var_enum_create_flag().
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pmix_common.h"
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/base/pmix_mca_base_var_enum.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* boolean enumerator                                                  */
+/* ------------------------------------------------------------------ */
+
+static void check_bool_accepts(const char *str, int expected)
+{
+    char name[128];
+    int value = -1;
+    int rc;
+
+    rc = pmix_mca_base_var_enum_bool.value_from_string(&pmix_mca_base_var_enum_bool, str, &value);
+    snprintf(name, sizeof(name), "bool: \"%s\" -> %d", str, expected);
+    report(name, PMIX_SUCCESS == rc && expected == value);
+}
+
+static void check_bool_rejects(const char *str)
+{
+    char name[128];
+    int value = -1;
+    int rc;
+
+    rc = pmix_mca_base_var_enum_bool.value_from_string(&pmix_mca_base_var_enum_bool, str, &value);
+    snprintf(name, sizeof(name), "bool: \"%s\" rejected", str);
+    report(name, PMIX_SUCCESS != rc);
+}
+
+static void test_bool_values(void)
+{
+    check_bool_accepts("0", 0);
+    check_bool_accepts("1", 1);
+    check_bool_accepts("2", 1);
+    check_bool_accepts("true", 1);
+    check_bool_accepts("false", 0);
+    check_bool_accepts("t", 1);
+    check_bool_accepts("f", 0);
+    check_bool_accepts("yes", 1);
+    check_bool_accepts("no", 0);
+    check_bool_accepts("enabled", 1);
+    check_bool_accepts("disabled", 0);
+
+    /* case insensitivity: the non-enumerated bool path in
+     * pmix_mca_base_var.c accepts these, so the enumerator must too */
+    check_bool_accepts("TRUE", 1);
+    check_bool_accepts("False", 0);
+    check_bool_accepts("Yes", 1);
+
+    /* leading whitespace is explicitly skipped */
+    check_bool_accepts("   true", 1);
+
+    /* the empty string parses as the integer 0, i.e. false - it is not
+     * an error */
+    check_bool_accepts("", 0);
+
+    check_bool_rejects("maybe");
+    check_bool_rejects("truthy");
+}
+
+/* Everything the bool enumerator's dump() advertises has to actually be
+ * accepted by its value_from_string(): the dump is what a user reads out
+ * of "pmix_info", so a value listed there and then refused is a bug.
+ * This walks the dump text and feeds every non-numeric token back in. */
+static void test_bool_dump_is_honest(void)
+{
+    char *dump = NULL;
+    char *copy, *tok, *saveptr = NULL;
+    int rc, ok = 1;
+
+    rc = pmix_mca_base_var_enum_bool.dump(&pmix_mca_base_var_enum_bool, &dump,
+                                          PMIX_MCA_BASE_VAR_ENUM_DUMP_READABLE);
+    report("bool: dump succeeds", PMIX_SUCCESS == rc && NULL != dump);
+    if (PMIX_SUCCESS != rc || NULL == dump) {
+        return;
+    }
+
+    copy = strdup(dump);
+    for (tok = strtok_r(copy, "|, ", &saveptr); NULL != tok;
+         tok = strtok_r(NULL, "|, ", &saveptr)) {
+        int value = -1;
+        if (PMIX_SUCCESS
+            != pmix_mca_base_var_enum_bool.value_from_string(&pmix_mca_base_var_enum_bool, tok,
+                                                             &value)) {
+            fprintf(stdout, "        dump advertises \"%s\" but it is rejected\n", tok);
+            ok = 0;
+        }
+    }
+    report("bool: every advertised value is accepted", ok);
+
+    free(copy);
+    free(dump);
+}
+
+static void test_bool_string_from_value(void)
+{
+    char *str = NULL;
+    int rc;
+
+    rc = pmix_mca_base_var_enum_bool.string_from_value(&pmix_mca_base_var_enum_bool, 1, &str);
+    report("bool: 1 -> \"true\"", PMIX_SUCCESS == rc && NULL != str && 0 == strcmp(str, "true"));
+    free(str);
+    str = NULL;
+
+    rc = pmix_mca_base_var_enum_bool.string_from_value(&pmix_mca_base_var_enum_bool, 0, &str);
+    report("bool: 0 -> \"false\"", PMIX_SUCCESS == rc && NULL != str && 0 == strcmp(str, "false"));
+    free(str);
+}
+
+/* ------------------------------------------------------------------ */
+/* verbosity enumerator                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_verbose_enum(void)
+{
+    int value = -1;
+    char *str = NULL;
+    int count = 0;
+    int rc;
+
+    rc = pmix_mca_base_var_enum_verbose.get_count(&pmix_mca_base_var_enum_verbose, &count);
+    report("verbose: get_count", PMIX_SUCCESS == rc && 8 == count);
+
+    rc = pmix_mca_base_var_enum_verbose.value_from_string(&pmix_mca_base_var_enum_verbose, "debug",
+                                                          &value);
+    report("verbose: \"debug\" resolves", PMIX_SUCCESS == rc && PMIX_MCA_BASE_VERBOSE_DEBUG == value);
+
+    rc = pmix_mca_base_var_enum_verbose.value_from_string(&pmix_mca_base_var_enum_verbose, "42",
+                                                          &value);
+    report("verbose: plain integer passes through", PMIX_SUCCESS == rc && 42 == value);
+
+    /* out of range integers clamp rather than fail */
+    rc = pmix_mca_base_var_enum_verbose.value_from_string(&pmix_mca_base_var_enum_verbose, "5000",
+                                                          &value);
+    report("verbose: above max clamps to max",
+           PMIX_SUCCESS == rc && PMIX_MCA_BASE_VERBOSE_MAX == value);
+
+    rc = pmix_mca_base_var_enum_verbose.value_from_string(&pmix_mca_base_var_enum_verbose, "bogus",
+                                                          &value);
+    report("verbose: unknown name rejected", PMIX_SUCCESS != rc);
+
+    rc = pmix_mca_base_var_enum_verbose.string_from_value(&pmix_mca_base_var_enum_verbose,
+                                                          PMIX_MCA_BASE_VERBOSE_INFO, &str);
+    report("verbose: value -> \"info\"",
+           PMIX_SUCCESS == rc && NULL != str && 0 == strcmp(str, "info"));
+    free(str);
+    str = NULL;
+
+    /* a value with no name is rendered numerically */
+    rc = pmix_mca_base_var_enum_verbose.string_from_value(&pmix_mca_base_var_enum_verbose, 42, &str);
+    report("verbose: unnamed value -> \"42\"",
+           PMIX_SUCCESS == rc && NULL != str && 0 == strcmp(str, "42"));
+    free(str);
+
+    /* string_value is documented as optional */
+    rc = pmix_mca_base_var_enum_verbose.string_from_value(&pmix_mca_base_var_enum_verbose,
+                                                          PMIX_MCA_BASE_VERBOSE_INFO, NULL);
+    report("verbose: NULL string_value tolerated", PMIX_SUCCESS == rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* generic value enumerator                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_value_enum(void)
+{
+    static const pmix_mca_base_var_enum_value_t values[] = {{1, "one"},
+                                                            {2, "two"},
+                                                            {7, "seven"},
+                                                            {0, NULL}};
+    pmix_mca_base_var_enum_t *e = NULL;
+    const char *sval = NULL;
+    char *str = NULL;
+    int value = -1, count = 0;
+    int rc;
+
+    rc = pmix_mca_base_var_enum_create("test-values", values, &e);
+    report("value enum: created", PMIX_SUCCESS == rc && NULL != e);
+    if (PMIX_SUCCESS != rc || NULL == e) {
+        return;
+    }
+
+    rc = e->get_count(e, &count);
+    report("value enum: count excludes terminator", PMIX_SUCCESS == rc && 3 == count);
+
+    rc = e->get_value(e, 1, &value, &sval);
+    report("value enum: get_value(1)",
+           PMIX_SUCCESS == rc && 2 == value && NULL != sval && 0 == strcmp(sval, "two"));
+
+    /* the string handed back by get_value is borrowed - it must point
+     * into the enumerator's own copy, not a fresh allocation the caller
+     * would have to free (which it has no way to know to do, since the
+     * bool enumerator returns a literal here) */
+    report("value enum: get_value string is borrowed", sval == e->enum_values[1].string);
+
+    rc = e->get_value(e, count, &value, &sval);
+    report("value enum: index == count rejected", PMIX_SUCCESS != rc);
+
+    rc = e->get_value(e, -1, &value, &sval);
+    report("value enum: negative index rejected", PMIX_SUCCESS != rc);
+
+    rc = e->value_from_string(e, "seven", &value);
+    report("value enum: name resolves", PMIX_SUCCESS == rc && 7 == value);
+
+    rc = e->value_from_string(e, "SEVEN", &value);
+    report("value enum: name match is case-insensitive", PMIX_SUCCESS == rc && 7 == value);
+
+    rc = e->value_from_string(e, "7", &value);
+    report("value enum: integer resolves", PMIX_SUCCESS == rc && 7 == value);
+
+    rc = e->value_from_string(e, "3", &value);
+    report("value enum: unlisted integer rejected", PMIX_SUCCESS != rc);
+
+    rc = e->string_from_value(e, 2, &str);
+    report("value enum: value -> name",
+           PMIX_SUCCESS == rc && NULL != str && 0 == strcmp(str, "two"));
+    free(str);
+    str = NULL;
+
+    rc = e->string_from_value(e, 3, &str);
+    report("value enum: unlisted value rejected", PMIX_SUCCESS != rc);
+
+    rc = e->dump(e, &str, PMIX_MCA_BASE_VAR_ENUM_DUMP_READABLE);
+    report("value enum: dump lists every entry",
+           PMIX_SUCCESS == rc && NULL != str && NULL != strstr(str, "one")
+               && NULL != strstr(str, "two") && NULL != strstr(str, "seven"));
+    free(str);
+
+    PMIX_RELEASE(e);
+}
+
+/* ------------------------------------------------------------------ */
+/* flag enumerator                                                     */
+/* ------------------------------------------------------------------ */
+
+/* The flag enumerator's value_from_string() takes a comma-delimited
+ * list. Its table lookup is nested inside the loop over the caller's
+ * tokens, and the two index spaces are unrelated -- a version of this
+ * code that confused them both matched the wrong flag and read past the
+ * end of the table whenever more tokens were passed than the enumerator
+ * had flags. Hence the deliberately-longer-than-the-table cases below. */
+static void test_flag_enum(void)
+{
+    static const pmix_mca_base_var_enum_value_flag_t flags[] = {{0x1, "alpha", 0x2},
+                                                                {0x2, "beta", 0x1},
+                                                                {0x4, "gamma", 0},
+                                                                {0, NULL, 0}};
+    pmix_mca_base_var_enum_flag_t *fe = NULL;
+    pmix_mca_base_var_enum_t *e;
+    const char *sval = NULL;
+    char *str = NULL;
+    int value = -1, count = 0;
+    int rc;
+
+    rc = pmix_mca_base_var_enum_create_flag("test-flags", flags, &fe);
+    report("flag enum: created", PMIX_SUCCESS == rc && NULL != fe);
+    if (PMIX_SUCCESS != rc || NULL == fe) {
+        return;
+    }
+    e = &fe->super;
+
+    rc = e->get_count(e, &count);
+    report("flag enum: count excludes terminator", PMIX_SUCCESS == rc && 3 == count);
+
+    rc = e->get_value(e, 2, &value, &sval);
+    report("flag enum: get_value(2)",
+           PMIX_SUCCESS == rc && 0x4 == value && NULL != sval && 0 == strcmp(sval, "gamma"));
+    report("flag enum: get_value string is borrowed", sval == fe->enum_flags[2].string);
+
+    /* single token, last entry in the table: only resolves if the table
+     * is searched by its own index */
+    rc = e->value_from_string(e, "gamma", &value);
+    report("flag enum: last table entry resolves", PMIX_SUCCESS == rc && 0x4 == value);
+
+    rc = e->value_from_string(e, "alpha", &value);
+    report("flag enum: first table entry resolves", PMIX_SUCCESS == rc && 0x1 == value);
+
+    /* two tokens in the reverse of table order */
+    rc = e->value_from_string(e, "gamma,alpha", &value);
+    report("flag enum: out-of-order pair ORs together",
+           PMIX_SUCCESS == rc && (0x4 | 0x1) == value);
+
+    rc = e->value_from_string(e, "0x4", &value);
+    report("flag enum: numeric token resolves", PMIX_SUCCESS == rc && 0x4 == value);
+
+    /* conflicting flags must be refused, not silently merged */
+    rc = e->value_from_string(e, "alpha,beta", &value);
+    report("flag enum: conflicting flags rejected", PMIX_ERR_BAD_PARAM == rc);
+
+    rc = e->value_from_string(e, "delta", &value);
+    report("flag enum: unknown token rejected", PMIX_ERR_VALUE_OUT_OF_BOUNDS == rc);
+
+    /* more tokens than the table has entries: an implementation that
+     * indexed the table with the token index would run off the end here */
+    rc = e->value_from_string(e, "gamma,gamma,gamma,gamma,gamma,gamma", &value);
+    report("flag enum: more tokens than table entries stays in bounds",
+           PMIX_SUCCESS == rc && 0x4 == value);
+
+    rc = e->value_from_string(e, "gamma,gamma,gamma,nope", &value);
+    report("flag enum: bad token past table length still rejected",
+           PMIX_ERR_VALUE_OUT_OF_BOUNDS == rc);
+
+    rc = e->string_from_value(e, 0x4 | 0x1, &str);
+    report("flag enum: value -> comma list",
+           PMIX_SUCCESS == rc && NULL != str && NULL != strstr(str, "alpha")
+               && NULL != strstr(str, "gamma"));
+    free(str);
+    str = NULL;
+
+    rc = e->string_from_value(e, 0x8, &str);
+    report("flag enum: unknown bit rejected", PMIX_ERR_VALUE_OUT_OF_BOUNDS == rc);
+
+    rc = e->dump(e, &str, PMIX_MCA_BASE_VAR_ENUM_DUMP_READABLE);
+    report("flag enum: dump lists every entry",
+           PMIX_SUCCESS == rc && NULL != str && NULL != strstr(str, "alpha")
+               && NULL != strstr(str, "beta") && NULL != strstr(str, "gamma"));
+    free(str);
+
+    PMIX_RELEASE(fe);
+}
+
+int main(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "\n=== pmix_mca_base_var_enum unit tests ===\n\n");
+
+    test_bool_values();
+    test_bool_dump_is_honest();
+    test_bool_string_from_value();
+    test_verbose_enum();
+    test_value_enum();
+    test_flag_enum();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
A deep review of `src/mca/base` — the MCA implementation itself. Six
commits: the defect fixes, the header corrections, a new unit suite, the
two missing `AGENTS.md` files, a dockerswarm runner, and one unrelated
help-text fix.

Every fix has a test that fails against the unfixed code; I checked each
one by reverting it individually. `make check` goes from 87 to 94
programs passing, warning-free under `--enable-devel-check`.

## Defects fixed

**Memory safety.** `pmix_mca_base_show_load_errors()` handed a NULL
component name to `strcmp` — a list entry naming a bare framework
(`^ptl`) plus any component query, which under `--enable-mca-dso` is
every component opened. `pmix_mca_base_var_build_env()` dereferenced
storage that synonyms and deregistered variables do not have
(`PMIX_MCA_mca_base_param_files` is enough to reach it). The flag
enumerator indexed its table with the caller's token index, matching the
wrong flag and reading past the end. `pmix_mca_base_component_repository_init()`
overflowed a stack buffer parsing `project@path` from a user-settable
MCA parameter. Plus a use-after-free of `lds_syslog_ident`, uninitialized
fields over a non-zeroing `PMIX_NEW`, and a `free()` of the caller's
stack buffer.

**Framework lifecycle.** `pmix_mca_base_framework_register()` leaked its
reference count on every error path and abandoned components discovery
had already found. `pmix_mca_base_framework_open()` decremented on
failure but left `REGISTERED` set, so the next close decremented 0 to -1,
found that non-zero, and returned success without tearing anything down —
wedging the framework so no later close could ever reach zero. The
`assert()` in `close()` catches that only when asserts are enabled, which
is not the configuration users get. Separately,
`mca_base_abort_on_load_error` was nested inside the test for whether to
*report* the error; those are independent parameters and
`mca_base_component_show_load_errors` defaults to `"none"`.

**Value precedence.** The override file could be defeated by the
environment: when the file named a variable by a deprecated synonym, the
promotion to `SOURCE_OVERRIDE` landed only on the synonym, so the
environment check that follows saw an ordinary file value and let the
user's setting win. A site administrator's override was enforced or not
depending on which spelling they happened to write, and the reported
source said `FILE` either way.

## Headers

These are installed, so companion projects build against them. Several
documented APIs that do not exist, in ways that would make a caller write
wrong code — most sharply `pmix_mca_base_var_get_value()`, documented as
copying the value out through a `value_size` parameter that has never
been in the signature. It returns a *pointer to* the registered storage,
so following the comment writes a pointer through an `int`.
`pmix_mca_base_var_register()` was documented with five parameters it
does not take; chasing those established that nothing ever assigns
`mbv_enumerator`, so the variable-side enumerator branches are
unreachable.

## Tests

`test/unit/mca`, seven programs and roughly 290 assertions, covering the
variable system, enumerators, component compare/parse/alias, the
`show_load_errors` parser, the framework lifecycle, the parameter-file
precedence rules, and component selection/filtering.

`contrib/dockerswarm/run-mca-tests.sh` covers what `make check` cannot:
roughly half of this directory is `#if PMIX_HAVE_PDL_SUPPORT` and never
executes in a static build, which is what a macOS developer has. It
builds an `--enable-mca-dso` tree, confirms `pmix_info` can name
components out of the repository, and feeds it malformed MCA parameters.

I also compile-checked `--disable-dlopen`, which nothing had exercised.

## Notes for review

- The one behavior change beyond bug fixes: the bool enumerator now
  accepts `y`/`n` case-insensitively, which its own `pmix_info` output
  already advertised as valid.
- `pmix_mca_base_var_group_t::group_index` was never assigned and is now
  set; nothing read it.
- No `docs/news` entry — there is no `news-v7.x.rst` yet, and creating
  one seemed a bigger call than this warrants. Happy to add it.
- The last commit (the `pmix_info` help text) is unrelated drive-by;
  drop it if you would rather it went separately.