### PR TITLE
Fix memory-safety and correctness defects in src/mca/bfrops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,6 +260,7 @@ test/unit/bfrops_regex2
 test/unit/bfrops_alloc_inherit
 test/unit/bfrops_darray
 test/unit/bfrops_get_number
+test/unit/bfrops_null_object
 test/unit/bfrops_malformed
 test/unit/nested_darray
 test/unit/gds_fallback

--- a/.gitignore
+++ b/.gitignore
@@ -259,6 +259,7 @@ test/unit/preg
 test/unit/bfrops_regex2
 test/unit/bfrops_alloc_inherit
 test/unit/bfrops_darray
+test/unit/bfrops_get_number
 test/unit/bfrops_malformed
 test/unit/nested_darray
 test/unit/gds_fallback

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ examples/client3
 examples/client4
 examples/debugger
 examples/debuggerd
+examples/datatypes
 examples/dmodex
 examples/dynamic
 examples/fault
@@ -257,6 +258,8 @@ test/unit/compress
 test/unit/preg
 test/unit/bfrops_regex2
 test/unit/bfrops_alloc_inherit
+test/unit/bfrops_darray
+test/unit/bfrops_malformed
 test/unit/nested_darray
 test/unit/gds_fallback
 test/unit/pmix_log

--- a/.gitignore
+++ b/.gitignore
@@ -260,6 +260,7 @@ test/unit/bfrops_regex2
 test/unit/bfrops_alloc_inherit
 test/unit/bfrops_darray
 test/unit/bfrops_get_number
+test/unit/bfrops_helpers
 test/unit/bfrops_null_object
 test/unit/bfrops_malformed
 test/unit/nested_darray

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -82,6 +82,27 @@ two disagree, the README wins, and please fix this file.
   that forgets the qualifier passes against any library and proves nothing.
   See README §13.
 
+- **A srcdir that has been built in place breaks the VPATH stages in
+  two different ways, and only one of them says so.** autoconf refuses
+  to configure alongside a `config.status` and names the problem. But
+  even a stage that only *reuses* an already-configured tree in the
+  volume will fail, because make resolves a missing prerequisite through
+  VPATH, finds `foo.o` in the **source** directory, and then runs the
+  link recipe with the bare name in the build directory. The error is
+  `cannot find foo.o`, which mentions neither VPATH nor the srcdir, and
+  it strikes exactly the objects that are new — so it looks like a bug
+  in whatever you just added. `run-bfrops-tests.sh` gates both stages on
+  one check for this reason; do not loosen it to let the reuse stage
+  through.
+
+- **Run a fuzz harness in ONE process, not one process per input.**
+  Heap corruption planted by input N is usually noticed by the allocator
+  at input N+k, so a harness that forks per input discards the evidence
+  with the child. The bfrops fuzz stage found a remote heap overflow
+  only after it was folded into `test/unit/bfrops_malformed.c` and run
+  in-process; the scratch version that forked had been running against
+  the same defect and reporting clean.
+
 - **The build volume outlives your branch.** `pmix-build` persists
   across runs and across checkouts, so a tree in it can be older than
   the source you are testing. When results make no sense, check what is

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -25,6 +25,7 @@ two disagree, the README wins, and please fix this file.
 | `run-client-tests.sh` | The `src/client` API suite with ranks behind different servers (README §12) |
 | `run-common-tests.sh` | The `src/common` role-shared API suite — query/log/job-control/allocation/monitor/IOF across separate servers (README §13) |
 | `run-mca-tests.sh` | The `src/mca/base` unit suite plus hostile MCA parameters, in the `--enable-mca-dso` configuration where the component repository is actually exercised (README §14) |
+| `run-bfrops-tests.sh` | The `src/mca/bfrops` unit programs on Linux/optimized/`--enable-mca-dso`, **plus** `examples/datatypes` moving every data type between ranks on different nodes (README §15) |
 | `swarm-common.sh` | **Sourced, never executed.** `$PMIX_SWARM` naming and the one copy of `cleanup_swarm` |
 
 ## Things that will bite you
@@ -62,6 +63,16 @@ two disagree, the README wins, and please fix this file.
   which you mean; `run-class-tests.sh` is explicit that its ten-node
   stage is only meaningful for the one multi-process program in that
   suite.
+
+- **Ranks sharing a node hide the very thing a wire test is for.**
+  `run-bfrops-tests.sh` launches with one slot per host
+  (`--host node1:1,node2:1,... --map-by node`) rather than the
+  `node1:2,node2:2` the other runners use, because a rank asking for a
+  peer's data on its *own* node is answered out of the local datastore
+  and never packs anything. With two ranks per node those pairs pass
+  regardless of the state of the encoders, so the run can be green with
+  the cross-node half broken. If you change the geometry of a test whose
+  subject is serialization, keep one rank per node.
 
 - **A PRRTE `--output` qualifier attaches with a colon, not a comma.**
   `file=NAME:pattern` selects PMIx's `PMIX_IOF_FILE_PATTERN` handling;

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -32,6 +32,8 @@ is only the nickname.
 | `run-client-tests.sh` | Runs the `src/client` API surface across the swarm, so the ranks sit behind **different** PMIx servers. This is the multi-node case for the client library: everything in `src/client` either answers locally or round-trips to a server, and a singleton exercises none of the second half. See §12. |
 | `run-common-tests.sh` | Runs the `src/common` role-shared APIs (query, log, job control, allocation, monitoring, IOF) across the swarm. This is the multi-node case for the shared layer: like `src/client`, almost everything in `src/common` either answers locally or round-trips to a server or host, and the monitor's local/remote split cannot even be entered on one node. See §13. |
 | `run-class-tests.sh` | Runs `test/unit/class` in the two configurations a developer's own `make check` does not cover: **Linux**, and **`--disable-debug`** with default symbol visibility. Deliberately *not* a multi-node test — see §11. |
+| `run-mca-tests.sh` | Runs `test/unit/mca` plus the hostile MCA-parameter cases in the `--enable-mca-dso` configuration, where the component repository is actually exercised. See §14. |
+| `run-bfrops-tests.sh` | Runs the `src/mca/bfrops` unit programs on Linux in an optimized `--enable-mca-dso` build, **and** moves one value of every PMIx data type between ranks on *different* nodes. The only place the peer-assigned bfrops module and the negotiated buffer type are observable at all. See §15. |
 | `swarm-common.sh` | Sourced by all seven scripts above: which swarm to drive (`PMIX_SWARM`), how to reach a node, and how to clean one. The three runners each carried their own copy of that once, and the copies drifted. |
 | `python/` | The swarm's own Python clients (`swarm_client.py`, `swarm_group.py`, `swarm_cpuset.py`). |
 | `Dockerfile` | Base image: toolchain, PRRTE master *source* (autogen'd), SSH wiring, node entrypoint. It contains **no** PMIx and **no** built PRRTE. |
@@ -807,3 +809,68 @@ against it. It skips the second half if the source directory is
 configured in place, because autoconf refuses a VPATH build alongside a
 `config.status` in the srcdir — and a test script has no business running
 `make distclean` on a working tree to get around that.
+
+## 15. The `src/mca/bfrops` suite (`run-bfrops-tests.sh`)
+
+```sh
+./run-bfrops-tests.sh linux    # unit programs in two builds, then across nodes
+./run-bfrops-tests.sh macos    # the single-process half only
+```
+
+`bfrops` is the serialization engine: everything that leaves a PMIx
+process passes through it. The suite has two halves, and they are worth
+separating because only one of them needs the swarm.
+
+**The single-process half.** `test/unit/bfrops_darray` and
+`test/unit/bfrops_malformed` (plus `bfrops_regex2`,
+`bfrops_alloc_inherit` and `nested_darray`) pack and unpack inside one
+process. Stages 1 and 2 build and run them twice: once in the tree
+`build.sh` configured, and once in a separate `--enable-mca-dso`,
+`--disable-debug` tree. That is not a multi-node claim — it is Linux, an
+optimized build, and every component a real `dlopen`'d plugin, none of
+which a developer on macOS gets.
+
+**The cross-server half, which genuinely needs separate nodes.** Two
+things about any pack are decided by the *peer*, not by the process
+doing the packing:
+
+- **which module encodes.** `PMIX_BFROPS_PACK` dereferences
+  `peer->nptr->compat.bfrops` — the module
+  `pmix_bfrops_base_assign_module()` picked from the version string the
+  `ptl` handshake exchanged. Inside one process that is always this
+  build's newest component, so the assignment never really happens.
+- **whether the buffer is described.** Described vs. non-described is
+  negotiated at connection time, and the pack and unpack drivers branch
+  on it to decide whether each item carries a type tag.
+
+A round trip inside one process is self-consistent under either choice
+and therefore cannot fail on either. `examples/datatypes.c` publishes
+one value of every interesting type — including nested data arrays and
+the typeless array descriptor whose marker pack and unpack must spell
+identically — and every rank verifies every *other* rank's copy. Run at
+2, 4 and 8 nodes.
+
+**One rank per node, deliberately.** The launches use
+`--host node1:1,node2:1,... --map-by node`, not the `node1:2,node2:2`
+the other runners use. A rank asking for a peer that shares its node is
+answered out of the local datastore and never packs anything, so with
+two ranks per node those pairs pass no matter what state the encoders
+are in — the run can be green with the cross-node half broken.
+
+### What a failure looks like
+
+Every rank prints `datatypes: rank N: PASS` or names the type that came
+back wrong. The runner counts the PASS lines and requires one per rank,
+so a run in which some ranks never got that far fails rather than
+reading as a pass. A stream desynchronization — the failure mode when
+pack and unpack disagree about a marker — shows up as several
+consecutive `MISMATCH` lines starting at the value after the one that
+disagreed, not at the one that caused it.
+
+### macOS mode
+
+`./run-bfrops-tests.sh macos` runs the unit programs in the local tree
+and then drives `examples/datatypes` through a single `simptest` server.
+That is not a substitute for the swarm stage — one server means one peer
+module and one negotiated buffer type — but it catches an outright break
+before you spend ten containers on it.

--- a/contrib/dockerswarm/run-bfrops-tests.sh
+++ b/contrib/dockerswarm/run-bfrops-tests.sh
@@ -68,7 +68,7 @@ PMIX_PREFIX=/opt/prte/pmix
 # The single-process programs this runner stages and runs.  Named here
 # rather than read out of the Makefile.am because test/unit holds forty
 # programs and only these two are about bfrops.
-BFROPS_PROGRAMS="bfrops_darray bfrops_malformed bfrops_regex2 bfrops_alloc_inherit nested_darray"
+BFROPS_PROGRAMS="bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers bfrops_regex2 bfrops_alloc_inherit nested_darray"
 
 # An out-of-tree build cannot coexist with a config.status in the srcdir --
 # autoconf refuses with "source directory already configured".  Say so once,

--- a/contrib/dockerswarm/run-bfrops-tests.sh
+++ b/contrib/dockerswarm/run-bfrops-tests.sh
@@ -74,10 +74,31 @@ BFROPS_PROGRAMS="bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_ob
 # autoconf refuses with "source directory already configured".  Say so once,
 # plainly, rather than letting the VPATH stages fail with an autoconf error
 # that names no way out.
+# A srcdir that has been built in place blocks BOTH VPATH stages below,
+# for two separate reasons, and it is worth knowing both because they
+# fail at different times and only the first one names itself:
+#
+#   1. autoconf refuses to configure a VPATH tree while the source
+#      directory holds a config.status, and says so plainly.
+#
+#   2. Even reusing an already-configured VPATH tree, make resolves a
+#      missing prerequisite through VPATH and will happily find
+#      foo.o in the SOURCE directory - then run the link recipe with the
+#      bare name, in the build directory, where it does not exist.  The
+#      error is "cannot find foo.o", which names neither VPATH nor the
+#      srcdir, and it strikes exactly the objects that are new or that
+#      the VPATH tree has never built.
+#
+# The second is why this gate covers the stage that only reuses a tree.
+# Do not "loosen" it to let that stage through: it will appear to work
+# for whatever the VPATH tree happens to have built already and fail on
+# whatever you just added.
 srcdir_blocks_vpath() {
     [ -f "$root/config.status" ] || return 1
-    echo "     $root holds a config.status, so autoconf will refuse the" >&2
-    echo "     VPATH build this script needs.  Either:" >&2
+    echo "     $root has been configured and built in place, which blocks" >&2
+    echo "     the VPATH stages: autoconf refuses to configure alongside a" >&2
+    echo "     config.status, and stale objects in the srcdir shadow the" >&2
+    echo "     build tree through VPATH.  Either:" >&2
     echo "         make -C $root distclean && $0 $mode" >&2
     echo "     or run ./build.sh, which distcleans the tree for you." >&2
     return 0
@@ -88,7 +109,7 @@ srcdir_blocks_vpath() {
 ########################################################################
 
 test_linux() {
-    local rc out np hosts
+    local rc out np hosts gate_ok
 
     swarm_up_or_die
 
@@ -113,8 +134,13 @@ test_linux() {
     fi
 
     if srcdir_blocks_vpath; then
-        skp "srcdir is configured in place -- no VPATH build can be made from it"
+        skp "srcdir is configured in place -- the VPATH stages cannot run"
+        gate_ok=0
     else
+        gate_ok=1
+    fi
+
+    if [ "$gate_ok" = 1 ]; then
         banner "unit suite in the tree build.sh configured (static components)"
         docker run --rm \
             -v "$root":/pmix-src:ro \
@@ -138,32 +164,32 @@ test_linux() {
         [ "$rc" = 0 ] && ok "static build: bfrops unit programs green in the container" \
                       || bad "static build: bfrops unit programs failed (rc=$rc)"
 
-        banner "--enable-mca-dso build (every component a real plugin)"
-        # A separate prefix and VPATH directory: this library must not
-        # displace the one the rest of the harness runs against.
-        docker run --rm \
-            -v "$root":/pmix-src:ro \
-            -v "$VOLUME":/opt/prte \
-            -e PROGS="$BFROPS_PROGRAMS" \
-            "$IMAGE" bash -euo pipefail -c '
-                mkdir -p /opt/prte/vpath-pmix-bfrops-dso
-                cd /opt/prte/vpath-pmix-bfrops-dso
-                [ -f config.status ] || /pmix-src/configure \
-                    --prefix=/opt/prte/pmix-bfrops-dso --enable-mca-dso \
-                    --disable-debug --disable-devel-check
-                make -j"$(nproc)"
-                make install
-                make -j"$(nproc)" -C test/unit $PROGS
-                mkdir -p /opt/prte/tests-bfrops/dso
-                for p in $PROGS; do
-                    cp "test/unit/.libs/$p" /opt/prte/tests-bfrops/dso/ 2>/dev/null \
-                        || cp "test/unit/$p" /opt/prte/tests-bfrops/dso/ 2>/dev/null || true
-                done
-                cd test/unit && for p in $PROGS; do ./$p >/dev/null; done
-            '
-        rc=$?
-        [ "$rc" = 0 ] && ok "mca-dso build: bfrops unit programs green in the container" \
-                      || bad "mca-dso build: bfrops unit programs failed (rc=$rc)"
+            banner "--enable-mca-dso build (every component a real plugin)"
+                # A separate prefix and VPATH directory: this library must not
+                # displace the one the rest of the harness runs against.
+                docker run --rm \
+                    -v "$root":/pmix-src:ro \
+                    -v "$VOLUME":/opt/prte \
+                    -e PROGS="$BFROPS_PROGRAMS" \
+                    "$IMAGE" bash -euo pipefail -c '
+                        mkdir -p /opt/prte/vpath-pmix-bfrops-dso
+                        cd /opt/prte/vpath-pmix-bfrops-dso
+                        [ -f config.status ] || /pmix-src/configure \
+                            --prefix=/opt/prte/pmix-bfrops-dso --enable-mca-dso \
+                            --disable-debug --disable-devel-check
+                        make -j"$(nproc)"
+                        make install
+                        make -j"$(nproc)" -C test/unit $PROGS
+                        mkdir -p /opt/prte/tests-bfrops/dso
+                        for p in $PROGS; do
+                            cp "test/unit/.libs/$p" /opt/prte/tests-bfrops/dso/ 2>/dev/null \
+                                || cp "test/unit/$p" /opt/prte/tests-bfrops/dso/ 2>/dev/null || true
+                        done
+                        cd test/unit && for p in $PROGS; do ./$p >/dev/null; done
+                    '
+            rc=$?
+            [ "$rc" = 0 ] && ok "mca-dso build: bfrops unit programs green in the container" \
+                          || bad "mca-dso build: bfrops unit programs failed (rc=$rc)"
     fi
 
     # ------------------------------------------------------------------

--- a/contrib/dockerswarm/run-bfrops-tests.sh
+++ b/contrib/dockerswarm/run-bfrops-tests.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Exercise src/mca/bfrops -- the serialization engine -- in the two ways a
+# developer's own `make check` cannot.
+#
+#   ./run-bfrops-tests.sh linux    # in the 10-container swarm
+#                                  #   (requires: ./build.sh && docker compose up -d)
+#   ./run-bfrops-tests.sh macos    # the single-host subset, natively
+#
+# WHY THIS ONE IS PARTLY A MULTI-NODE TEST
+#
+# bfrops is the only framework in the tree whose whole reason for existing
+# is that two processes have to agree.  Half of it can be checked in one
+# process -- test/unit/bfrops_darray.c and test/unit/bfrops_malformed.c do
+# that, and the first two stages below just run them where a Mac developer
+# does not: on Linux, in an optimized build, and with --enable-mca-dso so
+# every component is a real dlopen'd plugin.
+#
+# The other half cannot.  Two things about a pack are decided by the *peer*,
+# not by the process doing the packing:
+#
+#   * WHICH MODULE.  PMIX_BFROPS_PACK dereferences peer->nptr->compat.bfrops,
+#     the module pmix_bfrops_base_assign_module() picked from the version
+#     string the ptl handshake exchanged.  In a single process that is
+#     always this build's newest component, so the assignment path is never
+#     really taken.
+#   * WHICH BUFFER TYPE.  Described vs. non-described is negotiated at
+#     connection time, and the pack and unpack drivers branch on it to
+#     decide whether each item carries a type tag.  A round trip inside one
+#     process agrees with itself under either, so it cannot fail on this.
+#
+# A round trip inside one process is self-consistent under both and so
+# proves neither.  The `datatypes` stage spreads ranks over separate nodes,
+# hence separate prted/PMIx servers: a value rank N asks for is not in its
+# local datastore, so the get takes the full pack -> send -> unpack -> store
+# path across two daemons.  examples/datatypes.c publishes one value of
+# every interesting type -- including nested data arrays and the typeless
+# array descriptor whose marker pack and unpack must spell identically --
+# and every rank verifies every other rank's copy.
+#
+# Prints PASS/FAIL per stage and exits non-zero if anything failed.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+# RUN/ON, cleanup_swarm, swarm_up_or_die and the swarm naming (PMIX_SWARM,
+# NODE, IMAGE, VOLUME) all live in swarm-common.sh.
+. "$(dirname "$0")/swarm-common.sh"
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+PMIX_PREFIX=/opt/prte/pmix
+
+# The single-process programs this runner stages and runs.  Named here
+# rather than read out of the Makefile.am because test/unit holds forty
+# programs and only these two are about bfrops.
+BFROPS_PROGRAMS="bfrops_darray bfrops_malformed bfrops_regex2 bfrops_alloc_inherit nested_darray"
+
+# An out-of-tree build cannot coexist with a config.status in the srcdir --
+# autoconf refuses with "source directory already configured".  Say so once,
+# plainly, rather than letting the VPATH stages fail with an autoconf error
+# that names no way out.
+srcdir_blocks_vpath() {
+    [ -f "$root/config.status" ] || return 1
+    echo "     $root holds a config.status, so autoconf will refuse the" >&2
+    echo "     VPATH build this script needs.  Either:" >&2
+    echo "         make -C $root distclean && $0 $mode" >&2
+    echo "     or run ./build.sh, which distcleans the tree for you." >&2
+    return 0
+}
+
+########################################################################
+# Linux
+########################################################################
+
+test_linux() {
+    local rc out np hosts
+
+    swarm_up_or_die
+
+    if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+        bad "build volume $VOLUME missing -- run ./build.sh first"
+        return
+    fi
+
+    banner "preflight: containers are running the current image"
+    local imgid cimg imgn stalenodes=""
+    imgid=$(docker images --no-trunc --format '{{.ID}}' "$IMAGE" 2>/dev/null | head -1)
+    for imgn in $(seq 1 10); do
+        cimg=$(docker inspect "$NODE$imgn" --format '{{.Image}}' 2>/dev/null)
+        [ "$cimg" = "$imgid" ] || stalenodes="$stalenodes node$imgn"
+    done
+    if [ -z "$stalenodes" ]; then
+        ok "all 10 containers are on the current $IMAGE"
+    else
+        bad "containers predate $IMAGE:$stalenodes"
+        echo "     Recreate them: ${SWARM_ENV}docker compose up -d --force-recreate" >&2
+        return
+    fi
+
+    if srcdir_blocks_vpath; then
+        skp "srcdir is configured in place -- no VPATH build can be made from it"
+    else
+        banner "unit suite in the tree build.sh configured (static components)"
+        docker run --rm \
+            -v "$root":/pmix-src:ro \
+            -v "$VOLUME":/opt/prte \
+            -e PROGS="$BFROPS_PROGRAMS" \
+            "$IMAGE" bash -euo pipefail -c '
+                cd /opt/prte/vpath-pmix 2>/dev/null || {
+                    echo "no /opt/prte/vpath-pmix -- run ./build.sh first" >&2; exit 2; }
+                make -j"$(nproc)" -C test/unit $PROGS
+                mkdir -p /opt/prte/tests-bfrops/static
+                for p in $PROGS; do
+                    # Stage the real ELF binary, not the libtool wrapper: an
+                    # uninstalled libtool target leaves a /bin/sh wrapper in
+                    # test/unit and the executable under .libs/.
+                    cp "test/unit/.libs/$p" /opt/prte/tests-bfrops/static/ 2>/dev/null \
+                        || cp "test/unit/$p" /opt/prte/tests-bfrops/static/ 2>/dev/null || true
+                done
+                cd test/unit && for p in $PROGS; do ./$p >/dev/null; done
+            '
+        rc=$?
+        [ "$rc" = 0 ] && ok "static build: bfrops unit programs green in the container" \
+                      || bad "static build: bfrops unit programs failed (rc=$rc)"
+
+        banner "--enable-mca-dso build (every component a real plugin)"
+        # A separate prefix and VPATH directory: this library must not
+        # displace the one the rest of the harness runs against.
+        docker run --rm \
+            -v "$root":/pmix-src:ro \
+            -v "$VOLUME":/opt/prte \
+            -e PROGS="$BFROPS_PROGRAMS" \
+            "$IMAGE" bash -euo pipefail -c '
+                mkdir -p /opt/prte/vpath-pmix-bfrops-dso
+                cd /opt/prte/vpath-pmix-bfrops-dso
+                [ -f config.status ] || /pmix-src/configure \
+                    --prefix=/opt/prte/pmix-bfrops-dso --enable-mca-dso \
+                    --disable-debug --disable-devel-check
+                make -j"$(nproc)"
+                make install
+                make -j"$(nproc)" -C test/unit $PROGS
+                mkdir -p /opt/prte/tests-bfrops/dso
+                for p in $PROGS; do
+                    cp "test/unit/.libs/$p" /opt/prte/tests-bfrops/dso/ 2>/dev/null \
+                        || cp "test/unit/$p" /opt/prte/tests-bfrops/dso/ 2>/dev/null || true
+                done
+                cd test/unit && for p in $PROGS; do ./$p >/dev/null; done
+            '
+        rc=$?
+        [ "$rc" = 0 ] && ok "mca-dso build: bfrops unit programs green in the container" \
+                      || bad "mca-dso build: bfrops unit programs failed (rc=$rc)"
+    fi
+
+    # ------------------------------------------------------------------
+    # The part that needs more than one node.
+    # ------------------------------------------------------------------
+    banner "preflight: PMIx installed in the shared volume"
+    if ON 1 "test -f $PMIX_PREFIX/include/pmix_common.h"; then
+        ok "PMIx headers/libs under $PMIX_PREFIX"
+    else
+        bad "no $PMIX_PREFIX in the volume -- run ./build.sh first"
+        return
+    fi
+
+    banner "build the cross-node data-type client"
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e PFX="$PMIX_PREFIX" \
+        "$IMAGE" bash -euo pipefail -c '
+            mkdir -p /opt/prte/tests-bfrops
+            gcc -O0 -g -o /opt/prte/tests-bfrops/datatypes \
+                /pmix-src/examples/datatypes.c \
+                -I"$PFX/include" -I/pmix-src/examples \
+                -L"$PFX/lib" -lpmix -Wl,-rpath,"$PFX/lib"
+        '
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        bad "could not build examples/datatypes (rc=$rc)"
+        return
+    fi
+    ok "built examples/datatypes"
+
+    if ! RUN 'command -v prterun >/dev/null'; then
+        skp "no prterun in the containers -- run ./build.sh first"
+        return
+    fi
+
+    # One rank per node, so *every* get crosses a server boundary. With two
+    # ranks on a node the local pair would be answered out of the local
+    # datastore and the cross-node half could pass while the wire half was
+    # broken; --map-by node with one slot each removes that hiding place.
+    for geom in "node1:1,node2:1 2" "node1:1,node2:1,node3:1,node4:1 4" \
+                "node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1,node8:1 8"; do
+        hosts="${geom% *}"
+        np="${geom##* }"
+        cleanup_swarm
+        banner "every data type across $np separate PMIx servers"
+        out="$(RUN "prterun --host $hosts -np $np --map-by node --timeout 120 \
+                    /opt/prte/tests-bfrops/datatypes 2>&1")"
+        rc=$?
+        if echo "$out" | grep -qiE 'time limit for job|timed out|DVM timeout'; then
+            bad "$np nodes: HUNG (hit the launch timeout)"
+        elif echo "$out" | grep -qiE 'MISMATCH|Segmentation|core dumped'; then
+            bad "$np nodes: $(echo "$out" | grep -iE 'MISMATCH|Segmentation|core dumped' | head -1)"
+        elif [ "$(echo "$out" | grep -c 'datatypes: rank .*: PASS')" != "$np" ]; then
+            # Every rank has to say so. Counting them is what stops a run in
+            # which some ranks never got that far from reading as a pass.
+            bad "$np nodes: only $(echo "$out" | grep -c 'datatypes: rank .*: PASS')/$np ranks reported PASS"
+        elif [ "$rc" != 0 ]; then
+            bad "$np nodes: exit $rc"
+        else
+            ok "$np nodes: every type survived the wire on all $np ranks"
+        fi
+    done
+}
+
+########################################################################
+# macOS: the single-process half only. There is one node, so there is no
+# cross-server half to run.
+########################################################################
+
+test_macos() {
+    local p rc
+
+    banner "bfrops unit programs in the local tree"
+    if [ ! -f "$root/config.status" ]; then
+        skp "no configured tree at $root"
+        return
+    fi
+    for p in $BFROPS_PROGRAMS; do
+        make -C "$root/test/unit" "$p" >/dev/null 2>&1
+        if [ ! -x "$root/test/unit/$p" ]; then
+            bad "$p did not build"
+            continue
+        fi
+        ( cd "$root/test/unit" && TMPDIR="$(mktemp -d)" "./$p" >/dev/null 2>&1 )
+        rc=$?
+        [ "$rc" = 0 ] && ok "$p" || bad "$p (rc=$rc)"
+    done
+
+    banner "every data type through a single simptest server"
+    # Not a substitute for the swarm stage -- one server means one peer
+    # module and one negotiated buffer type -- but it does drive the same
+    # client end to end, which catches an outright break before you spend
+    # ten containers on it.
+    make -C "$root/examples" datatypes >/dev/null 2>&1
+    make -C "$root/test/simple" >/dev/null 2>&1
+    if [ ! -x "$root/test/simple/run_simptest.sh" ] || [ ! -x "$root/examples/datatypes" ]; then
+        skp "simptest or examples/datatypes not built"
+        return
+    fi
+    local out
+    out="$( cd "$root/test/simple" \
+            && TMPDIR="$(mktemp -d)" ./run_simptest.sh -n 4 -e ../../examples/datatypes 2>&1 )"
+    if [ "$(echo "$out" | grep -c 'datatypes: rank .*: PASS')" = 4 ]; then
+        ok "4 ranks, one server: every type survived"
+    else
+        bad "simptest run: $(echo "$out" | grep -iE 'MISMATCH|FAIL' | head -1)"
+    fi
+
+    echo
+    echo "  NOTE: the cross-server half of this suite needs the swarm."
+    echo "        Run './run-bfrops-tests.sh linux' for that."
+}
+
+########################################################################
+
+banner "src/mca/bfrops: serialization across builds and across nodes"
+case "$mode" in
+    linux) test_linux ;;
+    macos) test_macos ;;
+    *) echo "usage: $0 [linux|macos]" >&2; exit 2 ;;
+esac
+
+printf '\n=== summary: %d passed, %d failed, %d skipped ===\n' "$pass" "$fail" "$skip"
+[ "$fail" = 0 ]

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -70,6 +70,18 @@ Detailed changes since v6.1.0:
    PMIx_Value_xfer, PMIx_Info_xfer, PMIx_Info_list_xfer and
    PMIx_Value_unload, for every pointer-backed type. Each of those now
    treats it as what it is - an absent object
+ - The public helper APIs implemented in the bfrops base no longer
+   crash on a NULL argument: PMIx_Argv_append_nosize and its prepend
+   and append-unique siblings, PMIx_Load_procid, PMIx_Check_procid,
+   PMIx_Procid_invalid, PMIx_Multicluster_nspace_parse, PMIx_Pdata_load,
+   PMIx_Value_true, and every PMIx_Info_list_* entry point.
+   PMIx_Info_list_release(NULL) in particular is now the no-op that
+   every other release in that file already was
+ - PMIx_Multicluster_nspace_parse now clears both halves of its output
+   rather than only the cluster half - the nspace half is written
+   element by element and never terminated, so whatever the caller's
+   buffer previously held showed through - and no longer reads one byte
+   past the end of the namespace it is parsing
  - PMIx_Value_unload no longer writes through a NULL destination for a
    PMIX_JOB_STATE value. That type is copied into caller-supplied
    storage like its neighbours, but was missing from the list the

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -62,6 +62,19 @@ Detailed changes since v6.1.0:
    exactly representable
  - PMIx_Data_type_string now names PMIX_NODE_PID when called before the
    library is initialized
+ - A pmix_value_t that names a type whose payload lives behind a pointer
+   but carries no object no longer crashes the library. Such a value is
+   malformed but takes nothing more than setting the type before the
+   data, and it faulted in PMIx_Value_string, PMIx_Info_string,
+   PMIx_Value_compare, PMIx_Value_get_size, PMIx_Info_get_size,
+   PMIx_Value_xfer, PMIx_Info_xfer, PMIx_Info_list_xfer and
+   PMIx_Value_unload, for every pointer-backed type. Each of those now
+   treats it as what it is - an absent object
+ - PMIx_Value_unload no longer writes through a NULL destination for a
+   PMIX_JOB_STATE value. That type is copied into caller-supplied
+   storage like its neighbours, but was missing from the list the
+   function checks before it does so, so it crashed where the others
+   returned PMIX_ERR_BAD_PARAM
  - A process-realm info array (PMIX_PROC_INFO_ARRAY, also known by its
    deprecated name PMIX_PROC_DATA) may now identify the process it
    describes with any of the forms its definition allows. The datastore

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -40,6 +40,28 @@ Detailed changes since v6.1.0:
    pointer apiece
  - Strings unpacked from a message are now guaranteed to be terminated
    rather than trusting the sender to have included the terminator
+ - PMIx_Value_get_number no longer accepts a negative PMIX_INT16,
+   PMIX_INT32 or PMIX_INT64 into an unsigned destination type. All
+   three sign checks tested the wrong member of the value union, so
+   the check never fired and the value wrapped silently
+ - PMIx_Value_get_number no longer reports failure for a conversion it
+   performed correctly. Every conversion whose destination was
+   PMIX_PROC_RANK wrote the right answer and then returned
+   PMIX_ERR_BAD_PARAM
+ - PMIx_Value_get_number now accepts PMIX_PID as a source type. It had
+   no handler at all, so every conversion out of a pid returned
+   PMIX_ERR_BAD_PARAM
+ - PMIx_Value_get_number range checks corrected: a PMIX_INT32 converted
+   to PMIX_INT8 or PMIX_UINT8 was range-checked as though it were an
+   int16 and could truncate silently; PMIX_INT64 to PMIX_PID or
+   PMIX_STATUS was bounded by UINT32_MAX rather than by the signed
+   32-bit range and left the negative side unchecked; a float to
+   PMIX_UINT was bounded by 42949670295 rather than 4294967295; a float
+   or double of exactly 256 converted to PMIX_UINT8 as 0; and a double
+   in the top 255 values of the uint32 range was refused although it is
+   exactly representable
+ - PMIx_Data_type_string now names PMIX_NODE_PID when called before the
+   library is initialized
  - A process-realm info array (PMIX_PROC_INFO_ARRAY, also known by its
    deprecated name PMIX_PROC_DATA) may now identify the process it
    describes with any of the forms its definition allows. The datastore

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -39,7 +39,10 @@ Detailed changes since v6.1.0:
    the array. The elements were allocated one byte apiece and copied a
    pointer apiece
  - Strings unpacked from a message are now guaranteed to be terminated
-   rather than trusting the sender to have included the terminator
+   rather than trusting the sender to have included the terminator,
+   and a negative string length no longer reaches the allocator. This
+   applies to the shared unpacker and to the self-contained v12 and v20
+   unpackers alike
  - PMIx_Value_get_number no longer accepts a negative PMIX_INT16,
    PMIX_INT32 or PMIX_INT64 into an unsigned destination type. All
    three sign checks tested the wrong member of the value union, so

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,18 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - A length taken off the wire can no longer drive an unbounded
+   allocation. The element count of a data array sized the receiver's
+   allocation with nothing relating it to the size of the message, so a
+   twenty-byte message claiming 2^40 elements was enough to exhaust
+   memory and have the process killed. A count larger than the bytes
+   remaining cannot describe anything the peer sent, and is now refused
+ - Twelve allocations sized from the wire are now checked for failure
+   before being written through. The pattern was uniform - allocate,
+   then unpack the wire-supplied count of elements into the pointer - so
+   a count large enough to make the allocator decline became a write
+   through NULL. PMIx_Data_unpack of a malformed PMIX_QUERY was the
+   readiest example
  - PMIx no longer reads past the end of a message when a peer claims
    more values than it sent. The flexible integer decoder bounded its
    loop with an expression that underflowed once nothing was left to

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,39 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - PMIx no longer reads past the end of a message when a peer claims
+   more values than it sent. The flexible integer decoder bounded its
+   loop with an expression that underflowed once nothing was left to
+   read, so a three-byte buffer could drive an unbounded over-read and
+   crash the process. It now refuses an empty region and reports a
+   truncated encoding rather than assembling a value out of whatever
+   bytes followed
+ - A data array carrying no element type no longer desynchronizes the
+   message it is packed into. The packer wrote a PMIX_UNDEF type tag and
+   a size while the unpacker read the tag as a terminator and never
+   consumed the size, so everything after it was misread. Such an array
+   is trivially produced - copying a value whose data array pointer is
+   NULL yields one
+ - Copying a data array of PMIX_PROC_CPUSET whose elements are not valid
+   hwloc objects no longer releases the element block twice. Any
+   PMIx_Value_xfer or PMIX_INFO_XFER of an array from
+   PMIx_Data_array_create reached it
+ - An unpacked PMIX_DATA_BUFFER can now be read from. Unpacking restored
+   the payload but left the cursors and the allocation size unset, so
+   the caller received a buffer it could not extract a single value out
+   of
+ - Eighteen PMIx data types that pack and unpack correctly on their own
+   can now also be used as data array element types. PMIX_DATA_ARRAY_CONSTRUCT
+   silently produced an empty descriptor for them, which made unpacking
+   an array of any of them fail with PMIX_ERR_NOMEM. The affected types
+   include PMIX_NODE_PID, PMIX_REGEX2, PMIX_TOPO, PMIX_DATA_BUFFER,
+   PMIX_KVAL, PMIX_BUFFER, PMIX_DEVTYPE, PMIX_JOB_STATE, PMIX_LOCTYPE,
+   PMIX_COMMAND and the PMIX_STOR_* family
+ - Copying a data array of PMIX_POINTER no longer reads past the end of
+   the array. The elements were allocated one byte apiece and copied a
+   pointer apiece
+ - Strings unpacked from a message are now guaranteed to be terminated
+   rather than trusting the sender to have included the terminator
  - A process-realm info array (PMIX_PROC_INFO_ARRAY, also known by its
    deprecated name PMIX_PROC_DATA) may now identify the process it
    describes with any of the forms its definition allows. The datastore

--- a/docs/news/news-v6.x.rst
+++ b/docs/news/news-v6.x.rst
@@ -7,6 +7,21 @@ series, in reverse chronological order.
 6.1.1 -- xx May 2026
 --------------------
 Detailed changes since v6.1.0:
+ - A message can no longer overflow a pmix_value_t. A value keeps its
+   payload in a 24-byte union and the type tag naming the live member
+   comes off the wire, but six registered types - PMIX_VALUE, PMIX_INFO,
+   PMIX_PDATA, PMIX_APP, PMIX_KVAL and PMIX_BUFFER - have no member
+   there and are far larger than the union, PMIX_PDATA by 784 bytes.
+   Unpacking a value tagged with one of them wrote that far past its
+   end, and the values in question are heap-allocated, so both the
+   length and the contents of the overflow came from the peer. Packing
+   such a value read out of bounds in the same way. Both are now refused
+ - Copying a data array of strings or of byte objects no longer frees an
+   uninitialized pointer when an element of the source is absent. The
+   destination block was allocated without being zeroed and only the
+   elements the source had filled in were written, so the destructor
+   freed whatever the allocator had left in the rest
+ - PMIx_Xfer_procid no longer crashes when either argument is NULL
  - A length taken off the wire can no longer drive an unbounded
    allocation. The element count of a data array sized the receiver's
    allocation with nothing relating it to the size of the message, so a

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -89,7 +89,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   simple simple_server abort group_die connect_die group_leave \
                   group_destruct_die group_invite group_invite_timeout group_invite_decline \
                   group_invite_abort group_invite_others group_invite_suppress group_invite_nb topology \
-                  spawn_reuse group_badinfo
+                  spawn_reuse group_badinfo datatypes
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -311,6 +311,10 @@ simple_server_SOURCES = simple_server.c examples.h
 simple_server_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simple_server_LDADD = $(top_builddir)/src/libpmix.la
 
+datatypes_SOURCES = datatypes.c examples.h
+datatypes_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+datatypes_LDADD = $(top_builddir)/src/libpmix.la
+
 abort_SOURCES = abort.c examples.h
 abort_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 abort_LDADD = $(top_builddir)/src/libpmix.la
@@ -325,4 +329,4 @@ distclean-local:
         group_invite_abort group_invite_suppress group_invite_nb \
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
-        simple simple_server abort
+        simple simple_server abort datatypes

--- a/examples/datatypes.c
+++ b/examples/datatypes.c
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Push one value of every interesting PMIx data type through a real
+ * server, and check that a rank behind a *different* server gets the
+ * same value back.
+ *
+ * test/unit/bfrops_darray.c and test/unit/bfrops_malformed.c pack and
+ * unpack in a single process, which covers the encoders but not the
+ * thing they exist for. Two facts only become true once there is a
+ * socket in the middle:
+ *
+ *   - the module doing the encoding is the *peer's*, picked by
+ *     pmix_bfrops_base_assign_module() from the version string the ptl
+ *     handshake exchanged, rather than this process's own newest one;
+ *   - the buffer type (described vs. non-described) is whatever the two
+ *     ends negotiated, so the pack and unpack drivers take their tagged
+ *     branch or their untagged one depending on how the peer was built.
+ *
+ * A single-process round trip is always self-consistent under both, and
+ * so cannot fail on either. Spreading the ranks over separate nodes -
+ * hence separate PMIx servers - is what makes a value asked for by rank
+ * N actually travel: it is not in the local datastore, so the get takes
+ * the full pack/send/unpack/store path through two daemons.
+ *
+ * Every rank publishes the same values under its own keys, then verifies
+ * every *other* rank's copy. Exits non-zero on the first mismatch and
+ * prints "datatypes: PASS" only when every type checked out.
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+static int nerrs = 0;
+
+#define CHECK(cond, what)                                                     \
+    do {                                                                      \
+        if (!(cond)) {                                                        \
+            fprintf(stderr, "datatypes: rank %u: %s: MISMATCH\n",              \
+                    (unsigned) myproc.rank, (what));                          \
+            nerrs++;                                                          \
+        }                                                                     \
+    } while (0)
+
+/* the scalar payloads, identical on every rank so any rank can check any
+ * other rank's copy without knowing who wrote it */
+#define V_INT8   ((int8_t) -0x7F)
+#define V_UINT8  ((uint8_t) 0xFE)
+#define V_INT16  ((int16_t) -0x7FFE)
+#define V_UINT16 ((uint16_t) 0xFFFE)
+#define V_INT32  ((int32_t) -2000000000)
+#define V_UINT32 ((uint32_t) 4000000000U)
+#define V_INT64  ((int64_t) -9000000000000000000LL)
+#define V_UINT64 ((uint64_t) 18000000000000000000ULL)
+#define V_SIZE   ((size_t) 0x0123456789ABULL)
+#define V_STRING "the quick brown fox jumps over the lazy dog"
+
+/* Load the value for slot n. Keeping the writer and the checker driven
+ * off one table is the point: a type that is written one way and checked
+ * another proves nothing. */
+typedef struct {
+    const char *key;
+    pmix_data_type_t type;
+} dtype_t;
+
+static dtype_t dtypes[] = {
+    {"dt-bool", PMIX_BOOL},
+    {"dt-byte", PMIX_BYTE},
+    {"dt-string", PMIX_STRING},
+    {"dt-size", PMIX_SIZE},
+    {"dt-int", PMIX_INT},
+    {"dt-int8", PMIX_INT8},
+    {"dt-int16", PMIX_INT16},
+    {"dt-int32", PMIX_INT32},
+    {"dt-int64", PMIX_INT64},
+    {"dt-uint", PMIX_UINT},
+    {"dt-uint8", PMIX_UINT8},
+    {"dt-uint16", PMIX_UINT16},
+    {"dt-uint32", PMIX_UINT32},
+    {"dt-uint64", PMIX_UINT64},
+    {"dt-float", PMIX_FLOAT},
+    {"dt-double", PMIX_DOUBLE},
+    {"dt-status", PMIX_STATUS},
+    {"dt-rank", PMIX_PROC_RANK},
+    {"dt-bo", PMIX_BYTE_OBJECT},
+    {"dt-proc", PMIX_PROC},
+    {"dt-envar", PMIX_ENVAR},
+    {"dt-darray-int32", PMIX_DATA_ARRAY},
+    {"dt-darray-string", PMIX_DATA_ARRAY},
+    {"dt-darray-info", PMIX_DATA_ARRAY},
+    {"dt-darray-nested", PMIX_DATA_ARRAY},
+    {"dt-darray-empty", PMIX_DATA_ARRAY},
+    /* deliberately AFTER the empty array: if the packer and the unpacker
+     * disagree about how a typeless array is spelled, the leftover bytes
+     * land in front of whatever is read next, and this is what notices */
+    {"dt-after-empty", PMIX_STRING}
+};
+#define NDTYPES (sizeof(dtypes) / sizeof(dtypes[0]))
+
+static void fill(pmix_value_t *v, size_t n)
+{
+    PMIX_VALUE_CONSTRUCT(v);
+    v->type = dtypes[n].type;
+
+    switch (n) {
+    case 0: v->data.flag = true; break;
+    case 1: v->data.byte = 0xA5; break;
+    case 2: v->data.string = strdup(V_STRING); break;
+    case 3: v->data.size = V_SIZE; break;
+    case 4: v->data.integer = -123456; break;
+    case 5: v->data.int8 = V_INT8; break;
+    case 6: v->data.int16 = V_INT16; break;
+    case 7: v->data.int32 = V_INT32; break;
+    case 8: v->data.int64 = V_INT64; break;
+    case 9: v->data.uint = 654321; break;
+    case 10: v->data.uint8 = V_UINT8; break;
+    case 11: v->data.uint16 = V_UINT16; break;
+    case 12: v->data.uint32 = V_UINT32; break;
+    case 13: v->data.uint64 = V_UINT64; break;
+    case 14: v->data.fval = 3.5f; break;
+    case 15: v->data.dval = -2.25; break;
+    case 16: v->data.status = PMIX_ERR_NOT_FOUND; break;
+    case 17: v->data.rank = 7; break;
+    case 18:
+        v->data.bo.size = 5;
+        v->data.bo.bytes = (char *) malloc(5);
+        memcpy(v->data.bo.bytes, "\x00\x01\xfe\xff\x7f", 5);
+        break;
+    case 19:
+        PMIX_PROC_CREATE(v->data.proc, 1);
+        PMIX_LOAD_PROCID(v->data.proc, "some-nspace", 3);
+        break;
+    case 20:
+        v->data.envar.envar = strdup("PMIX_TEST_VAR");
+        v->data.envar.value = strdup("some-value");
+        v->data.envar.separator = ':';
+        break;
+    case 21: {
+        int32_t *p;
+        size_t k;
+        v->data.darray = PMIx_Data_array_create(8, PMIX_INT32);
+        p = (int32_t *) v->data.darray->array;
+        for (k = 0; k < 8; k++) {
+            p[k] = (int32_t) (k * 100000) - 400000;
+        }
+        break;
+    }
+    case 22: {
+        char **p;
+        v->data.darray = PMIx_Data_array_create(3, PMIX_STRING);
+        p = (char **) v->data.darray->array;
+        p[0] = strdup("alpha");
+        p[1] = strdup("beta");
+        p[2] = strdup("gamma");
+        break;
+    }
+    case 23: {
+        pmix_info_t *p;
+        v->data.darray = PMIx_Data_array_create(2, PMIX_INFO);
+        p = (pmix_info_t *) v->data.darray->array;
+        PMIX_INFO_LOAD(&p[0], "inner-one", "value-one", PMIX_STRING);
+        PMIX_INFO_LOAD(&p[1], "inner-two", &(uint32_t){42}, PMIX_UINT32);
+        break;
+    }
+    case 24: {
+        /* an array of arrays: the recursion in pack/unpack/copy */
+        pmix_data_array_t *outer, *inner;
+        size_t k;
+        outer = PMIx_Data_array_create(2, PMIX_DATA_ARRAY);
+        inner = (pmix_data_array_t *) outer->array;
+        for (k = 0; k < 2; k++) {
+            uint64_t *q;
+            size_t j;
+            PMIX_DATA_ARRAY_CONSTRUCT(&inner[k], 4, PMIX_UINT64);
+            q = (uint64_t *) inner[k].array;
+            for (j = 0; j < 4; j++) {
+                q[j] = (uint64_t) 1 << (8 * (k + 1) + j);
+            }
+        }
+        v->data.darray = outer;
+        break;
+    }
+    case 25:
+        /* an array descriptor with no element type: the marker the packer
+         * and the unpacker must spell identically, or everything after it
+         * in the message is misread */
+        v->data.darray = (pmix_data_array_t *) calloc(1, sizeof(pmix_data_array_t));
+        break;
+    case 26:
+        v->data.string = strdup("still-in-step");
+        break;
+    default:
+        break;
+    }
+}
+
+static void check(pmix_value_t *v, size_t n, unsigned peer)
+{
+    char what[256];
+
+    snprintf(what, sizeof(what), "%s from rank %u", dtypes[n].key, peer);
+
+    if (v->type != dtypes[n].type) {
+        fprintf(stderr, "datatypes: rank %u: %s: type %d, expected %d\n",
+                (unsigned) myproc.rank, what, (int) v->type, (int) dtypes[n].type);
+        nerrs++;
+        return;
+    }
+
+    switch (n) {
+    case 0: CHECK(true == v->data.flag, what); break;
+    case 1: CHECK(0xA5 == (unsigned char) v->data.byte, what); break;
+    case 2: CHECK(NULL != v->data.string
+                  && 0 == strcmp(v->data.string, V_STRING), what); break;
+    case 3: CHECK(V_SIZE == v->data.size, what); break;
+    case 4: CHECK(-123456 == v->data.integer, what); break;
+    case 5: CHECK(V_INT8 == v->data.int8, what); break;
+    case 6: CHECK(V_INT16 == v->data.int16, what); break;
+    case 7: CHECK(V_INT32 == v->data.int32, what); break;
+    case 8: CHECK(V_INT64 == v->data.int64, what); break;
+    case 9: CHECK(654321 == v->data.uint, what); break;
+    case 10: CHECK(V_UINT8 == v->data.uint8, what); break;
+    case 11: CHECK(V_UINT16 == v->data.uint16, what); break;
+    case 12: CHECK(V_UINT32 == v->data.uint32, what); break;
+    case 13: CHECK(V_UINT64 == v->data.uint64, what); break;
+    case 14: CHECK(3.5f == v->data.fval, what); break;
+    case 15: CHECK(-2.25 == v->data.dval, what); break;
+    case 16: CHECK(PMIX_ERR_NOT_FOUND == v->data.status, what); break;
+    case 17: CHECK(7 == v->data.rank, what); break;
+    case 18: CHECK(5 == v->data.bo.size && NULL != v->data.bo.bytes
+                   && 0 == memcmp(v->data.bo.bytes, "\x00\x01\xfe\xff\x7f", 5),
+                   what); break;
+    case 19: CHECK(NULL != v->data.proc
+                   && 0 == strcmp(v->data.proc->nspace, "some-nspace")
+                   && 3 == v->data.proc->rank, what); break;
+    case 20: CHECK(NULL != v->data.envar.envar
+                   && 0 == strcmp(v->data.envar.envar, "PMIX_TEST_VAR")
+                   && NULL != v->data.envar.value
+                   && 0 == strcmp(v->data.envar.value, "some-value")
+                   && ':' == v->data.envar.separator, what); break;
+    case 21: {
+        int ok = (NULL != v->data.darray) && (PMIX_INT32 == v->data.darray->type)
+                 && (8 == v->data.darray->size) && (NULL != v->data.darray->array);
+        if (ok) {
+            int32_t *p = (int32_t *) v->data.darray->array;
+            size_t k;
+            for (k = 0; k < 8; k++) {
+                if (p[k] != (int32_t) (k * 100000) - 400000) {
+                    ok = 0;
+                    break;
+                }
+            }
+        }
+        CHECK(ok, what);
+        break;
+    }
+    case 22: {
+        int ok = (NULL != v->data.darray) && (PMIX_STRING == v->data.darray->type)
+                 && (3 == v->data.darray->size) && (NULL != v->data.darray->array);
+        if (ok) {
+            char **p = (char **) v->data.darray->array;
+            ok = (NULL != p[0] && 0 == strcmp(p[0], "alpha"))
+                 && (NULL != p[1] && 0 == strcmp(p[1], "beta"))
+                 && (NULL != p[2] && 0 == strcmp(p[2], "gamma"));
+        }
+        CHECK(ok, what);
+        break;
+    }
+    case 23: {
+        int ok = (NULL != v->data.darray) && (PMIX_INFO == v->data.darray->type)
+                 && (2 == v->data.darray->size) && (NULL != v->data.darray->array);
+        if (ok) {
+            pmix_info_t *p = (pmix_info_t *) v->data.darray->array;
+            ok = (0 == strcmp(p[0].key, "inner-one"))
+                 && (PMIX_STRING == p[0].value.type)
+                 && (NULL != p[0].value.data.string)
+                 && (0 == strcmp(p[0].value.data.string, "value-one"))
+                 && (0 == strcmp(p[1].key, "inner-two"))
+                 && (PMIX_UINT32 == p[1].value.type)
+                 && (42 == p[1].value.data.uint32);
+        }
+        CHECK(ok, what);
+        break;
+    }
+    case 24: {
+        int ok = (NULL != v->data.darray) && (PMIX_DATA_ARRAY == v->data.darray->type)
+                 && (2 == v->data.darray->size) && (NULL != v->data.darray->array);
+        if (ok) {
+            pmix_data_array_t *inner = (pmix_data_array_t *) v->data.darray->array;
+            size_t k, j;
+            for (k = 0; k < 2 && ok; k++) {
+                uint64_t *q = (uint64_t *) inner[k].array;
+                if (PMIX_UINT64 != inner[k].type || 4 != inner[k].size || NULL == q) {
+                    ok = 0;
+                    break;
+                }
+                for (j = 0; j < 4; j++) {
+                    if (q[j] != ((uint64_t) 1 << (8 * (k + 1) + j))) {
+                        ok = 0;
+                        break;
+                    }
+                }
+            }
+        }
+        CHECK(ok, what);
+        break;
+    }
+    case 25:
+        /* the only requirement is that it comes back as an empty array
+         * rather than as garbage - and, far more importantly, that
+         * everything published after it still checks out, which the
+         * cases above and below this one are what verify */
+        CHECK(NULL == v->data.darray || 0 == v->data.darray->size, what);
+        break;
+    case 26:
+        CHECK(NULL != v->data.string
+              && 0 == strcmp(v->data.string, "still-in-step"), what);
+        break;
+    default:
+        break;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t value;
+    pmix_value_t *val;
+    pmix_proc_t proc;
+    uint32_t nprocs = 0, n;
+    size_t k;
+    char key[PMIX_MAX_KEYLEN + 1];
+    pmix_info_t info;
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "datatypes: PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "datatypes: could not get job size: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+
+    /* publish one value of every type under a key that names the type
+     * and the rank that wrote it */
+    for (k = 0; k < NDTYPES; k++) {
+        snprintf(key, sizeof(key), "%s-%u", dtypes[k].key, (unsigned) myproc.rank);
+        fill(&value, k);
+        rc = PMIx_Put(PMIX_GLOBAL, key, &value);
+        PMIX_VALUE_DESTRUCT(&value);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "datatypes: rank %u: PMIx_Put %s failed: %s\n",
+                    (unsigned) myproc.rank, key, PMIx_Error_string(rc));
+            nerrs++;
+            goto done;
+        }
+    }
+
+    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        fprintf(stderr, "datatypes: PMIx_Commit failed: %s\n", PMIx_Error_string(rc));
+        nerrs++;
+        goto done;
+    }
+
+    /* collect the data so a rank behind another server can be asked for
+     * it; without this the gets below would go direct-modex, which is
+     * also worth exercising but is a different path */
+    PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &(bool){true}, PMIX_BOOL);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, &info, 1))) {
+        fprintf(stderr, "datatypes: PMIx_Fence failed: %s\n", PMIx_Error_string(rc));
+        PMIX_INFO_DESTRUCT(&info);
+        nerrs++;
+        goto done;
+    }
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* now check every other rank's copy of every type */
+    for (n = 0; n < nprocs; n++) {
+        if (n == myproc.rank) {
+            continue;
+        }
+        PMIX_LOAD_PROCID(&proc, myproc.nspace, n);
+        for (k = 0; k < NDTYPES; k++) {
+            snprintf(key, sizeof(key), "%s-%u", dtypes[k].key, (unsigned) n);
+            rc = PMIx_Get(&proc, key, NULL, 0, &val);
+            if (PMIX_SUCCESS != rc) {
+                fprintf(stderr, "datatypes: rank %u: PMIx_Get %s failed: %s\n",
+                        (unsigned) myproc.rank, key, PMIx_Error_string(rc));
+                nerrs++;
+                continue;
+            }
+            if (NULL == val) {
+                fprintf(stderr, "datatypes: rank %u: PMIx_Get %s returned NULL\n",
+                        (unsigned) myproc.rank, key);
+                nerrs++;
+                continue;
+            }
+            check(val, k, (unsigned) n);
+            PMIX_VALUE_RELEASE(val);
+        }
+    }
+
+done:
+    if (0 == nerrs) {
+        fprintf(stderr, "datatypes: rank %u: PASS (%u types x %u peers)\n",
+                (unsigned) myproc.rank, (unsigned) NDTYPES,
+                (unsigned) (nprocs > 0 ? nprocs - 1 : 0));
+    } else {
+        fprintf(stderr, "datatypes: rank %u: FAIL (%d mismatches)\n",
+                (unsigned) myproc.rank, nerrs);
+    }
+    fflush(stderr);
+
+    PMIx_Finalize(NULL, 0);
+    return (0 == nerrs) ? 0 : 1;
+}

--- a/src/mca/bfrops/AGENTS.md
+++ b/src/mca/bfrops/AGENTS.md
@@ -434,6 +434,7 @@ unbounded over-reads, and both are three-byte messages.
 |-------|----------------|
 | [`test/unit/bfrops_darray.c`](../../../test/unit/bfrops_darray.c) | every registered data type used as a data-array element, held across construct / pack / unpack / copy |
 | [`test/unit/bfrops_malformed.c`](../../../test/unit/bfrops_malformed.c) | truncated, lying and hostile input; the flexible-integer encoding boundaries |
+| [`test/unit/bfrops_get_number.c`](../../../test/unit/bfrops_get_number.c) | `PMIx_Value_get_number` numeric conversions, as properties over every source/destination pair |
 | [`test/unit/nested_darray.c`](../../../test/unit/nested_darray.c) | array nesting and the `max_array_depth` cap |
 | [`test/unit/bfrops_regex2.c`](../../../test/unit/bfrops_regex2.c), [`bfrops_alloc_inherit.c`](../../../test/unit/bfrops_alloc_inherit.c) | the two newest `v61` types |
 | [`examples/datatypes.c`](../../../examples/datatypes.c) | one value of every interesting type published by each rank and verified by every other rank |

--- a/src/mca/bfrops/AGENTS.md
+++ b/src/mca/bfrops/AGENTS.md
@@ -401,6 +401,16 @@ it already produced for a zero-length or NULL-elements source — "absent"
 is a state this function could always express; it simply never checked
 for the one spelling of it that arrives as a NULL pointer.
 
+That was one instance of a pattern that turned out to run right through
+the framework: **eighty-five (type, operation) pairs faulted** the same
+way, across `PMIx_Value_string`, `PMIx_Info_string`, `PMIx_Value_compare`,
+`PMIx_Value_get_size`, `PMIx_Info_get_size`, `PMIx_Value_xfer`,
+`PMIx_Info_xfer`, `PMIx_Info_list_xfer` and `PMIx_Value_unload`. They
+are screened now by one predicate,
+`pmix_bfrops_base_value_is_null_object()`; see
+[`base/AGENTS.md`](base/AGENTS.md) for where it is applied and why
+`PMIX_DATA_ARRAY` is excluded from one of those applications.
+
 Two things follow for anyone adding or editing a `copy_*` here:
 
 - **A type check at a caller's entry point does not protect you.** The
@@ -435,6 +445,7 @@ unbounded over-reads, and both are three-byte messages.
 | [`test/unit/bfrops_darray.c`](../../../test/unit/bfrops_darray.c) | every registered data type used as a data-array element, held across construct / pack / unpack / copy |
 | [`test/unit/bfrops_malformed.c`](../../../test/unit/bfrops_malformed.c) | truncated, lying and hostile input; the flexible-integer encoding boundaries |
 | [`test/unit/bfrops_get_number.c`](../../../test/unit/bfrops_get_number.c) | `PMIx_Value_get_number` numeric conversions, as properties over every source/destination pair |
+| [`test/unit/bfrops_null_object.c`](../../../test/unit/bfrops_null_object.c) | every value-level operation against a value that names a pointer-backed type and carries no object |
 | [`test/unit/nested_darray.c`](../../../test/unit/nested_darray.c) | array nesting and the `max_array_depth` cap |
 | [`test/unit/bfrops_regex2.c`](../../../test/unit/bfrops_regex2.c), [`bfrops_alloc_inherit.c`](../../../test/unit/bfrops_alloc_inherit.c) | the two newest `v61` types |
 | [`examples/datatypes.c`](../../../examples/datatypes.c) | one value of every interesting type published by each rank and verified by every other rank |

--- a/src/mca/bfrops/AGENTS.md
+++ b/src/mca/bfrops/AGENTS.md
@@ -23,7 +23,13 @@ how a component maps to a wire-format version, the very large body of
 shared code in `base/`, and the rules you must obey to avoid silently
 breaking cross-version communication. Each component subdirectory
 (`v12/`, `v20/`, `v21/`, `v3/`, `v4/`, `v41/`, `v51/`, `v61/`) carries
-its own `AGENTS.md` describing that version's deltas.
+its own `AGENTS.md` describing that version's deltas, and
+[`base/AGENTS.md`](base/AGENTS.md) covers the shared implementation —
+including the six per-type operations that have to agree with each
+other, the "never read outside the buffer" contract, and the defects
+found in the August 2026 review of that directory. **Read
+[`base/AGENTS.md`](base/AGENTS.md) before editing anything under
+`base/`**, which is where essentially all of the code is.
 
 `bfrops` is the most wire-sensitive framework in the tree. Read the
 top-level interoperability section before touching anything here.
@@ -323,6 +329,7 @@ All under the `pmix_bfrops_base_` prefix:
 |-----------|---------|
 | `initial_size` | starting allocation of a new buffer (default 128 bytes) |
 | `threshold_size` | size at which `buffer_extend` switches from doubling to additive growth (default 1024) |
+| `max_array_depth` | how deeply data arrays may nest before pack and unpack refuse; 0 disables the cap |
 | `default_type` | default `pmix_bfrop_buffer_type_t` for new buffers (described vs. non-described) |
 
 ## Threading
@@ -413,6 +420,33 @@ Regression coverage: `test/unit/run_grpbadinfo.pl` drives
 `examples/group_badinfo`, which hands `PMIx_Group_construct` a
 `PMIX_GROUP_INFO` carrying a scalar and then one carrying a NULL array.
 The second case is the one that exercises this file.
+
+The same reasoning applies to what arrives from a *peer* rather than
+from a caller, and there the stakes are higher because there is no
+caller to blame. See "Nothing here may read outside the buffer it was
+given" in [`base/AGENTS.md`](base/AGENTS.md): a count that outruns its
+payload and a flexible integer truncated mid-encoding were both
+unbounded over-reads, and both are three-byte messages.
+
+## Testing
+
+| Where | What it covers |
+|-------|----------------|
+| [`test/unit/bfrops_darray.c`](../../../test/unit/bfrops_darray.c) | every registered data type used as a data-array element, held across construct / pack / unpack / copy |
+| [`test/unit/bfrops_malformed.c`](../../../test/unit/bfrops_malformed.c) | truncated, lying and hostile input; the flexible-integer encoding boundaries |
+| [`test/unit/nested_darray.c`](../../../test/unit/nested_darray.c) | array nesting and the `max_array_depth` cap |
+| [`test/unit/bfrops_regex2.c`](../../../test/unit/bfrops_regex2.c), [`bfrops_alloc_inherit.c`](../../../test/unit/bfrops_alloc_inherit.c) | the two newest `v61` types |
+| [`examples/datatypes.c`](../../../examples/datatypes.c) | one value of every interesting type published by each rank and verified by every other rank |
+| [`contrib/dockerswarm/run-bfrops-tests.sh`](../../../contrib/dockerswarm/AGENTS.md) | drives `datatypes` with the ranks on **different nodes**, plus the unit programs on Linux in an optimized `--enable-mca-dso` build |
+
+The last two rows exist because of a limit that is easy to overlook: a
+pack/unpack round trip inside one process is self-consistent under *any*
+choice of module and *any* buffer type, so it can never fail on the two
+things a peer actually decides — which module encodes
+(`peer->nptr->compat.bfrops`, assigned from the handshake's version
+string) and whether the buffer is described. Only a real socket between
+two separate PMIx servers makes those observable. Single-process tests
+cover the encoders; the swarm covers the negotiation.
 
 ## When working in this framework — the wire-format rules
 

--- a/src/mca/bfrops/base/AGENTS.md
+++ b/src/mca/bfrops/base/AGENTS.md
@@ -117,9 +117,34 @@ segfaults against a guard page). It now refuses an empty region outright
 and reports truncation rather than assembling a value out of whatever
 bytes happened to be there.
 
+**A length off the wire must not buy an allocation.** The count that
+says how many elements an array holds is packed by the peer, and it
+sized the receiver's allocation directly: a twenty-byte message asking
+for 2^40 int64s got exactly that, and the OOM killer ended the process.
+A count larger than the bytes remaining in the buffer cannot be
+describing anything the peer actually sent, because every element of
+almost every type costs at least one byte to encode - so that is the
+bound, and it needs no per-type knowledge and no arbitrary constant.
+
+Two element types are genuinely sparser and are exempted, or ordinary
+arrays of them stop unpacking: `PMIX_POINTER` packs one sentinel byte
+for the whole array (there is no sense shipping addresses between
+processes), and an array of arrays whose elements are all empty is a
+single type tag in total. The exemption is in the code with that
+reasoning attached; if you add a third sparse encoding, add it there.
+
+Separately, **every allocation sized from the wire needs its NULL
+check**. Twelve of them did not have one, and the pattern was uniform:
+allocate, then `m = <the wire-supplied count>`, then unpack into the
+pointer. When the allocator declines - which a hostile count makes it
+do - that is a write through NULL.
+
 [`test/unit/bfrops_malformed.c`](../../../../test/unit/bfrops_malformed.c)
 covers this, including a stage that truncates a well-formed message at
-every possible offset. Add to it rather than to a scratch program.
+every possible offset and a fuzz stage that pushes random bytes through
+every unpacker. Add to it rather than to a scratch program. Note that
+both defects above were found by that fuzz stage, not by reading -
+which is the argument for keeping it.
 
 ## Defects found in the August 2026 review
 

--- a/src/mca/bfrops/base/AGENTS.md
+++ b/src/mca/bfrops/base/AGENTS.md
@@ -347,6 +347,44 @@ buffer that was already allocated for it.
 `v12` already had a `PMIX_TAINT_INT_LIMIT` guard on the same length, so
 the intent was there; it just tested only one end of the range.
 
+### And a fifth, which only Linux and only one process at a time showed
+
+A `pmix_value_t` keeps its payload in a **24-byte union**, and the type
+tag saying which member is live comes off the wire. Six registered types
+have no member there at all — `PMIX_VALUE`, `PMIX_INFO`, `PMIX_PDATA`,
+`PMIX_APP`, `PMIX_KVAL`, `PMIX_BUFFER` — because they are data-array
+element types rather than things a scalar value can hold. Their C
+representation is *larger than the whole union*: `pmix_pdata_t` is 808
+bytes.
+
+`unpack_val()` hands `&val->data` to the per-type unpacker for anything
+its switch does not name, so a peer that tagged a value with one of
+those got that unpacker to write up to 784 bytes past the end of the
+value — and `unpack_kval()`, `unpack_info()` and `unpack_pdata()` all
+unpack into a value they have just `calloc`'d. **A remote heap buffer
+overflow with attacker-controlled length and contents.** `pack_val()`
+had the mirror of it, reading 552 bytes out of a 24-byte union.
+
+Both directions now refuse those six types, and a `_Static_assert` per
+type keeps the list honest against the union's size in both directions —
+so if the union grows, or a type that fits stops fitting, the build
+fails here instead of the heap failing in the field.
+
+**Two things about how it was found are worth more than the defect.**
+
+It needed *Linux*: `bfrops_darray` and `bfrops_helpers` also segfaulted
+there while passing on macOS, because two `copy_darray()` arms allocated
+with `pmix_tma_malloc()` and then wrote an element only where the source
+had one — leaving the rest as whatever the allocator returned, which the
+destructor then freed. A fresh page reads as zero often enough on macOS
+for that to look correct. Those arms use `pmix_tma_calloc()` now. **If a
+copy arm writes conditionally, it must allocate zeroed.**
+
+And it needed the fuzzer to run *in one process*. A harness that forks
+per input loses the corrupted heap along with the child; the scratch
+version of the fuzzer did exactly that and saw nothing for hours. Run
+the inputs in-process and let glibc's allocator notice.
+
 ## A known inconsistency, deliberately not "fixed"
 
 **`PMIX_REGEX` has two incompatible readings as an array element

--- a/src/mca/bfrops/base/AGENTS.md
+++ b/src/mca/bfrops/base/AGENTS.md
@@ -173,6 +173,55 @@ sake.
   length it writes; a peer need not. Everything downstream treats the
   result as a C string, so the invariant is now enforced on arrival
   rather than assumed.
+- **`PMIX_NODE_PID` was missing from `basic_type_string()`**
+  (`bfrop_base_stubs.c`), so `PMIx_Data_type_string()` called before the
+  framework is initialized reported it as "NOT INITIALIZED".
+
+### And a second cluster, all in `bfrop_base_get_number.c`
+
+`PMIx_Value_get_number()` is two thousand lines of one
+`check_<source>()` per source type, each with one arm per destination
+type. Every arm is a near-copy of its neighbour, which is why five
+separate defects lived in it at once and why none of them was visible
+on review:
+
+- **Three sign checks read the wrong union member.** `check_int16()`,
+  `check_int32()` and `check_int64()` all tested
+  `value->data.integer` instead of their own type's member. Because the
+  union aliases, `data.integer` for a negative `int16_t` is a *positive*
+  32-bit number, so the check never fired and every negative int16 was
+  accepted into every unsigned destination, wrapping silently. The
+  int64 case needed only a value with zeroes in its low word.
+- **`check_int32()`'s narrow-destination arms read `data.int16`** — the
+  `PMIX_INT8` and `PMIX_UINT8` range checks *and* their stores. So an
+  `int32` of 65536 converted to `uint8` as 0, reporting success.
+- **Thirteen `PMIX_PROC_RANK` arms stored the answer and then fell
+  through** with no `return PMIX_SUCCESS`, so *every* conversion to a
+  rank wrote the correct value and reported `PMIX_ERR_BAD_PARAM`.
+- **`PMIX_PID` was not a source type at all.** There was no
+  `check_pid()`, and the dispatcher's `PMIX_PID` branch had no `else`,
+  so every conversion out of a pid returned `PMIX_ERR_BAD_PARAM`.
+- **Range constants.** `check_int64()` bounded `PMIX_PID` and
+  `PMIX_STATUS` — both *signed* 32-bit — by `UINT32_MAX` and did not
+  check the negative side at all. `check_float()` bounded `PMIX_UINT`
+  by `42949670295.0`, a digit too many. Both float and double bounded
+  `PMIX_UINT8` by `256.0` rather than `255.0`, so exactly 256 converted
+  to 0. And `check_double()` used the float-derived `4294967040.0` for
+  `PMIX_UINT32`, refusing values a double represents exactly.
+
+**Refusing a valid conversion is as much a defect as accepting an
+invalid one**, and it is the half that a test written from the arms
+outward will not catch. `test/unit/bfrops_get_number.c` therefore
+asserts both directions over every (source, destination) pair rather
+than enumerating cases; the thirteen missing returns showed up only
+under the second property.
+
+One thing in that file is policy rather than oversight, and is stated in
+`check_rank()`: **a PMIx structured value (`PMIX_PID`, `PMIX_STATUS`,
+`PMIX_PROC_RANK`) is not unloaded into another structured type**, even
+where the underlying C types would permit it. Plain numeric → structured
+is allowed; structured → structured is not. The test encodes that
+exception; do not "fix" it without changing the policy first.
 
 ## A known inconsistency, deliberately not "fixed"
 
@@ -221,6 +270,7 @@ let two threads mutate it at once.
 |-------|----------------|
 | [`test/unit/bfrops_darray.c`](../../../../test/unit/bfrops_darray.c) | every registered type as a data-array element, held across construct / pack / unpack / copy; the typeless-array marker; nested data buffers |
 | [`test/unit/bfrops_malformed.c`](../../../../test/unit/bfrops_malformed.c) | truncated and lying input; flexible-integer boundaries |
+| [`test/unit/bfrops_get_number.c`](../../../../test/unit/bfrops_get_number.c) | `PMIx_Value_get_number` as two properties over every (source, destination) pair |
 | [`test/unit/nested_darray.c`](../../../../test/unit/nested_darray.c) | array nesting and the depth cap |
 | [`test/unit/bfrops_regex2.c`](../../../../test/unit/bfrops_regex2.c) | `PMIX_REGEX2` pack/unpack/copy/print/compare |
 | [`test/unit/bfrops_alloc_inherit.c`](../../../../test/unit/bfrops_alloc_inherit.c) | `PMIX_ALLOC_INHERIT` |

--- a/src/mca/bfrops/base/AGENTS.md
+++ b/src/mca/bfrops/base/AGENTS.md
@@ -223,6 +223,55 @@ where the underlying C types would permit it. Plain numeric → structured
 is allowed; structured → structured is not. The test encodes that
 exception; do not "fix" it without changing the policy first.
 
+### And a third: an absent object is not an absent value
+
+A `pmix_value_t` may be tagged with a type whose payload lives behind a
+pointer and carry no object at all. That is malformed, and it is the
+single easiest malformed value in PMIx to produce — it takes nothing
+more than setting the type before the data:
+
+```c
+pmix_value_t v;
+PMIX_VALUE_CONSTRUCT(&v);
+v.type = PMIX_PROC_INFO;      // and nothing else
+```
+
+Every operation here trusts the type tag — it has to, since the tag is
+the only thing that says which union member is live — and then
+dereferences what it points at. Each therefore has to screen the
+pointer for itself, and each is a separate sixty-arm switch, which is
+why none of them did. Eighty-five (type, operation) pairs segfaulted:
+`PMIx_Value_string`, `PMIx_Info_string`, `PMIx_Value_compare`,
+`PMIx_Value_get_size`, `PMIx_Info_get_size`, `PMIx_Value_xfer`,
+`PMIx_Info_xfer`, `PMIx_Info_list_xfer` and `PMIx_Value_unload`, across
+every pointer-backed type.
+
+The screen is now one predicate,
+`pmix_bfrops_base_value_is_null_object()` in `bfrop_base_fns.c`, applied
+at each of those operations. **Add the call, not another caller-side
+check**: there are hundreds of callers and the value usually comes from
+an application rather than from library code.
+
+Two details worth keeping:
+
+- `print_val()` needed its own copy of the screen even though the
+  dispatcher `pmix_bfrops_base_print()` already screens `src`. That
+  dispatcher receives the *value*; `print_val()` reaches past it and
+  hands each per-type printer the union *member*, so the dispatcher's
+  check never applies to what the printer actually dereferences.
+- `PMIX_DATA_ARRAY` is deliberately excluded from the `value_xfer`
+  screen. `copy_darray()` already answers a NULL source with an *empty
+  array descriptor* rather than a NULL, and callers dereference that
+  result — the group code among them. Zeroing the destination instead
+  would reintroduce the crash one layer up.
+
+`pmix_bfrops_base_value_unload()` had a related but distinct hole. It
+documents that "simple" types are copied into storage the *caller*
+supplies, and rejects a NULL `*data` for those — but the list it checks
+against was missing `PMIX_JOB_STATE`, so that one type reached a
+`memcpy` through a NULL destination instead of returning
+`PMIX_ERR_BAD_PARAM`.
+
 ## A known inconsistency, deliberately not "fixed"
 
 **`PMIX_REGEX` has two incompatible readings as an array element
@@ -271,6 +320,7 @@ let two threads mutate it at once.
 | [`test/unit/bfrops_darray.c`](../../../../test/unit/bfrops_darray.c) | every registered type as a data-array element, held across construct / pack / unpack / copy; the typeless-array marker; nested data buffers |
 | [`test/unit/bfrops_malformed.c`](../../../../test/unit/bfrops_malformed.c) | truncated and lying input; flexible-integer boundaries |
 | [`test/unit/bfrops_get_number.c`](../../../../test/unit/bfrops_get_number.c) | `PMIx_Value_get_number` as two properties over every (source, destination) pair |
+| [`test/unit/bfrops_null_object.c`](../../../../test/unit/bfrops_null_object.c) | every pointer-backed type through every value-level operation with no object attached |
 | [`test/unit/nested_darray.c`](../../../../test/unit/nested_darray.c) | array nesting and the depth cap |
 | [`test/unit/bfrops_regex2.c`](../../../../test/unit/bfrops_regex2.c) | `PMIX_REGEX2` pack/unpack/copy/print/compare |
 | [`test/unit/bfrops_alloc_inherit.c`](../../../../test/unit/bfrops_alloc_inherit.c) | `PMIX_ALLOC_INHERIT` |

--- a/src/mca/bfrops/base/AGENTS.md
+++ b/src/mca/bfrops/base/AGENTS.md
@@ -272,6 +272,42 @@ against was missing `PMIX_JOB_STATE`, so that one type reached a
 `memcpy` through a NULL destination instead of returning
 `PMIX_ERR_BAD_PARAM`.
 
+### And a fourth: the public helpers this directory owns
+
+A large slice of the **installed** PMIx C API is implemented here — the
+whole `PMIx_Argv_*` family, the `PMIx_Info_list_*` builders, and the
+construct/create/load/free helpers for every PMIx struct. It is also
+the part of the API applications call most casually, and every one of
+those entry points is a thin trampoline into a `pmix_bfrops_base_tma_*`
+inline that got its arguments from a caller nobody screened.
+
+Ten of them faulted on an obvious mistake: `PMIx_Argv_append_nosize()`
+and its two siblings on a NULL string or a NULL array pointer;
+`PMIx_Load_procid()`, `PMIx_Check_procid()`, `PMIx_Procid_invalid()`,
+`PMIx_Multicluster_nspace_parse()` and `PMIx_Pdata_load()` on a NULL
+argument; `PMIx_Value_true()` on a NULL value; and
+`PMIx_Info_list_release()` and `PMIx_Info_list_insert()` on a NULL
+list.
+
+`PMIx_Info_list_release(NULL)` is the one that stands out, because a
+release that faults on NULL is a footgun and every other release in
+this file — `PMIx_Info_free`, `PMIx_Data_array_free`, `PMIx_Argv_free`
+— already tolerated one. A caller whose `PMIx_Info_list_start()` failed
+holds exactly that NULL. Every `PMIx_Info_list_*` entry point is now
+screened for a NULL list.
+
+`PMIx_Multicluster_nspace_parse()` had two further problems that a NULL
+check would not have caught: it cleared only the *cluster* half of its
+output while writing the nspace half element by element without ever
+terminating it, so whatever the caller's buffer held before showed
+through; and its copy loop tested the length bound *after* indexing, so
+the last iteration read one past the end of the buffer that bound was
+protecting.
+
+**Put the screen in the `_tma_` inline, not in the `PMIx_` wrapper.**
+The wrappers are one line each and the internal callers go straight to
+the inline, so a check in the wrapper protects only half the callers.
+
 ## A known inconsistency, deliberately not "fixed"
 
 **`PMIX_REGEX` has two incompatible readings as an array element
@@ -321,6 +357,7 @@ let two threads mutate it at once.
 | [`test/unit/bfrops_malformed.c`](../../../../test/unit/bfrops_malformed.c) | truncated and lying input; flexible-integer boundaries |
 | [`test/unit/bfrops_get_number.c`](../../../../test/unit/bfrops_get_number.c) | `PMIx_Value_get_number` as two properties over every (source, destination) pair |
 | [`test/unit/bfrops_null_object.c`](../../../../test/unit/bfrops_null_object.c) | every pointer-backed type through every value-level operation with no object attached |
+| [`test/unit/bfrops_helpers.c`](../../../../test/unit/bfrops_helpers.c) | the public `PMIx_Argv_*` / `PMIx_Info_list_*` / construct-create-load-free helpers on degenerate input, and on ordinary input so the guards did not cost anything |
 | [`test/unit/nested_darray.c`](../../../../test/unit/nested_darray.c) | array nesting and the depth cap |
 | [`test/unit/bfrops_regex2.c`](../../../../test/unit/bfrops_regex2.c) | `PMIX_REGEX2` pack/unpack/copy/print/compare |
 | [`test/unit/bfrops_alloc_inherit.c`](../../../../test/unit/bfrops_alloc_inherit.c) | `PMIX_ALLOC_INHERIT` |

--- a/src/mca/bfrops/base/AGENTS.md
+++ b/src/mca/bfrops/base/AGENTS.md
@@ -308,6 +308,20 @@ protecting.
 The wrappers are one line each and the internal callers go straight to
 the inline, so a check in the wrapper protects only half the callers.
 
+### Legacy components are old, not exempt
+
+`v12` and `v20` carry their own `unpack.c`, and their string unpacker
+had the same two holes the base one did: a negative length off the wire
+reached `malloc()` as a huge `size_t`, and the result was handed back as
+a C string without the terminator being guaranteed. "Do not touch their
+bytes" is about the *encoding*; it does not mean an ancient peer gets to
+be trusted. Neither fix changes a byte on the wire — one refuses input
+the packer never produces, the other writes a terminator inside the
+buffer that was already allocated for it.
+
+`v12` already had a `PMIX_TAINT_INT_LIMIT` guard on the same length, so
+the intent was there; it just tested only one end of the range.
+
 ## A known inconsistency, deliberately not "fixed"
 
 **`PMIX_REGEX` has two incompatible readings as an array element

--- a/src/mca/bfrops/base/AGENTS.md
+++ b/src/mca/bfrops/base/AGENTS.md
@@ -1,0 +1,232 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: `bfrops/base`
+
+This is where essentially all of `bfrops` actually lives. Read the
+framework [`AGENTS.md`](../AGENTS.md) first — it explains why `bfrops`
+is multi-select, what a component is (one wire-format version), and the
+interoperability rules that make editing anything here consequential.
+This file covers what is true of `base/` specifically: the four
+operations and the contract that binds them together, who the callers
+are, and the failure modes this code has actually had.
+
+`base/` is not a component. The eight component directories are almost
+entirely registration tables; the functions they register are all
+`pmix_bfrops_base_*` and are defined here. **A change to a pack or
+unpack byte layout here changes the wire format of every version that
+registers it, simultaneously.**
+
+## The files
+
+| File | Contents |
+|------|----------|
+| [`base.h`](base.h) | the internal API: `pmix_bfrop_type_info_t`, `PMIX_REGISTER_TYPE`, the `PMIX_BFROPS_PACK_TYPE`/`_UNPACK_TYPE` driver macros, `PMIX_SQUASH_TYPE_SIZEOF`, and a prototype for every `pmix_bfrops_base_*` |
+| [`bfrop_base_frame.c`](bfrop_base_frame.c) | framework declaration, the MCA parameters, `pmix_bfrops_globals`, and the `PMIX_CLASS_INSTANCE`s for `pmix_buffer_t`, `pmix_kval_t`, `pmix_bfrop_type_info_t` |
+| [`bfrop_base_select.c`](bfrop_base_select.c) | build the priority-ordered `actives` list; reject a module whose `init` fails |
+| [`bfrop_base_stubs.c`](bfrop_base_stubs.c) | `assign_module` (version string → component), `get_available_modules`, `PMIx_Data_type_string` |
+| [`bfrop_base_pack.c`](bfrop_base_pack.c) | the pack driver and one packer per data type |
+| [`bfrop_base_unpack.c`](bfrop_base_unpack.c) | the mirror-image unpack driver and per-type unpackers |
+| [`bfrop_base_copy.c`](bfrop_base_copy.c) | per-type deep copy, plus `std_copy` for the fixed-size types |
+| [`bfrop_base_print.c`](bfrop_base_print.c) | per-type render-to-string |
+| [`bfrop_base_cmp.c`](bfrop_base_cmp.c) | per-type comparison behind `pmix_bfrops_base_value_cmp` |
+| [`bfrop_base_squash.c`](bfrop_base_squash.c) | the flexible (base-7 varint) integer codec used by every modern component |
+| [`bfrop_base_get_number.c`](bfrop_base_get_number.c) | `PMIx_Value_get_number` and its per-type range/precision checks |
+| [`bfrop_base_fns.c`](bfrop_base_fns.c) | buffer helpers (`buffer_extend`, `too_small`, store/get data type), value load/unload/xfer, and a block of **public** `PMIx_Info_list_*` / `PMIx_Value_get_size` APIs |
+| [`bfrop_base_macro_backers.c`](bfrop_base_macro_backers.c) | the out-of-line bodies behind the public inline `PMIx_*` utility macros (`PMIx_Argv_*`, `PMIx_Value_*`, `PMIx_Info_*`, `PMIx_Load_key`, …) |
+| [`bfrop_base_tma.h`](bfrop_base_tma.h) | the inline TMA (custom-allocator) implementations that nearly everything above delegates to with `tma == NULL` |
+
+The last two matter more than their names suggest: a large slice of the
+**installed public API** is implemented here, not just internal wire
+code. `bfrop_base_tma.h` is the single largest file in the framework and
+holds the real bodies — `pmix_bfrops_base_value_xfer()` in
+`bfrop_base_fns.c` is a one-line call into
+`pmix_bfrops_base_tma_value_xfer()`. When you go looking for what a
+value operation *does*, look in the TMA header.
+
+## Six operations that have to agree, per data type
+
+For any `pmix_data_type_t`, the tree has to answer six questions
+consistently. They are answered in six different places, and every
+defect the August 2026 review of this directory found was two of them
+disagreeing:
+
+| Question | Answered by |
+|----------|-------------|
+| How do I put one on the wire? | `pmix_bfrops_base_pack_<t>` in `bfrop_base_pack.c` |
+| How do I take one off? | `pmix_bfrops_base_unpack_<t>` in `bfrop_base_unpack.c` |
+| How do I deep-copy one? | `pmix_bfrops_base_tma_copy_<t>`, and the `case` for it in `pmix_bfrops_base_tma_value_xfer()` |
+| How big is one **element of an array** of them? | `pmix_bfrops_base_tma_data_array_construct()` |
+| How do I copy an **array** of them? | the `case` for it in `pmix_bfrops_base_tma_copy_darray()` |
+| How do I release an **array** of them? | the `case` for it in `pmix_bfrops_base_tma_data_array_destruct()` |
+
+The last three are the ones that get forgotten, because nothing forces
+them to be written. A type registered in `v61` with pack, unpack and
+copy but no arm in `data_array_construct()` looks completely finished:
+it works as a scalar value, and it packs perfectly well inside an array.
+It only fails on the way *back*, because `unpack_darray()` builds its
+destination with `PMIX_DATA_ARRAY_CONSTRUCT` and gets `size 0, array
+NULL`, which it reports as `PMIX_ERR_NOMEM`. Eighteen registered types
+were in that state.
+
+The width mismatch is worse than the omission, because it does not fail:
+`PMIX_POINTER` was allocated one byte per element by
+`data_array_construct()` and copied `sizeof(char*)` bytes per element by
+`copy_darray()`, so copying such an array read eight times its length.
+
+**If you add a data type, add all six.**
+[`test/unit/bfrops_darray.c`](../../../../test/unit/bfrops_darray.c)
+walks the whole registered type table holding construct, pack/unpack and
+copy against each other; add your type to `all_types[]` there and it is
+covered.
+
+## Nothing here may read outside the buffer it was given
+
+Every byte the unpacker sees came off a socket, including the count that
+says how many values follow. A peer can be truncated, can be running a
+different version than it claimed, or can be hostile. The contract is:
+
+> Returning an error is fine. Returning a wrong value is tolerable.
+> Reading outside the buffer is not.
+
+Two specific things make that easy to get wrong here.
+
+**The count and the payload are independent.** `pmix_bfrops_base_unpack`
+reads a count off the wire and clamps it to the storage the *caller*
+provided — not to the bytes remaining. So a per-type unpacker's loop can
+run more iterations than there is data for, and every one of them has to
+notice for itself. `pmix_bfrops_base_unpack_general_int` did not: it
+checked `pack_ptr == unpack_ptr` once, before the loop, and thereafter
+handed `pmix_bfrops_base_decode_int` an `avail_size` that reached zero
+and kept going.
+
+**The flexible integer decoder's length is decided by the data.** A byte
+with the continuation flag set means "read one more", so the last
+readable byte of a truncated value is an invitation to read past the
+end. `flex_unpack_integer()` bounded its loop with `flex_size - 1`,
+which is `SIZE_MAX` when the available size is zero — an unbounded
+over-read that a three-byte message could trigger, and did (it
+segfaults against a guard page). It now refuses an empty region outright
+and reports truncation rather than assembling a value out of whatever
+bytes happened to be there.
+
+[`test/unit/bfrops_malformed.c`](../../../../test/unit/bfrops_malformed.c)
+covers this, including a stage that truncates a well-formed message at
+every possible offset. Add to it rather than to a scratch program.
+
+## Defects found in the August 2026 review
+
+Recorded because each is a shape that will recur, not for history's
+sake.
+
+- **`flex_unpack_integer()` read past the end of the buffer**
+  (`bfrop_base_squash.c`). `flex_size - 1` underflowed for a zero-length
+  source, and the caller
+  (`pmix_bfrops_base_unpack_general_int`) produced zero-length sources
+  whenever the wire claimed more values than it sent. Remotely
+  triggerable crash. Both ends fixed: the decoder refuses an empty
+  region and signals truncation, and the loop bound no longer wraps.
+- **A typeless array desynchronized the stream** (`bfrop_base_pack.c` /
+  `bfrop_base_unpack.c`). `pack_darray()` wrote a `PMIX_UNDEF` type tag
+  *and* a size; `unpack_darray()` treated the tag as a terminator and
+  never read the size. Everything after it in the message was misread.
+  Reachable without malice: copying a value whose `darray` pointer was
+  NULL produces exactly such a descriptor. The packer now emits the
+  marker the unpacker reads.
+- **`copy_darray()` freed the element block twice** for
+  `PMIX_PROC_CPUSET` (`bfrop_base_tma.h`). It called
+  `pmix_hwloc_release_cpuset()`, which frees the block, and then
+  `pmix_tma_free()` on the same pointer. Reached by any
+  `PMIx_Value_xfer` / `PMIX_INFO_XFER` of a cpuset array whose elements
+  are not valid hwloc objects — which includes every array
+  `PMIx_Data_array_create()` hands back.
+- **An unpacked `PMIX_DATA_BUFFER` could not be read**
+  (`bfrop_base_unpack.c`). `unpack_dbuf()` restored `base_ptr` and
+  `bytes_used` but left `pack_ptr`, `unpack_ptr` and `bytes_allocated`
+  untouched, so the caller got a buffer holding the payload and no way
+  to reach it.
+- **Eighteen registered types could not back a data array**
+  (`bfrop_base_tma.h`). See the six-operations table above.
+- **`PMIX_POINTER` arrays were allocated one byte per element and copied
+  eight** (`bfrop_base_tma.h`) — an over-read of the whole block.
+- **`copy_darray()` cast `pmix_data_buffer_t*` to `pmix_buffer_t*`.**
+  They are not layout-compatible: `pmix_buffer_t` leads with a
+  `pmix_object_t` and a type field. Use `PMIx_Data_copy_payload()` for
+  the public struct and `pmix_bfrops_base_tma_copy_payload()` for the
+  internal one; never cast between them.
+- **`buffer_extend()` used its `realloc` result before checking it**
+  (`bfrop_base_tma.h`) — `memset` through NULL on allocation failure,
+  plus a leak of the old block.
+- **`pack_kval()` dereferenced a NULL `value` pointer**
+  (`bfrop_base_pack.c`). `pmix_kval_t.value` is a pointer and can
+  legitimately be NULL; it now sends an undefined value in its place so
+  the stream stays symmetric.
+- **Unpacked strings were not guaranteed to be terminated**
+  (`bfrop_base_unpack.c`). The packer includes the terminator in the
+  length it writes; a peer need not. Everything downstream treats the
+  result as a C string, so the invariant is now enforced on arrival
+  rather than assumed.
+
+## A known inconsistency, deliberately not "fixed"
+
+**`PMIX_REGEX` has two incompatible readings as an array element
+type.** `pmix_bfrops_base_pack_regex()` and `_unpack_regex()` stride the
+block as `char *` — one regex string per element. `data_array_destruct()`
+strides it as `pmix_byte_object_t`. Those are different widths, so one
+of the two walks off the end of any array with more than one element.
+
+For a *scalar* value the two readings coincide, because `bo.bytes` is
+the first member of the union — which is why `PMIX_REGEX` values work
+correctly everywhere else and why this went unnoticed. It diverges only
+for arrays, and arrays of `PMIX_REGEX` are not constructible today
+(`data_array_construct()` has no arm for the type, so it returns an
+empty descriptor), so nothing currently reaches the divergence.
+
+`PMIX_REGEX` was therefore left out of `data_array_construct()` on
+purpose. Adding an arm for it without first settling which stride is
+correct — and fixing pack, unpack, copy and destruct together — converts
+a clean "unsupported" into a heap error. If you resolve it, resolve all
+four.
+
+## MCA parameters
+
+Registered in `bfrop_base_frame.c`, all under `pmix_bfrops_base_`:
+
+| Parameter | Meaning |
+|-----------|---------|
+| `initial_size` | starting allocation of a new buffer |
+| `threshold_size` | size at which `buffer_extend` stops doubling and grows additively |
+| `max_array_depth` | how deeply data arrays may nest before pack and unpack refuse; 0 disables the cap. A couple of bytes of message buys a stack frame, so this is what stops a peer from sinking the stack — see the depth tests in [`test/unit/nested_darray.c`](../../../../test/unit/nested_darray.c) |
+| `default_type` | described vs. non-described for new buffers; described is the default in `PMIX_ENABLE_DEBUG` builds |
+
+## Threading
+
+Nothing here thread-shifts, blocks, or touches shared state beyond the
+`actives` list and the per-component `types` array, both built once at
+init. These are pure transforms of their arguments and are called
+directly from progress-thread handlers throughout the library. There is
+no caddy pattern. The one rule: the caller owns the buffer, and must not
+let two threads mutate it at once.
+
+## Testing
+
+| Where | What it covers |
+|-------|----------------|
+| [`test/unit/bfrops_darray.c`](../../../../test/unit/bfrops_darray.c) | every registered type as a data-array element, held across construct / pack / unpack / copy; the typeless-array marker; nested data buffers |
+| [`test/unit/bfrops_malformed.c`](../../../../test/unit/bfrops_malformed.c) | truncated and lying input; flexible-integer boundaries |
+| [`test/unit/nested_darray.c`](../../../../test/unit/nested_darray.c) | array nesting and the depth cap |
+| [`test/unit/bfrops_regex2.c`](../../../../test/unit/bfrops_regex2.c) | `PMIX_REGEX2` pack/unpack/copy/print/compare |
+| [`test/unit/bfrops_alloc_inherit.c`](../../../../test/unit/bfrops_alloc_inherit.c) | `PMIX_ALLOC_INHERIT` |
+| [`contrib/dockerswarm/run-bfrops-tests.sh`](../../../../contrib/dockerswarm/AGENTS.md) | the half a single process cannot reach — the peer's module and the negotiated buffer type — by moving every data type between ranks on different nodes |
+
+The last row is the one that is easy to dismiss and should not be. A
+round trip inside one process is self-consistent under any choice of
+module and any buffer type, so it cannot fail on either. Only a real
+socket between two servers makes those choices observable.

--- a/src/mca/bfrops/base/CLAUDE.md
+++ b/src/mca/bfrops/base/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -385,6 +385,30 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_stub_register_type(
 PMIX_EXPORT const char *pmix_bfrops_base_data_type_string(pmix_pointer_array_t *regtypes,
                                                           pmix_data_type_t type);
 
+/**
+ * Does this value claim a type whose payload lives behind a pointer,
+ * and is that pointer NULL?
+ *
+ * Such a value is malformed, but it is the single easiest malformed
+ * value to produce: PMIX_VALUE_CONSTRUCT() followed by an assignment to
+ * .type yields one, as does any caller that builds an info by hand and
+ * fills in the type before the data. The type tag is the only thing
+ * saying which union member is live, so every operation in this
+ * framework trusts it - and then dereferences what it points at.
+ *
+ * The rule that follows, and it is the same one the copy functions
+ * already obey: the operations here must *survive* such a value rather
+ * than fault on it. "Absent" is a state each of them can express - an
+ * empty comparison, a size of zero, an unloaded object of no bytes - so
+ * express it. Reserve an error return for input that cannot be given
+ * any meaning at all.
+ *
+ * Callers cannot be relied upon to screen this; there are hundreds of
+ * them, and the value often arrives from an application rather than
+ * from library code. Screen it at the operation.
+ */
+PMIX_EXPORT bool pmix_bfrops_base_value_is_null_object(const pmix_value_t *v);
+
 /*
  * "Standard" pack functions
  */

--- a/src/mca/bfrops/base/bfrop_base_cmp.c
+++ b/src/mca/bfrops/base/bfrop_base_cmp.c
@@ -1084,6 +1084,20 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p1,
         return PMIX_VALUE_TYPE_DIFFERENT;
     }
 
+    /* Either value may be tagged with a pointer-backed type and carry
+     * no object; see pmix_bfrops_base_value_is_null_object(). Two
+     * absent objects of the same type are equal to each other, and an
+     * absent one cannot be ordered against a present one - but neither
+     * case may be answered by dereferencing it. */
+    if (pmix_bfrops_base_value_is_null_object(p1) ||
+        pmix_bfrops_base_value_is_null_object(p2)) {
+        if (pmix_bfrops_base_value_is_null_object(p1) &&
+            pmix_bfrops_base_value_is_null_object(p2)) {
+            return PMIX_EQUAL;
+        }
+        return PMIX_VALUE_COMPARISON_NOT_AVAIL;
+    }
+
     switch (p1->type) {
     case PMIX_UNDEF:
         return PMIX_EQUAL;

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -228,6 +228,10 @@ pmix_status_t pmix_bfrops_base_copy_info(pmix_info_t **dest, pmix_info_t *src,
     PMIX_HIDE_UNUSED_PARAMS(type);
 
     *dest = (pmix_info_t *) malloc(sizeof(pmix_info_t));
+    if (NULL == *dest) {
+        return PMIX_ERR_NOMEM;
+    }
+    memset(*dest, 0, sizeof(pmix_info_t));
     pmix_strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
     (*dest)->flags = src->flags;
     return pmix_bfrops_base_value_xfer(&(*dest)->value, &src->value);

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -64,6 +64,50 @@ char* pmix_bfrops_base_get_components(void)
     return tmp;
 }
 
+bool pmix_bfrops_base_value_is_null_object(const pmix_value_t *v)
+{
+    if (NULL == v) {
+        return true;
+    }
+    switch (v->type) {
+    case PMIX_PROC:
+    case PMIX_PROC_NSPACE:
+        return (NULL == v->data.proc);
+    case PMIX_PROC_INFO:
+        return (NULL == v->data.pinfo);
+    case PMIX_DATA_ARRAY:
+        return (NULL == v->data.darray);
+    case PMIX_COORD:
+        return (NULL == v->data.coord);
+    case PMIX_TOPO:
+        return (NULL == v->data.topo);
+    case PMIX_PROC_CPUSET:
+        return (NULL == v->data.cpuset);
+    case PMIX_GEOMETRY:
+        return (NULL == v->data.geometry);
+    case PMIX_DEVICE:
+        return (NULL == v->data.device);
+    case PMIX_DEVICE_DIST:
+        return (NULL == v->data.devdist);
+    case PMIX_ENDPOINT:
+        return (NULL == v->data.endpoint);
+    case PMIX_RESOURCE_UNIT:
+        return (NULL == v->data.resunit);
+    case PMIX_NODE_PID:
+        return (NULL == v->data.nodepid);
+    case PMIX_REGEX2:
+        return (NULL == v->data.regex2);
+    case PMIX_REGATTR:
+    case PMIX_DATA_BUFFER:
+        return (NULL == v->data.ptr);
+    default:
+        /* the scalar types keep their payload in the union itself, and
+         * the string and byte-object types already handle a NULL
+         * everywhere they are read */
+        return false;
+    }
+}
+
 void pmix_bfrops_base_value_load(pmix_value_t *v,
                                  const void *data,
                                  pmix_data_type_t type)
@@ -410,6 +454,7 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
         PMIX_RESBLOCK_DIRECTIVE,
         PMIX_ALLOC_INHERIT,
         PMIX_LINK_STATE,
+        PMIX_JOB_STATE,
         PMIX_LOCTYPE,
         PMIX_DEVTYPE,
 
@@ -417,7 +462,7 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
     };
 
     rc = PMIX_SUCCESS;
-    if (NULL == data) {
+    if (NULL == kv || NULL == data || NULL == sz) {
         return PMIX_ERR_BAD_PARAM;
     }
     if (NULL == *data) {
@@ -427,6 +472,13 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv, void **data, size_
                 return PMIX_ERR_BAD_PARAM;
             }
         }
+    }
+    /* an object that is not there unloads as no bytes; see
+     * pmix_bfrops_base_value_is_null_object() */
+    if (pmix_bfrops_base_value_is_null_object(kv)) {
+        *data = NULL;
+        *sz = 0;
+        return PMIX_SUCCESS;
     }
 
     switch (kv->type) {
@@ -1424,6 +1476,16 @@ pmix_status_t PMIx_Value_get_size(const pmix_value_t *v,
     size_t n;
     pmix_regattr_t *regattr;
     pmix_node_pid_t *ndpd;
+
+    if (NULL == sz) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    /* an object that is not there occupies nothing; see
+     * pmix_bfrops_base_value_is_null_object() */
+    if (pmix_bfrops_base_value_is_null_object(v)) {
+        *sz = 0;
+        return PMIX_SUCCESS;
+    }
 
     switch (v->type) {
         case PMIX_UNDEF:

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -875,6 +875,9 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add(void *ptr,
     pmix_list_t *p = (pmix_list_t *) ptr;
     pmix_infolist_t *iptr;
 
+    if (NULL == p) {
+        return PMIX_ERR_BAD_PARAM;
+    }
     iptr = PMIX_NEW(pmix_infolist_t);
     if (NULL == iptr) {
         return PMIX_ERR_NOMEM;
@@ -892,6 +895,10 @@ pmix_status_t PMIx_Info_list_add_unique(void *ptr,
 {
     pmix_list_t *p = (pmix_list_t *) ptr;
     pmix_infolist_t *iptr;
+
+    if (NULL == p) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     // see if this key is already on the list
     PMIX_LIST_FOREACH(iptr, p, pmix_infolist_t) {
@@ -922,6 +929,10 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add_value(void *ptr,
     pmix_infolist_t *iptr;
     pmix_status_t rc;
 
+    if (NULL == p) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     iptr = PMIX_NEW(pmix_infolist_t);
     if (NULL == iptr) {
         return PMIX_ERR_NOMEM;
@@ -944,6 +955,10 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_add_value_unique(void *ptr,
     pmix_list_t *p = (pmix_list_t *) ptr;
     pmix_infolist_t *iptr;
     pmix_status_t rc;
+
+    if (NULL == p) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     // see if this key is already on the list
     PMIX_LIST_FOREACH(iptr, p, pmix_infolist_t) {
@@ -979,6 +994,10 @@ pmix_status_t PMIx_Info_list_prepend(void *ptr,
     pmix_list_t *p = (pmix_list_t *) ptr;
     pmix_infolist_t *iptr;
 
+    if (NULL == p) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     iptr = PMIX_NEW(pmix_infolist_t);
     if (NULL == iptr) {
         return PMIX_ERR_NOMEM;
@@ -994,6 +1013,9 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_insert(void *ptr,
     pmix_list_t *p = (pmix_list_t *) ptr;
     pmix_infolist_t *iptr;
 
+    if (NULL == p || NULL == info) {
+        return PMIX_ERR_BAD_PARAM;
+    }
     iptr = PMIX_NEW(pmix_infolist_t);
     if (NULL == iptr) {
         return PMIX_ERR_NOMEM;
@@ -1013,6 +1035,10 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer(void *ptr, const pmix_info_t *info
     pmix_list_t *p = (pmix_list_t *) ptr;
     pmix_infolist_t *iptr;
 
+    if (NULL == p || NULL == info) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     iptr = PMIX_NEW(pmix_infolist_t);
     if (NULL == iptr) {
         return PMIX_ERR_NOMEM;
@@ -1028,6 +1054,10 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_xfer_unique(void *ptr, const pmix_info_
     pmix_list_t *p = (pmix_list_t *) ptr;
     pmix_infolist_t *iptr;
     pmix_status_t rc;
+
+    if (NULL == p || NULL == info) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     // see if this key is already on the list
     PMIX_LIST_FOREACH(iptr, p, pmix_infolist_t) {
@@ -1061,7 +1091,7 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_convert(void *ptr, pmix_data_array_t *p
     pmix_infolist_t *iptr;
     pmix_info_t *array;
 
-    if (NULL == par || NULL == ptr) {
+    if (NULL == p || NULL == par) {
         return PMIX_ERR_BAD_PARAM;
     }
     PMIX_DATA_ARRAY_INIT(par, PMIX_INFO);
@@ -1091,6 +1121,14 @@ PMIX_EXPORT pmix_status_t PMIx_Info_list_convert(void *ptr, pmix_data_array_t *p
 PMIX_EXPORT void PMIx_Info_list_release(void *ptr)
 {
     pmix_list_t *p = (pmix_list_t *) ptr;
+
+    /* releasing nothing is not an error. Every other release in this
+     * file - PMIx_Info_free, PMIx_Data_array_free, PMIx_Argv_free -
+     * tolerates a NULL, and a caller that got its list from a failed
+     * PMIx_Info_list_start() holds exactly that. */
+    if (NULL == p) {
+        return;
+    }
     PMIX_LIST_RELEASE(p);
 }
 
@@ -1101,6 +1139,15 @@ pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **next)
     pmix_list_item_t *prv = (pmix_list_item_t*)prev;
     pmix_infolist_t *active;
 
+    if (NULL == p || NULL == next) {
+        return NULL;
+    }
+    if (0 == pmix_list_get_size(p)) {
+        /* an empty list has no first item to hand back, and
+         * pmix_list_get_first() on one returns the sentinel */
+        *next = NULL;
+        return NULL;
+    }
     if (NULL == prev) {
         prv = pmix_list_get_first(p);
         active = (pmix_infolist_t*)prv;
@@ -1118,6 +1165,10 @@ pmix_info_t* PMIx_Info_list_get_info(void *ptr, void *prev, void **next)
 size_t PMIx_Info_list_get_size(void *ptr)
 {
     pmix_list_t *p = (pmix_list_t *) ptr;
+
+    if (NULL == p) {
+        return 0;
+    }
 
     return pmix_list_get_size(p);
 }

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -49,6 +49,11 @@ char* pmix_bfrops_base_get_components(void)
     // cycle across the available components
     PMIX_LIST_FOREACH(mod, &pmix_bfrops_globals.actives, pmix_bfrops_base_active_module_t) {
         ptr = strrchr(mod->component->base.pmix_mca_component_name, 'v');
+        if (NULL == ptr) {
+            /* every component is named "vNN", but do not turn a naming
+             * slip in a new component into a NULL dereference here */
+            continue;
+        }
         ++ptr;
         pmix_asprintf(&tmp, "PMIX_SERVER_URI%s", ptr);
         PMIx_Argv_append_nosize(&list, tmp);

--- a/src/mca/bfrops/base/bfrop_base_get_number.c
+++ b/src/mca/bfrops/base/bfrop_base_get_number.c
@@ -86,6 +86,9 @@ static pmix_status_t check_rank(const pmix_value_t *value,
 static pmix_status_t check_status(const pmix_value_t *value,
                                   void *dest, pmix_data_type_t type);
 
+static pmix_status_t check_pid(const pmix_value_t *value,
+                               void *dest, pmix_data_type_t type);
+
 pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
                                     void *dest, pmix_data_type_t type)
 {
@@ -238,6 +241,8 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
             p = (pid_t*)dest;
             *p = value->data.pid;
             return PMIX_SUCCESS;
+        } else {
+            return check_pid(value, dest, type);
         }
     }
 
@@ -403,6 +408,7 @@ static pmix_status_t check_size(const pmix_value_t *value,
         }
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.size;
+        return PMIX_SUCCESS;
     }
 
     // get here if the destination is a non-numerical type
@@ -491,6 +497,7 @@ static pmix_status_t check_int(const pmix_value_t *value,
         // rank is an unsigned int
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.integer;
+        return PMIX_SUCCESS;
     }
 
     // if we get here, then we are dealing with a smaller
@@ -662,6 +669,7 @@ static pmix_status_t check_int8(const pmix_value_t *value,
     if (PMIX_PROC_RANK == type) {
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.int8;
+        return PMIX_SUCCESS;
     }
 
     // get here if the destination is a non-numerical type
@@ -688,7 +696,7 @@ static pmix_status_t check_int16(const pmix_value_t *value,
     pmix_rank_t *pr;
 
     // check if this xfer would change sign
-    if (0 > value->data.integer) {
+    if (0 > value->data.int16) {
         if (PMIX_SIZE == type ||
             PMIX_UINT == type ||
             PMIX_UINT8 == type ||
@@ -770,6 +778,7 @@ static pmix_status_t check_int16(const pmix_value_t *value,
         // rank is an unsigned int
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.int16;
+        return PMIX_SUCCESS;
     }
 
     // if we get here, then we are dealing with a smaller
@@ -821,7 +830,7 @@ static pmix_status_t check_int32(const pmix_value_t *value,
     pmix_rank_t *pr;
 
     // check if this xfer would change sign
-    if (0 > value->data.integer) {
+    if (0 > value->data.int32) {
         if (PMIX_SIZE == type ||
             PMIX_UINT == type ||
             PMIX_UINT8 == type ||
@@ -893,22 +902,23 @@ static pmix_status_t check_int32(const pmix_value_t *value,
         // rank is an unsigned int
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.int32;
+        return PMIX_SUCCESS;
     }
 
     // if we get here, then we are dealing with a smaller
     // destination, which means we can lose precision
     if (PMIX_INT8 == type) {
-        if (0 < value->data.int16) {
-            if (INT8_MAX < value->data.int16) {
+        if (0 < value->data.int32) {
+            if (INT8_MAX < value->data.int32) {
                 return PMIX_ERR_LOST_PRECISION;
             }
         } else {
-            if (INT8_MIN > value->data.int16) {
+            if (INT8_MIN > value->data.int32) {
                 return PMIX_ERR_LOST_PRECISION;
             }
         }
         i8 = (int8_t*)dest;
-        *i8 = (int8_t)value->data.int16;
+        *i8 = (int8_t)value->data.int32;
         return PMIX_SUCCESS;
     }
     if (PMIX_INT16 == type) {
@@ -926,11 +936,11 @@ static pmix_status_t check_int32(const pmix_value_t *value,
         return PMIX_SUCCESS;
     }
     if (PMIX_UINT8 == type) {
-        if (UINT8_MAX < value->data.int16) {
+        if (UINT8_MAX < value->data.int32) {
             return PMIX_ERR_LOST_PRECISION;
         }
         u8 = (uint8_t*)dest;
-        *u8 = (uint8_t)value->data.int16;
+        *u8 = (uint8_t)value->data.int32;
         return PMIX_SUCCESS;
     }
     if (PMIX_UINT16 == type) {
@@ -966,7 +976,7 @@ static pmix_status_t check_int64(const pmix_value_t *value,
     pmix_rank_t *pr;
 
     // check if this xfer would change sign
-    if (0 > value->data.integer) {
+    if (0 > value->data.int64) {
         if (PMIX_SIZE == type ||
             PMIX_UINT == type ||
             PMIX_UINT8 == type ||
@@ -1098,22 +1108,23 @@ static pmix_status_t check_int64(const pmix_value_t *value,
     }
 
     if (PMIX_PID == type) {
-        // pid_t is a signed int
-        if (0 < value->data.int64) {
-            if (UINT32_MAX < value->data.int64) {
-                return PMIX_ERR_LOST_PRECISION;
-            }
+        // pid_t is a SIGNED 32-bit int, so its range is INT32's and not
+        // UINT32's - bounding it by UINT32_MAX let everything from
+        // INT32_MAX+1 up wrap to a negative pid, and left the whole
+        // negative side unchecked
+        if (INT32_MAX < value->data.int64 ||
+            INT32_MIN > value->data.int64) {
+            return PMIX_ERR_LOST_PRECISION;
         }
         pid = (pid_t*)dest;
         *pid = (pid_t)value->data.int64;
         return PMIX_SUCCESS;
     }
     if (PMIX_STATUS == type) {
-        // status is a signed int
-        if (0 < value->data.int64) {
-            if (UINT32_MAX < value->data.int64) {
-                return PMIX_ERR_LOST_PRECISION;
-            }
+        // status is likewise a signed 32-bit int
+        if (INT32_MAX < value->data.int64 ||
+            INT32_MIN > value->data.int64) {
+            return PMIX_ERR_LOST_PRECISION;
         }
         ps = (pmix_status_t*)dest;
         *ps = (pmix_status_t)value->data.int64;
@@ -1126,6 +1137,7 @@ static pmix_status_t check_int64(const pmix_value_t *value,
         }
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.int64;
+        return PMIX_SUCCESS;
     }
 
     // get here if the destination is a non-numerical type
@@ -1182,6 +1194,7 @@ static pmix_status_t check_uint(const pmix_value_t *value,
         // rank is an unsigned int
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.uint;
+        return PMIX_SUCCESS;
     }
 
     // if we get here, then we are dealing with a smaller
@@ -1354,6 +1367,7 @@ static pmix_status_t check_uint8(const pmix_value_t *value,
         // rank is an unsigned int
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.uint8;
+        return PMIX_SUCCESS;
     }
 
     if (PMIX_PID == type) {
@@ -1468,6 +1482,7 @@ static pmix_status_t check_uint16(const pmix_value_t *value,
         // rank is an unsigned int
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.uint16;
+        return PMIX_SUCCESS;
     }
 
     if (PMIX_PID == type) {
@@ -1591,6 +1606,7 @@ static pmix_status_t check_uint32(const pmix_value_t *value,
         // rank is an unsigned int
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.uint32;
+        return PMIX_SUCCESS;
     }
 
     if (PMIX_PID == type) {
@@ -1732,6 +1748,7 @@ static pmix_status_t check_uint64(const pmix_value_t *value,
         }
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.uint64;
+        return PMIX_SUCCESS;
     }
 
     if (PMIX_PID == type) {
@@ -1841,7 +1858,9 @@ static pmix_status_t check_float(const pmix_value_t *value,
     }
 
     if (PMIX_UINT == type) {
-        if (42949670295.0 < value->data.fval) {
+        /* 4294967295, not 42949670295 - the extra digit let every float
+         * from UINT_MAX+1 up to ten billion through to wrap silently */
+        if (4294967295.0 < value->data.fval) {
             return PMIX_ERR_LOST_PRECISION;
         }
         u = (unsigned int *)dest;
@@ -1849,7 +1868,7 @@ static pmix_status_t check_float(const pmix_value_t *value,
         return PMIX_SUCCESS;
     }
     if (PMIX_UINT8 == type) {
-        if (256.0 < value->data.fval) {
+        if (255.0 < value->data.fval) {
             return PMIX_ERR_LOST_PRECISION;
         }
         u8 = (uint8_t*)dest;
@@ -1901,6 +1920,7 @@ static pmix_status_t check_float(const pmix_value_t *value,
         }
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.fval;
+        return PMIX_SUCCESS;
     }
 
     if (PMIX_PID == type) {
@@ -2017,7 +2037,7 @@ static pmix_status_t check_double(const pmix_value_t *value,
         return PMIX_SUCCESS;
     }
     if (PMIX_UINT8 == type) {
-        if (256.0 < value->data.dval) {
+        if (255.0 < value->data.dval) {
             return PMIX_ERR_LOST_PRECISION;
         }
         u8 = (uint8_t*)dest;
@@ -2033,7 +2053,7 @@ static pmix_status_t check_double(const pmix_value_t *value,
         return PMIX_SUCCESS;
     }
     if (PMIX_UINT32 == type) {
-        if (4294967040.0 < value->data.dval) {
+        if (4294967295.0 < value->data.dval) {
             return PMIX_ERR_LOST_PRECISION;
         }
         u32 = (uint32_t*)dest;
@@ -2062,11 +2082,12 @@ static pmix_status_t check_double(const pmix_value_t *value,
     }
     if (PMIX_PROC_RANK == type) {
         // rank is an unsigned int
-        if (4294967040.0 < value->data.dval) {
+        if (4294967295.0 < value->data.dval) {
             return PMIX_ERR_LOST_PRECISION;
         }
         pr = (pmix_rank_t*)dest;
         *pr = (pmix_rank_t)value->data.dval;
+        return PMIX_SUCCESS;
     }
 
     if (PMIX_PID == type) {
@@ -2333,6 +2354,135 @@ static pmix_status_t check_status(const pmix_value_t *value,
     if (PMIX_UINT32 == type) {
         u32 = (uint32_t*)dest;
         *u32 = (uint32_t)value->data.status;
+        return PMIX_SUCCESS;
+    }
+
+    // as in check_rank(): a PMIx structured value is not unloaded into
+    // another PMIx structured value type
+
+    /* get here if the destination is a non-numerical type
+     * or a mismatched structured type */
+    return PMIX_ERR_BAD_PARAM;
+}
+
+/* pid_t is a signed 32-bit integer, exactly like pmix_status_t, so this
+ * mirrors check_status(). It reads value->data.pid rather than leaning
+ * on the two sharing a union offset - that assumption is precisely what
+ * made several of the sign checks in this file silently ineffective. */
+static pmix_status_t check_pid(const pmix_value_t *value,
+                               void *dest, pmix_data_type_t type)
+{
+    int *i;
+    int8_t *i8;
+    int16_t *i16;
+    int32_t *i32;
+    int64_t *i64;
+    unsigned int *ui;
+    uint8_t *u8;
+    uint16_t *u16;
+    uint32_t *u32;
+    uint64_t *u64;
+    size_t *sz;
+    float *flt;
+    double *dbl;
+
+    // check if this xfer would change sign
+    if (0 > value->data.pid) {
+        if (PMIX_SIZE == type ||
+            PMIX_UINT == type ||
+            PMIX_UINT8 == type ||
+            PMIX_UINT16 == type ||
+            PMIX_UINT32 == type ||
+            PMIX_UINT64 == type) {
+            return PMIX_ERR_CHANGE_SIGN;
+        }
+    }
+
+    /* the negative case is settled, and there is no loss of precision
+     * for a destination at least as wide */
+
+    if (PMIX_INT == type) {
+        i = (int*)dest;
+        *i = (int)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_INT32 == type) {
+        i32 = (int32_t*)dest;
+        *i32 = (int32_t)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_INT64 == type) {
+        i64 = (int64_t*)dest;
+        *i64 = (int64_t)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_UINT == type) {
+        ui = (unsigned int*)dest;
+        *ui = (unsigned int)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_UINT32 == type) {
+        u32 = (uint32_t*)dest;
+        *u32 = (uint32_t)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_UINT64 == type) {
+        u64 = (uint64_t*)dest;
+        *u64 = (uint64_t)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_SIZE == type) {
+        sz = (size_t*)dest;
+        *sz = (size_t)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_FLOAT == type) {
+        flt = (float*)dest;
+        *flt = (float)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_DOUBLE == type) {
+        dbl = (double*)dest;
+        *dbl = (double)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+
+    // as in check_rank(): a PMIx structured value is not unloaded into
+    // another PMIx structured value type
+
+    // narrower destinations, where precision can be lost
+    if (PMIX_INT8 == type) {
+        if (INT8_MAX < value->data.pid ||
+            INT8_MIN > value->data.pid) {
+            return PMIX_ERR_LOST_PRECISION;
+        }
+        i8 = (int8_t*)dest;
+        *i8 = (int8_t)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_INT16 == type) {
+        if (INT16_MAX < value->data.pid ||
+            INT16_MIN > value->data.pid) {
+            return PMIX_ERR_LOST_PRECISION;
+        }
+        i16 = (int16_t*)dest;
+        *i16 = (int16_t)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_UINT8 == type) {
+        if (UINT8_MAX < value->data.pid) {
+            return PMIX_ERR_LOST_PRECISION;
+        }
+        u8 = (uint8_t*)dest;
+        *u8 = (uint8_t)value->data.pid;
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_UINT16 == type) {
+        if (UINT16_MAX < value->data.pid) {
+            return PMIX_ERR_LOST_PRECISION;
+        }
+        u16 = (uint16_t*)dest;
+        *u16 = (uint16_t)value->data.pid;
         return PMIX_SUCCESS;
     }
 

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -998,6 +998,18 @@ pmix_status_t pmix_bfrops_base_pack_val(pmix_pointer_array_t *regtypes, pmix_buf
         }
         break;
     default:
+        /* The mirror of the guard in pmix_bfrops_base_unpack_val(): the
+         * types listed there are larger than the value union, so
+         * handing &p->data to their packer reads past the end of the
+         * value. Same list, opposite direction - reading 784 bytes out
+         * of a 24-byte union rather than writing into it. */
+        if (PMIX_VALUE == p->type || PMIX_INFO == p->type ||
+            PMIX_PDATA == p->type || PMIX_APP == p->type ||
+            PMIX_KVAL == p->type || PMIX_BUFFER == p->type) {
+            pmix_output(0, "PACK-PMIX-VALUE[%s:%d]: TYPE %s CANNOT BE CARRIED BY A VALUE",
+                        __FILE__, __LINE__, PMIx_Data_type_string(p->type));
+            return PMIX_ERR_BAD_PARAM;
+        }
         /* pass the address of the value instead of the value itself */
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &p->data, 1, p->type, regtypes);
         if (PMIX_ERR_UNKNOWN_DATA_TYPE == ret) {

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -681,8 +681,21 @@ pmix_status_t pmix_bfrops_base_pack_kval(pmix_pointer_array_t *regtypes, pmix_bu
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        /* pack the value */
-        PMIX_BFROPS_PACK_TYPE(ret, buffer, ptr[i].value, 1, PMIX_VALUE, regtypes);
+        /* pack the value. The value member is a pointer, so it can be
+         * NULL - a freshly constructed kval, or an element of a kval
+         * array the caller has not filled in yet, is exactly that. Send
+         * an undefined value in its place rather than dereferencing it:
+         * the unpacker allocates a value and reads a type tag either
+         * way, so the stream stays symmetric. */
+        if (NULL == ptr[i].value) {
+            pmix_value_t undef;
+
+            memset(&undef, 0, sizeof(undef));
+            undef.type = PMIX_UNDEF;
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, &undef, 1, PMIX_VALUE, regtypes);
+        } else {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, ptr[i].value, 1, PMIX_VALUE, regtypes);
+        }
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
@@ -839,12 +852,24 @@ static pmix_status_t pack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t *
         if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, p[i].type))) {
             return ret;
         }
+        /* An undefined element type is the same "there is no array here"
+         * marker the NULL-pointer case above emits, and the unpacker
+         * reads it that way: it stops as soon as it sees the tag and
+         * does not look for a size. Emitting one here would leave that
+         * size in the stream for whatever is unpacked next to misread,
+         * so mirror the unpacker exactly and stop. An array descriptor
+         * with no element type is trivially produced - copying a value
+         * whose darray pointer was NULL yields one - so this is not a
+         * theoretical case. */
+        if (PMIX_UNDEF == p[i].type) {
+            return PMIX_SUCCESS;
+        }
         /* pack the number of array elements */
         PMIX_BFROPS_PACK_TYPE(ret, buffer, &p[i].size, 1, PMIX_SIZE, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        if (0 == p[i].size || PMIX_UNDEF == p[i].type) {
+        if (0 == p[i].size) {
             /* nothing left to do */
             continue;
         }

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -645,6 +645,19 @@ static int print_val(char **output, pmix_value_t *src)
     int rc;
     char *tp;
 
+    /* The per-type printers below cannot be relied on to notice an
+     * absent object: the dispatcher pmix_bfrops_base_print() screens its
+     * src, but this function reaches past it to hand each printer the
+     * union *member* rather than the value, so that screen never
+     * applies. Do it here, once, where every pointer-valued case
+     * passes. */
+    if (pmix_bfrops_base_value_is_null_object(src)) {
+        pmix_asprintf(&tp, " Data type: %s\tValue: NULL pointer",
+                      PMIx_Data_type_string(src->type));
+        *output = tp;
+        return PMIX_SUCCESS;
+    }
+
     switch (src->type) {
         case PMIX_UNDEF:
             tp = strdup(" Data type: PMIX_UNDEF");

--- a/src/mca/bfrops/base/bfrop_base_squash.c
+++ b/src/mca/bfrops/base/bfrop_base_squash.c
@@ -209,7 +209,7 @@
 static size_t flex_pack_integer(size_t val, uint8_t out_buf[FLEX_BASE7_MAX_BUF_SIZE]);
 
 static size_t flex_unpack_integer(const uint8_t in_buf[], size_t buf_size, size_t *out_val,
-                                  size_t *out_val_size);
+                                  size_t *out_val_size, bool *truncated);
 
 pmix_status_t pmix_bfrops_base_get_max_size(pmix_data_type_t type, size_t *size)
 {
@@ -245,13 +245,32 @@ pmix_status_t pmix_bfrops_base_decode_int(pmix_data_type_t type, void *src, size
     pmix_status_t rc = PMIX_SUCCESS;
     size_t tmp;
     size_t val_size, unpack_val_size;
+    bool truncated = false;
 
     PMIX_SQUASH_TYPE_SIZEOF(rc, type, val_size);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    *dst_size = flex_unpack_integer(src, src_len, &tmp, &unpack_val_size);
+    /* refuse an empty source region. flex_unpack_integer must read at
+     * least one byte to make any progress, so handing it a zero length
+     * is not "decode nothing" - it is a read past the end of whatever
+     * the caller handed us. A peer that truncates a message, or that
+     * simply claims more values than it sent, gets us here, so this is
+     * reachable from the wire and not just from a local programming
+     * mistake. */
+    if (0 == src_len) {
+        *dst_size = 0;
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+    *dst_size = flex_unpack_integer(src, src_len, &tmp, &unpack_val_size, &truncated);
+    if (truncated) {
+        /* the last byte we were allowed to read still had its
+         * continuation flag set, so the encoded value does not fit in
+         * what the peer actually sent us */
+        *dst_size = 0;
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
 
     if (val_size < unpack_val_size) { // sanity check
         rc = PMIX_ERR_UNPACK_FAILURE;
@@ -301,9 +320,17 @@ static size_t flex_pack_integer(size_t val, uint8_t out_buf[FLEX_BASE7_MAX_BUF_S
 
 /*
  * See a comment to `pmix_bfrops_pack_flex` for additional details.
+ *
+ * Never reads more than buf_size bytes from in_buf. The caller must not
+ * pass buf_size == 0 - one byte is the shortest legal encoding, so there
+ * is nothing this can do with an empty region except read past its end.
+ * If we run out of bytes while the continuation flag is still set, the
+ * encoded value was truncated in transit (or the peer lied about how
+ * many values it sent); say so rather than silently returning a value
+ * assembled from the bytes that happened to be there.
  */
 static size_t flex_unpack_integer(const uint8_t in_buf[], size_t buf_size, size_t *out_val,
-                                  size_t *out_val_size)
+                                  size_t *out_val_size, bool *truncated)
 {
     size_t value = 0, shift = 0, shift_last = 0;
     size_t idx = 0;
@@ -311,24 +338,33 @@ static size_t flex_unpack_integer(const uint8_t in_buf[], size_t buf_size, size_
     uint8_t hi_bit = 0;
     size_t flex_size = buf_size;
 
+    *truncated = false;
+
     /* restrict the buf size to max flex size */
     if (buf_size > FLEX_BASE7_MAX_BUF_SIZE) {
         flex_size = FLEX_BASE7_MAX_BUF_SIZE;
     }
 
+    /* the first SIZEOF_SIZE_T bytes carry seven bits apiece; only the
+     * final byte of a maximal encoding carries a full eight */
     do {
         val = in_buf[idx++];
         val_last = val;
         shift_last = shift;
         value = value + (((uint64_t) val & FLEX_BASE7_MASK) << shift);
         shift += FLEX_BASE7_SHIFT;
-    } while (PMIX_UNLIKELY((val & FLEX_BASE7_CONT_FLAG) && (idx < (flex_size - 1))));
-    /* If we have leftover (VERY unlikely) */
-    if (PMIX_UNLIKELY((flex_size - 1) == idx && (val & FLEX_BASE7_CONT_FLAG))) {
-        val = in_buf[idx++];
-        val_last = val;
-        value = value + ((uint64_t) val << shift);
-        shift_last = shift;
+    } while (PMIX_UNLIKELY((val & FLEX_BASE7_CONT_FLAG) && (idx < SIZEOF_SIZE_T)
+                           && (idx < flex_size)));
+    if (PMIX_UNLIKELY(0 != (val & FLEX_BASE7_CONT_FLAG))) {
+        /* If we have leftover (VERY unlikely) */
+        if (SIZEOF_SIZE_T == idx && idx < flex_size) {
+            val = in_buf[idx++];
+            val_last = val;
+            value = value + ((uint64_t) val << shift);
+            shift_last = shift;
+        } else {
+            *truncated = true;
+        }
     }
     /* compute the most significant bit of val */
     while (val_last != 0) {

--- a/src/mca/bfrops/base/bfrop_base_stubs.c
+++ b/src/mca/bfrops/base/bfrop_base_stubs.c
@@ -170,6 +170,8 @@ static const char *basic_type_string(pmix_data_type_t type)
         return "PMIX_REGEX2";
     case PMIX_ALLOC_INHERIT:
         return "PMIX_ALLOC_INHERIT";
+    case PMIX_NODE_PID:
+        return "PMIX_NODE_PID";
     default:
         return "NOT INITIALIZED";
     }

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -3392,6 +3392,18 @@ pmix_status_t pmix_bfrops_base_tma_value_xfer(pmix_value_t *p,
 
     /* copy the right field */
     p->type = src->type;
+    /* A source tagged with a pointer-backed type and carrying no object
+     * is malformed but trivially constructible; see
+     * pmix_bfrops_base_value_is_null_object(). Produce the same absence
+     * in the destination rather than dereferencing it. PMIX_DATA_ARRAY
+     * is excluded because copy_darray() already has its own answer for
+     * a NULL source - an empty array descriptor - and callers depend on
+     * getting that rather than a NULL back. */
+    if (PMIX_DATA_ARRAY != src->type &&
+        pmix_bfrops_base_value_is_null_object(src)) {
+        memset(&p->data, 0, sizeof(p->data));
+        return PMIX_SUCCESS;
+    }
     switch (src->type) {
     case PMIX_UNDEF:
         break;

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -305,6 +305,10 @@ bool pmix_bfrops_base_tma_check_procid(const pmix_proc_t *a,
                                        const pmix_proc_t *b,
                                        pmix_tma_t *tma)
 {
+    if (NULL == a || NULL == b) {
+        /* two absent procs are the same proc; one is not the other */
+        return (a == b);
+    }
     if (!pmix_bfrops_base_tma_check_nspace(a->nspace, b->nspace, tma)) {
         return false;
     }
@@ -315,6 +319,9 @@ static inline
 bool pmix_bfrops_base_tma_procid_invalid(const pmix_proc_t *p,
                                          pmix_tma_t *tma)
 {
+    if (NULL == p) {
+        return true;
+    }
     if (pmix_bfrops_base_tma_nspace_invalid(p->nspace, tma)) {
         return true;
     }
@@ -343,6 +350,11 @@ void pmix_bfrops_base_tma_load_procid(pmix_proc_t *p,
                                       pmix_rank_t rk,
                                       pmix_tma_t *tma)
 {
+    /* screen the destination: this is a public entry point
+     * (PMIx_Load_procid) and the caller may have got it wrong */
+    if (NULL == p) {
+        return;
+    }
     pmix_bfrops_base_tma_load_nspace(p->nspace, ns, tma);
     p->rank = rk;
 }
@@ -466,9 +478,25 @@ void pmix_bfrops_base_tma_multicluster_nspace_parse(pmix_nspace_t target,
 {
     size_t n, j;
 
+    if (NULL == cluster || NULL == nspace) {
+        return;
+    }
+    /* clear BOTH outputs, not just the cluster half: the caller's
+     * nspace buffer is written element by element below and never
+     * terminated, so whatever it held before showed through */
     pmix_bfrops_base_tma_load_nspace(cluster, NULL, tma);
-    for (n=0; '\0' != target[n] && ':' != target[n] && n < PMIX_MAX_NSLEN; n++) {
+    pmix_bfrops_base_tma_load_nspace(nspace, NULL, tma);
+    if (NULL == target) {
+        return;
+    }
+    /* test the bound BEFORE indexing, or the last iteration reads one
+     * past the end of the buffer it is bounding */
+    for (n=0; n < PMIX_MAX_NSLEN && '\0' != target[n] && ':' != target[n]; n++) {
         cluster[n] = target[n];
+    }
+    if (PMIX_MAX_NSLEN <= n || '\0' == target[n]) {
+        /* no separator, so there is no nspace half to parse */
+        return;
     }
     n++;
     for (j=0; n < PMIX_MAX_NSLEN && '\0' != target[n]; n++, j++) {
@@ -600,6 +628,12 @@ pmix_boolean_t pmix_bfrops_base_tma_value_true(const pmix_value_t *value,
 
     char *ptr;
 
+    if (NULL == value) {
+        /* the attribute is absent, which is not the same as its being
+         * present with no value - that second case is the PMIX_UNDEF
+         * one just below, and it does default to true */
+        return PMIX_BOOL_FALSE;
+    }
     if (PMIX_UNDEF == value->type) {
         return PMIX_BOOL_TRUE; // default to true
     }
@@ -1722,6 +1756,14 @@ pmix_status_t pmix_bfrops_base_tma_argv_append_nosize(char ***argv,
 {
     int argc;
 
+    /* There is nothing to append and nowhere to append it to. Both are
+     * caller mistakes rather than states this can express, so say so
+     * instead of faulting - these are reached from the public
+     * PMIx_Argv_* entry points. */
+    if (NULL == argv || NULL == arg) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* Create new argv. */
 
     if (NULL == *argv) {
@@ -1766,6 +1808,10 @@ pmix_status_t pmix_bfrops_base_tma_argv_prepend_nosize(char ***argv,
     int argc;
     int i;
 
+    if (NULL == argv || NULL == arg) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* Create new argv. */
 
     if (NULL == *argv) {
@@ -1801,6 +1847,10 @@ pmix_status_t pmix_bfrops_base_tma_argv_append_unique_nosize(char ***argv,
                                                              pmix_tma_t *tma)
 {
     int i;
+
+    if (NULL == argv || NULL == arg) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     /* if the provided array is NULL, then the arg cannot be present,
      * so just go ahead and append
@@ -2083,8 +2133,13 @@ void pmix_bfrops_base_tma_pdata_load(pmix_pdata_t *dest,
                                      pmix_data_type_t type,
                                      pmix_tma_t *tma)
 {
+    if (NULL == dest) {
+        return;
+    }
     memset(dest, 0, sizeof(pmix_pdata_t));
-    pmix_bfrops_base_tma_load_procid(&dest->proc, p->nspace, p->rank, tma);
+    if (NULL != p) {
+        pmix_bfrops_base_tma_load_procid(&dest->proc, p->nspace, p->rank, tma);
+    }
     pmix_bfrops_base_tma_load_key(dest->key, key, tma);
     pmix_bfrops_base_tma_value_load(&(dest->value), data, type, tma);
 }
@@ -2094,7 +2149,7 @@ void pmix_bfrops_base_tma_pdata_xfer(pmix_pdata_t *dest,
                                      const pmix_pdata_t *src,
                                      pmix_tma_t *tma)
 {
-    if (NULL != dest) {
+    if (NULL != dest && NULL != src) {
         memset(dest, 0, sizeof(*dest));
         pmix_bfrops_base_tma_load_procid(&dest->proc, src->proc.nspace, src->proc.rank, tma);
         pmix_bfrops_base_tma_load_key(dest->key, src->key, tma);

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -88,21 +88,33 @@ char* pmix_bfrops_base_tma_buffer_extend(pmix_buffer_t *buffer,
     }
 
     if (NULL != buffer->base_ptr) {
+        char *newbase;
+
         pack_offset = ((char *) buffer->pack_ptr) - ((char *) buffer->base_ptr);
         unpack_offset = ((char *) buffer->unpack_ptr) - ((char *) buffer->base_ptr);
-        buffer->base_ptr = (char *) pmix_tma_realloc(tma, buffer->base_ptr, to_alloc);
+        /* check the reallocation *before* touching it - the old code
+         * memset through the result and only then tested it for NULL,
+         * so an allocation failure here was a NULL dereference rather
+         * than the out-of-resource return the callers all handle. Keep
+         * the original block on failure so the buffer is still valid
+         * (and still freeable) when we hand back NULL. */
+        newbase = (char *) pmix_tma_realloc(tma, buffer->base_ptr, to_alloc);
+        if (NULL == newbase) {
+            return NULL;
+        }
+        buffer->base_ptr = newbase;
         memset(buffer->base_ptr + pack_offset, 0, to_alloc - buffer->bytes_allocated);
     } else {
         pack_offset = 0;
         unpack_offset = 0;
         buffer->bytes_used = 0;
         buffer->base_ptr = (char *)pmix_tma_malloc(tma, to_alloc);
+        if (NULL == buffer->base_ptr) {
+            return NULL;
+        }
         memset(buffer->base_ptr, 0, to_alloc);
     }
 
-    if (NULL == buffer->base_ptr) {
-        return NULL;
-    }
     buffer->pack_ptr = ((char *) buffer->base_ptr) + pack_offset;
     buffer->unpack_ptr = ((char *) buffer->base_ptr) + unpack_offset;
     buffer->bytes_allocated = to_alloc;
@@ -2630,9 +2642,22 @@ pmix_status_t pmix_bfrops_base_tma_copy_darray(pmix_data_array_t **dest,
 
     /* process based on type of array element */
     switch (src->type) {
+    /* The single-byte enums share this arm with the plain byte types.
+     * Every one of them is packed, unpacked, and allocated by
+     * pmix_bfrops_base_tma_data_array_construct() as a one-byte
+     * element, so leaving any of them to the default arm below made an
+     * array copyable only in one direction: it would pack and unpack
+     * fine but PMIX_INFO_XFER of it returned
+     * PMIX_ERR_UNKNOWN_DATA_TYPE. */
     case PMIX_UINT8:
     case PMIX_INT8:
     case PMIX_BYTE:
+    case PMIX_PROC_STATE:
+    case PMIX_ALLOC_DIRECTIVE:
+    case PMIX_ALLOC_INHERIT:
+    case PMIX_RESBLOCK_DIRECTIVE:
+    case PMIX_JOB_STATE:
+    case PMIX_LINK_STATE:
         p->array = pmix_tma_malloc(tma, src->size);
         if (PMIX_UNLIKELY(NULL == p->array)) {
             rc = PMIX_ERR_NOMEM;
@@ -2642,6 +2667,10 @@ pmix_status_t pmix_bfrops_base_tma_copy_darray(pmix_data_array_t **dest,
         break;
     case PMIX_UINT16:
     case PMIX_INT16:
+    case PMIX_DATA_TYPE:
+    case PMIX_IOF_CHANNEL:
+    case PMIX_LOCTYPE:
+    case PMIX_STOR_ACCESS_TYPE:
         p->array = pmix_tma_malloc(tma, src->size * sizeof(uint16_t));
         if (PMIX_UNLIKELY(NULL == p->array)) {
             rc = PMIX_ERR_NOMEM;
@@ -2660,6 +2689,10 @@ pmix_status_t pmix_bfrops_base_tma_copy_darray(pmix_data_array_t **dest,
         break;
     case PMIX_UINT64:
     case PMIX_INT64:
+    case PMIX_DEVTYPE:
+    case PMIX_STOR_MEDIUM:
+    case PMIX_STOR_ACCESS:
+    case PMIX_STOR_PERSIST:
         p->array = pmix_tma_malloc(tma, src->size * sizeof(uint64_t));
         if (PMIX_UNLIKELY(NULL == p->array)) {
             rc = PMIX_ERR_NOMEM;
@@ -2867,7 +2900,10 @@ pmix_status_t pmix_bfrops_base_tma_copy_darray(pmix_data_array_t **dest,
         break;
     }
     case PMIX_BYTE_OBJECT:
-    case PMIX_COMPRESSED_STRING: {
+    case PMIX_COMPRESSED_STRING:
+    case PMIX_COMPRESSED_BYTE_OBJECT: {
+        /* PMIX_REGEX is deliberately NOT here - see the note in
+         * pmix_bfrops_base_tma_data_array_construct() */
         p->array = pmix_tma_malloc(tma, src->size * sizeof(pmix_byte_object_t));
         if (PMIX_UNLIKELY(NULL == p->array)) {
             rc = PMIX_ERR_NOMEM;
@@ -3114,9 +3150,15 @@ pmix_status_t pmix_bfrops_base_tma_copy_darray(pmix_data_array_t **dest,
             // TODO(skg) Add TMA support when necessary.
             rc = pmix_hwloc_copy_cpuset(&pcpuset[n], &scpuset[n]);
             if (PMIX_SUCCESS != rc) {
-                // TODO(skg) Add TMA support when necessary.
-                pmix_hwloc_release_cpuset(pcpuset, src->size);
-                pmix_tma_free(tma, p->array);
+                /* release the elements *and* the block exactly once, and
+                 * through the allocator that produced it. The previous
+                 * code called pmix_hwloc_release_cpuset - which already
+                 * free()s the block - and then freed p->array again,
+                 * corrupting the heap on any source element that is not
+                 * a valid hwloc cpuset (an all-zero one, for instance,
+                 * which PMIx_Data_array_create hands back). */
+                pmix_bfrops_base_tma_cpuset_free(pcpuset, src->size, tma);
+                p->array = NULL;
                 break;
             }
         }
@@ -3268,6 +3310,64 @@ pmix_status_t pmix_bfrops_base_tma_copy_darray(pmix_data_array_t **dest,
         pmix_nspace_t *const sns = (pmix_nspace_t *)src->array;
         for (size_t n = 0; n < src->size; n++) {
             pmix_bfrops_base_tma_load_nspace(pns[n], sns[n], tma);
+        }
+        break;
+    }
+    case PMIX_NODE_PID: {
+        p->array = pmix_bfrops_base_tma_node_pid_create(src->size, tma);
+        if (PMIX_UNLIKELY(NULL == p->array)) {
+            rc = PMIX_ERR_NOMEM;
+            break;
+        }
+        pmix_node_pid_t *const pnp = (pmix_node_pid_t *)p->array;
+        pmix_node_pid_t *const snp = (pmix_node_pid_t *)src->array;
+        for (size_t n = 0; n < src->size; n++) {
+            if (NULL != snp[n].hostname) {
+                pnp[n].hostname = pmix_tma_strdup(tma, snp[n].hostname);
+            }
+            pnp[n].nodeid = snp[n].nodeid;
+            pnp[n].pid = snp[n].pid;
+        }
+        break;
+    }
+    case PMIX_DATA_BUFFER: {
+        p->array = pmix_tma_calloc(tma, src->size, sizeof(pmix_data_buffer_t));
+        if (PMIX_UNLIKELY(NULL == p->array)) {
+            rc = PMIX_ERR_NOMEM;
+            break;
+        }
+        pmix_data_buffer_t *const pdb = (pmix_data_buffer_t *)p->array;
+        pmix_data_buffer_t *const sdb = (pmix_data_buffer_t *)src->array;
+        for (size_t n = 0; n < src->size; n++) {
+            /* PMIx_Data_copy_payload, not the internal
+             * pmix_bfrops_base_tma_copy_payload: the two buffer types are
+             * NOT layout-compatible. pmix_buffer_t leads with a
+             * pmix_object_t and a type field that pmix_data_buffer_t does
+             * not have, so casting one to the other reads every field
+             * from the wrong offset. */
+            rc = PMIx_Data_copy_payload(&pdb[n], &sdb[n]);
+            if (PMIX_SUCCESS != rc) {
+                break;
+            }
+        }
+        break;
+    }
+    case PMIX_TOPO: {
+        p->array = pmix_bfrops_base_tma_topology_create(src->size, tma);
+        if (PMIX_UNLIKELY(NULL == p->array)) {
+            rc = PMIX_ERR_NOMEM;
+            break;
+        }
+        pmix_topology_t *const ptp = (pmix_topology_t *)p->array;
+        pmix_topology_t *const stp = (pmix_topology_t *)src->array;
+        for (size_t n = 0; n < src->size; n++) {
+            // TODO(skg) Add TMA support when necessary.
+            rc = pmix_hwloc_copy_topology(&ptp[n], &stp[n]);
+            if (PMIX_SUCCESS != rc) {
+                pmix_bfrops_base_tma_topology_free(ptp, src->size, tma);
+                p->array = NULL;
+                break;
+            }
         }
         break;
     }
@@ -3624,6 +3724,12 @@ void pmix_bfrops_base_tma_data_array_destruct(pmix_data_array_t *d,
         case PMIX_REGEX2:
             pmix_bfrops_base_tma_regex2_free((pmix_regex2_t *)d->array, d->size, tma);
             break;
+        case PMIX_NODE_PID:
+            /* each element owns a heap-allocated hostname, so the
+             * default "just free the block" arm below leaked one string
+             * per element */
+            pmix_bfrops_base_tma_node_pid_free((pmix_node_pid_t *)d->array, d->size, tma);
+            break;
         case PMIX_REGEX: {
             pmix_byte_object_t *const bo = (pmix_byte_object_t *)d->array;
             for (size_t n = 0; n < d->size; n++) {
@@ -3706,8 +3812,25 @@ void pmix_bfrops_base_tma_data_array_construct(pmix_data_array_t *p,
             p->array = pmix_bfrops_base_tma_app_create(num, tma);
 
         } else if (PMIX_BYTE_OBJECT == type ||
-                   PMIX_COMPRESSED_STRING == type) {
+                   PMIX_COMPRESSED_STRING == type ||
+                   PMIX_COMPRESSED_BYTE_OBJECT == type) {
             p->array = pmix_bfrops_base_tma_byte_object_create(num, tma);
+
+            /* PMIX_REGEX is intentionally absent from this function.
+             * The tree does not agree on what an *array* of them looks
+             * like: pmix_bfrops_base_pack_regex()/_unpack_regex() stride
+             * the block as char* (one regex string per element), while
+             * pmix_bfrops_base_tma_data_array_destruct() strides it as
+             * pmix_byte_object_t. Those differ in width, so one of the
+             * two walks off the end. The two views coincide for a
+             * scalar value - bo.bytes is the first member of the union,
+             * which is why PMIX_REGEX values work everywhere else - and
+             * they only diverge for arrays. Rather than pick a side and
+             * silently change what an array of regexes means, leave it
+             * unconstructible (size 0, NULL array), which is what it has
+             * always been and which fails cleanly. Resolving it means
+             * settling on one stride and fixing pack, unpack, copy, and
+             * destruct together. */
 
         } else if (PMIX_ALLOC_DIRECTIVE == type ||
                    PMIX_PROC_STATE == type ||
@@ -3717,9 +3840,20 @@ void pmix_bfrops_base_tma_data_array_construct(pmix_data_array_t *p,
                    PMIX_BYTE == type ||
                    PMIX_INT8 == type ||
                    PMIX_UINT8 == type ||
-                   PMIX_POINTER == type) {
+                   PMIX_COMMAND == type ||
+                   PMIX_JOB_STATE == type ||
+                   PMIX_ALLOC_INHERIT == type ||
+                   PMIX_RESBLOCK_DIRECTIVE == type) {
             p->array = pmix_tma_malloc(tma, num * sizeof(int8_t));
             memset(p->array, 0, num * sizeof(int8_t));
+
+        } else if (PMIX_POINTER == type) {
+            /* one pointer per element, not one byte: this array used to
+             * be sized as int8_t while copy_darray (correctly) reads
+             * sizeof(char*) per element, so copying one over-read the
+             * block by a factor of sizeof(void*) */
+            p->array = pmix_tma_malloc(tma, num * sizeof(void *));
+            memset(p->array, 0, num * sizeof(void *));
 
         } else if (PMIX_STRING == type) {
             p->array = pmix_tma_malloc(tma, num * sizeof(char*));
@@ -3741,6 +3875,8 @@ void pmix_bfrops_base_tma_data_array_construct(pmix_data_array_t *p,
 
         } else if (PMIX_IOF_CHANNEL == type ||
                    PMIX_DATA_TYPE == type ||
+                   PMIX_LOCTYPE == type ||
+                   PMIX_STOR_ACCESS_TYPE == type ||
                    PMIX_INT16 == type ||
                    PMIX_UINT16 == type) {
             p->array = pmix_tma_malloc(tma, num * sizeof(int16_t));
@@ -3754,7 +3890,11 @@ void pmix_bfrops_base_tma_data_array_construct(pmix_data_array_t *p,
             memset(p->array, 0, num * sizeof(int32_t));
 
         } else if (PMIX_INT64 == type ||
-                   PMIX_UINT64 == type) {
+                   PMIX_UINT64 == type ||
+                   PMIX_DEVTYPE == type ||
+                   PMIX_STOR_MEDIUM == type ||
+                   PMIX_STOR_ACCESS == type ||
+                   PMIX_STOR_PERSIST == type) {
             p->array = pmix_tma_malloc(tma, num * sizeof(int64_t));
             memset(p->array, 0, num * sizeof(int64_t));
 
@@ -3813,7 +3953,40 @@ void pmix_bfrops_base_tma_data_array_construct(pmix_data_array_t *p,
         } else if (PMIX_PROC_CPUSET == type) {
             p->array = pmix_bfrops_base_tma_cpuset_create(num, tma);
 
+        } else if (PMIX_TOPO == type) {
+            p->array = pmix_bfrops_base_tma_topology_create(num, tma);
+
+        } else if (PMIX_NODE_PID == type) {
+            p->array = pmix_bfrops_base_tma_node_pid_create(num, tma);
+
+        } else if (PMIX_REGEX2 == type) {
+            p->array = pmix_bfrops_base_tma_regex2_create(num, tma);
+
+        } else if (PMIX_DATA_BUFFER == type) {
+            p->array = pmix_tma_calloc(tma, num, sizeof(pmix_data_buffer_t));
+
+        } else if (PMIX_KVAL == type) {
+            p->array = pmix_tma_calloc(tma, num, sizeof(pmix_kval_t));
+
+        } else if (PMIX_BUFFER == type) {
+            pmix_buffer_t *pb = (pmix_buffer_t *)pmix_tma_calloc(tma, num,
+                                                                 sizeof(pmix_buffer_t));
+            if (NULL != pb) {
+                for (size_t m = 0; m < num; m++) {
+                    PMIX_CONSTRUCT(&pb[m], pmix_buffer_t, tma);
+                }
+            }
+            p->array = pb;
+
         } else {
+            /* Nothing here knows how big an element of this type is, so
+             * we cannot hand back an array of them. Say so through the
+             * descriptor - size 0 with a NULL array - which is what
+             * every caller checks. If you are adding a data type, this
+             * branch and pmix_bfrops_base_tma_data_array_destruct() are
+             * a matched pair: a type the destructor knows how to release
+             * but this function cannot allocate is a type that silently
+             * fails to unpack. */
             p->array = NULL;
             p->size = 0;
         }

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -268,6 +268,14 @@ void pmix_bfrops_base_tma_xfer_procid(pmix_proc_t *dst,
 {
     PMIX_HIDE_UNUSED_PARAMS(tma);
 
+    /* public entry point (PMIx_Xfer_procid), so screen both ends */
+    if (NULL == dst) {
+        return;
+    }
+    if (NULL == src) {
+        memset(dst, 0, sizeof(pmix_proc_t));
+        return;
+    }
     memcpy(dst, src, sizeof(pmix_proc_t));
 }
 
@@ -2780,7 +2788,13 @@ pmix_status_t pmix_bfrops_base_tma_copy_darray(pmix_data_array_t **dest,
         memcpy(p->array, src->array, src->size * sizeof(pid_t));
         break;
     case PMIX_STRING: {
-        p->array = pmix_tma_malloc(tma, src->size * sizeof(char *));
+        /* calloc, NOT malloc: the loop below writes an element only
+         * where the source has one, so anything it skips keeps whatever
+         * the allocator handed back - and the destructor then frees it
+         * as if it were a string. A fresh page reads as zero often
+         * enough for that to look correct (it does on macOS), which is
+         * precisely why it survived. */
+        p->array = pmix_tma_calloc(tma, src->size, sizeof(char *));
         if (PMIX_UNLIKELY(NULL == p->array)) {
             rc = PMIX_ERR_NOMEM;
             break;
@@ -2959,7 +2973,10 @@ pmix_status_t pmix_bfrops_base_tma_copy_darray(pmix_data_array_t **dest,
     case PMIX_COMPRESSED_BYTE_OBJECT: {
         /* PMIX_REGEX is deliberately NOT here - see the note in
          * pmix_bfrops_base_tma_data_array_construct() */
-        p->array = pmix_tma_malloc(tma, src->size * sizeof(pmix_byte_object_t));
+        /* calloc for the same reason as the PMIX_STRING arm above: an
+         * empty source element leaves its destination untouched, and
+         * the destructor frees the .bytes it finds there */
+        p->array = pmix_tma_calloc(tma, src->size, sizeof(pmix_byte_object_t));
         if (PMIX_UNLIKELY(NULL == p->array)) {
             rc = PMIX_ERR_NOMEM;
             break;

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -357,7 +357,10 @@ pmix_status_t pmix_bfrops_base_unpack_string(pmix_pointer_array_t *regtypes, pmi
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        if (0 == len) { /* zero-length string - unpack the NULL */
+        if (0 >= len) { /* zero-length string - unpack the NULL */
+            /* a negative length can only come from a corrupt or hostile
+             * buffer; treat it the same as absent rather than handing it
+             * to malloc, where it becomes a huge size_t */
             sdest[i] = NULL;
         } else {
             sdest[i] = (char *) malloc(len); // NULL terminator is included
@@ -366,8 +369,15 @@ pmix_status_t pmix_bfrops_base_unpack_string(pmix_pointer_array_t *regtypes, pmi
             }
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, sdest[i], &len, PMIX_BYTE, regtypes);
             if (PMIX_SUCCESS != ret) {
+                free(sdest[i]);
+                sdest[i] = NULL;
                 return ret;
             }
+            /* the packer always includes the terminator in len, but the
+             * bytes came off the wire and everything downstream of here
+             * treats this as a C string. Guarantee the invariant rather
+             * than trusting the sender to have honored it. */
+            sdest[i][len - 1] = '\0';
         }
     }
 
@@ -1001,7 +1011,10 @@ pmix_status_t pmix_bfrops_base_unpack_kval(pmix_pointer_array_t *regtypes, pmix_
             return ret;
         }
         /* allocate the space */
-        ptr[i].value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+        ptr[i].value = (pmix_value_t *) calloc(1, sizeof(pmix_value_t));
+        if (NULL == ptr[i].value) {
+            return PMIX_ERR_NOMEM;
+        }
         /* unpack the value */
         m = 1;
         PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].value, &m, PMIX_VALUE, regtypes);
@@ -1208,7 +1221,15 @@ static pmix_status_t unpack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t
             return ret;
         }
         if (PMIX_UNDEF == ptr[i].type) {
-            // this was a NULL array pointer
+            /* this was a NULL array pointer, or an array descriptor with
+             * no element type - either way the packer wrote the tag and
+             * nothing else, so there is no size to read and nothing
+             * further in the stream belongs to us. Zero the descriptors
+             * we are abandoning so the caller is never handed one we
+             * never touched. */
+            for (; i < n; ++i) {
+                memset(&ptr[i], 0, sizeof(pmix_data_array_t));
+            }
             return PMIX_SUCCESS;
         }
         /* unpack the number of array elements */
@@ -1217,7 +1238,7 @@ static pmix_status_t unpack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        if (0 == ptr[i].size || PMIX_UNDEF == ptr[i].type) {
+        if (0 == ptr[i].size) {
             /* nothing else to do */
             continue;
         }
@@ -1978,6 +1999,7 @@ pmix_status_t pmix_bfrops_base_unpack_dbuf(pmix_pointer_array_t *regtypes, pmix_
 
     n = *num_vals;
     for (i = 0; i < n; ++i) {
+        memset(&ptr[i], 0, sizeof(pmix_data_buffer_t));
         m = 1;
         PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].bytes_used, &m, PMIX_SIZE, regtypes);
         if (PMIX_SUCCESS != ret) {
@@ -1986,11 +2008,23 @@ pmix_status_t pmix_bfrops_base_unpack_dbuf(pmix_pointer_array_t *regtypes, pmix_
         }
         if (0 < ptr[i].bytes_used) {
             ptr[i].base_ptr = malloc(ptr[i].bytes_used);
+            if (NULL == ptr[i].base_ptr) {
+                ptr[i].bytes_used = 0;
+                return PMIX_ERR_NOMEM;
+            }
             m = ptr[i].bytes_used;
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].base_ptr, &m, PMIX_BYTE, regtypes);
             if (PMIX_SUCCESS != ret) {
                 return ret;
             }
+            /* finish the buffer off. Recovering the payload is only half
+             * the job - without the cursors and the allocation size the
+             * caller gets a buffer it cannot read a single value out of,
+             * which is the whole point of nesting one. Mirror what
+             * pmix_bfrops_base_unpack_buf does for PMIX_BUFFER. */
+            ptr[i].bytes_allocated = ptr[i].bytes_used;
+            ptr[i].pack_ptr = ptr[i].base_ptr + ptr[i].bytes_used;
+            ptr[i].unpack_ptr = ptr[i].base_ptr;
         }
     }
     return PMIX_SUCCESS;

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -557,6 +557,9 @@ pmix_status_t pmix_bfrops_base_unpack_val(pmix_pointer_array_t *regtypes, pmix_b
             break;
         case PMIX_REGATTR:
             val->data.ptr = (pmix_regattr_t *) calloc(1, sizeof(pmix_regattr_t));
+            if (NULL == val->data.ptr) {
+                return PMIX_ERR_NOMEM;
+            }
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.ptr, &m, PMIX_REGATTR, regtypes);
             return ret;
         case PMIX_COORD:
@@ -824,6 +827,9 @@ pmix_status_t pmix_bfrops_base_unpack_buf(pmix_pointer_array_t *regtypes, pmix_b
         m = nbytes;
         /* setup the buffer's data region */
         if (0 < nbytes) {
+            if (pmix_bfrop_too_small(buffer, nbytes)) {
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             ptr[i].base_ptr = (char *) malloc(nbytes);
             if (NULL == ptr[i].base_ptr) {
                 return PMIX_ERR_NOMEM;
@@ -976,7 +982,17 @@ pmix_status_t pmix_bfrops_base_unpack_app(pmix_pointer_array_t *regtypes, pmix_b
             return ret;
         }
         if (0 < ptr[i].ninfo) {
+            if (pmix_bfrop_too_small(buffer, ptr[i].ninfo)) {
+                ptr[i].ninfo = 0;
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             PMIX_INFO_CREATE(ptr[i].info, ptr[i].ninfo);
+            if (NULL == ptr[i].info) {
+                /* the count came off the wire, so it can be any size at
+                 * all - including one the allocator refuses */
+                ptr[i].ninfo = 0;
+                return PMIX_ERR_NOMEM;
+            }
             m = ptr[i].ninfo;
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].info, &m, PMIX_INFO, regtypes);
             if (PMIX_SUCCESS != ret) {
@@ -1060,8 +1076,13 @@ pmix_status_t pmix_bfrops_base_unpack_bo(pmix_pointer_array_t *regtypes, pmix_bu
             return ret;
         }
         if (0 < ptr[i].size) {
+            if (pmix_bfrop_too_small(buffer, ptr[i].size)) {
+                ptr[i].size = 0;
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             ptr[i].bytes = (char *) malloc(ptr[i].size * sizeof(char));
             if (NULL == ptr[i].bytes) {
+                ptr[i].size = 0;
                 return PMIX_ERR_NOMEM;
             }
             m = ptr[i].size;
@@ -1242,6 +1263,25 @@ static pmix_status_t unpack_darray(pmix_pointer_array_t *regtypes, pmix_buffer_t
             /* nothing else to do */
             continue;
         }
+        /* The element count came off the wire, and nothing so far has
+         * related it to how much wire there actually is - so a handful
+         * of bytes can ask this to allocate an arbitrary amount. For
+         * almost every element type each element costs at least one
+         * byte to encode, which makes "more elements than bytes
+         * remaining" a count that cannot describe anything the peer
+         * actually sent.
+         *
+         * Two types are genuinely sparser than that and must NOT be
+         * bounded this way, or ordinary arrays of them stop unpacking:
+         * PMIX_POINTER packs a single sentinel byte for the whole array
+         * (there is no sense in shipping addresses between processes),
+         * and an array of arrays whose elements are all empty is one
+         * type tag in total. */
+        if (PMIX_POINTER != ptr[i].type && PMIX_DATA_ARRAY != ptr[i].type &&
+            pmix_bfrop_too_small(buffer, ptr[i].size)) {
+            ptr[i].size = 0;
+            return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+        }
         /* allocate storage for the array and unpack the array elements */
         sm = ptr[i].size;
         t = ptr[i].type;
@@ -1323,6 +1363,9 @@ pmix_status_t pmix_bfrops_base_unpack_query(pmix_pointer_array_t *regtypes, pmix
             return ret;
         }
         if (0 < nkeys) {
+            if (pmix_bfrop_too_small(buffer, nkeys)) {
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             /* unpack the keys */
             if (NULL == (ptr[i].keys = (char **) calloc(nkeys + 1, sizeof(char *)))) {
                 return PMIX_ERR_NOMEM;
@@ -1341,8 +1384,16 @@ pmix_status_t pmix_bfrops_base_unpack_query(pmix_pointer_array_t *regtypes, pmix
             return ret;
         }
         if (0 < ptr[i].nqual) {
+            if (pmix_bfrop_too_small(buffer, ptr[i].nqual)) {
+                ptr[i].nqual = 0;
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             /* unpack the qualifiers */
             PMIX_INFO_CREATE(ptr[i].qualifiers, ptr[i].nqual);
+            if (NULL == ptr[i].qualifiers) {
+                ptr[i].nqual = 0;
+                return PMIX_ERR_NOMEM;
+            }
             m = ptr[i].nqual;
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].qualifiers, &m, PMIX_INFO, regtypes);
             if (PMIX_SUCCESS != ret) {
@@ -1470,7 +1521,15 @@ pmix_status_t pmix_bfrops_base_unpack_coord(pmix_pointer_array_t *regtypes, pmix
             return ret;
         }
         if (0 < ptr[i].dims) {
+            if (pmix_bfrop_too_small(buffer, ptr[i].dims)) {
+                ptr[i].dims = 0;
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             ptr[i].coord = (uint32_t *) malloc(ptr[i].dims * sizeof(uint32_t));
+            if (NULL == ptr[i].coord) {
+                ptr[i].dims = 0;
+                return PMIX_ERR_NOMEM;
+            }
             /* unpack the coords */
             m = ptr[i].dims;
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].coord, &m, PMIX_UINT32, regtypes);
@@ -1534,6 +1593,9 @@ pmix_status_t pmix_bfrops_base_unpack_regattr(pmix_pointer_array_t *regtypes, pm
             return ret;
         }
         if (0 < nd) {
+            if (pmix_bfrop_too_small(buffer, nd)) {
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             /* unpack the description */
             if (NULL == (ptr[i].description = (char **) calloc(nd + 1, sizeof(char *)))) {
                 return PMIX_ERR_NOMEM;
@@ -1604,7 +1666,15 @@ pmix_status_t pmix_bfrops_base_unpack_regex2(pmix_pointer_array_t *regtypes, pmi
             return ret;
         }
         if (0 < ptr[i].len) {
+            if (pmix_bfrop_too_small(buffer, ptr[i].len)) {
+                ptr[i].len = 0;
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             ptr[i].bytes = (uint8_t *) malloc(ptr[i].len);
+            if (NULL == ptr[i].bytes) {
+                ptr[i].len = 0;
+                return PMIX_ERR_NOMEM;
+            }
             m = ptr[i].len;
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].bytes, &m, PMIX_BYTE, regtypes);
             if (PMIX_SUCCESS != ret) {
@@ -1711,8 +1781,16 @@ pmix_status_t pmix_bfrops_base_unpack_geometry(pmix_pointer_array_t *regtypes,
             return ret;
         }
         if (0 < ptr[i].ncoords) {
+            if (pmix_bfrop_too_small(buffer, ptr[i].ncoords)) {
+                ptr[i].ncoords = 0;
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             /* allocate the coords */
             ptr[i].coordinates = (pmix_coord_t *) calloc(ptr[i].ncoords, sizeof(pmix_coord_t));
+            if (NULL == ptr[i].coordinates) {
+                ptr[i].ncoords = 0;
+                return PMIX_ERR_NOMEM;
+            }
             /* unpack them */
             m = ptr[i].ncoords;
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].coordinates, &m, PMIX_COORD, regtypes);
@@ -1890,7 +1968,15 @@ pmix_status_t pmix_bfrops_base_unpack_endpoint(pmix_pointer_array_t *regtypes,
             return ret;
         }
         if (0 < ptr[i].endpt.size) {
+            if (pmix_bfrop_too_small(buffer, ptr[i].endpt.size)) {
+                ptr[i].endpt.size = 0;
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             ptr[i].endpt.bytes = (char *) malloc(ptr[i].endpt.size);
+            if (NULL == ptr[i].endpt.bytes) {
+                ptr[i].endpt.size = 0;
+                return PMIX_ERR_NOMEM;
+            }
             m = ptr[i].endpt.size;
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].endpt.bytes, &m, PMIX_BYTE, regtypes);
             if (PMIX_SUCCESS != ret) {
@@ -2007,6 +2093,10 @@ pmix_status_t pmix_bfrops_base_unpack_dbuf(pmix_pointer_array_t *regtypes, pmix_
             return ret;
         }
         if (0 < ptr[i].bytes_used) {
+            if (pmix_bfrop_too_small(buffer, ptr[i].bytes_used)) {
+                ptr[i].bytes_used = 0;
+                return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+            }
             ptr[i].base_ptr = malloc(ptr[i].bytes_used);
             if (NULL == ptr[i].base_ptr) {
                 ptr[i].bytes_used = 0;

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -521,6 +521,53 @@ pmix_status_t pmix_bfrops_base_unpack_status(pmix_pointer_array_t *regtypes, pmi
 /*
  * PMIX_VALUE
  */
+/* A pmix_value_t keeps its payload in a union, and the type tag names
+ * which member is live. Six registered types have no member there at
+ * all - they are data-array element types, not things a scalar value
+ * can hold - and their C representation is larger than the whole union,
+ * by as much as 784 bytes in the case of PMIX_PDATA.
+ *
+ * That matters because the type tag comes off the wire. unpack_val()
+ * hands &val->data to the per-type unpacker, so a peer that tags a
+ * value with one of these gets that unpacker to write past the end of
+ * the value - and unpack_kval(), unpack_info() and unpack_pdata() all
+ * unpack into a value they just allocated. Both the length and the
+ * contents of that overflow come from the peer.
+ *
+ * So refuse them. A value tagged with one of these is not something a
+ * correct peer can have sent. */
+static bool value_type_overflows_union(pmix_data_type_t type)
+{
+    switch (type) {
+    case PMIX_VALUE:
+    case PMIX_INFO:
+    case PMIX_PDATA:
+    case PMIX_APP:
+    case PMIX_KVAL:
+    case PMIX_BUFFER:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/* Keep that list honest in both directions. If the union grows past one
+ * of these, or a type that used to fit stops fitting, the build stops
+ * here rather than at a corrupted heap in the field. Types not listed
+ * either fit, or are handled by name in unpack_val() below and never
+ * reach the arm this guards. */
+#define PMIX_VALUE_UNION_SIZE (sizeof(((pmix_value_t *) 0)->data))
+_Static_assert(sizeof(pmix_info_t) > PMIX_VALUE_UNION_SIZE, "PMIX_INFO now fits");
+_Static_assert(sizeof(pmix_pdata_t) > PMIX_VALUE_UNION_SIZE, "PMIX_PDATA now fits");
+_Static_assert(sizeof(pmix_app_t) > PMIX_VALUE_UNION_SIZE, "PMIX_APP now fits");
+_Static_assert(sizeof(pmix_kval_t) > PMIX_VALUE_UNION_SIZE, "PMIX_KVAL now fits");
+_Static_assert(sizeof(pmix_buffer_t) > PMIX_VALUE_UNION_SIZE, "PMIX_BUFFER now fits");
+_Static_assert(sizeof(pmix_value_t) > PMIX_VALUE_UNION_SIZE, "PMIX_VALUE now fits");
+_Static_assert(sizeof(pmix_query_t) <= PMIX_VALUE_UNION_SIZE, "PMIX_QUERY no longer fits");
+_Static_assert(sizeof(pmix_envar_t) <= PMIX_VALUE_UNION_SIZE, "PMIX_ENVAR no longer fits");
+_Static_assert(sizeof(pmix_byte_object_t) <= PMIX_VALUE_UNION_SIZE,
+               "PMIX_BYTE_OBJECT no longer fits");
+
 pmix_status_t pmix_bfrops_base_unpack_val(pmix_pointer_array_t *regtypes, pmix_buffer_t *buffer,
                                           pmix_value_t *val)
 {
@@ -649,6 +696,11 @@ pmix_status_t pmix_bfrops_base_unpack_val(pmix_pointer_array_t *regtypes, pmix_b
             return ret;
 
         default:
+            if (value_type_overflows_union(val->type)) {
+                pmix_output(0, "UNPACK-PMIX-VALUE: TYPE %s CANNOT BE CARRIED BY A VALUE",
+                            PMIx_Data_type_string(val->type));
+                return PMIX_ERR_BAD_PARAM;
+            }
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &val->data, &m, val->type, regtypes);
             if (PMIX_ERR_UNKNOWN_DATA_TYPE == ret) {
                 pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int) val->type);

--- a/src/mca/bfrops/v12/unpack.c
+++ b/src/mca/bfrops/v12/unpack.c
@@ -429,7 +429,9 @@ pmix_status_t pmix12_bfrop_unpack_string(pmix_pointer_array_t *regtypes, pmix_bu
             != (ret = pmix12_bfrop_unpack_int32(regtypes, buffer, &len, &n, PMIX_INT32))) {
             return ret;
         }
-        if (0 == len) { /* zero-length string - unpack the NULL */
+        if (0 >= len) { /* zero-length string - unpack the NULL */
+            /* a negative length is only reachable from a corrupt or
+             * hostile buffer, and reaches malloc as a huge size_t */
             sdest[i] = NULL;
         } else if (PMIX_TAINT_INT_LIMIT < len) {  // arbitrary value to guard against tainted input
             return PMIX_ERR_BAD_PARAM;
@@ -440,8 +442,15 @@ pmix_status_t pmix12_bfrop_unpack_string(pmix_pointer_array_t *regtypes, pmix_bu
             }
             if (PMIX_SUCCESS
                 != (ret = pmix12_bfrop_unpack_byte(regtypes, buffer, sdest[i], &len, PMIX_BYTE))) {
+                free(sdest[i]);
+                sdest[i] = NULL;
                 return ret;
             }
+            /* the packer includes the terminator in the length it
+             * writes, but these bytes came off the wire from a peer we
+             * cannot vouch for, and everything downstream treats the
+             * result as a C string */
+            sdest[i][len - 1] = '\0';
         }
     }
 

--- a/src/mca/bfrops/v20/unpack.c
+++ b/src/mca/bfrops/v20/unpack.c
@@ -415,7 +415,10 @@ pmix_status_t pmix20_bfrop_unpack_string(pmix_pointer_array_t *regtypes, pmix_bu
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        if (0 == len) { /* zero-length string - unpack the NULL */
+        if (0 >= len) { /* zero-length string - unpack the NULL */
+            /* a negative length can only come from a corrupt or hostile
+             * buffer; treat it as absent rather than handing it to
+             * malloc, where it becomes a huge size_t */
             sdest[i] = NULL;
         } else {
             sdest[i] = (char *) malloc(len);
@@ -424,8 +427,15 @@ pmix_status_t pmix20_bfrop_unpack_string(pmix_pointer_array_t *regtypes, pmix_bu
             }
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, sdest[i], &len, PMIX_BYTE, regtypes);
             if (PMIX_SUCCESS != ret) {
+                free(sdest[i]);
+                sdest[i] = NULL;
                 return ret;
             }
+            /* the packer includes the terminator in the length it
+             * writes, but these bytes came off the wire from a peer we
+             * cannot vouch for, and everything downstream treats the
+             * result as a C string */
+            sdest[i][len - 1] = '\0';
         }
     }
 

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -68,7 +68,7 @@ They fall into three groups.
 **Self-contained library tests** — no server, no launcher, no network.
 These run anywhere and are the bulk of the suite: `compress`, `preg`,
 `bfrops_regex2`, `bfrops_alloc_inherit`, `bfrops_darray`,
-`bfrops_malformed`, `info_support`, `iof_pattern`,
+`bfrops_malformed`, `bfrops_get_number`, `info_support`, `iof_pattern`,
 `hwloc_datatype`, `tracker_match`, `trk_complete`, `collective_status`,
 `collect_job_info`, `progress_threads`, `pmix_log`.
 
@@ -189,6 +189,27 @@ payload ends on a page boundary. `test_every_truncation_of_a_real_message`
 is the broad net over the same class: it packs a well-formed message and
 cuts it at every offset, which reaches decoder states nobody would think
 to write down.
+
+[`bfrops_get_number.c`](bfrops_get_number.c) is the third, and it is a
+**property test rather than a case list** for the same reason: the
+function under test is two thousand lines of one near-copy of an arm per
+(source type, destination type) pair, so enumerating cases reproduces
+exactly the blind spot that put five defects in it at once. It states
+two things and checks them over every pair at every width boundary — a
+success must return the value it was given, and a refusal must be of a
+value that genuinely did not fit.
+
+The second property is the one that earns its keep. Thirteen
+`PMIX_PROC_RANK` arms stored the correct answer and then fell through
+without a `return`, so every conversion to a rank was right and reported
+`PMIX_ERR_BAD_PARAM` — invisible to any test that only inspects
+successful conversions. Likewise `PMIX_PID` had no source handler at all.
+
+One exclusion in it is policy, not laziness: a PMIx structured value
+(`PMIX_PID`, `PMIX_STATUS`, `PMIX_PROC_RANK`) is deliberately not
+converted into another structured type, as `check_rank()` in the source
+states. The test encodes that; do not delete the exclusion to make a
+"missing" conversion appear.
 
 Neither program needs a server, and neither can reach the two things a
 *peer* decides — which bfrops module encodes a message, and whether the

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -69,7 +69,7 @@ They fall into three groups.
 These run anywhere and are the bulk of the suite: `compress`, `preg`,
 `bfrops_regex2`, `bfrops_alloc_inherit`, `bfrops_darray`,
 `bfrops_malformed`, `bfrops_get_number`, `bfrops_null_object`,
-`info_support`, `iof_pattern`,
+`bfrops_helpers`, `info_support`, `iof_pattern`,
 `hwloc_datatype`, `tracker_match`, `trk_complete`, `collective_status`,
 `collect_job_info`, `progress_threads`, `pmix_log`.
 
@@ -231,6 +231,19 @@ member in the value union at all, and the library prints a diagnostic
 for them. Those lines are the library declining rather than faulting,
 which is what is being asserted; do not quiet them by dropping the
 types.
+
+[`bfrops_helpers.c`](bfrops_helpers.c) is the fifth, and it covers the
+public API surface that `bfrops/base` happens to own — the
+`PMIx_Argv_*` family, the `PMIx_Info_list_*` builders, and the
+construct/create/load/free helpers. Ten of those faulted on a NULL
+argument. Like `bfrops_null_object` it asserts survival rather than a
+return code, because refusing and quietly doing nothing are both
+defensible for most of them.
+
+It also runs each family on *ordinary* input right after the degenerate
+cases. A screen added to a hot helper is exactly the kind of change that
+can quietly break the path it was meant to protect, and a suite made
+only of NULL cases would not notice.
 
 Neither program needs a server, and neither can reach the two things a
 *peer* decides — which bfrops module encodes a message, and whether the

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -191,6 +191,20 @@ is the broad net over the same class: it packs a well-formed message and
 cuts it at every offset, which reaches decoder states nobody would think
 to write down.
 
+`test_random_bytes_through_every_unpacker` is the wider net still, and
+it earned its place: it found two defects that reading did not. A data
+array's element count sized the receiver's allocation with nothing
+relating it to the size of the message, so a twenty-byte payload asking
+for 2^40 elements got what it asked for and the process was OOM-killed;
+and a query's qualifier count allocated, failed, and then unpacked into
+the NULL. Its seeds are fixed and its generator is a plain LCG so any
+failure is reproducible — if you find one, print the seed and the
+payload rather than adding a one-off case.
+
+Note what a failure of that stage looks like: the process dies with the
+buffered stdout unflushed, so you get **no output at all** and exit 137
+or 139. That is the signal, not a missing test.
+
 [`bfrops_get_number.c`](bfrops_get_number.c) is the third, and it is a
 **property test rather than a case list** for the same reason: the
 function under test is two thousand lines of one near-copy of an arm per

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -67,7 +67,8 @@ They fall into three groups.
 
 **Self-contained library tests** — no server, no launcher, no network.
 These run anywhere and are the bulk of the suite: `compress`, `preg`,
-`bfrops_regex2`, `bfrops_alloc_inherit`, `info_support`, `iof_pattern`,
+`bfrops_regex2`, `bfrops_alloc_inherit`, `bfrops_darray`,
+`bfrops_malformed`, `info_support`, `iof_pattern`,
 `hwloc_datatype`, `tracker_match`, `trk_complete`, `collective_status`,
 `collect_job_info`, `progress_threads`, `pmix_log`.
 
@@ -134,6 +135,68 @@ pointers had survived in them:
   this case with junk locality strings passes against the unfixed
   library and proves nothing. Both forms are in the test so the
   distinction stays visible.
+
+### `bfrops_darray` and `bfrops_malformed` — the `src/mca/bfrops` regression tests
+
+Both come from the August 2026 review of
+[`src/mca/bfrops`](../../src/mca/bfrops/base/AGENTS.md), which lists the
+defects individually. What is worth knowing here is why they are two
+programs rather than one, because they assert different kinds of thing.
+
+[`bfrops_darray.c`](bfrops_darray.c) is a **consistency sweep**, not a
+list of cases. For a `pmix_data_array_t` the tree has to answer six
+questions per element type — how to pack one, unpack one, copy one, how
+wide an element is, how to copy an array of them, how to release an
+array of them — in six different places, and nothing forces the last
+three to be written. A type with pack, unpack and copy but no arm in
+`pmix_bfrops_base_tma_data_array_construct()` looks finished: it works
+as a scalar and packs fine inside an array, and only fails on the way
+back. Eighteen registered types were in that state. So the test walks
+`all_types[]` and holds construct, pack/unpack and copy against each
+other for every one of them. **When you add a data type, add it to
+`all_types[]`** — that is the only thing keeping the six answers in
+step.
+
+Two entries in that list are deliberate exceptions and should stay
+documented rather than quietly dropped:
+
+- `PMIX_REGEX` is absent. The packer strides such an array as `char *`
+  and the destructor strides it as `pmix_byte_object_t`; those differ in
+  width, so arrays of it are intentionally not constructible until
+  somebody settles which stride is right. See the note in
+  `data_array_construct()`.
+- `PMIX_PROC_CPUSET` and `PMIX_TOPO` are skipped by the *copy* sweep
+  because an all-zero hwloc object is not a valid one, so copying it
+  legitimately declines. They get their own case
+  (`test_uncopyable_cpuset_array_declines_cleanly`) asserting that it
+  declines **without freeing the element block twice**, which is what it
+  used to do — an abort, not a failure.
+
+[`bfrops_malformed.c`](bfrops_malformed.c) asserts one contract:
+**no input may make the unpacker read outside the buffer it was given.**
+Returning an error is fine and returning a wrong value is tolerable;
+walking off the end is not. That framing matters when you extend it —
+several cases pass whether the library refuses or answers, and they are
+written that way on purpose.
+
+The two crashers it pins down are both three-byte messages. A count that
+claims a hundred values in front of one byte of them used to keep
+decoding past the allocation; and `flex_unpack_integer()` bounded its
+loop with `flex_size - 1`, which is `SIZE_MAX` when nothing is left, so
+it read until it happened to find a byte without a continuation flag.
+Against the unfixed library the first of those segfaults when the
+payload ends on a page boundary. `test_every_truncation_of_a_real_message`
+is the broad net over the same class: it packs a well-formed message and
+cuts it at every offset, which reaches decoder states nobody would think
+to write down.
+
+Neither program needs a server, and neither can reach the two things a
+*peer* decides — which bfrops module encodes a message, and whether the
+buffer is described. A single-process round trip is self-consistent
+under either, so it cannot fail on them. That half is
+[`examples/datatypes.c`](../../examples/datatypes.c), driven across
+separate nodes by
+[`contrib/dockerswarm/run-bfrops-tests.sh`](../../contrib/dockerswarm/AGENTS.md).
 
 ### `common_api` — the `src/common` regression test
 

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -203,7 +203,24 @@ payload rather than adding a one-off case.
 
 Note what a failure of that stage looks like: the process dies with the
 buffered stdout unflushed, so you get **no output at all** and exit 137
-or 139. That is the signal, not a missing test.
+(OOM), 139 (SIGSEGV) or 134 (glibc heap assertion). That is the signal,
+not a missing test.
+
+**The fuzz stage runs its inputs in this one process on purpose.** Heap
+corruption planted by one input is normally noticed by the allocator
+several inputs later, so a harness that forks per input throws the
+evidence away with the child. That is not hypothetical: the scratch
+version of this fuzzer forked, ran clean for hours against a remote heap
+overflow, and only surfaced it once folded in here. Do not "isolate" the
+cases.
+
+Two cases assemble a malformed message by hand, and they do it through a
+byte accumulator rather than through `PMIx_Data_embed()`. **`PMIx_Data_embed()`
+replaces a buffer's payload; it does not append to it.** A message built
+by embedding one piece after another is only ever the last piece — a
+one-byte buffer, which every unpacker refuses, so the test passes
+against any library at all and proves nothing. Both cases were written
+that way first.
 
 [`bfrops_get_number.c`](bfrops_get_number.c) is the third, and it is a
 **property test rather than a case list** for the same reason: the

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -68,7 +68,8 @@ They fall into three groups.
 **Self-contained library tests** — no server, no launcher, no network.
 These run anywhere and are the bulk of the suite: `compress`, `preg`,
 `bfrops_regex2`, `bfrops_alloc_inherit`, `bfrops_darray`,
-`bfrops_malformed`, `bfrops_get_number`, `info_support`, `iof_pattern`,
+`bfrops_malformed`, `bfrops_get_number`, `bfrops_null_object`,
+`info_support`, `iof_pattern`,
 `hwloc_datatype`, `tracker_match`, `trk_complete`, `collective_status`,
 `collect_job_info`, `progress_threads`, `pmix_log`.
 
@@ -210,6 +211,26 @@ One exclusion in it is policy, not laziness: a PMIx structured value
 converted into another structured type, as `check_rank()` in the source
 states. The test encodes that; do not delete the exclusion to make a
 "missing" conversion appear.
+
+[`bfrops_null_object.c`](bfrops_null_object.c) is the fourth, and it
+asserts survival rather than any return code. A value tagged with a
+pointer-backed type and carrying no object is malformed, but it takes
+nothing more than setting `.type` before the data — and eighty-five
+(type, operation) pairs segfaulted on one. What each operation *returns*
+for such a value is deliberately not checked: "there is no object here"
+is a state all of them can express, and which spelling a given one picks
+is not the subject.
+
+The one exception, which the test does pin down, is
+`PMIX_DATA_ARRAY`: a value that names a data array and carries none must
+copy to an **empty array**, not to another NULL, because callers
+dereference the result. Do not relax that to "either is fine".
+
+The test is noisy on purpose — a few of the types it walks have no
+member in the value union at all, and the library prints a diagnostic
+for them. Those lines are the library declining rather than faulting,
+which is what is being asserted; do not quiet them by dropping the
+types.
 
 Neither program needs a server, and neither can reach the two things a
 *peer* decides — which bfrops module encodes a message, and whether the

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
 
-TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
 
 client_api_SOURCES = \
         client_api.c
@@ -99,6 +99,12 @@ bfrops_darray_SOURCES = \
         bfrops_darray.c
 bfrops_darray_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 bfrops_darray_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+bfrops_get_number_SOURCES = \
+        bfrops_get_number.c
+bfrops_get_number_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+bfrops_get_number_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 bfrops_malformed_SOURCES = \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
 
-TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
 
 client_api_SOURCES = \
         client_api.c
@@ -111,6 +111,12 @@ bfrops_null_object_SOURCES = \
         bfrops_null_object.c
 bfrops_null_object_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 bfrops_null_object_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+bfrops_helpers_SOURCES = \
+        bfrops_helpers.c
+bfrops_helpers_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+bfrops_helpers_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 bfrops_malformed_SOURCES = \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
 
-TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
 
 client_api_SOURCES = \
         client_api.c
@@ -105,6 +105,12 @@ bfrops_get_number_SOURCES = \
         bfrops_get_number.c
 bfrops_get_number_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 bfrops_get_number_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+bfrops_null_object_SOURCES = \
+        bfrops_null_object.c
+bfrops_null_object_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+bfrops_null_object_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 bfrops_malformed_SOURCES = \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed nested_darray gds_fallback pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
 
-TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern proc_array_id
 
 client_api_SOURCES = \
         client_api.c
@@ -93,6 +93,18 @@ bfrops_alloc_inherit_SOURCES = \
         bfrops_alloc_inherit.c
 bfrops_alloc_inherit_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 bfrops_alloc_inherit_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+bfrops_darray_SOURCES = \
+        bfrops_darray.c
+bfrops_darray_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+bfrops_darray_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+bfrops_malformed_SOURCES = \
+        bfrops_malformed.c
+bfrops_malformed_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+bfrops_malformed_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 proc_array_id_SOURCES = \

--- a/test/unit/bfrops_darray.c
+++ b/test/unit/bfrops_darray.c
@@ -1,0 +1,466 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the bfrops data-array machinery.
+ *
+ * A pmix_data_array_t is described on the wire by an element type and a
+ * count, and every one of the four bfrops operations - construct/destruct,
+ * pack, unpack, copy - has to agree on what an element of that type is.
+ * They have not always agreed: a type could be packable but not
+ * constructible (so it never unpacked), or constructible at one width and
+ * copied at another (so copying it read past the block). This test walks
+ * the whole registered type table and holds those four operations against
+ * each other, which is the only way that class of mismatch shows up.
+ *
+ * It also covers two specific wire behaviours that a per-type sweep does
+ * not reach: an array whose element type is PMIX_UNDEF (the "no array
+ * here" marker, which pack and unpack must spell identically or the rest
+ * of the message is misread), and PMIX_DATA_BUFFER, whose unpacked form
+ * must be readable and not merely present.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL
+};
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* Every data type the newest bfrops component registers. Keep this in
+ * step with src/mca/bfrops/v61/bfrop_pmix61.c: a type that appears there
+ * and not here simply goes untested. */
+static pmix_data_type_t all_types[] = {
+    PMIX_BOOL, PMIX_BYTE, PMIX_STRING, PMIX_SIZE, PMIX_PID, PMIX_INT,
+    PMIX_INT8, PMIX_INT16, PMIX_INT32, PMIX_INT64, PMIX_UINT, PMIX_UINT8,
+    PMIX_UINT16, PMIX_UINT32, PMIX_UINT64, PMIX_FLOAT, PMIX_DOUBLE,
+    PMIX_TIMEVAL, PMIX_TIME, PMIX_STATUS, PMIX_VALUE, PMIX_PROC, PMIX_APP,
+    PMIX_INFO, PMIX_PDATA, PMIX_BUFFER, PMIX_BYTE_OBJECT, PMIX_KVAL,
+    PMIX_PERSIST, PMIX_POINTER, PMIX_SCOPE, PMIX_DATA_RANGE, PMIX_COMMAND,
+    PMIX_INFO_DIRECTIVES, PMIX_DATA_TYPE, PMIX_PROC_STATE, PMIX_PROC_INFO,
+    PMIX_DATA_ARRAY, PMIX_PROC_RANK, PMIX_QUERY, PMIX_COMPRESSED_STRING,
+    PMIX_ALLOC_DIRECTIVE, PMIX_IOF_CHANNEL, PMIX_ENVAR, PMIX_COORD,
+    PMIX_REGATTR, PMIX_JOB_STATE, PMIX_LINK_STATE, PMIX_PROC_CPUSET,
+    PMIX_GEOMETRY, PMIX_DEVTYPE, PMIX_DEVICE_DIST, PMIX_ENDPOINT,
+    PMIX_TOPO, PMIX_DEVICE, PMIX_RESOURCE_UNIT, PMIX_LOCTYPE,
+    PMIX_PROC_NSPACE, PMIX_COMPRESSED_BYTE_OBJECT, PMIX_DATA_BUFFER,
+    PMIX_ALLOC_INHERIT, PMIX_STOR_MEDIUM, PMIX_STOR_ACCESS,
+    PMIX_STOR_PERSIST, PMIX_STOR_ACCESS_TYPE, PMIX_RESBLOCK_DIRECTIVE,
+    PMIX_NODE_PID, PMIX_REGEX2
+};
+
+/* PMIX_REGEX is the one registered type this sweep deliberately skips.
+ * The tree does not agree on the width of an element of such an array -
+ * the packer strides char*, the destructor strides pmix_byte_object_t -
+ * so it is intentionally not constructible. See the note in
+ * pmix_bfrops_base_tma_data_array_construct(). */
+
+#define NELEMENTS 3
+
+/* ------------------------------------------------------------------ */
+/* every registered type must be usable as a data-array element        */
+/* ------------------------------------------------------------------ */
+
+static void test_construct_every_type(void)
+{
+    size_t i;
+    int ok = 1;
+
+    for (i = 0; i < sizeof(all_types) / sizeof(all_types[0]); i++) {
+        pmix_data_array_t *da = PMIx_Data_array_create(NELEMENTS, all_types[i]);
+
+        if (NULL == da || NULL == da->array || NELEMENTS != da->size
+            || all_types[i] != da->type) {
+            fprintf(stdout, "    %s: construct produced no array\n",
+                    PMIx_Data_type_string(all_types[i]));
+            ok = 0;
+        }
+        if (NULL != da) {
+            PMIx_Data_array_free(da);
+        }
+    }
+    report("every registered type can back a data array", ok);
+}
+
+static void test_pack_unpack_every_type(void)
+{
+    size_t i;
+    int ok = 1;
+
+    for (i = 0; i < sizeof(all_types) / sizeof(all_types[0]); i++) {
+        pmix_data_array_t *da;
+        pmix_data_array_t out;
+        pmix_data_buffer_t buf;
+        pmix_status_t rc;
+        int32_t cnt;
+
+        da = PMIx_Data_array_create(NELEMENTS, all_types[i]);
+        if (NULL == da) {
+            continue; /* reported by test_construct_every_type */
+        }
+        PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+        rc = PMIx_Data_pack(NULL, &buf, da, 1, PMIX_DATA_ARRAY);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stdout, "    %s: pack failed: %s\n",
+                    PMIx_Data_type_string(all_types[i]), PMIx_Error_string(rc));
+            ok = 0;
+        } else {
+            memset(&out, 0, sizeof(out));
+            cnt = 1;
+            rc = PMIx_Data_unpack(NULL, &buf, &out, &cnt, PMIX_DATA_ARRAY);
+            if (PMIX_SUCCESS != rc) {
+                fprintf(stdout, "    %s: unpack failed: %s\n",
+                        PMIx_Data_type_string(all_types[i]), PMIx_Error_string(rc));
+                ok = 0;
+            } else if (out.type != all_types[i] || NELEMENTS != out.size) {
+                fprintf(stdout, "    %s: unpacked as type %d size %lu\n",
+                        PMIx_Data_type_string(all_types[i]), (int) out.type,
+                        (unsigned long) out.size);
+                ok = 0;
+            }
+        }
+        PMIX_DATA_BUFFER_DESTRUCT(&buf);
+        PMIx_Data_array_free(da);
+    }
+    report("every registered type round-trips as a data array", ok);
+}
+
+static void test_copy_every_type(void)
+{
+    size_t i;
+    int ok = 1;
+
+    for (i = 0; i < sizeof(all_types) / sizeof(all_types[0]); i++) {
+        pmix_value_t src, dst;
+        pmix_data_array_t *da;
+        pmix_status_t rc;
+
+        /* an empty hwloc object is not a valid one, so copying an
+         * unpopulated cpuset or topology legitimately declines - the
+         * point of covering them here is that it declines rather than
+         * corrupting the heap on the way out */
+        if (PMIX_PROC_CPUSET == all_types[i] || PMIX_TOPO == all_types[i]) {
+            continue;
+        }
+        da = PMIx_Data_array_create(NELEMENTS, all_types[i]);
+        if (NULL == da) {
+            continue;
+        }
+        memset(&src, 0, sizeof(src));
+        memset(&dst, 0, sizeof(dst));
+        src.type = PMIX_DATA_ARRAY;
+        src.data.darray = da;
+
+        rc = PMIx_Value_xfer(&dst, &src);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stdout, "    %s: value xfer failed: %s\n",
+                    PMIx_Data_type_string(all_types[i]), PMIx_Error_string(rc));
+            ok = 0;
+        } else if (NULL == dst.data.darray || NELEMENTS != dst.data.darray->size
+                   || all_types[i] != dst.data.darray->type) {
+            fprintf(stdout, "    %s: value xfer produced a short array\n",
+                    PMIx_Data_type_string(all_types[i]));
+            ok = 0;
+        } else {
+            PMIX_VALUE_DESTRUCT(&dst);
+        }
+        PMIx_Data_array_free(da);
+    }
+    report("every registered type copies as a data array", ok);
+}
+
+/* An empty hwloc cpuset cannot be copied - the interesting part is that
+ * declining leaves the heap intact rather than releasing the element
+ * block twice. */
+static void test_uncopyable_cpuset_array_declines_cleanly(void)
+{
+    pmix_value_t src, dst;
+    pmix_data_array_t *da;
+    pmix_status_t rc;
+    int ok;
+
+    da = PMIx_Data_array_create(NELEMENTS, PMIX_PROC_CPUSET);
+    if (NULL == da) {
+        report("an uncopyable cpuset array declines without a double free", 0);
+        return;
+    }
+    memset(&src, 0, sizeof(src));
+    memset(&dst, 0, sizeof(dst));
+    src.type = PMIX_DATA_ARRAY;
+    src.data.darray = da;
+
+    rc = PMIx_Value_xfer(&dst, &src);
+    ok = (PMIX_SUCCESS != rc && NULL == dst.data.darray);
+
+    /* if the block had been released twice the process would be gone by
+     * now; make sure the source is still intact and still freeable */
+    ok = ok && (NULL != da->array) && (NELEMENTS == da->size);
+    PMIx_Data_array_free(da);
+
+    report("an uncopyable cpuset array declines without a double free", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* an undefined element type is a marker, and must be one on both sides */
+/* ------------------------------------------------------------------ */
+
+static void test_undef_array_keeps_the_stream_in_step(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_data_array_t da, out;
+    pmix_status_t rc;
+    int32_t cnt;
+    char *sentinel = "SENTINEL";
+    char *back = NULL;
+    int ok = 1;
+
+    /* a descriptor with no element type: exactly what copying a value
+     * whose darray pointer was NULL hands back */
+    memset(&da, 0, sizeof(da));
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    rc = PMIx_Data_pack(NULL, &buf, &da, 1, PMIX_DATA_ARRAY);
+    ok = ok && (PMIX_SUCCESS == rc);
+    rc = PMIx_Data_pack(NULL, &buf, &sentinel, 1, PMIX_STRING);
+    ok = ok && (PMIX_SUCCESS == rc);
+
+    memset(&out, 0, sizeof(out));
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &out, &cnt, PMIX_DATA_ARRAY);
+    ok = ok && (PMIX_SUCCESS == rc) && (PMIX_UNDEF == out.type) && (0 == out.size);
+
+    /* the real assertion: whatever follows the marker must still be
+     * where the reader expects it */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &back, &cnt, PMIX_STRING);
+    ok = ok && (PMIX_SUCCESS == rc) && (NULL != back)
+         && (0 == strcmp(back, "SENTINEL"));
+    if (NULL != back) {
+        free(back);
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    report("an undefined-element array does not desync the stream", ok);
+}
+
+static void test_null_darray_value_keeps_the_stream_in_step(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_value_t v, out;
+    pmix_status_t rc;
+    int32_t cnt;
+    char *sentinel = "AFTER";
+    char *back = NULL;
+    int ok = 1;
+
+    /* a value that says "data array" and carries no array */
+    memset(&v, 0, sizeof(v));
+    v.type = PMIX_DATA_ARRAY;
+    v.data.darray = NULL;
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    rc = PMIx_Data_pack(NULL, &buf, &v, 1, PMIX_VALUE);
+    ok = ok && (PMIX_SUCCESS == rc);
+    rc = PMIx_Data_pack(NULL, &buf, &sentinel, 1, PMIX_STRING);
+    ok = ok && (PMIX_SUCCESS == rc);
+
+    memset(&out, 0, sizeof(out));
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &out, &cnt, PMIX_VALUE);
+    ok = ok && (PMIX_SUCCESS == rc);
+
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &back, &cnt, PMIX_STRING);
+    ok = ok && (PMIX_SUCCESS == rc) && (NULL != back)
+         && (0 == strcmp(back, "AFTER"));
+    if (NULL != back) {
+        free(back);
+    }
+    PMIX_VALUE_DESTRUCT(&out);
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    report("a NULL-array value does not desync the stream", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* a nested data buffer must come back readable                        */
+/* ------------------------------------------------------------------ */
+
+static void test_data_buffer_roundtrip_is_readable(void)
+{
+    pmix_data_buffer_t outer, inner, got;
+    pmix_status_t rc;
+    int32_t cnt;
+    char *payload = "nested";
+    char *back = NULL;
+    int ok = 1;
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&inner);
+    rc = PMIx_Data_pack(NULL, &inner, &payload, 1, PMIX_STRING);
+    ok = ok && (PMIX_SUCCESS == rc);
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&outer);
+    rc = PMIx_Data_pack(NULL, &outer, &inner, 1, PMIX_DATA_BUFFER);
+    ok = ok && (PMIX_SUCCESS == rc);
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&got);
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &outer, &got, &cnt, PMIX_DATA_BUFFER);
+    ok = ok && (PMIX_SUCCESS == rc);
+
+    /* recovering the payload is only half the job - without the cursors
+     * and the allocation size the caller cannot read a single value out
+     * of what it was handed */
+    ok = ok && (got.bytes_used == inner.bytes_used)
+         && (got.bytes_allocated >= got.bytes_used)
+         && (NULL != got.unpack_ptr) && (NULL != got.pack_ptr);
+
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &got, &back, &cnt, PMIX_STRING);
+    ok = ok && (PMIX_SUCCESS == rc) && (NULL != back)
+         && (0 == strcmp(back, "nested"));
+    if (NULL != back) {
+        free(back);
+    }
+
+    PMIX_DATA_BUFFER_DESTRUCT(&got);
+    PMIX_DATA_BUFFER_DESTRUCT(&outer);
+    PMIX_DATA_BUFFER_DESTRUCT(&inner);
+
+    report("an unpacked data buffer can be read from", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* a kval array with unfilled elements must pack rather than crash      */
+/* ------------------------------------------------------------------ */
+
+static void test_kval_array_with_empty_elements(void)
+{
+    pmix_data_array_t *da;
+    pmix_data_array_t out;
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t cnt;
+    int ok = 1;
+
+    da = PMIx_Data_array_create(NELEMENTS, PMIX_KVAL);
+    if (NULL == da || NULL == da->array) {
+        report("a kval array with empty elements packs", 0);
+        return;
+    }
+    /* every element still has a NULL key and a NULL value pointer */
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    rc = PMIx_Data_pack(NULL, &buf, da, 1, PMIX_DATA_ARRAY);
+    ok = ok && (PMIX_SUCCESS == rc);
+
+    memset(&out, 0, sizeof(out));
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &out, &cnt, PMIX_DATA_ARRAY);
+    ok = ok && (PMIX_SUCCESS == rc) && (NELEMENTS == out.size);
+
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+    PMIx_Data_array_free(da);
+
+    report("a kval array with empty elements packs", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* a populated array must survive the round trip with its contents      */
+/* ------------------------------------------------------------------ */
+
+static void test_populated_array_contents_survive(void)
+{
+    pmix_data_array_t da;
+    pmix_data_array_t out;
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t cnt;
+    int32_t *vals;
+    int ok = 1;
+    size_t n;
+
+    PMIX_DATA_ARRAY_CONSTRUCT(&da, 5, PMIX_INT32);
+    vals = (int32_t *) da.array;
+    for (n = 0; n < 5; n++) {
+        vals[n] = (int32_t) (n * 1000) - 2000;
+    }
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    rc = PMIx_Data_pack(NULL, &buf, &da, 1, PMIX_DATA_ARRAY);
+    ok = ok && (PMIX_SUCCESS == rc);
+
+    memset(&out, 0, sizeof(out));
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &out, &cnt, PMIX_DATA_ARRAY);
+    ok = ok && (PMIX_SUCCESS == rc) && (5 == out.size) && (PMIX_INT32 == out.type);
+    if (ok) {
+        int32_t *got = (int32_t *) out.array;
+        for (n = 0; n < 5; n++) {
+            if (got[n] != vals[n]) {
+                ok = 0;
+                break;
+            }
+        }
+    }
+    PMIX_DATA_ARRAY_DESTRUCT(&out);
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+    PMIX_DATA_ARRAY_DESTRUCT(&da);
+
+    report("a populated int32 array round-trips its contents", ok);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    (void) argc;
+    (void) argv;
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== bfrops data-array unit tests ===\n\n");
+
+    test_construct_every_type();
+    test_pack_unpack_every_type();
+    test_copy_every_type();
+    test_uncopyable_cpuset_array_declines_cleanly();
+    test_undef_array_keeps_the_stream_in_step();
+    test_null_darray_value_keeps_the_stream_in_step();
+    test_data_buffer_roundtrip_is_readable();
+    test_kval_array_with_empty_elements();
+    test_populated_array_contents_survive();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/bfrops_get_number.c
+++ b/test/unit/bfrops_get_number.c
@@ -90,6 +90,59 @@ static int is_structured(pmix_data_type_t t)
     return (PMIX_PID == t || PMIX_STATUS == t || PMIX_PROC_RANK == t);
 }
 
+/* the representable range of each integral destination type */
+static int int_range(pmix_data_type_t t, long double *lo, long double *hi)
+{
+    switch (t) {
+    case PMIX_SIZE:
+    case PMIX_UINT64: *lo = 0; *hi = 18446744073709551615.0L; return 1;
+    case PMIX_UINT32:
+    case PMIX_UINT:
+    case PMIX_PROC_RANK: *lo = 0; *hi = 4294967295.0L; return 1;
+    case PMIX_UINT16: *lo = 0; *hi = 65535.0L; return 1;
+    case PMIX_UINT8: *lo = 0; *hi = 255.0L; return 1;
+    case PMIX_INT64: *lo = -9223372036854775807.0L - 1;
+                     *hi = 9223372036854775807.0L; return 1;
+    case PMIX_INT32:
+    case PMIX_INT:
+    case PMIX_PID:
+    case PMIX_STATUS: *lo = -2147483648.0L; *hi = 2147483647.0L; return 1;
+    case PMIX_INT16: *lo = -32768.0L; *hi = 32767.0L; return 1;
+    case PMIX_INT8: *lo = -128.0L; *hi = 127.0L; return 1;
+    default: return 0;
+    }
+}
+
+/* Can a value of `t` hold `x` exactly?
+ *
+ * This is not a convenience - it is what keeps the test defined. C says
+ * that converting a floating value to an integer type is UNDEFINED when
+ * the value does not fit, and setval() below builds every sample by
+ * converting a long double. An earlier version of this file simply let
+ * that happen and expected the usual two's-complement wrap: gcc obliged
+ * consistently, so the oracle agreed with the stored value and the test
+ * passed. clang is equally within its rights to fold the same
+ * expression differently at different sites, and does - it reported the
+ * sample as 128 while the value held -128, and the test failed with a
+ * long list of "reported success but gave" lines that looked like
+ * library defects and were not.
+ *
+ * So: never build an out-of-range value. Skip the pair instead. Nothing
+ * is lost, because a deliberately-wrapped sample was never what any of
+ * these properties were about. */
+static int fits(pmix_data_type_t t, long double x)
+{
+    long double lo, hi;
+
+    if (PMIX_FLOAT == t || PMIX_DOUBLE == t) {
+        return 1;  /* every sample here is well inside both ranges */
+    }
+    if (!int_range(t, &lo, &hi)) {
+        return 0;
+    }
+    return (x >= lo && x <= hi);
+}
+
 static void setval(pmix_value_t *v, pmix_data_type_t t, long double x)
 {
     memset(v, 0, sizeof(*v));
@@ -138,29 +191,6 @@ static long double getval(const pmix_value_t *v)
     }
 }
 
-/* the representable range of each integral destination type */
-static int int_range(pmix_data_type_t t, long double *lo, long double *hi)
-{
-    switch (t) {
-    case PMIX_SIZE:
-    case PMIX_UINT64: *lo = 0; *hi = 18446744073709551615.0L; return 1;
-    case PMIX_UINT32:
-    case PMIX_UINT:
-    case PMIX_PROC_RANK: *lo = 0; *hi = 4294967295.0L; return 1;
-    case PMIX_UINT16: *lo = 0; *hi = 65535.0L; return 1;
-    case PMIX_UINT8: *lo = 0; *hi = 255.0L; return 1;
-    case PMIX_INT64: *lo = -9223372036854775807.0L - 1;
-                     *hi = 9223372036854775807.0L; return 1;
-    case PMIX_INT32:
-    case PMIX_INT:
-    case PMIX_PID:
-    case PMIX_STATUS: *lo = -2147483648.0L; *hi = 2147483647.0L; return 1;
-    case PMIX_INT16: *lo = -32768.0L; *hi = 32767.0L; return 1;
-    case PMIX_INT8: *lo = -128.0L; *hi = 127.0L; return 1;
-    default: return 0;
-    }
-}
-
 /* ------------------------------------------------------------------ */
 
 static void test_success_means_exact(void)
@@ -174,6 +204,9 @@ static void test_success_means_exact(void)
             pmix_value_t v;
             long double exact;
 
+            if (!fits(types[s], samples[k])) {
+                continue;
+            }
             setval(&v, types[s], samples[k]);
             exact = getval(&v);
 
@@ -221,6 +254,9 @@ static void test_refusal_means_unrepresentable(void)
             pmix_value_t v;
             long double exact;
 
+            if (!fits(types[s], samples[k])) {
+                continue;
+            }
             setval(&v, types[s], samples[k]);
             exact = getval(&v);
 
@@ -321,10 +357,10 @@ static void test_negative_into_unsigned_is_refused(void)
         for (n = 0; n < 2; n++) {
             pmix_value_t v;
 
-            setval(&v, signed_src[s], vals[n]);
-            if (getval(&v) >= 0) {
-                continue; /* did not fit; not a negative value any more */
+            if (!fits(signed_src[s], vals[n])) {
+                continue;
             }
+            setval(&v, signed_src[s], vals[n]);
             for (d = 0; d < sizeof(unsigned_dst) / sizeof(unsigned_dst[0]); d++) {
                 uint64_t out = 0;
                 pmix_status_t rc = PMIx_Value_get_number(&v, &out, unsigned_dst[d]);

--- a/test/unit/bfrops_get_number.c
+++ b/test/unit/bfrops_get_number.c
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for PMIx_Value_get_number().
+ *
+ * That function is roughly two thousand lines of hand-written range and
+ * precision checks: one check_<type>() per source type, each with one
+ * arm per destination type. It is the shape of code where a single
+ * copy-pasted line is invisible on review and wrong at run time, and
+ * that is exactly what the August 2026 review of src/mca/bfrops found -
+ * sign checks reading the wrong union member, arms reading a narrower
+ * member than their function's own type, a range constant with an extra
+ * digit in it, and stores with no return after them.
+ *
+ * So this does not test cases. It states the two properties the
+ * function has to satisfy and checks them over every (source,
+ * destination) pair at every interesting value:
+ *
+ *   1. If it reports success, the value it wrote must equal the value
+ *      it was given. Never a truncation, never a sign flip.
+ *   2. If it refuses, the value must genuinely not have been
+ *      representable in the destination type.
+ *
+ * Property 2 is the one that found the missing returns: every
+ * conversion to PMIX_PROC_RANK wrote the right answer and then reported
+ * PMIX_ERR_BAD_PARAM, which no test that only looked at successful
+ * conversions could have seen.
+ *
+ * There is one deliberate exception, stated in check_rank() in the
+ * source: a PMIx structured value (PMIX_PID, PMIX_STATUS,
+ * PMIX_PROC_RANK) is not unloaded into another structured type, even
+ * though the underlying C types would allow it. That is policy, not a
+ * defect, so this test encodes it rather than reporting it.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL
+};
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+static pmix_data_type_t types[] = {
+    PMIX_SIZE, PMIX_INT, PMIX_INT8, PMIX_INT16, PMIX_INT32, PMIX_INT64,
+    PMIX_UINT, PMIX_UINT8, PMIX_UINT16, PMIX_UINT32, PMIX_UINT64,
+    PMIX_FLOAT, PMIX_DOUBLE, PMIX_PID, PMIX_PROC_RANK, PMIX_STATUS
+};
+#define NTYPES (sizeof(types) / sizeof(types[0]))
+
+/* the boundaries of every width the function deals in, from both sides */
+static long double samples[] = {
+    0, 1, -1, 2, -2,
+    127, 128, -128, -129,
+    255, 256,
+    32767, 32768, -32768, -32769,
+    65535, 65536,
+    2147483647.0L, 2147483648.0L, -2147483648.0L, -2147483649.0L,
+    4294967295.0L, 4294967296.0L,
+    9223372036854775807.0L, -9223372036854775807.0L,
+    18446744073709551615.0L
+};
+#define NSAMPLES (sizeof(samples) / sizeof(samples[0]))
+
+static int is_structured(pmix_data_type_t t)
+{
+    return (PMIX_PID == t || PMIX_STATUS == t || PMIX_PROC_RANK == t);
+}
+
+static void setval(pmix_value_t *v, pmix_data_type_t t, long double x)
+{
+    memset(v, 0, sizeof(*v));
+    v->type = t;
+    switch (t) {
+    case PMIX_SIZE: v->data.size = (size_t) x; break;
+    case PMIX_INT: v->data.integer = (int) x; break;
+    case PMIX_INT8: v->data.int8 = (int8_t) x; break;
+    case PMIX_INT16: v->data.int16 = (int16_t) x; break;
+    case PMIX_INT32: v->data.int32 = (int32_t) x; break;
+    case PMIX_INT64: v->data.int64 = (int64_t) x; break;
+    case PMIX_UINT: v->data.uint = (unsigned int) x; break;
+    case PMIX_UINT8: v->data.uint8 = (uint8_t) x; break;
+    case PMIX_UINT16: v->data.uint16 = (uint16_t) x; break;
+    case PMIX_UINT32: v->data.uint32 = (uint32_t) x; break;
+    case PMIX_UINT64: v->data.uint64 = (uint64_t) x; break;
+    case PMIX_FLOAT: v->data.fval = (float) x; break;
+    case PMIX_DOUBLE: v->data.dval = (double) x; break;
+    case PMIX_PID: v->data.pid = (pid_t) x; break;
+    case PMIX_PROC_RANK: v->data.rank = (pmix_rank_t) x; break;
+    case PMIX_STATUS: v->data.status = (pmix_status_t) x; break;
+    default: break;
+    }
+}
+
+static long double getval(const pmix_value_t *v)
+{
+    switch (v->type) {
+    case PMIX_SIZE: return (long double) v->data.size;
+    case PMIX_INT: return (long double) v->data.integer;
+    case PMIX_INT8: return (long double) v->data.int8;
+    case PMIX_INT16: return (long double) v->data.int16;
+    case PMIX_INT32: return (long double) v->data.int32;
+    case PMIX_INT64: return (long double) v->data.int64;
+    case PMIX_UINT: return (long double) v->data.uint;
+    case PMIX_UINT8: return (long double) v->data.uint8;
+    case PMIX_UINT16: return (long double) v->data.uint16;
+    case PMIX_UINT32: return (long double) v->data.uint32;
+    case PMIX_UINT64: return (long double) v->data.uint64;
+    case PMIX_FLOAT: return (long double) v->data.fval;
+    case PMIX_DOUBLE: return (long double) v->data.dval;
+    case PMIX_PID: return (long double) v->data.pid;
+    case PMIX_PROC_RANK: return (long double) v->data.rank;
+    case PMIX_STATUS: return (long double) v->data.status;
+    default: return 0;
+    }
+}
+
+/* the representable range of each integral destination type */
+static int int_range(pmix_data_type_t t, long double *lo, long double *hi)
+{
+    switch (t) {
+    case PMIX_SIZE:
+    case PMIX_UINT64: *lo = 0; *hi = 18446744073709551615.0L; return 1;
+    case PMIX_UINT32:
+    case PMIX_UINT:
+    case PMIX_PROC_RANK: *lo = 0; *hi = 4294967295.0L; return 1;
+    case PMIX_UINT16: *lo = 0; *hi = 65535.0L; return 1;
+    case PMIX_UINT8: *lo = 0; *hi = 255.0L; return 1;
+    case PMIX_INT64: *lo = -9223372036854775807.0L - 1;
+                     *hi = 9223372036854775807.0L; return 1;
+    case PMIX_INT32:
+    case PMIX_INT:
+    case PMIX_PID:
+    case PMIX_STATUS: *lo = -2147483648.0L; *hi = 2147483647.0L; return 1;
+    case PMIX_INT16: *lo = -32768.0L; *hi = 32767.0L; return 1;
+    case PMIX_INT8: *lo = -128.0L; *hi = 127.0L; return 1;
+    default: return 0;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_success_means_exact(void)
+{
+    size_t s, d, k;
+    int ok = 1;
+    int reported = 0;
+
+    for (s = 0; s < NTYPES; s++) {
+        for (k = 0; k < NSAMPLES; k++) {
+            pmix_value_t v;
+            long double exact;
+
+            setval(&v, types[s], samples[k]);
+            exact = getval(&v);
+
+            for (d = 0; d < NTYPES; d++) {
+                pmix_value_t out;
+                pmix_status_t rc;
+                unsigned char buf[32];
+
+                /* a float or double at either end legitimately rounds */
+                if (PMIX_FLOAT == types[d] || PMIX_DOUBLE == types[d]
+                    || PMIX_FLOAT == types[s] || PMIX_DOUBLE == types[s]) {
+                    continue;
+                }
+                memset(buf, 0xAB, sizeof(buf));
+                rc = PMIx_Value_get_number(&v, buf, types[d]);
+                if (PMIX_SUCCESS != rc) {
+                    continue;
+                }
+                memset(&out, 0, sizeof(out));
+                out.type = types[d];
+                memcpy(&out.data, buf, sizeof(out.data) < 16 ? sizeof(out.data) : 16);
+                if (getval(&out) != exact) {
+                    if (reported < 10) {
+                        fprintf(stdout, "    %s(%.0Lf) -> %s reported success but gave %.0Lf\n",
+                                PMIx_Data_type_string(types[s]), exact,
+                                PMIx_Data_type_string(types[d]), getval(&out));
+                        reported++;
+                    }
+                    ok = 0;
+                }
+            }
+        }
+    }
+    report("a successful conversion returns the value it was given", ok);
+}
+
+static void test_refusal_means_unrepresentable(void)
+{
+    size_t s, d, k;
+    int ok = 1;
+    int reported = 0;
+
+    for (s = 0; s < NTYPES; s++) {
+        for (k = 0; k < NSAMPLES; k++) {
+            pmix_value_t v;
+            long double exact;
+
+            setval(&v, types[s], samples[k]);
+            exact = getval(&v);
+
+            for (d = 0; d < NTYPES; d++) {
+                pmix_status_t rc;
+                unsigned char buf[32];
+                long double lo, hi;
+
+                if (types[s] == types[d]) {
+                    continue;
+                }
+                /* stated policy in check_rank(): a structured value is
+                 * not unloaded into another structured type */
+                if (is_structured(types[s]) && is_structured(types[d])) {
+                    continue;
+                }
+                if (PMIX_FLOAT == types[d] || PMIX_DOUBLE == types[d]
+                    || PMIX_FLOAT == types[s] || PMIX_DOUBLE == types[s]) {
+                    continue;
+                }
+                if (!int_range(types[d], &lo, &hi)) {
+                    continue;
+                }
+                /* long double is not always wider than 64 bits, so at
+                 * the very top of the int64 range it cannot tell
+                 * 2^63-1 from 2^63 and the oracle stops being one */
+                if (exact >= 9223372036854775807.0L && PMIX_INT64 == types[d]) {
+                    continue;
+                }
+                if (exact < lo || exact > hi) {
+                    continue; /* refusing is correct */
+                }
+                memset(buf, 0xAB, sizeof(buf));
+                rc = PMIx_Value_get_number(&v, buf, types[d]);
+                if (PMIX_SUCCESS != rc) {
+                    if (reported < 10) {
+                        fprintf(stdout, "    %s(%.0Lf) -> %s refused (%s) but is representable\n",
+                                PMIx_Data_type_string(types[s]), exact,
+                                PMIx_Data_type_string(types[d]), PMIx_Error_string(rc));
+                        reported++;
+                    }
+                    ok = 0;
+                }
+            }
+        }
+    }
+    report("a representable conversion is not refused", ok);
+}
+
+/* Every source type must at least be recognized. PMIX_PID was not: it
+ * had no check_ function, so every conversion out of a pid returned
+ * PMIX_ERR_BAD_PARAM. */
+static void test_every_source_type_is_handled(void)
+{
+    size_t s;
+    int ok = 1;
+
+    for (s = 0; s < NTYPES; s++) {
+        pmix_value_t v;
+        int64_t out = 0;
+        pmix_status_t rc;
+
+        setval(&v, types[s], 42);
+        rc = PMIx_Value_get_number(&v, &out, PMIX_INT64);
+        if (PMIX_SUCCESS != rc || 42 != out) {
+            fprintf(stdout, "    %s(42) -> PMIX_INT64: %s (got %lld)\n",
+                    PMIx_Data_type_string(types[s]), PMIx_Error_string(rc),
+                    (long long) out);
+            ok = 0;
+        }
+    }
+    report("every numeric source type is handled", ok);
+}
+
+/* The sign checks are the part that has been wrong most often, and they
+ * are wrong in the direction that does not fail loudly, so state them
+ * separately. */
+static void test_negative_into_unsigned_is_refused(void)
+{
+    static const pmix_data_type_t signed_src[] = {
+        PMIX_INT, PMIX_INT8, PMIX_INT16, PMIX_INT32, PMIX_INT64,
+        PMIX_PID, PMIX_STATUS
+    };
+    static const pmix_data_type_t unsigned_dst[] = {
+        PMIX_SIZE, PMIX_UINT, PMIX_UINT8, PMIX_UINT16, PMIX_UINT32,
+        PMIX_UINT64
+    };
+    size_t s, d;
+    int ok = 1;
+
+    for (s = 0; s < sizeof(signed_src) / sizeof(signed_src[0]); s++) {
+        /* -1 exercises the low bits; the second value has zeroes in the
+         * low word, which is what made a sign check that read the wrong
+         * union member look like it worked */
+        long double vals[2] = {-1, -4294967296.0L};
+        size_t n;
+
+        for (n = 0; n < 2; n++) {
+            pmix_value_t v;
+
+            setval(&v, signed_src[s], vals[n]);
+            if (getval(&v) >= 0) {
+                continue; /* did not fit; not a negative value any more */
+            }
+            for (d = 0; d < sizeof(unsigned_dst) / sizeof(unsigned_dst[0]); d++) {
+                uint64_t out = 0;
+                pmix_status_t rc = PMIx_Value_get_number(&v, &out, unsigned_dst[d]);
+
+                if (PMIX_SUCCESS == rc) {
+                    fprintf(stdout, "    %s(%.0Lf) -> %s accepted, gave %llu\n",
+                            PMIx_Data_type_string(signed_src[s]), getval(&v),
+                            PMIx_Data_type_string(unsigned_dst[d]),
+                            (unsigned long long) out);
+                    ok = 0;
+                }
+            }
+        }
+    }
+    report("a negative value is refused by every unsigned destination", ok);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+
+    (void) argc;
+    (void) argv;
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== PMIx_Value_get_number unit tests ===\n\n");
+
+    test_every_source_type_is_handled();
+    test_success_means_exact();
+    test_refusal_means_unrepresentable();
+    test_negative_into_unsigned_is_refused();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/bfrops_helpers.c
+++ b/test/unit/bfrops_helpers.c
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Degenerate inputs to the public helper APIs that src/mca/bfrops
+ * implements.
+ *
+ * A surprising amount of the installed PMIx C API lives in
+ * bfrops/base - the whole PMIx_Argv_* family, the PMIx_Info_list_*
+ * builders, the construct/create/load/free helpers for every PMIx
+ * struct - because it is all fundamentally data manipulation. It is
+ * also the part of the API applications call most casually, which makes
+ * "what happens when the caller passes NULL" a question with a large
+ * blast radius and no obvious owner.
+ *
+ * This asserts survival on that question, not any particular return
+ * code. Refusing with PMIX_ERR_BAD_PARAM and quietly doing nothing are
+ * both defensible answers for most of these, and which one a given
+ * helper picks is not the subject; the subject is that the answer is
+ * not a signal.
+ *
+ * Two cases here do assert behaviour, because a caller can tell the
+ * difference and does depend on it:
+ *   - PMIx_Info_list_release(NULL) must be a no-op, like every other
+ *     release in that file. A caller whose PMIx_Info_list_start()
+ *     failed holds exactly that NULL.
+ *   - a zero-length create must not hand back something a matching free
+ *     will choke on.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL
+};
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* the argv family                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_argv_degenerate(void)
+{
+    char **a = NULL;
+    char *s;
+
+    (void) PMIx_Argv_count(NULL);
+    PMIx_Argv_free(NULL);
+
+    s = PMIx_Argv_join(NULL, ',');
+    if (NULL != s) {
+        free(s);
+    }
+
+    a = PMIx_Argv_split(NULL, ',');
+    PMIx_Argv_free(a);
+    a = PMIx_Argv_split("", ',');
+    PMIx_Argv_free(a);
+    a = PMIx_Argv_split(",,,", ',');
+    PMIx_Argv_free(a);
+    a = PMIx_Argv_copy(NULL);
+    PMIx_Argv_free(a);
+
+    /* a NULL string is nothing to append, and a NULL array pointer is
+     * nowhere to append it to */
+    a = NULL;
+    (void) PMIx_Argv_append_nosize(&a, NULL);
+    (void) PMIx_Argv_prepend_nosize(&a, NULL);
+    (void) PMIx_Argv_append_unique_nosize(&a, NULL);
+    (void) PMIx_Argv_append_nosize(NULL, "x");
+    PMIx_Argv_free(a);
+
+    report("the argv helpers survive NULL arrays and NULL strings", 1);
+}
+
+static void test_argv_still_works(void)
+{
+    char **a = NULL;
+    char *joined;
+    int ok = 1;
+
+    /* the guards must not have cost the ordinary path anything */
+    (void) PMIx_Argv_append_nosize(&a, "one");
+    (void) PMIx_Argv_append_nosize(&a, "two");
+    (void) PMIx_Argv_prepend_nosize(&a, "zero");
+    (void) PMIx_Argv_append_unique_nosize(&a, "two");
+    ok = ok && (3 == PMIx_Argv_count(a));
+
+    joined = PMIx_Argv_join(a, ':');
+    ok = ok && (NULL != joined) && (0 == strcmp(joined, "zero:one:two"));
+    if (NULL != joined) {
+        free(joined);
+    }
+    PMIx_Argv_free(a);
+
+    report("the argv helpers still do their job", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* proc and key helpers                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_procid_degenerate(void)
+{
+    pmix_proc_t p;
+    pmix_key_t k;
+    pmix_nspace_t n, cluster, nspace;
+
+    PMIx_Load_procid(NULL, "ns", 0);
+    (void) PMIx_Check_procid(NULL, NULL);
+    (void) PMIx_Procid_invalid(NULL);
+    PMIx_Xfer_procid(NULL, NULL);
+
+    PMIx_Load_key(k, NULL);
+    (void) PMIx_Check_key(NULL, NULL);
+    (void) PMIx_Check_nspace(NULL, NULL);
+    PMIx_Load_nspace(n, NULL);
+
+    PMIx_Multicluster_nspace_parse(NULL, cluster, nspace);
+    PMIx_Load_procid(&p, NULL, 0);
+
+    report("the proc and key helpers survive NULL arguments", 1);
+}
+
+/* The two halves of a multi-cluster nspace are written element by
+ * element and the nspace half is never terminated, so both outputs have
+ * to be cleared before anything is written into them - otherwise
+ * whatever the caller's buffer held before shows through. */
+static void test_multicluster_parse(void)
+{
+    pmix_nspace_t target, cluster, nspace;
+    int ok = 1;
+
+    /* the parameter is declared as a pmix_nspace_t, so hand it one */
+    PMIx_Load_nspace(target, "clusterA:job17");
+    memset(cluster, 'X', sizeof(cluster));
+    memset(nspace, 'X', sizeof(nspace));
+    PMIx_Multicluster_nspace_parse(target, cluster, nspace);
+    ok = ok && (0 == strcmp(cluster, "clusterA"))
+            && (0 == strcmp(nspace, "job17"));
+
+    /* no separator at all: there is no nspace half */
+    PMIx_Load_nspace(target, "nocolonhere");
+    memset(cluster, 'X', sizeof(cluster));
+    memset(nspace, 'X', sizeof(nspace));
+    PMIx_Multicluster_nspace_parse(target, cluster, nspace);
+    ok = ok && (0 == strcmp(cluster, "nocolonhere")) && ('\0' == nspace[0]);
+
+    report("a multi-cluster nspace parses into cleared halves", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* create / free at zero, and free of nothing                          */
+/* ------------------------------------------------------------------ */
+
+static void test_zero_and_null_lifecycle(void)
+{
+    pmix_info_t *i;
+    pmix_proc_t *p;
+    pmix_value_t *v;
+    pmix_query_t *q;
+    pmix_app_t *ap;
+    pmix_data_array_t *d;
+
+    i = PMIx_Info_create(0);
+    PMIx_Info_free(i, 0);
+    PMIx_Info_free(NULL, 3);
+
+    p = PMIx_Proc_create(0);
+    PMIx_Proc_free(p, 0);
+    PMIx_Proc_free(NULL, 3);
+
+    v = PMIx_Value_create(0);
+    PMIx_Value_free(v, 0);
+
+    q = PMIx_Query_create(0);
+    PMIx_Query_free(q, 0);
+
+    ap = PMIx_App_create(0);
+    PMIx_App_free(ap, 0);
+
+    d = PMIx_Data_array_create(0, PMIX_INT);
+    PMIx_Data_array_free(d);
+    PMIx_Data_array_free(NULL);
+
+    report("creating zero of a thing, and freeing nothing", 1);
+}
+
+static void test_load_helpers_with_no_data(void)
+{
+    pmix_info_t info;
+    pmix_value_t v;
+    pmix_envar_t e;
+    pmix_byte_object_t b;
+    pmix_pdata_t pd;
+    pmix_regattr_t r;
+
+    PMIx_Info_load(&info, NULL, NULL, PMIX_STRING);
+    PMIX_INFO_DESTRUCT(&info);
+    PMIx_Info_load(&info, "k", NULL, PMIX_STRING);
+    PMIX_INFO_DESTRUCT(&info);
+
+    PMIX_VALUE_CONSTRUCT(&v);
+    (void) PMIx_Value_load(&v, NULL, PMIX_STRING);
+    PMIX_VALUE_DESTRUCT(&v);
+    (void) PMIx_Value_true(NULL);
+
+    PMIx_Envar_construct(&e);
+    PMIx_Envar_load(&e, NULL, NULL, ':');
+    PMIx_Envar_destruct(&e);
+
+    PMIx_Byte_object_construct(&b);
+    PMIx_Byte_object_load(&b, NULL, 0);
+    PMIx_Byte_object_destruct(&b);
+
+    PMIx_Pdata_construct(&pd);
+    PMIx_Pdata_load(&pd, NULL, NULL, NULL, PMIX_STRING);
+    PMIx_Pdata_destruct(&pd);
+
+    PMIx_Regattr_construct(&r);
+    PMIx_Regattr_load(&r, NULL, NULL, PMIX_STRING, NULL);
+    PMIx_Regattr_destruct(&r);
+
+    report("the load helpers survive absent data", 1);
+}
+
+/* ------------------------------------------------------------------ */
+/* the info list builders                                              */
+/* ------------------------------------------------------------------ */
+
+static void test_info_list_degenerate(void)
+{
+    pmix_info_t info;
+    pmix_data_array_t d;
+    void *lst;
+    void *nxt = NULL;
+
+    /* every entry point with no list at all */
+    (void) PMIx_Info_list_add(NULL, "k", "v", PMIX_STRING);
+    (void) PMIx_Info_list_add_unique(NULL, "k", "v", PMIX_STRING, true);
+    (void) PMIx_Info_list_prepend(NULL, "k", "v", PMIX_STRING);
+    (void) PMIx_Info_list_convert(NULL, &d);
+    (void) PMIx_Info_list_get_size(NULL);
+    (void) PMIx_Info_list_get_info(NULL, NULL, &nxt);
+    PMIx_Info_list_release(NULL);
+
+    PMIx_Info_load(&info, "k", "v", PMIX_STRING);
+    (void) PMIx_Info_list_insert(NULL, &info);
+    (void) PMIx_Info_list_xfer(NULL, &info);
+
+    /* a real but empty list */
+    lst = PMIx_Info_list_start();
+    if (NULL != lst) {
+        (void) PMIx_Info_list_add(lst, NULL, NULL, PMIX_STRING);
+        (void) PMIx_Info_list_get_size(lst);
+        nxt = NULL;
+        (void) PMIx_Info_list_get_info(lst, NULL, &nxt);
+        (void) PMIx_Info_list_convert(lst, &d);
+        PMIx_Info_list_release(lst);
+    }
+    PMIX_INFO_DESTRUCT(&info);
+
+    report("the info list builders survive a NULL or empty list", 1);
+}
+
+static void test_info_list_still_works(void)
+{
+    void *lst;
+    pmix_data_array_t d;
+    pmix_status_t rc;
+    int ok = 1;
+
+    lst = PMIx_Info_list_start();
+    if (NULL == lst) {
+        report("the info list builders still do their job", 0);
+        return;
+    }
+    rc = PMIx_Info_list_add(lst, "first", "one", PMIX_STRING);
+    ok = ok && (PMIX_SUCCESS == rc);
+    rc = PMIx_Info_list_add(lst, "second", "two", PMIX_STRING);
+    ok = ok && (PMIX_SUCCESS == rc);
+    ok = ok && (2 == PMIx_Info_list_get_size(lst));
+
+    memset(&d, 0, sizeof(d));
+    rc = PMIx_Info_list_convert(lst, &d);
+    ok = ok && (PMIX_SUCCESS == rc) && (2 == d.size) && (NULL != d.array);
+    if (PMIX_SUCCESS == rc) {
+        pmix_info_t *ip = (pmix_info_t *) d.array;
+        ok = ok && (0 == strcmp(ip[0].key, "first"))
+                && (0 == strcmp(ip[1].key, "second"));
+        PMIX_DATA_ARRAY_DESTRUCT(&d);
+    }
+    PMIx_Info_list_release(lst);
+
+    report("the info list builders still do their job", ok);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+
+    (void) argc;
+    (void) argv;
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== bfrops public helper unit tests ===\n\n");
+
+    test_argv_degenerate();
+    test_argv_still_works();
+    test_procid_degenerate();
+    test_multicluster_parse();
+    test_zero_and_null_lifecycle();
+    test_load_helpers_with_no_data();
+    test_info_list_degenerate();
+    test_info_list_still_works();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/bfrops_malformed.c
+++ b/test/unit/bfrops_malformed.c
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for bfrops behaviour on malformed input.
+ *
+ * Everything the unpacker reads came off a socket. A peer that is
+ * truncated, that is running a different version than it claimed, or
+ * that is simply hostile can put any bytes at all in front of these
+ * functions, and the count that says how many values follow is itself
+ * one of those bytes. The contract this file pins down is narrow but
+ * absolute: no input may make the unpacker read outside the buffer it
+ * was given. Returning an error is fine; returning a wrong value is
+ * tolerable; walking off the end is not.
+ *
+ * The interesting cases all involve the flexible integer codec, because
+ * that is the one decoder whose consumed length is decided by the data
+ * rather than by the type - a continuation flag in the last readable
+ * byte is an invitation to read one more.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL
+};
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* Load a literal byte sequence into a data buffer. PMIx_Data_load takes
+ * ownership of the block, so hand it a copy each time. */
+static void load_wire(pmix_data_buffer_t *buf, const unsigned char *bytes, size_t n)
+{
+    pmix_byte_object_t bo;
+
+    bo.bytes = (char *) malloc(n);
+    memcpy(bo.bytes, bytes, n);
+    bo.size = n;
+    PMIX_DATA_BUFFER_CONSTRUCT(buf);
+    PMIx_Data_load(buf, &bo);
+}
+
+/* ------------------------------------------------------------------ */
+/* a count that outruns the payload                                    */
+/* ------------------------------------------------------------------ */
+
+/* The wire says "100 int32 values follow" and then supplies one byte of
+ * them. The unpacker must run out of buffer and say so. Before this was
+ * fixed it kept decoding past the end of the allocation, one flexible
+ * integer at a time, until it found a byte without a continuation flag. */
+static void test_count_larger_than_payload(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t dest[100];
+    int32_t cnt;
+    /* flex-encoded INT32 count of 100, then a single value byte */
+    static const unsigned char wire[] = {0xC8, 0x01, 0x02};
+
+    memset(dest, 0, sizeof(dest));
+    load_wire(&buf, wire, sizeof(wire));
+
+    cnt = 100;
+    rc = PMIx_Data_unpack(NULL, &buf, dest, &cnt, PMIX_INT32);
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    report("a count larger than the payload is refused, not read past",
+           PMIX_SUCCESS != rc);
+}
+
+/* The same shape, with a size_t element type, so the decoder is working
+ * at its widest. */
+static void test_size_count_larger_than_payload(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    size_t dest[64];
+    int32_t cnt;
+    static const unsigned char wire[] = {0x80, 0x01, 0xFF};
+
+    memset(dest, 0, sizeof(dest));
+    load_wire(&buf, wire, sizeof(wire));
+
+    cnt = 64;
+    rc = PMIx_Data_unpack(NULL, &buf, dest, &cnt, PMIX_SIZE);
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    report("an oversized size_t count is refused", PMIX_SUCCESS != rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* a value truncated mid-encoding                                      */
+/* ------------------------------------------------------------------ */
+
+/* Every byte here carries the continuation flag, so the encoding claims
+ * to continue past the end of the buffer. There is no correct value to
+ * return; the only correct behaviour is to refuse. */
+static void test_truncated_flex_value(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    uint64_t dest[4];
+    int32_t cnt;
+    /* count of 1, then a value whose every byte says "more follows" */
+    static const unsigned char wire[] = {0x02, 0xFF, 0xFF, 0xFF};
+
+    memset(dest, 0, sizeof(dest));
+    load_wire(&buf, wire, sizeof(wire));
+
+    cnt = 4;
+    rc = PMIx_Data_unpack(NULL, &buf, dest, &cnt, PMIX_UINT64);
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    report("a flexible integer truncated mid-encoding is refused",
+           PMIX_SUCCESS != rc);
+}
+
+/* An empty buffer is the degenerate case of the same thing. */
+static void test_empty_buffer(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    int32_t dest = 0;
+    int32_t cnt = 1;
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    rc = PMIx_Data_unpack(NULL, &buf, &dest, &cnt, PMIX_INT32);
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    report("unpacking from an empty buffer is refused", PMIX_SUCCESS != rc);
+}
+
+/* Truncating a well-formed message at every offset must never do worse
+ * than fail. This is the broad net: it exercises the string, size and
+ * count decoders at every possible cut point rather than at the handful
+ * we thought to write down. */
+static void test_every_truncation_of_a_real_message(void)
+{
+    pmix_data_buffer_t src;
+    pmix_byte_object_t whole;
+    pmix_status_t rc;
+    char *key = "a-reasonably-long-key-string";
+    size_t sz = 4096;
+    int32_t i32 = -12345;
+    size_t cut;
+    int ok = 1;
+
+    /* build something with a mix of strings, flexible integers and a
+     * nested array, then chop it short in every possible place */
+    PMIX_DATA_BUFFER_CONSTRUCT(&src);
+    rc = PMIx_Data_pack(NULL, &src, &key, 1, PMIX_STRING);
+    rc = (PMIX_SUCCESS == rc) ? PMIx_Data_pack(NULL, &src, &sz, 1, PMIX_SIZE) : rc;
+    rc = (PMIX_SUCCESS == rc) ? PMIx_Data_pack(NULL, &src, &i32, 1, PMIX_INT32) : rc;
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DATA_BUFFER_DESTRUCT(&src);
+        report("every truncation of a real message fails safely", 0);
+        return;
+    }
+    whole.size = src.bytes_used;
+    whole.bytes = (char *) malloc(whole.size);
+    memcpy(whole.bytes, src.base_ptr, whole.size);
+    PMIX_DATA_BUFFER_DESTRUCT(&src);
+
+    for (cut = 0; cut < whole.size; cut++) {
+        pmix_data_buffer_t buf;
+        char *s = NULL;
+        size_t gotsz = 0;
+        int32_t got32 = 0;
+        int32_t cnt;
+
+        load_wire(&buf, (const unsigned char *) whole.bytes, cut);
+
+        cnt = 1;
+        rc = PMIx_Data_unpack(NULL, &buf, &s, &cnt, PMIX_STRING);
+        if (PMIX_SUCCESS == rc) {
+            /* if it claims success the value must be a real C string */
+            if (NULL != s) {
+                (void) strlen(s);
+                free(s);
+            }
+            cnt = 1;
+            rc = PMIx_Data_unpack(NULL, &buf, &gotsz, &cnt, PMIX_SIZE);
+            if (PMIX_SUCCESS == rc) {
+                cnt = 1;
+                (void) PMIx_Data_unpack(NULL, &buf, &got32, &cnt, PMIX_INT32);
+            }
+        }
+        PMIX_DATA_BUFFER_DESTRUCT(&buf);
+    }
+    free(whole.bytes);
+
+    report("every truncation of a real message fails safely", ok);
+}
+
+/* ------------------------------------------------------------------ */
+/* strings must arrive terminated                                      */
+/* ------------------------------------------------------------------ */
+
+/* The packer always includes the terminator in the length it writes, but
+ * a peer need not. An unterminated payload must not turn into an
+ * unterminated C string, because everything downstream treats it as one. */
+static void test_unterminated_string(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    char *s = NULL;
+    int32_t cnt;
+    /* count of 1 string, string length 4, then "abcd" with no NUL */
+    static const unsigned char wire[] = {0x02, 0x08, 'a', 'b', 'c', 'd'};
+    int ok;
+
+    load_wire(&buf, wire, sizeof(wire));
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &s, &cnt, PMIX_STRING);
+    if (PMIX_SUCCESS == rc && NULL != s) {
+        /* must be terminated within the four bytes we were given */
+        ok = (strlen(s) < 4);
+        free(s);
+    } else {
+        /* refusing it outright is equally acceptable */
+        ok = 1;
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    report("an unterminated string payload does not escape as a C string", ok);
+}
+
+/* A negative string length is only reachable from a corrupt buffer, and
+ * must not reach malloc as a huge size_t. */
+static void test_negative_string_length(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    char *s = (char *) 0x1;
+    int32_t cnt;
+    /* count of 1 string, then a flex-encoded INT32 of -1 */
+    static const unsigned char wire[] = {0x02, 0x01};
+
+    load_wire(&buf, wire, sizeof(wire));
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &s, &cnt, PMIX_STRING);
+    if (PMIX_SUCCESS == rc && NULL != s && (char *) 0x1 != s) {
+        free(s);
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    report("a negative string length does not reach the allocator", 1);
+}
+
+/* ------------------------------------------------------------------ */
+/* well-formed values must still decode exactly                        */
+/* ------------------------------------------------------------------ */
+
+/* The hardening above changes the decoder's loop bounds, so pin the
+ * values that live at the edges of the flexible encoding. */
+static void test_flex_boundary_values(void)
+{
+    static const uint64_t u64s[] = {
+        0, 1, 127, 128, 16383, 16384, 0x7FFFFFFFULL, 0x80000000ULL,
+        0xFFFFFFFFULL, 0x0100000000ULL, 0x7FFFFFFFFFFFFFFFULL,
+        0x8000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL
+    };
+    static const int64_t i64s[] = {
+        0, 1, -1, 127, -127, 128, -128, 16383, -16384,
+        2147483647LL, -2147483648LL, 9223372036854775807LL,
+        (-9223372036854775807LL - 1)
+    };
+    size_t n;
+    int ok = 1;
+
+    for (n = 0; n < sizeof(u64s) / sizeof(u64s[0]); n++) {
+        pmix_data_buffer_t buf;
+        uint64_t v = u64s[n], back = 0;
+        int32_t cnt = 1;
+        pmix_status_t rc;
+
+        PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+        rc = PMIx_Data_pack(NULL, &buf, &v, 1, PMIX_UINT64);
+        if (PMIX_SUCCESS == rc) {
+            rc = PMIx_Data_unpack(NULL, &buf, &back, &cnt, PMIX_UINT64);
+        }
+        if (PMIX_SUCCESS != rc || back != v) {
+            fprintf(stdout, "    uint64 %llu came back as %llu (%s)\n",
+                    (unsigned long long) v, (unsigned long long) back,
+                    PMIx_Error_string(rc));
+            ok = 0;
+        }
+        PMIX_DATA_BUFFER_DESTRUCT(&buf);
+    }
+
+    for (n = 0; n < sizeof(i64s) / sizeof(i64s[0]); n++) {
+        pmix_data_buffer_t buf;
+        int64_t v = i64s[n], back = 0;
+        int32_t cnt = 1;
+        pmix_status_t rc;
+
+        PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+        rc = PMIx_Data_pack(NULL, &buf, &v, 1, PMIX_INT64);
+        if (PMIX_SUCCESS == rc) {
+            rc = PMIx_Data_unpack(NULL, &buf, &back, &cnt, PMIX_INT64);
+        }
+        if (PMIX_SUCCESS != rc || back != v) {
+            fprintf(stdout, "    int64 %lld came back as %lld (%s)\n",
+                    (long long) v, (long long) back, PMIx_Error_string(rc));
+            ok = 0;
+        }
+        PMIX_DATA_BUFFER_DESTRUCT(&buf);
+    }
+
+    report("flexible integers round-trip at their encoding boundaries", ok);
+}
+
+/* Many values in one buffer, so the decoder's per-value length has to be
+ * right or every value after the first lands in the wrong place. */
+static void test_flex_stream_of_many_values(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_status_t rc;
+    uint64_t src[256], back[256];
+    int32_t cnt;
+    size_t n;
+    int ok = 1;
+
+    for (n = 0; n < 256; n++) {
+        /* span the whole width, one bit at a time */
+        src[n] = (n < 64) ? (1ULL << n) : (uint64_t) (n * 2654435761ULL);
+    }
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    rc = PMIx_Data_pack(NULL, &buf, src, 256, PMIX_UINT64);
+    if (PMIX_SUCCESS != rc) {
+        ok = 0;
+    } else {
+        memset(back, 0, sizeof(back));
+        cnt = 256;
+        rc = PMIx_Data_unpack(NULL, &buf, back, &cnt, PMIX_UINT64);
+        ok = (PMIX_SUCCESS == rc) && (256 == cnt)
+             && (0 == memcmp(src, back, sizeof(src)));
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    report("a stream of 256 flexible integers decodes in step", ok);
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    (void) argc;
+    (void) argv;
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== bfrops malformed-input unit tests ===\n\n");
+
+    test_count_larger_than_payload();
+    test_size_count_larger_than_payload();
+    test_truncated_flex_value();
+    test_empty_buffer();
+    test_every_truncation_of_a_real_message();
+    test_unterminated_string();
+    test_negative_string_length();
+    test_flex_boundary_values();
+    test_flex_stream_of_many_values();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/bfrops_malformed.c
+++ b/test/unit/bfrops_malformed.c
@@ -427,19 +427,30 @@ static void test_random_bytes_through_every_unpacker(void)
  * elements than this whole message has bytes" cannot be describing
  * anything the peer sent, and must not be allowed to size an
  * allocation. */
+/* A growable byte accumulator, used to assemble a message by hand while
+ * still letting the real encoder decide every byte of it.
+ *
+ * Note what this does NOT use: PMIx_Data_embed() replaces a buffer's
+ * payload rather than appending to it, so building a message by
+ * embedding one piece after another silently leaves you with only the
+ * last piece. A test built that way still "passes" - a one-byte buffer
+ * is refused by everything - and proves nothing at all. That mistake is
+ * why this accumulator exists. */
+typedef struct {
+    char *bytes;
+    size_t len;
+} wire_acc_t;
+
 /* Append the encoding of ONE value of `type`, without the count the
  * pack driver normally puts in front of it. PMIx_Data_pack always emits
- * [count][values], so packing a single value and dropping the first
- * byte - the flex encoding of the count 1, which is one byte - leaves
- * exactly the bare value. That is the piece needed to assemble a
- * message by hand while still having the real encoder decide every
- * byte of it. */
-static int append_bare(pmix_data_buffer_t *out, const void *val,
-                       pmix_data_type_t type)
+ * [count][values], and the count 1 flex-encodes to a single byte, so
+ * dropping the first byte leaves exactly the bare value. */
+static int append_bare(wire_acc_t *acc, const void *val, pmix_data_type_t type)
 {
     pmix_data_buffer_t tmp;
-    pmix_byte_object_t bo;
     pmix_status_t rc;
+    size_t add;
+    char *grown;
 
     PMIX_DATA_BUFFER_CONSTRUCT(&tmp);
     rc = PMIx_Data_pack(NULL, &tmp, (void *) val, 1, type);
@@ -447,13 +458,37 @@ static int append_bare(pmix_data_buffer_t *out, const void *val,
         PMIX_DATA_BUFFER_DESTRUCT(&tmp);
         return 0;
     }
-    bo.bytes = tmp.base_ptr + 1;          /* skip the count byte */
-    bo.size = tmp.bytes_used - 1;
-    rc = PMIx_Data_embed(out, &bo);
+    add = tmp.bytes_used - 1;               /* skip the count byte */
+    grown = (char *) realloc(acc->bytes, acc->len + add);
+    if (NULL == grown) {
+        PMIX_DATA_BUFFER_DESTRUCT(&tmp);
+        return 0;
+    }
+    acc->bytes = grown;
+    memcpy(acc->bytes + acc->len, tmp.base_ptr + 1, add);
+    acc->len += add;
     PMIX_DATA_BUFFER_DESTRUCT(&tmp);
-    return (PMIX_SUCCESS == rc);
+    return 1;
 }
 
+static int append_raw(wire_acc_t *acc, size_t n)
+{
+    char *grown = (char *) realloc(acc->bytes, acc->len + n);
+
+    if (NULL == grown) {
+        return 0;
+    }
+    acc->bytes = grown;
+    memset(acc->bytes + acc->len, 0, n);
+    acc->len += n;
+    return 1;
+}
+
+/* The specific shape the fuzzer found, kept as its own case so a
+ * regression names itself: a count that says "this array has more
+ * elements than this whole message has bytes" cannot be describing
+ * anything the peer sent, and must not be allowed to size an
+ * allocation. */
 /* The specific shape the fuzzer found, kept as its own case so a
  * regression names itself. A data array is described on the wire by an
  * element type and a count, and the count sizes the allocation the
@@ -469,19 +504,19 @@ static void test_element_count_cannot_exceed_the_message(void)
     int32_t cnt, one = 1;
     uint16_t etype = PMIX_INT64;
     size_t huge = (size_t) 1 << 40;
-    int built;
+    wire_acc_t acc = {NULL, 0};
 
     /* [count of arrays][element type][element count] and then nothing,
      * which is what the unpack driver reads */
-    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
-    built = append_bare(&buf, &one, PMIX_INT32)
-            && append_bare(&buf, &etype, PMIX_UINT16)
-            && append_bare(&buf, &huge, PMIX_SIZE);
-    if (!built) {
-        PMIX_DATA_BUFFER_DESTRUCT(&buf);
+    if (!append_bare(&acc, &one, PMIX_INT32)
+        || !append_bare(&acc, &etype, PMIX_UINT16)
+        || !append_bare(&acc, &huge, PMIX_SIZE)) {
+        free(acc.bytes);
         report("an element count larger than the message is refused", 0);
         return;
     }
+    load_wire(&buf, (const unsigned char *) acc.bytes, acc.len);
+    free(acc.bytes);
 
     memset(&out, 0, sizeof(out));
     cnt = 1;
@@ -492,6 +527,67 @@ static void test_element_count_cannot_exceed_the_message(void)
      * allocated eight terabytes is the rest */
     report("an element count larger than the message is refused",
            PMIX_SUCCESS != rc);
+}
+
+/* A pmix_value_t keeps its payload in a union, and the type tag that
+ * says which member is live comes off the wire. Six registered types
+ * have no member there at all - they are data-array element types - and
+ * their C representation is larger than the whole union, PMIX_PDATA by
+ * 784 bytes. Unpacking one into a value writes that far past its end,
+ * and unpack_kval/unpack_info/unpack_pdata all unpack into a value they
+ * just allocated: a heap overflow whose length and contents both come
+ * from the peer.
+ *
+ * This is the case the fuzz stage above found, kept separately so a
+ * regression names itself. Note it took the fuzzer running everything
+ * in ONE process to surface: a harness that forks per input loses the
+ * corrupted heap with the child, which is exactly what the scratch
+ * version of this did before it was folded in here. */
+static void test_a_value_cannot_carry_an_oversized_type(void)
+{
+    static const pmix_data_type_t too_big[] = {
+        PMIX_VALUE, PMIX_INFO, PMIX_PDATA, PMIX_APP, PMIX_KVAL, PMIX_BUFFER
+    };
+    size_t i;
+    int ok = 1;
+
+    for (i = 0; i < sizeof(too_big) / sizeof(too_big[0]); i++) {
+        pmix_data_buffer_t buf;
+        pmix_value_t *heapval;
+        pmix_status_t rc;
+        int32_t cnt, one = 1;
+        uint16_t tag = (uint16_t) too_big[i];
+        wire_acc_t acc = {NULL, 0};
+
+        /* [count of values][type tag][plenty of plausible bytes] - the
+         * shape unpack_value() reads. The trailing bytes matter: without
+         * them a regression merely runs out of buffer, and what is being
+         * tested is that it never starts writing. */
+        if (!append_bare(&acc, &one, PMIX_INT32)
+            || !append_bare(&acc, &tag, PMIX_UINT16)
+            || !append_raw(&acc, 512)) {
+            free(acc.bytes);
+            ok = 0;
+            break;
+        }
+        load_wire(&buf, (const unsigned char *) acc.bytes, acc.len);
+        free(acc.bytes);
+
+        /* heap-allocated and exactly sizeof(pmix_value_t), so an
+         * overflow lands on the heap rather than harmlessly on a
+         * generous stack buffer */
+        heapval = (pmix_value_t *) calloc(1, sizeof(pmix_value_t));
+        cnt = 1;
+        rc = PMIx_Data_unpack(NULL, &buf, heapval, &cnt, PMIX_VALUE);
+        if (PMIX_SUCCESS == rc) {
+            fprintf(stdout, "    a value claiming to hold %s was accepted\n",
+                    PMIx_Data_type_string(too_big[i]));
+            ok = 0;
+        }
+        free(heapval);
+        PMIX_DATA_BUFFER_DESTRUCT(&buf);
+    }
+    report("a value cannot claim a type larger than its union", ok);
 }
 
 /* ------------------------------------------------------------------ */
@@ -520,6 +616,7 @@ int main(int argc, char **argv)
     test_flex_boundary_values();
     test_flex_stream_of_many_values();
     test_element_count_cannot_exceed_the_message();
+    test_a_value_cannot_carry_an_oversized_type();
     test_random_bytes_through_every_unpacker();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);

--- a/test/unit/bfrops_malformed.c
+++ b/test/unit/bfrops_malformed.c
@@ -364,6 +364,137 @@ static void test_flex_stream_of_many_values(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* a length off the wire must not buy an unbounded allocation           */
+/* ------------------------------------------------------------------ */
+
+/* Random bytes through every unpacker. This is not looking for a
+ * particular defect - it is the standing assertion that the contract at
+ * the top of this file holds for input nobody wrote down. It has earned
+ * its keep twice: a data-array element count that drove the allocator
+ * straight off a cliff (a twenty-byte message, killed by the OOM
+ * killer), and a query's qualifier count that allocated, failed, and
+ * then unpacked into the NULL.
+ *
+ * The seeds are fixed so a failure is reproducible; the generator is a
+ * plain LCG for the same reason. If you find a crash, print the seed
+ * and the payload rather than adding a one-off case for it. */
+static void test_random_bytes_through_every_unpacker(void)
+{
+    static const pmix_data_type_t fuzz_types[] = {
+        PMIX_BOOL, PMIX_STRING, PMIX_SIZE, PMIX_INT, PMIX_INT64, PMIX_UINT64,
+        PMIX_FLOAT, PMIX_DOUBLE, PMIX_TIMEVAL, PMIX_TIME, PMIX_STATUS,
+        PMIX_VALUE, PMIX_PROC, PMIX_APP, PMIX_INFO, PMIX_PDATA, PMIX_BUFFER,
+        PMIX_BYTE_OBJECT, PMIX_KVAL, PMIX_PROC_INFO, PMIX_DATA_ARRAY,
+        PMIX_PROC_RANK, PMIX_QUERY, PMIX_ENVAR, PMIX_COORD, PMIX_REGATTR,
+        PMIX_GEOMETRY, PMIX_DEVICE_DIST, PMIX_ENDPOINT, PMIX_DEVICE,
+        PMIX_RESOURCE_UNIT, PMIX_PROC_NSPACE, PMIX_DATA_BUFFER,
+        PMIX_NODE_PID, PMIX_REGEX2
+    };
+    static const unsigned long seeds[] = {1, 12345, 20031, 31337, 424242};
+    size_t t, sd, r, n;
+    unsigned long state;
+
+    for (t = 0; t < sizeof(fuzz_types) / sizeof(fuzz_types[0]); t++) {
+        for (sd = 0; sd < sizeof(seeds) / sizeof(seeds[0]); sd++) {
+            for (r = 0; r < 40; r++) {
+                pmix_data_buffer_t buf;
+                unsigned char wire[64];
+                unsigned char dest[8192];
+                size_t len;
+                int32_t cnt;
+
+                state = seeds[sd] + (unsigned long) (t * 1000 + r);
+#define NEXTB() (state = state * 6364136223846793005UL + 1442695040888963407UL, \
+                 (unsigned char) (state >> 33))
+                len = 4 + (NEXTB() % 60);
+                for (n = 0; n < len; n++) {
+                    wire[n] = NEXTB();
+                }
+#undef NEXTB
+                load_wire(&buf, wire, len);
+                memset(dest, 0, sizeof(dest));
+                cnt = 8;
+                (void) PMIx_Data_unpack(NULL, &buf, dest, &cnt, fuzz_types[t]);
+                PMIX_DATA_BUFFER_DESTRUCT(&buf);
+            }
+        }
+    }
+    report("random bytes through every unpacker", 1);
+}
+
+/* The specific shape the fuzzer found, kept as its own case so a
+ * regression names itself: a count that says "this array has more
+ * elements than this whole message has bytes" cannot be describing
+ * anything the peer sent, and must not be allowed to size an
+ * allocation. */
+/* Append the encoding of ONE value of `type`, without the count the
+ * pack driver normally puts in front of it. PMIx_Data_pack always emits
+ * [count][values], so packing a single value and dropping the first
+ * byte - the flex encoding of the count 1, which is one byte - leaves
+ * exactly the bare value. That is the piece needed to assemble a
+ * message by hand while still having the real encoder decide every
+ * byte of it. */
+static int append_bare(pmix_data_buffer_t *out, const void *val,
+                       pmix_data_type_t type)
+{
+    pmix_data_buffer_t tmp;
+    pmix_byte_object_t bo;
+    pmix_status_t rc;
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&tmp);
+    rc = PMIx_Data_pack(NULL, &tmp, (void *) val, 1, type);
+    if (PMIX_SUCCESS != rc || tmp.bytes_used < 2) {
+        PMIX_DATA_BUFFER_DESTRUCT(&tmp);
+        return 0;
+    }
+    bo.bytes = tmp.base_ptr + 1;          /* skip the count byte */
+    bo.size = tmp.bytes_used - 1;
+    rc = PMIx_Data_embed(out, &bo);
+    PMIX_DATA_BUFFER_DESTRUCT(&tmp);
+    return (PMIX_SUCCESS == rc);
+}
+
+/* The specific shape the fuzzer found, kept as its own case so a
+ * regression names itself. A data array is described on the wire by an
+ * element type and a count, and the count sizes the allocation the
+ * receiver makes. A count larger than the whole message cannot be
+ * describing anything the peer sent - but before this was bounded, a
+ * twenty-byte message asking for 2^40 int64s got exactly what it asked
+ * for, and the OOM killer ended the process. */
+static void test_element_count_cannot_exceed_the_message(void)
+{
+    pmix_data_buffer_t buf;
+    pmix_data_array_t out;
+    pmix_status_t rc;
+    int32_t cnt, one = 1;
+    uint16_t etype = PMIX_INT64;
+    size_t huge = (size_t) 1 << 40;
+    int built;
+
+    /* [count of arrays][element type][element count] and then nothing,
+     * which is what the unpack driver reads */
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    built = append_bare(&buf, &one, PMIX_INT32)
+            && append_bare(&buf, &etype, PMIX_UINT16)
+            && append_bare(&buf, &huge, PMIX_SIZE);
+    if (!built) {
+        PMIX_DATA_BUFFER_DESTRUCT(&buf);
+        report("an element count larger than the message is refused", 0);
+        return;
+    }
+
+    memset(&out, 0, sizeof(out));
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, &buf, &out, &cnt, PMIX_DATA_ARRAY);
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    /* surviving at all is most of the point; having refused rather than
+     * allocated eight terabytes is the rest */
+    report("an element count larger than the message is refused",
+           PMIX_SUCCESS != rc);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -388,6 +519,8 @@ int main(int argc, char **argv)
     test_negative_string_length();
     test_flex_boundary_values();
     test_flex_stream_of_many_values();
+    test_element_count_cannot_exceed_the_message();
+    test_random_bytes_through_every_unpacker();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 

--- a/test/unit/bfrops_null_object.c
+++ b/test/unit/bfrops_null_object.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * A pmix_value_t may be tagged with a type whose payload lives behind a
+ * pointer and carry no object at all. That value is malformed - but it
+ * is the single easiest malformed value in PMIx to produce, because
+ * producing it takes nothing more than setting the type before the
+ * data:
+ *
+ *     pmix_value_t v;
+ *     PMIX_VALUE_CONSTRUCT(&v);
+ *     v.type = PMIX_PROC_INFO;      // and nothing else
+ *
+ * Every operation in bfrops trusts the type tag - it has to; the tag is
+ * the only thing that says which union member is live - and then
+ * dereferences what it points at. So each of them has to screen the
+ * pointer for itself, and each of them is a separate switch statement
+ * with sixty-odd arms, which is why they did not.
+ *
+ * This walks every pointer-backed type through every value-level
+ * operation and asserts one thing: the library survives. What each
+ * operation returns is deliberately not checked. "There is no object
+ * here" is a state all of them can express - an empty comparison, a
+ * size of zero, an unloaded object of no bytes, a printed "NULL
+ * pointer" - and which one a given operation chooses is not the
+ * subject. The subject is that an ordinary caller mistake does not take
+ * the process down.
+ *
+ * Every case in here segfaulted before the August 2026 review of
+ * src/mca/bfrops. If one of them starts failing, the fix is a screen at
+ * the operation, not a screen at whatever caller happened to reach it -
+ * see pmix_bfrops_base_value_is_null_object().
+ *
+ * This test is noisy on purpose. A few of the types below - PMIX_APP,
+ * PMIX_INFO, PMIX_PDATA, PMIX_QUERY, PMIX_KVAL, PMIX_BUFFER, PMIX_VALUE
+ * - have no member in the value union at all: they are element types
+ * for a data array, not things a scalar value can hold. Handing one to
+ * a value operation is a caller error, and the library says so on
+ * stderr. Those lines are the library diagnosing rather than faulting,
+ * which is precisely what is being asserted; do not silence them by
+ * dropping the types.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static pmix_server_module_t mymodule = {
+    .client_connected = NULL
+};
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* Every type whose value union member is a pointer, plus a handful of
+ * neighbours so a regression that widens the blast radius is visible
+ * here rather than somewhere else. */
+static pmix_data_type_t types[] = {
+    PMIX_STRING, PMIX_VALUE, PMIX_PROC, PMIX_APP, PMIX_INFO, PMIX_PDATA,
+    PMIX_BUFFER, PMIX_BYTE_OBJECT, PMIX_KVAL, PMIX_PROC_INFO,
+    PMIX_DATA_ARRAY, PMIX_QUERY, PMIX_COMPRESSED_STRING, PMIX_ENVAR,
+    PMIX_COORD, PMIX_REGATTR, PMIX_REGEX, PMIX_JOB_STATE,
+    PMIX_PROC_CPUSET, PMIX_GEOMETRY, PMIX_DEVICE_DIST, PMIX_ENDPOINT,
+    PMIX_TOPO, PMIX_DEVICE, PMIX_RESOURCE_UNIT, PMIX_PROC_NSPACE,
+    PMIX_COMPRESSED_BYTE_OBJECT, PMIX_DATA_BUFFER, PMIX_NODE_PID,
+    PMIX_REGEX2, PMIX_LINK_STATE, PMIX_DEVTYPE, PMIX_LOCTYPE
+};
+#define NTYPES (sizeof(types) / sizeof(types[0]))
+
+/* type-tagged, payload absent: the malformed value under test */
+static void empty_value(pmix_value_t *v, pmix_data_type_t t)
+{
+    memset(v, 0, sizeof(*v));
+    v->type = t;
+}
+
+static void test_print(void)
+{
+    size_t i;
+
+    for (i = 0; i < NTYPES; i++) {
+        pmix_value_t v;
+        pmix_info_t info;
+        char *s;
+
+        empty_value(&v, types[i]);
+        s = PMIx_Value_string(&v);
+        if (NULL != s) {
+            free(s);
+        }
+
+        memset(&info, 0, sizeof(info));
+        PMIx_Load_key(info.key, "a-key");
+        info.value.type = types[i];
+        s = PMIx_Info_string(&info);
+        if (NULL != s) {
+            free(s);
+        }
+    }
+    report("printing a value with no object", 1);
+}
+
+static void test_compare(void)
+{
+    size_t i;
+
+    for (i = 0; i < NTYPES; i++) {
+        pmix_value_t a, b;
+
+        empty_value(&a, types[i]);
+        empty_value(&b, types[i]);
+        (void) PMIx_Value_compare(&a, &b);
+    }
+    report("comparing two values with no object", 1);
+}
+
+static void test_get_size(void)
+{
+    size_t i;
+
+    for (i = 0; i < NTYPES; i++) {
+        pmix_value_t v;
+        pmix_info_t info;
+        size_t sz = 0;
+
+        empty_value(&v, types[i]);
+        (void) PMIx_Value_get_size(&v, &sz);
+
+        memset(&info, 0, sizeof(info));
+        PMIx_Load_key(info.key, "a-key");
+        info.value.type = types[i];
+        sz = 0;
+        (void) PMIx_Info_get_size(&info, &sz);
+    }
+    report("sizing a value with no object", 1);
+}
+
+static void test_xfer(void)
+{
+    size_t i;
+
+    for (i = 0; i < NTYPES; i++) {
+        pmix_value_t src, dst;
+        pmix_info_t isrc, idst;
+
+        empty_value(&src, types[i]);
+        memset(&dst, 0, sizeof(dst));
+        (void) PMIx_Value_xfer(&dst, &src);
+        PMIX_VALUE_DESTRUCT(&dst);
+
+        memset(&isrc, 0, sizeof(isrc));
+        memset(&idst, 0, sizeof(idst));
+        PMIx_Load_key(isrc.key, "a-key");
+        isrc.value.type = types[i];
+        (void) PMIx_Info_xfer(&idst, &isrc);
+        PMIX_INFO_DESTRUCT(&idst);
+    }
+    report("transferring a value with no object", 1);
+}
+
+static void test_unload(void)
+{
+    size_t i;
+
+    for (i = 0; i < NTYPES; i++) {
+        pmix_value_t v;
+        void *data = NULL;
+        size_t sz = 0;
+
+        empty_value(&v, types[i]);
+        (void) PMIx_Value_unload(&v, &data, &sz);
+        if (NULL != data) {
+            free(data);
+        }
+    }
+    report("unloading a value with no object", 1);
+}
+
+static void test_info_list(void)
+{
+    size_t i;
+
+    for (i = 0; i < NTYPES; i++) {
+        pmix_info_t info;
+        void *lst;
+
+        memset(&info, 0, sizeof(info));
+        PMIx_Load_key(info.key, "a-key");
+        info.value.type = types[i];
+
+        lst = PMIx_Info_list_start();
+        if (NULL == lst) {
+            continue;
+        }
+        (void) PMIx_Info_list_xfer(lst, &info);
+        PMIx_Info_list_release(lst);
+    }
+    report("adding a value with no object to an info list", 1);
+}
+
+/* The one case where "absent" has a specific required spelling: a value
+ * that says PMIX_DATA_ARRAY and carries no array copies to an *empty
+ * array*, not to another NULL. Callers - the group code among them -
+ * dereference the result. */
+static void test_null_darray_copies_to_an_empty_array(void)
+{
+    pmix_value_t src, dst;
+    pmix_status_t rc;
+    int ok;
+
+    empty_value(&src, PMIX_DATA_ARRAY);
+    memset(&dst, 0, sizeof(dst));
+
+    rc = PMIx_Value_xfer(&dst, &src);
+    ok = (PMIX_SUCCESS == rc) && (PMIX_DATA_ARRAY == dst.type)
+         && (NULL != dst.data.darray) && (0 == dst.data.darray->size);
+    PMIX_VALUE_DESTRUCT(&dst);
+
+    report("a NULL data array copies to an empty array, not to NULL", ok);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+
+    (void) argc;
+    (void) argv;
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== bfrops absent-object unit tests ===\n\n");
+
+    test_print();
+    test_compare();
+    test_get_size();
+    test_xfer();
+    test_unload();
+    test_info_list();
+    test_null_darray_copies_to_an_empty_array();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}


### PR DESCRIPTION
A deep review of `src/mca/bfrops`, driven by property tests, fuzzing, and
the multi-node swarm rather than by reading alone. Seven commits, each one
defect class, each with a test that was confirmed to fail against the
unfixed library first.

## Memory safety — reachable from the wire

| | |
|---|---|
| **Heap buffer overflow in `unpack_val()`** | A `pmix_value_t` keeps its payload in a **24-byte union**, and the type tag naming the live member comes off the wire. Six registered types have no member there (`PMIX_VALUE`, `PMIX_INFO`, `PMIX_PDATA`, `PMIX_APP`, `PMIX_KVAL`, `PMIX_BUFFER`) and are much larger than the union — `pmix_pdata_t` is 808 bytes. The default arm handed `&val->data` to their unpacker, writing **up to 784 bytes past the end**, and `unpack_kval`/`unpack_info`/`unpack_pdata` all unpack into a value they just `calloc`'d. Length *and* contents attacker-controlled. `pack_val()` had the mirror over-read. |
| **Unbounded out-of-bounds read in the flexible integer decoder** | `flex_unpack_integer()` bounded its loop with `flex_size - 1`, which wraps when nothing is left. Its caller produced exactly that case. A three-byte message segfaults against a guard page. |
| **Unbounded allocation from a wire-supplied count** | A data array's element count sized the receiver's allocation with nothing relating it to the message. A twenty-byte message claiming 2^40 elements is enough to get the process OOM-killed. |
| **Double free in `copy_darray()`** | `PMIX_PROC_CPUSET` called `pmix_hwloc_release_cpuset()` (which frees the block) and then freed `p->array` again. Reached by any `PMIx_Value_xfer` of a cpuset array from `PMIx_Data_array_create()`. |
| **Free of uninitialized pointers** | Two `copy_darray()` arms allocated with `malloc` and wrote an element only where the source had one; the destructor then freed whatever the allocator had left. Looks correct on macOS, segfaults on Linux. |
| **12 wire-sized allocations written through unchecked** | Uniform pattern: allocate, take the count from the wire, unpack into the pointer. A count large enough to make the allocator decline became a write through NULL. |
| **85 (type, operation) pairs faulted on an absent object** | A value tagged with a pointer-backed type carrying no object — trivially produced by setting `.type` before the data — segfaulted `PMIx_Value_string`, `_compare`, `_get_size`, `_xfer`, `_unload` and the `PMIx_Info_*` family. Screened now by one predicate. |

## Correctness

- **Silent stream desync.** `pack_darray()` wrote a `PMIX_UNDEF` tag *and* a size while `unpack_darray()` read the tag as a terminator and never consumed the size, so everything after it was misread. Reachable by copying a value whose `darray` was NULL. Across real servers this poisoned the whole `PMIx_Commit` payload.
- **`PMIx_Value_get_number`.** Three sign checks read the wrong union member, so negative ints wrapped silently into unsigned. `check_int32`'s narrow arms read `.int16`. **Thirteen `PMIX_PROC_RANK` arms wrote the correct answer and then returned `PMIX_ERR_BAD_PARAM`.** `PMIX_PID` had no source handler at all. Four range constants were wrong (one had an extra digit).
- **An unpacked `PMIX_DATA_BUFFER` could not be read** — payload restored, cursors and allocation size left unset.
- **18 registered types could not back a data array**, and `PMIX_POINTER` arrays were allocated at 1 byte/element but copied at 8.
- Public helpers (`PMIx_Argv_*`, `PMIx_Info_list_*`, `PMIx_Xfer_procid`, …) crashed on NULL; `PMIx_Info_list_release(NULL)` in particular, where every other release in the file already tolerated it.

## Deliberately not fixed

`PMIX_REGEX` as a data-array element type: the packer strides `char *`, the destructor strides `pmix_byte_object_t`. Those differ in width, so one walks off the end. The two views coincide for a scalar, which is why it went unnoticed. Rather than pick a side, it stays cleanly unconstructible; resolving it means fixing pack, unpack, copy and destruct together. Reasoning is in the code and in `base/AGENTS.md`.

## Tests

Five new `make check` programs — property and consistency sweeps rather than case lists, because every defect here was two near-identical switch arms disagreeing:

- `bfrops_darray` — construct/pack/unpack/copy held against each other for every registered type
- `bfrops_malformed` — truncated and lying input, every-offset truncation, and an in-process fuzz stage
- `bfrops_get_number` — two properties over every (source, destination) pair
- `bfrops_null_object` — every pointer-backed type through every value operation with no object
- `bfrops_helpers` — the public helpers on degenerate *and* ordinary input

Plus `examples/datatypes` and `contrib/dockerswarm/run-bfrops-tests.sh`, which moves one value of every type between ranks on **different nodes**. That matters because two things about any pack are decided by the *peer* — which module encodes, and whether the buffer is described — and a round trip inside one process is self-consistent under either, so it cannot fail on them.

Three of the defects above were found only by the swarm; the heap overflow needed the fuzzer running **in one process** (a harness that forks per input loses the corrupted heap with the child).

## Documentation

New `src/mca/bfrops/base/AGENTS.md` (+ `CLAUDE.md` symlink); framework and `test/unit` guides extended; two traps recorded in `contrib/dockerswarm/AGENTS.md`; `docs/news/news-v6.x.rst` updated.

## Verification

- **macOS/clang**, `--enable-devel-check`: 99/99 tests pass, warning-free.
- **Linux/aarch64 in the swarm**: static build, `--enable-mca-dso` optimized build, and `datatypes` across **2, 4 and 8 separate PMIx servers** — 8 passed, 0 failed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
