### PR TITLE
Capture example output in the group test suite

### DIFF
--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -90,6 +90,13 @@ jobs:
          export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
          export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
          log=$RUNNER_TEMP/group_bootstrap.log
-         prterun -n 6 ./examples/group_bootstrap > "$log" 2>&1 || \
+         # This test has an intermittent failure (a construct that completes
+         # with PMIX_GROUP_CONSTRUCT_ABORT).  Run it verbosely so that when it
+         # does trip, the log dumped below names the code path that aborted.
+         # Costs a passing run nothing: the log is only shown on failure.
+         export PMIX_MCA_pmix_server_group_verbose=5
+         prterun --prtemca grpcomm_base_verbose 5 \
+                 --pmixmca pmix_client_group_verbose 5 \
+                 -n 6 ./examples/group_bootstrap > "$log" 2>&1 || \
              { rc=$?; echo "=== example failed with exit status $rc - output follows ==="; cat "$log"; exit $rc; }
 

--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -47,35 +47,49 @@ jobs:
       run: |
          export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
          export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
-         prterun -n 4 ./examples/group >& /dev/null
+         log=$RUNNER_TEMP/group.log
+         prterun -n 4 ./examples/group > "$log" 2>&1 || \
+             { rc=$?; echo "=== example failed with exit status $rc - output follows ==="; cat "$log"; exit $rc; }
     - name: Run simple group with query
       run: |
          export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
          export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
-         prterun -n 4 ./examples/group --test-query >& /dev/null
+         log=$RUNNER_TEMP/group-query.log
+         prterun -n 4 ./examples/group --test-query > "$log" 2>&1 || \
+             { rc=$?; echo "=== example failed with exit status $rc - output follows ==="; cat "$log"; exit $rc; }
     - name: Run local CID group
       run: |
          export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
          export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
-         prterun -n 4 ./examples/group_lcl_cid >& /dev/null
+         log=$RUNNER_TEMP/group_lcl_cid.log
+         prterun -n 4 ./examples/group_lcl_cid > "$log" 2>&1 || \
+             { rc=$?; echo "=== example failed with exit status $rc - output follows ==="; cat "$log"; exit $rc; }
     - name: Run async group
       run: |
          export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
          export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
-         prterun -n 4 ./examples/asyncgroup >& /dev/null
+         log=$RUNNER_TEMP/asyncgroup.log
+         prterun -n 4 ./examples/asyncgroup > "$log" 2>&1 || \
+             { rc=$?; echo "=== example failed with exit status $rc - output follows ==="; cat "$log"; exit $rc; }
     - name: Run group dmodex
       run: |
          export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
          export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
-         prterun -n 4 ./examples/group_dmodex >& /dev/null
+         log=$RUNNER_TEMP/group_dmodex.log
+         prterun -n 4 ./examples/group_dmodex > "$log" 2>&1 || \
+             { rc=$?; echo "=== example failed with exit status $rc - output follows ==="; cat "$log"; exit $rc; }
     - name: Run spawn group
       run: |
          export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
          export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
-         prterun -n 2 ./examples/multi_nspace_group >& /dev/null
+         log=$RUNNER_TEMP/multi_nspace_group.log
+         prterun -n 2 ./examples/multi_nspace_group > "$log" 2>&1 || \
+             { rc=$?; echo "=== example failed with exit status $rc - output follows ==="; cat "$log"; exit $rc; }
     - name: Run group bootstrap
       run: |
          export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
          export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
-         prterun -n 6 ./examples/group_bootstrap >& /dev/null
+         log=$RUNNER_TEMP/group_bootstrap.log
+         prterun -n 6 ./examples/group_bootstrap > "$log" 2>&1 || \
+             { rc=$?; echo "=== example failed with exit status $rc - output follows ==="; cat "$log"; exit $rc; }
 


### PR DESCRIPTION
Every step in the GROUP workflow ran its example as

```sh
prterun -n N ./examples/foo >& /dev/null
```

so when one failed, all CI reported was the step's exit status.

The motivating case is the recent flake in `Run group bootstrap`: the
step exited 91, which is a truncated -165 — `PMIX_GROUP_CONSTRUCT_ABORT`,
since the example returns the PMIx status straight out of `main()` — and
nothing else survived. Working out which rank aborted, and what the
library said on the way down, meant reasoning from the source instead of
reading the run.

Each example now writes to a per-step log file, dumped only when the run
fails. A passing job produces the same (empty) output it does today, so
the logs stay quiet in the common case; a failure carries the example's
stderr, including the per-rank progress messages and the
`PMIx_Error_string` of whatever status came back. The failing exit status
is preserved and re-raised, so the step still fails exactly as before.

Verified that the YAML parses with all seven run-steps intact, and that
the pattern behaves correctly under the workflow's `bash -e` shell in
both directions: a command exiting 91 dumps stdout and stderr and
propagates 91; a passing command prints nothing and the step continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)