### PR TITLE
Enable modex data storage in gds/shmem3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,10 @@ test/run_tests12.pl
 test/run_tests13.pl
 test/run_tests14.pl
 test/run_tests15.pl
+test/run_tests16.pl
+test/run_tests17.pl
+test/run_tests18.pl
+test/run_tests19.pl
 test/simple/run_*.sh
 test/simple/doubleget
 test/simple/quietclient

--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,8 @@ test/run_tests16.pl
 test/run_tests17.pl
 test/run_tests18.pl
 test/run_tests19.pl
+test/run_tests20.pl
+test/run_tests21.pl
 test/simple/run_*.sh
 test/simple/doubleget
 test/simple/quietclient

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1030,6 +1030,8 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests17.pl], [chmod +x test/run_tests17.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests18.pl], [chmod +x test/run_tests18.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests19.pl], [chmod +x test/run_tests19.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests20.pl], [chmod +x test/run_tests20.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests21.pl], [chmod +x test/run_tests21.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_gds_fallback.pl], [chmod +x test/unit/run_gds_fallback.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_simpcycle.pl], [chmod +x test/unit/run_simpcycle.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_toolcycle.pl], [chmod +x test/unit/run_toolcycle.pl])

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1025,6 +1025,11 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests11.pl], [chmod +x test/run_tests11.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests12.pl], [chmod +x test/run_tests12.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests13.pl], [chmod +x test/run_tests13.pl])
+    dnl 14 and 15 are deliberately absent - their cases exist but are not run
+    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests16.pl], [chmod +x test/run_tests16.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests17.pl], [chmod +x test/run_tests17.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests18.pl], [chmod +x test/run_tests18.pl])
+    AC_CONFIG_FILES(pmix_config_prefix[test/run_tests19.pl], [chmod +x test/run_tests19.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_gds_fallback.pl], [chmod +x test/unit/run_gds_fallback.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_simpcycle.pl], [chmod +x test/unit/run_simpcycle.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/unit/run_toolcycle.pl], [chmod +x test/unit/run_toolcycle.pl])

--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -15,6 +15,7 @@ find information on that subject here.
    schedulers/index.rst
    sets_groups/index.rst
    collectives/index.rst
+   modex.rst
    inheritance/index.rst
    resolve.rst
    adding_datatypes.rst

--- a/docs/how-things-work/modex.rst
+++ b/docs/how-things-work/modex.rst
@@ -1,0 +1,416 @@
+Modex: Exchanging Process Data
+==============================
+
+This document describes how data published by one process with
+``PMIx_Put`` reaches every other process in a job — the operation
+universally called the **modex** (short for "module exchange", a name
+inherited from the MPI runtimes that first needed it). It follows a
+single value from the ``PMIx_Put`` that creates it, through
+``PMIx_Commit``, the server's collection of local contributions, the
+handoff to the host environment, and the storage of the aggregated
+result. It then explains the **key index** — the integer that PMIx
+substitutes for a key string inside the datastore — because that index
+is the reason modex data is stored where it is, and the constraint that
+governs any attempt to move it.
+
+For a code-oriented orientation aimed at contributors working *inside*
+the datastore, ``src/mca/gds/AGENTS.md`` covers the framework and each
+component directory carries its own.
+
+
+The Problem
+-----------
+
+A process that wants to communicate with its peers must publish
+something about itself — a network endpoint, a shared-memory key, a
+device identifier — and must learn the same about everyone else. PMIx
+offers two ways to do this:
+
+* **Direct modex**, in which a process asks for one specific peer's data
+  and the request is routed to whichever server owns that peer. This is
+  lazy and cheap when only a few peers are of interest.
+
+* **Full modex**, in which every process contributes its data to a
+  collective (``PMIx_Fence`` with ``PMIX_COLLECT_DATA``) and every
+  server ends up holding the data of every process. This costs one
+  all-gather but makes every subsequent lookup local.
+
+This document is about the second. The distinguishing property of a full
+modex is that the result is *bulk* data — on a large job, the single
+largest block of memory PMIx holds — which is why where and how it is
+stored matters so much.
+
+
+Scope and Roles
+---------------
+
+Three roles appear throughout:
+
+* the **client**, an application process that calls ``PMIx_Put``,
+  ``PMIx_Commit``, ``PMIx_Fence`` and ``PMIx_Get``;
+* the **PMIx server**, embedded in the resource manager's local daemon,
+  which holds data on behalf of its local clients;
+* the **host environment**, the RM itself, which performs the actual
+  cross-node all-gather. PMIx does not move the bytes between nodes; it
+  hands the host a blob and receives an aggregated blob back.
+
+Note that a PMIx server is also a client of itself: it has its own
+``pmix_globals.mypeer`` peer object and its own datastore module.
+
+
+Following a Value
+-----------------
+
+Publication: ``PMIx_Put``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``PMIx_Put`` (``src/client/pmix_client.c``) validates its arguments and
+thread-shifts to ``_putfn``, which builds a ``pmix_kval_t`` holding a
+copy of the key string and the value — compressing large strings into a
+``PMIX_COMPRESSED_STRING`` — and hands it to the datastore::
+
+    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, cb->scope, kv);
+    ...
+    pmix_globals.commits_pending = true;
+
+Two things about the destination are fixed and worth knowing:
+
+#. A client pins its **own** peer to the ``hash`` module during
+   ``PMIx_Init`` unless the application explicitly asked for another via
+   ``PMIX_GDS_MODULE``.
+#. The ``shmem3`` module leaves its ``store`` slot ``NULL`` on purpose,
+   and ``PMIX_GDS_STORE_KV`` routes a ``NULL`` slot to the local
+   module.
+
+So a ``PMIx_Put`` **always** lands in ``gds/hash``, whatever module the
+namespace otherwise uses. ``pmix_gds_hash_store`` files the value by
+scope into one of three hash tables on the namespace's tracker:
+``internal`` (for ``PMIX_INTERNAL``), ``local``, and ``remote``, with
+``PMIX_GLOBAL`` stored into both ``local`` and ``remote``.
+
+The value is *not* sent anywhere yet. ``PMIx_Put`` is purely local; only
+the ``commits_pending`` flag records that something is outstanding.
+
+Transmission: ``PMIx_Commit``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``_commitfn`` reads the process's own contributions back out of the
+datastore — once for ``PMIX_LOCAL`` scope and once for ``PMIX_REMOTE``
+— and packs each set into a sub-buffer preceded by its scope::
+
+    PMIX_COMMAND (PMIX_COMMIT_CMD)
+    PMIX_SCOPE (PMIX_LOCAL)   PMIX_BUFFER < kval, kval, ... >
+    PMIX_SCOPE (PMIX_REMOTE)  PMIX_BUFFER < kval, kval, ... >
+
+The message is sent even when the process contributed nothing, so the
+server always learns that this client has finished contributing.
+
+**The wire carries key strings, not indices.**
+``pmix_bfrops_base_pack_kval`` packs ``kval->key`` as a ``PMIX_STRING``
+followed by the value. This is the single most important fact about the
+modex format, and the rest of this document depends on it.
+
+Server ingest: ``pmix_server_commit``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``pmix_server_commit`` (``src/server/pmix_server_fence.c``) unpacks each
+scope block and stores its kvals, splitting them by destination::
+
+    if (PMIX_LOCAL == scope || PMIX_GLOBAL == scope) {
+        PMIX_GDS_STORE_KV(rc, peer, &proc, scope, kp);
+    }
+    if (PMIX_REMOTE == scope || PMIX_GLOBAL == scope) {
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &proc, scope, kp);
+    }
+
+Local-scope data goes to the contributing peer's module, so sibling
+processes on the same node can read it. Remote-scope data goes to the
+*server's own* module — that copy is what is later harvested for the
+collective, and what answers a direct-modex request from another node.
+
+The server then marks the peer as having contributed, and immediately
+services any direct-modex requests that were waiting on this exact
+process.
+
+Collection: ``pmix_server_collect_data``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a fence carrying ``PMIX_COLLECT_DATA`` has gathered all of its
+local participants, ``pmix_server_collect_data`` builds this server's
+contribution. For each local participant it fetches the
+``PMIX_REMOTE``-scope kvals and packs a per-rank blob — the
+``pmix_proc_t`` followed by that process's kvals — then wraps the
+collection, compresses it, and wraps it again.
+
+The result is nested three deep::
+
+    buff
+     └── PMIX_BYTE_OBJECT          one per contributing server
+          ├── bool                 was the rank-level block compressed?
+          └── PMIX_BYTE_OBJECT     the rank-level block
+               ├── byte            collect flag (PMIX_COLLECT_YES / _NO)
+               └── PMIX_BYTE_OBJECT   one per contributing process
+                    └── pmix_proc_t, then that process's kvals
+
+The collect flag is recorded per server so the receiving end can detect
+participants that disagreed about whether data was being collected; a
+mismatch raises the ``collection-mismatch`` help message rather than
+silently producing a short result.
+
+Handoff to the host
+^^^^^^^^^^^^^^^^^^^
+
+The assembled bucket is handed to the resource manager::
+
+    rc = pmix_host_server.fence_nb(trk->pcs, trk->npcs, trk->info, trk->ninfo,
+                                   data, sz, trk->modexcbfunc, trk);
+
+PMIx takes no part in the cross-node exchange. The host performs the
+all-gather and returns the concatenation of every server's contribution
+— which is why the outermost layer of the envelope repeats once per
+server.
+
+Several paths short-circuit this and invoke the callback directly with a
+``NULL`` blob: a fence whose participants are all local, a host with no
+``fence_nb`` entry point, a host that returns
+``PMIX_OPERATION_SUCCEEDED``, and the error paths.
+
+Return storage
+^^^^^^^^^^^^^^
+
+``modex_cbfunc`` may run on the host's own thread, so it does nothing but
+thread-shift onto the progress thread, landing in ``_mdxcbfunc``
+(``src/server/pmix_server.c``). That function stores the returned blob
+and then replies to each waiting participant::
+
+    PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &xfer, scd->data, scd->ndata);
+    PMIX_GDS_STORE_MODEX(rc, &xfer, tracker);
+
+Both datastore components delegate the unwrapping to
+``pmix_gds_base_store_modex`` (``src/mca/gds/base/gds_base_fns.c``), so
+neither reimplements the envelope. The walker decompresses where
+flagged, checks the collect flag for consistency across servers, and
+invokes a component-supplied callback once per process blob — plus once
+per namespace with a ``NULL`` buffer, to signal that the modex is
+complete.
+
+.. note::
+
+   The callback must return ``PMIX_SUCCESS`` for a blob it consumed.
+   Running off the end of a blob is how a callback knows it has finished,
+   but the walker reads any non-success return as a failure of the whole
+   server contribution and abandons the remaining processes in it — while
+   still reporting success to its own caller. Convert the end-of-buffer
+   status inside the callback.
+
+For ``gds/hash``, the callback stores each kval into the namespace
+tracker's ``remote`` table under the contributing process's rank. From
+there ``PMIx_Get`` for a remote peer is answered locally.
+
+
+The Key Index
+-------------
+
+Everything above describes strings moving between processes. Inside the
+datastore, however, a key is not a string.
+
+``pmix_hash_store`` (``src/util/pmix_hash.c``) converts the key before
+storing anything::
+
+    p = pmix_hash_lookup_key(UINT32_MAX, kin->key, keyindex);
+    ...
+    kid = p->index;
+
+and the stored record carries only the number:
+
+.. code-block:: c
+
+   typedef struct {
+       uint32_t index;
+       uint32_t qualindex;
+       pmix_value_t *value;
+   } pmix_dstor_t;
+
+The mapping lives in a ``pmix_keyindex_t``: a ``pmix_pointer_array_t``
+of ``pmix_regattr_input_t`` entries in which an entry's **index is its
+slot number**, plus a ``next_id`` counter. Retrieval reverses the
+substitution — ``make_copy`` rebuilds a ``pmix_kval_t`` from
+``p->string`` — so the conversion is invisible from outside.
+
+There is exactly **one** key index per process,
+``pmix_globals.keyindex``. Every caller in the tree passes ``NULL`` for
+the ``kidx`` argument, and ``get_keyindex_ptr`` turns that ``NULL`` into
+the global.
+
+Reserved and non-reserved keys
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The index space has two halves, divided at ``PMIX_INDEX_BOUNDARY``:
+
+* **Below the boundary** are the *reserved* keys — the ``PMIX_*``
+  attributes defined by the Standard. ``pmix_init_registered_attrs``
+  pre-loads them from the generated ``pmix_dictionary[]`` table at
+  startup, in dictionary order, so their indices are fixed for the
+  lifetime of the process and are identical in any two processes built
+  from the *same* PMIx release.
+
+* **At and above the boundary** are the *non-reserved* keys — anything an
+  application invents and publishes with ``PMIx_Put``. These cannot be
+  known in advance, so ``pmix_hash_lookup_key`` registers them on first
+  sight, and ``pmix_hash_register_key`` assigns ``next_id++``.
+
+The consequence is the crux of this document:
+
+.. important::
+
+   A non-reserved key's index is assigned **per process, in order of
+   first encounter**. Two processes that publish different keys, or the
+   same keys in a different order, assign different indices to the same
+   key string. Nothing reconciles them.
+
+Nor is the reserved half as stable as it first appears. The dictionary
+is generated from the public headers, so a client and a server built
+from *different* PMIx releases have different dictionaries — the same
+attribute can occupy a different slot in each. Version interoperability
+is a requirement, so no process may assume another's numbering.
+
+Why this is normally invisible
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Because indices never cross a process boundary. Every wire format —
+commit, the modex envelope, a ``PMIx_Get`` reply — carries the key
+string, and each process re-derives its own index on receipt. A client,
+its server, and a remote server therefore run three unrelated index
+spaces that never need to agree.
+
+The one place indices *are* shared is ``gds/shmem3``, and that is
+precisely what makes it a special case.
+
+
+Storing the Modex in Shared Memory
+----------------------------------
+
+On a node running many processes, every local client holding its own
+copy of the full modex is pure duplication. The ``gds/shmem3`` component
+exists to remove it: the server builds the data structures inside an
+``mmap``'d segment and every local client maps that same segment
+**read-only at the same virtual address**, so in-segment pointers
+resolve without fix-up and N clients share one physical copy.
+
+Applying that to modex data runs straight into the key index. The shared
+hash table stores ``pmix_dstor_t`` records keyed by integer, the server
+writes those integers, and every client reads them — so for the first
+time, an index really does cross a process boundary.
+
+What the job segment does today
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For *job-level* data, ``shmem3`` handles this by having the server
+dictate its numbering to its clients. ``register_job_info`` packs the
+server's dictionary into the reply, and the client rebuilds
+``pmix_globals.keyindex`` to match, appending any entries of its own that
+the server did not send. The code's own comment states the reason
+plainly:
+
+.. code-block:: text
+
+   We can _never_ assume that the indices in our dictionary match the
+   ones in the server's dictionary. Even if the number of entries is the
+   same, there is no guarantee that they are in the same order.
+
+That works for job data because it happens once, during ``PMIx_Init``,
+before the application has published anything. It does not generalize to
+the modex:
+
+* it ships only the reserved dictionary, and a modex is largely
+  non-reserved keys;
+* the server assigns non-reserved indices in *modex arrival* order, which
+  no client can predict, so no scheme that assigns indices earlier can
+  converge on it; and
+* re-running the rebuild after a fence would renumber indices already
+  recorded in the client's own local tables, silently invalidating its
+  own stored data.
+
+The approach that does work
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Rather than making every process agree on one global numbering, give the
+shared data its own numbering and put it next to the data:
+
+.. code-block:: text
+
+   MODEX SEGMENT (server writes; clients map read-only)
+    +---------------------------------------------+
+    | pmix_shmem_header_t   (layout id stamp)     |
+    +---------------------------------------------+
+    | shared modex data                           |
+    |   tma, current_addr                         |
+    |   keyindex        <-- describes the table   |
+    |   hashtab         (pmix_dstor_t.index ->)   |
+    +---------------------------------------------+
+
+The key index becomes a property of the segment, not of the process. The
+server populates it as it stores; clients read it in place and pass it as
+the ``kidx`` argument that ``pmix_hash_store`` and ``pmix_hash_fetch``
+already accept. Indices then need only be consistent *within one
+segment*, which is guaranteed because exactly one process writes them.
+
+Three existing properties make this practical:
+
+* ``pmix_keyindex_t`` is already allocator-aware — its constructor
+  allocates through the ``pmix_tma_t`` of the object it hangs off, and
+  ``pmix_pointer_array_t`` is likewise — so it can be built inside a
+  segment with no new machinery.
+* The segment index needs only the keys the modex actually carries, not
+  the whole reserved dictionary.
+* The job-data path above is untouched and keeps working as it does now.
+
+One rule follows from the client's mapping being read-only:
+**the retrieval path must never register a key.** The lookup used by
+``pmix_hash_fetch`` has to fail rather than insert, because inserting
+would mean writing into a read-only mapping. A key that was never stored
+is simply not found, which is the correct answer anyway.
+
+Per-namespace routing
+^^^^^^^^^^^^^^^^^^^^^
+
+All local clients *of a given namespace* share a datastore module, but
+clients of *different* namespaces need not. A fence can therefore span a
+namespace using ``shmem3`` and another using ``hash``, and the returned
+modex has to be stored into each participating namespace's module.
+``shmem3`` is built for this — its modex segment is per-namespace, so
+each namespace's data lands in its own segment, and
+``mark_modex_complete`` hands each client the segment information for
+every namespace that took part.
+
+Reaching the data from elsewhere
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A connected **tool** only ever uses ``hash``, but it may still ask for a
+value that now lives in a namespace's shared segment. The server answers
+on the tool's behalf: when a request cannot be satisfied from the
+server's own module, it consults the module assigned to the namespace
+that owns the target process. Retrieval returns fully-formed
+``pmix_kval_t`` objects with their key strings restored, so the reply is
+packed exactly as it always was — the requester never learns which
+module produced it.
+
+
+Summary
+-------
+
+* ``PMIx_Put`` is local; ``PMIx_Commit`` sends; ``PMIx_Fence`` with
+  ``PMIX_COLLECT_DATA`` exchanges.
+* Every wire format carries **key strings**. Indices are an internal
+  storage detail.
+* Inside the datastore a key is a ``uint32_t`` index. Reserved keys are
+  pre-loaded from the generated dictionary; non-reserved keys are
+  numbered on first sight, **per process**, so no two processes can be
+  assumed to agree — and neither can two PMIx releases.
+* That is harmless while indices stay inside one process, and becomes the
+  governing constraint the moment a datastore is shared between
+  processes.
+* ``gds/shmem3`` resolves it for job data by having the server dictate
+  its numbering once at initialization, and for modex data by giving each
+  modex segment its own key index, written by the one process that owns
+  the segment.

--- a/docs/how-things-work/modex.rst
+++ b/docs/how-things-work/modex.rst
@@ -207,6 +207,60 @@ For ``gds/hash``, the callback stores each kval into the namespace
 tracker's ``remote`` table under the contributing process's rank. From
 there ``PMIx_Get`` for a remote peer is answered locally.
 
+Reading the result, and re-publishing a key
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The point of a full modex is that the answer is already local, so
+``PMIx_Get`` for a peer's key is served from the requesting process's own
+copy without touching the network. Two consequences are worth knowing,
+because both surprise people.
+
+**Asking for one non-reserved key fetches the peer's whole set.** When a
+request does have to go to the server, ``_satisfy_request()``
+(``src/server/pmix_server_get.c``) narrows the lookup to a single key only
+for *reserved* keys; for a non-reserved key it returns everything that
+process published. The comment in the code gives the reasoning — a request
+for one value from a proc is usually followed by requests for more — and
+the effect is that the first miss for a peer populates the cache for all
+of that peer's data at once.
+
+**A second fence does not, by itself, update what a reader sees.**
+Suppose a process publishes ``mykey``, fences, and every peer reads it;
+then it publishes a *new value* under the same ``mykey`` and fences again.
+The new value does reach the other servers — the commit and the collective
+work exactly as described above. But a peer that already read ``mykey`` has
+it cached, and a plain ``PMIx_Get`` is answered from that cache, so it
+keeps returning the first value.
+
+That is deliberate, not an oversight, and ``PMIX_GET_REFRESH_CACHE`` is
+the documented way to override it. Its definition in
+``include/pmix_common.h.in`` says so directly:
+
+   when retrieving data for a remote process, refresh the existing local
+   data cache for the process in case new values have been put and
+   committed by it since the last refresh
+
+So a reader that expects an *updated* value has to ask for it:
+
+.. code-block:: c
+
+   pmix_info_t info;
+   bool refresh = true;
+
+   PMIX_INFO_LOAD(&info, PMIX_GET_REFRESH_CACHE, &refresh, PMIX_BOOL);
+   rc = PMIx_Get(&peer, "mykey", &info, 1, &val);
+
+Because of the first point above, one such refresh brings that peer's
+whole published set up to date, not just the key named in the call.
+
+This is easy to get wrong. The in-tree fence test has a ``--use-same-keys``
+mode that re-publishes the same key names before each fence, and it read
+them back with a plain ``PMIx_Get`` — so it saw the previous fence's values
+and reported the library broken. The mode had never worked, and nothing
+noticed because the harness printed the mismatch and still exited zero.
+If you are chasing a "stale modex value," check for this before suspecting
+the datastore.
+
 
 The Key Index
 -------------

--- a/docs/how-things-work/modex.rst
+++ b/docs/how-things-work/modex.rst
@@ -251,7 +251,8 @@ So a reader that expects an *updated* value has to ask for it:
    rc = PMIx_Get(&peer, "mykey", &info, 1, &val);
 
 Because of the first point above, one such refresh brings that peer's
-whole published set up to date, not just the key named in the call.
+whole published set up to date, not just the key named in the call. See
+:ref:`PMIx_Get(3) <man3-PMIx_Get>` for the directive's full description.
 
 This is easy to get wrong. The in-tree fence test has a ``--use-same-keys``
 mode that re-publishes the same key names before each fence, and it read

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -344,6 +344,27 @@ desired qualifiers in the ``info`` array to select among the values stored under
 that key. ``PMIx_Get`` returns the primary value of the matching entry; the
 qualifiers themselves are used only for matching and are not returned.
 
+**Values from another process are cached, and a later exchange does not
+refresh them.** Once a process's data has been retrieved, subsequent calls for
+that process are answered from the local cache without consulting the server.
+So if the target process posts a *new* value under a key it had already
+published, and the data is circulated again, this call keeps returning the
+value read the first time. That is deliberate |mdash| it is what makes a
+lookup after a full exchange cost nothing |mdash| but it means a caller that
+expects an updated value must ask for one with ``PMIX_GET_REFRESH_CACHE``:
+
+.. code-block:: c
+
+   pmix_info_t info;
+   bool refresh = true;
+
+   PMIX_INFO_LOAD(&info, PMIX_GET_REFRESH_CACHE, &refresh, PMIX_BOOL);
+   rc = PMIx_Get(&proc, "mykey", &info, 1, &val);
+
+Note that a refresh for a non-reserved key brings across everything the target
+process has published, not only the key named in the call, so one refresh
+updates the caller's whole view of that process.
+
 
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
@@ -353,4 +374,5 @@ qualifiers themselves are used only for matching and are not returned.
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
    :ref:`pmix_value_t(5) <man5-pmix_value_t>`,
    :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
-   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :doc:`Modex: Exchanging Process Data </how-things-work/modex>`

--- a/docs/man/man3/PMIx_Put.3.rst
+++ b/docs/man/man3/PMIx_Put.3.rst
@@ -117,6 +117,13 @@ processes until they are committed with :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`
 and, typically, a subsequent synchronization such as
 :ref:`PMIx_Fence(3) <man3-PMIx_Fence>` has completed.
 
+**Posting a new value under a key already published** is permitted, but note
+that peers which have already retrieved that key will continue to see the
+earlier value: retrieved data is cached locally, and a later exchange does not
+by itself invalidate it. Such a peer must ask for the update with
+``PMIX_GET_REFRESH_CACHE`` |mdash| see
+:ref:`PMIx_Get(3) <man3-PMIx_Get>`.
+
 **Qualified values.** A value may be posted together with one or more qualifiers
 that scope its later retrieval by using the reserved key
 ``PMIX_QUALIFIED_VALUE``. In that case ``val`` must be a ``pmix_value_t`` of type
@@ -133,4 +140,5 @@ qualifiers, allowing several distinct values to be posted under the same key.
    :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
    :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
    :ref:`pmix_value_t(5) <man5-pmix_value_t>`,
-   :ref:`pmix_scope_t(5) <man5-pmix_scope_t>`
+   :ref:`pmix_scope_t(5) <man5-pmix_scope_t>`,
+   :doc:`Modex: Exchanging Process Data </how-things-work/modex>`

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -202,6 +202,11 @@ static void keyindex_construct(pmix_keyindex_t *ki)
     ki->table = PMIX_NEW(pmix_pointer_array_t, tma);
     pmix_pointer_array_init(ki->table, 1024, INT_MAX, 128);
 
+    /* the string -> entry side. Sized past the reserved dictionary so
+     * the common case never rehashes. */
+    ki->lookup = PMIX_NEW(pmix_hash_table_t, tma);
+    pmix_hash_table_init(ki->lookup, 2048);
+
     ki->next_id = 0;
 }
 
@@ -223,6 +228,11 @@ static void keyindex_destruct(pmix_keyindex_t *ki)
             }
             pmix_tma_free(tma, p);
         }
+    }
+    /* the lookup table holds borrowed pointers to the entries just
+     * freed above, so it only needs its own storage released */
+    if (NULL != ki->lookup) {
+        PMIX_RELEASE(ki->lookup);
     }
     PMIX_RELEASE(ki->table);
 }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -804,8 +804,17 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_notify_caddy_t);
 
 typedef struct {
     pmix_object_t super;
-    /** Points to key <--> index translation table. */
+    /** Points to key <--> index translation table. An entry's index is
+     *  its slot number here, so this is the index -> entry direction and
+     *  it owns the entries. */
     pmix_pointer_array_t *table;
+    /** The string -> entry direction, keyed by the key string. Holds
+     *  borrowed pointers to the same entries "table" owns, purely so a
+     *  key does not have to be found by scanning. Anything that adds to,
+     *  removes from, or renumbers "table" without going through
+     *  pmix_hash_register_key() must call pmix_hash_keyindex_rebuild()
+     *  afterwards to put the two back in step. */
+    pmix_hash_table_t *lookup;
     /** Stores the next ID. */
     uint32_t next_id;
 } pmix_keyindex_t;
@@ -815,6 +824,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_keyindex_t);
 {                                                 \
     .super = PMIX_OBJ_STATIC_INIT(pmix_object_t), \
     .table = NULL,                                \
+    .lookup = NULL,                               \
     .next_id = PMIX_INDEX_BOUNDARY                \
 }
 

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -126,7 +126,16 @@ pmix_gds_base_get_fallback_module(pmix_gds_base_module_t *failing);
  */
 PMIX_EXPORT pmix_status_t pmix_gds_base_setup_fork(const pmix_proc_t *proc, char ***env);
 
+/* Walk an aggregated fence result and hand each proc's blob to cb_fn,
+ * then call cb_fn once per nspace with a NULL buffer to signal "done".
+ *
+ * nspace, if not NULL, restricts the walk to blobs belonging to that
+ * nspace. Local clients of different nspaces may be assigned different
+ * gds modules, and each module has to be given its own nspaces' data,
+ * so the same payload is walked once per participating nspace. Pass
+ * NULL to store everything in the payload. */
 PMIX_EXPORT pmix_status_t pmix_gds_base_store_modex(pmix_buffer_t *buff,
+                                                    const char *nspace,
                                                     pmix_gds_base_store_modex_cb_fn_t cb_fn,
                                                     void *cbdata);
 

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -124,6 +124,7 @@ pmix_status_t pmix_gds_base_setup_fork(const pmix_proc_t *proc, char ***env)
 }
 
 pmix_status_t pmix_gds_base_store_modex(pmix_buffer_t *buff,
+                                        const char *nspace,
                                         pmix_gds_base_store_modex_cb_fn_t cb_fn,
                                         void *cbdata)
 {
@@ -250,6 +251,19 @@ pmix_status_t pmix_gds_base_store_modex(pmix_buffer_t *buff,
                     PMIX_ERROR_LOG(rc);
                     PMIX_DESTRUCT(&pbkt);
                     break;
+                }
+
+                /* the caller may have asked for only one nspace's data -
+                 * local clients of different nspaces can be on different
+                 * gds modules, so the same payload gets walked once for
+                 * each of them, each time storing only its own share */
+                if (NULL != nspace && !PMIX_CHECK_NSPACE(nspace, proc.nspace)) {
+                    PMIX_DESTRUCT(&pbkt);
+                    /* get the next peer-level blob */
+                    cnt = 1;
+                    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &bkt3, &bo4, &cnt,
+                                       PMIX_BYTE_OBJECT);
+                    continue;
                 }
 
                 // track the nspace involved

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -267,46 +267,76 @@ typedef pmix_status_t (*pmix_gds_base_module_store_fn_t)(const pmix_proc_t *proc
  * cbdata - pointer to modex callback data
  *
  */
-typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(pmix_buffer_t *buff, void *cbdata);
+typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(pmix_buffer_t *buff,
+                                                               const char *nspace,
+                                                               void *cbdata);
 
 /**
  * define a convenience macro for storing modex byte objects
  *
  * r - return status code
  *
+ * p - pointer to a pmix_peer_t of a local client of the nspace whose
+ *     data is being stored. All local clients of one nspace share a
+ *     gds module, but clients of *different* nspaces need not, so the
+ *     module is resolved from a peer of the nspace being stored - not
+ *     from the local server, whose own module may be neither.
+ *
+ * ns - the nspace whose blobs are to be stored from this payload. The
+ *      aggregated result carries every participant's data, so the
+ *      caller walks it once per participating nspace.
+ *
  * b - pointer to pmix_buffer_t containing the data
  *
  * t - pointer to the modex server tracker
  */
-#define PMIX_GDS_STORE_MODEX(r, b, t)                                       \
+#define PMIX_GDS_STORE_MODEX(r, p, ns, b, t)                                \
     do {                                                                    \
-        pmix_gds_base_module_t *_g = pmix_globals.mypeer->nptr->compat.gds; \
+        pmix_gds_base_module_t *_g = PMIX_GDS_PEER_MODULE(p);               \
         pmix_output_verbose(1, pmix_gds_base_output,                        \
-                            "[%s:%d] GDS STORE MODEX WITH %s", __FILE__,    \
-                            __LINE__, _g->name);                            \
-        (r) = _g->store_modex(b, t);                                        \
+                            "[%s:%d] GDS STORE MODEX FOR %s WITH %s",       \
+                            __FILE__, __LINE__,                             \
+                            (NULL == (ns)) ? "ALL" : (ns), _g->name);       \
+        if (NULL == _g->store_modex) {                                      \
+            (r) = PMIX_ERR_NOT_SUPPORTED;                                   \
+        } else {                                                            \
+            (r) = _g->store_modex(b, ns, t);                                \
+        }                                                                   \
     } while (0)
 
 typedef pmix_status_t (*pmix_gds_base_module_mark_modex_complete_fn_t)(struct pmix_peer_t *peer,
                                                                        pmix_list_t *nslist,
                                                                        pmix_buffer_t *buff);
+/* Resolved from the peer being replied to, not from the local server:
+ * this adds whatever that peer's own module needs in order to reach the
+ * modex data - for shmem3, the segment info it must map. */
 #define PMIX_GDS_MARK_MODEX_COMPLETE(r, p, l, b)                            \
     do {                                                                    \
-        pmix_gds_base_module_t *_g = pmix_globals.mypeer->nptr->compat.gds; \
+        pmix_gds_base_module_t *_g = PMIX_GDS_PEER_MODULE(p);               \
         pmix_output_verbose(1, pmix_gds_base_output,                        \
                             "[%s:%d] GDS MARK MODEX COMPLETE WITH %s",      \
                             __FILE__, __LINE__, _g->name);                  \
-        (r) = _g->mark_modex_complete(p, l, b);                             \
+        if (NULL == _g->mark_modex_complete) {                              \
+            (r) = PMIX_SUCCESS;                                             \
+        } else {                                                            \
+            (r) = _g->mark_modex_complete(p, l, b);                         \
+        }                                                                   \
     } while (0)
 
 typedef pmix_status_t (*pmix_gds_base_module_recv_modex_complete_fn_t)(pmix_buffer_t *buff);
+/* The client side of the above, resolved from the server peer that sent
+ * it - which is the peer carrying this client's assigned module. */
 #define PMIX_GDS_RECV_MODEX_COMPLETE(r, p, b)                               \
     do {                                                                    \
-        pmix_gds_base_module_t *_g = pmix_globals.mypeer->nptr->compat.gds; \
+        pmix_gds_base_module_t *_g = PMIX_GDS_PEER_MODULE(p);               \
         pmix_output_verbose(1, pmix_gds_base_output,                        \
                             "[%s:%d] GDS RECV MODEX COMPLETE WITH %s",      \
                             __FILE__, __LINE__, _g->name);                  \
-        (r) = _g->recv_modex_complete(b);                                   \
+        if (NULL == _g->recv_modex_complete) {                              \
+            (r) = PMIX_SUCCESS;                                             \
+        } else {                                                            \
+            (r) = _g->recv_modex_complete(b);                               \
+        }                                                                   \
     } while (0)
 
 /**

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -65,6 +65,7 @@ static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr, pmix_buffer_
 static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf);
 
 static pmix_status_t hash_store_modex(pmix_buffer_t *buff,
+                                      const char *nspace,
                                       void *cbdata);
 
 static pmix_status_t _hash_store_modex(pmix_proc_t *proc,
@@ -1433,9 +1434,10 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
 static pmix_status_t hash_store_modex(pmix_buffer_t *buf,
+                                      const char *nspace,
                                       void *cbdata)
 {
-    return pmix_gds_base_store_modex(buf, _hash_store_modex, cbdata);
+    return pmix_gds_base_store_modex(buf, nspace, _hash_store_modex, cbdata);
 }
 
 static pmix_status_t _hash_store_modex(pmix_proc_t *proc,

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -2188,6 +2188,9 @@ client_update_global_keyindex_if_necessary(
         pmix_pointer_array_set_item(pmix_globals.keyindex.table, rb->index, rb);
         pmix_globals.keyindex.next_id++;
     }
+    // we filled the array by hand, so the string -> entry side of the
+    // keyindex knows nothing about any of it yet
+    pmix_hash_keyindex_rebuild(&pmix_globals.keyindex);
     PMIX_DESTRUCT(&tmpindex);
 
     job->client_keyindex_fixup_done = true;

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -917,6 +917,17 @@ modex_smdata_construct(
     }
     pmix_hash_table_init(job->smmodex->hashtab, htsize);
 
+    // The indices stored in that table are meaningless without the
+    // translation, and the translation cannot be the process-global one
+    // because clients do not share our numbering. Build it here, in the
+    // segment, so it travels with the data it describes.
+    job->smmodex->keyindex = PMIX_NEW(pmix_keyindex_t, tma);
+    if (!job->smmodex->keyindex) {
+        rc = PMIX_ERR_NOMEM;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
     pmix_gds_shmem3_vout_smmodex(job);
 
     return rc;
@@ -2875,6 +2886,22 @@ get_modex_sizing_data(const pmix_buffer_t *buff)
     // We also need storage space for the hash table and its elements.
     segment_size += sizeof(pmix_hash_table_t);
     segment_size += nhtelems * pmix_hash_table_sizeof_hash_element();
+    // The keyindex that translates the indices in that hash table lives
+    // in this segment too: the object, its pointer array, its own string
+    // -> entry hash table, and one entry per distinct key with two
+    // copies of the key string (the entry's name and string) plus the
+    // copy the lookup table makes of its key. We cannot know the number
+    // of distinct keys without unpacking, so bound it by nkvals - the
+    // real count is normally far smaller, and the fluff below covers the
+    // per-entry allocations.
+    segment_size += sizeof(pmix_keyindex_t);
+    segment_size += sizeof(pmix_pointer_array_t);
+    segment_size += sizeof(pmix_hash_table_t);
+    segment_size += nkvals * (sizeof(pmix_regattr_input_t)
+                              + sizeof(void *)
+                              + 3 * (PMIX_MAX_KEYLEN + 1));
+    segment_size += get_actual_hashtab_capacity(nkvals)
+                    * pmix_hash_table_sizeof_hash_element();
     // Include some extra fluff that empirically seems reasonable.
     segment_size *= fluff;
     // Adjust (increase or decrease) segment size by the given parameter size.
@@ -2967,12 +2994,18 @@ server_store_modex_cb(pmix_proc_t *proc,
         // rank=0 as we know that rank must always exist.
         if (PMIX_CHECK_KEY(&kv, PMIX_QUALIFIED_VALUE)) {
             rc = pmix_gds_shmem3_store_qualified(
-                ht, (PMIX_RANK_UNDEF == rank) ? 0 : rank, kv.value
+                ht, (PMIX_RANK_UNDEF == rank) ? 0 : rank, kv.value,
+                job->smmodex->keyindex
             );
         }
         else {
+            // Note the keyindex: the indices this store mints have to be
+            // readable by every local client that maps the segment, so
+            // they come from the segment's own translation table rather
+            // than from this process's global one.
             rc = pmix_hash_store(
-                ht, (PMIX_RANK_UNDEF == rank) ? 0 : rank, &kv, NULL, 0, NULL
+                ht, (PMIX_RANK_UNDEF == rank) ? 0 : rank, &kv, NULL, 0,
+                job->smmodex->keyindex
             );
         }
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -3037,6 +3037,7 @@ server_store_modex_cb(pmix_proc_t *proc,
  */
 static pmix_status_t
 server_store_modex(pmix_buffer_t *buff,
+                   const char *nspace,
                    void *cbdata)
 {
     PMIX_GDS_SHMEM3_VVOUT_HERE();
@@ -3045,7 +3046,7 @@ server_store_modex(pmix_buffer_t *buff,
         "%s:%s buff_size=%zd", __func__,
         PMIX_NAME_PRINT(&pmix_globals.myid), buff->bytes_used
     );
-    return pmix_gds_base_store_modex(buff, server_store_modex_cb, cbdata);
+    return pmix_gds_base_store_modex(buff, nspace, server_store_modex_cb, cbdata);
 }
 
 static pmix_status_t

--- a/src/mca/gds/shmem3/gds_shmem3.h
+++ b/src/mca/gds/shmem3/gds_shmem3.h
@@ -81,6 +81,9 @@
       +  41u * (uint32_t)sizeof(pmix_gds_shmem3_nodeinfo_t)                  \
       +  43u * (uint32_t)sizeof(pmix_gds_shmem3_app_t)                       \
       +  47u * (uint32_t)sizeof(pmix_gds_shmem3_host_alias_t)                \
+      +  53u * (uint32_t)sizeof(pmix_keyindex_t)                             \
+      +  59u * (uint32_t)sizeof(pmix_regattr_input_t)                        \
+      +  61u * (uint32_t)sizeof(pmix_pointer_array_t)                        \
     ))
 
 /**
@@ -215,6 +218,22 @@ typedef struct {
     void *current_addr;
     /** Stores static modex data. */
     pmix_hash_table_t *hashtab;
+    /** Translates the key indices stored in hashtab above.
+     *
+     * This lives in the segment, rather than being the process-global
+     * keyindex, because the indices in that table cross a process
+     * boundary here: the server writes them and every local client
+     * reads them. A non-reserved key's global index is assigned per
+     * process in order of first encounter, so no two processes can be
+     * assumed to agree on one - and the reserved half is only stable
+     * between processes built from the same PMIx release. Keeping the
+     * translation beside the data it describes means the indices only
+     * have to be consistent within this segment, which they are because
+     * exactly one process writes them.
+     *
+     * Clients map the segment read-only, so they must reach this only
+     * through pmix_hash_find_key() and friends, which never register. */
+    pmix_keyindex_t *keyindex;
 } pmix_gds_shmem3_shared_modex_data_t;
 
 typedef struct {

--- a/src/mca/gds/shmem3/gds_shmem3_fetch.c
+++ b/src/mca/gds/shmem3/gds_shmem3_fetch.c
@@ -595,6 +595,13 @@ pmix_gds_shmem3_fetch(
     );
     // Modex data are stored in PMIX_REMOTE.
     pmix_hash_table_t *const remote_ht = mdrfu ? job->smmodex->hashtab : NULL;
+    // The indices in that table were minted by the server against the
+    // segment's own keyindex, not against this process's global one, so
+    // reads of it have to translate through the same table. See the
+    // comment on pmix_gds_shmem3_shared_modex_data_t.keyindex. The job
+    // segment's tables still use the global keyindex, which the
+    // client-side fixup has already aligned with the server's.
+    pmix_keyindex_t *const remote_kidx = mdrfu ? job->smmodex->keyindex : NULL;
 
     // If the rank is wildcard and key is NULL, then the caller is asking for a
     // complete copy of the job-level info for this nspace, so retrieve it.
@@ -764,7 +771,8 @@ doover:
     // be the source.
     if (PMIX_RANK_UNDEF == proc->rank && ht) {
         for (pmix_rank_t rnk = 0; rnk < job->nspace->nprocs; rnk++) {
-            rc = pmix_hash_fetch(ht, rnk, key, qualifiers, nqual, kvs, NULL);
+            rc = pmix_hash_fetch(ht, rnk, key, qualifiers, nqual, kvs,
+                                 (ht == remote_ht) ? remote_kidx : NULL);
             if (PMIX_ERR_NOMEM == rc) {
                 return rc;
             }
@@ -804,7 +812,8 @@ doover:
     else {
         if (ht) {
             rc = pmix_hash_fetch(
-                ht, proc->rank, key, qualifiers, nqual, kvs, NULL
+                ht, proc->rank, key, qualifiers, nqual, kvs,
+                (ht == remote_ht) ? remote_kidx : NULL
             );
         }
         else {
@@ -846,7 +855,8 @@ doover:
             if (PMIX_LOCAL == scope) {
                 if (NULL != remote_ht) {
                     /* check the remote scope */
-                    rc = pmix_hash_fetch(remote_ht, proc->rank, key, qualifiers, nqual, kvs, NULL);
+                    rc = pmix_hash_fetch(remote_ht, proc->rank, key, qualifiers, nqual, kvs,
+                                         remote_kidx);
                     if (PMIX_SUCCESS == rc || 0 < pmix_list_get_size(kvs)) {
                         while (NULL != (kv = (pmix_kval_t *) pmix_list_remove_first(kvs))) {
                             PMIX_RELEASE(kv);

--- a/src/mca/gds/shmem3/gds_shmem3_store.c
+++ b/src/mca/gds/shmem3/gds_shmem3_store.c
@@ -546,7 +546,8 @@ pmix_status_t
 pmix_gds_shmem3_store_qualified(
     pmix_hash_table_t *ht,
     pmix_rank_t rank,
-    pmix_value_t *value
+    pmix_value_t *value,
+    pmix_keyindex_t *kidx
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_tma_t *const tma = pmix_obj_get_tma(&ht->super);
@@ -586,7 +587,7 @@ pmix_gds_shmem3_store_qualified(
     kv->key = info[0].key;
     kv->value = &info[0].value;
     // Store the result.
-    rc = pmix_hash_store(ht, rank, kv, quals, nquals, NULL);
+    rc = pmix_hash_store(ht, rank, kv, quals, nquals, kidx);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
     }

--- a/src/mca/gds/shmem3/gds_shmem3_store.h
+++ b/src/mca/gds/shmem3/gds_shmem3_store.h
@@ -21,11 +21,16 @@
 
 BEGIN_C_DECLS
 
+/* Store a qualified value. kidx names the keyindex that translates the
+ * key and its qualifiers; pass NULL for the process-global one, or the
+ * segment's own keyindex when storing into a shared-memory table whose
+ * indices other processes will read. */
 PMIX_EXPORT pmix_status_t
 pmix_gds_shmem3_store_qualified(
     pmix_hash_table_t *ht,
     pmix_rank_t rank,
-    pmix_value_t *value
+    pmix_value_t *value,
+    pmix_keyindex_t *kidx
 );
 
 PMIX_EXPORT pmix_status_t

--- a/src/mca/gds/shmem3/gds_shmem3_utils.h
+++ b/src/mca/gds/shmem3/gds_shmem3_utils.h
@@ -160,11 +160,19 @@ pmix_gds_shmem3_vout_smmodex(
 ) {
     PMIX_GDS_SHMEM3_VOUT(
         "modex_shmem3@%p, "
+        "smmodex@%p, "
         "smmodex tma@%p, "
-        "hashtab@%p",
+        "hashtab@%p, "
+        "keyindex@%p (table@%p, next_id=%u)",
         (void *)job->modex_shmem3->data_address,
+        (void *)job->smmodex,
         (void *)&job->smmodex->tma,
-        (void *)job->smmodex->hashtab
+        (void *)job->smmodex->hashtab,
+        (void *)job->smmodex->keyindex,
+        (NULL == job->smmodex->keyindex)
+            ? NULL : (void *)job->smmodex->keyindex->table,
+        (NULL == job->smmodex->keyindex)
+            ? 0u : (unsigned)job->smmodex->keyindex->next_id
     );
 }
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4003,11 +4003,38 @@ static void _mdxcbfunc(int sd, short args, void *cbdata)
         goto finish_collective;
     }
 
-    /* pass the blobs being returned */
-    PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &xfer, scd->data, scd->ndata);
-    PMIX_GDS_STORE_MODEX(rc, &xfer, tracker);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    /* Store the returned blobs, once per participating nspace.
+     *
+     * All local clients of one nspace share a gds module, but clients of
+     * *different* nspaces need not - so there is no single module that
+     * can be handed the whole payload. Walk it once for each nspace,
+     * through a peer of that nspace, storing only that nspace's blobs.
+     * The walk is cheap relative to the collective, and a real job has
+     * only a couple of local nspaces.
+     *
+     * Note the buffer is reloaded each pass: the walker consumes it, and
+     * PMIX_LOAD_BUFFER_NON_DESTRUCT simply re-points at the payload the
+     * host handed us without copying or taking ownership of it. */
+    PMIX_LIST_FOREACH (nptr, &nslist, pmix_nspace_caddy_t) {
+        pmix_peer_t *nspeer = NULL;
+
+        /* find a local peer of this nspace to resolve its module */
+        PMIX_LIST_FOREACH (cd, &tracker->local_cbs, pmix_server_caddy_t) {
+            if (0 == strcmp(nptr->ns->nspace, cd->peer->nptr->nspace)) {
+                nspeer = cd->peer;
+                break;
+            }
+        }
+        if (NULL == nspeer) {
+            /* cannot happen - the nspace came from this very list */
+            continue;
+        }
+        PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &xfer, scd->data, scd->ndata);
+        PMIX_GDS_STORE_MODEX(rc, nspeer, nptr->ns->nspace, &xfer, tracker);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            break;
+        }
     }
     /* do NOT destruct the xfer buffer as that would release the payload! */
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -844,6 +844,29 @@ static pmix_status_t get_job_data(char *nspace,
     return PMIX_SUCCESS;
 }
 
+/* Find a local client of this nspace so that its assigned gds module can
+ * be resolved. Returns NULL when the nspace has no local clients - in
+ * which case there is no other module here to ask. */
+static pmix_peer_t *local_peer_of_nspace(pmix_namespace_t *nptr)
+{
+    pmix_rank_info_t *rptr;
+    pmix_peer_t *peer;
+
+    if (NULL == nptr || 0 == nptr->nlocalprocs) {
+        return NULL;
+    }
+    PMIX_LIST_FOREACH (rptr, &nptr->ranks, pmix_rank_info_t) {
+        if (0 <= rptr->peerid) {
+            peer = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients,
+                                                               rptr->peerid);
+            if (NULL != peer) {
+                return peer;
+            }
+        }
+    }
+    return NULL;
+}
+
 static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank, char *key,
                                       pmix_server_caddy_t *cd, bool diffnspace, pmix_scope_t scope,
                                       pmix_modex_cbfunc_t cbfunc, void *cbdata)
@@ -901,7 +924,24 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank, 
     cb.info = cd->info;
     cb.ninfo = cd->ninfo;
     PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-    /* if we didn't find it on my peer, then it isn't found */
+    if (PMIX_SUCCESS != rc) {
+        /* Not in our own store - but that does not mean it is not here.
+         * The target nspace's clients may be on a different gds module
+         * than we are: gds/shmem3 keeps their modex in a shared-memory
+         * segment that our module knows nothing about. A requester that
+         * cannot read that segment itself - a tool, which only ever has
+         * "hash" - still has to be able to ask us for the value, so
+         * consult the nspace's own module before giving up. */
+        pmix_peer_t *nspeer = local_peer_of_nspace(nptr);
+        if (NULL != nspeer && !PMIX_GDS_CHECK_PEER_COMPONENT(nspeer, pmix_globals.mypeer)) {
+            pmix_kval_t *kvtmp;
+            /* a failed fetch may still have appended something */
+            while (NULL != (kvtmp = (pmix_kval_t *) pmix_list_remove_first(&cb.kvs))) {
+                PMIX_RELEASE(kvtmp);
+            }
+            PMIX_GDS_FETCH_KV(rc, nspeer, &cb);
+        }
+    }
     if (PMIX_SUCCESS != rc) {
         PMIX_DESTRUCT(&cb);
         goto complete;

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2024 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -380,12 +380,18 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table,
     if (NULL != key) {
         /* lookup the key's corresponding index - this should be
          * moved to the periphery of the PMIx library so we can
-         * refer to the key numerically throughout the internals
-         */
-        p = pmix_hash_lookup_key(UINT32_MAX, key, keyindex);
+         * refer to the key numerically throughout the internals.
+         *
+         * Note that we deliberately do NOT register the key if it is
+         * missing. A key nobody ever stored cannot be in this table, so
+         * "not found" is the right answer - and registering it here
+         * would grow the keyindex on every failed fetch. It would also
+         * be fatal for a keyindex that lives in a shared-memory segment
+         * the caller has mapped read-only. */
+        p = pmix_hash_find_key(UINT32_MAX, key, keyindex);
         if (NULL == p) {
-            /* we don't know this key */
-            return PMIX_ERR_BAD_PARAM;
+            /* this key has never been stored anywhere */
+            return PMIX_ERR_NOT_FOUND;
         }
         kid = p->index;
     }
@@ -476,10 +482,12 @@ pmix_status_t pmix_hash_remove_data(pmix_hash_table_t *table,
     pmix_keyindex_t *const keyindex = get_keyindex_ptr(kidx);
 
     if (NULL != key) {
-        p = pmix_hash_lookup_key(UINT32_MAX, key, keyindex);
+        /* removing a key we never registered is a no-op, so look
+         * without registering - see the note in pmix_hash_fetch */
+        p = pmix_hash_find_key(UINT32_MAX, key, keyindex);
         if (PMIX_UNLIKELY(NULL == p)) {
-            /* we don't know this key */
-            return PMIX_ERR_BAD_PARAM;
+            /* this key has never been stored anywhere */
+            return PMIX_ERR_NOT_FOUND;
         }
         kid = p->index;
     }
@@ -612,7 +620,10 @@ static pmix_dstor_t *lookup_keyval(pmix_proc_data_t *proc_data, uint32_t kid,
                     if (!PMIX_INFO_IS_QUALIFIER(&qualifiers[m])) {
                         continue;
                     }
-                    p = pmix_hash_lookup_key(UINT32_MAX, qualifiers[m].key, keyindex);
+                    /* a qualifier key we have never registered cannot
+                     * match anything already stored, so look without
+                     * registering - see the note in pmix_hash_fetch */
+                    p = pmix_hash_find_key(UINT32_MAX, qualifiers[m].key, keyindex);
                     if (NULL == p) {
                         /* we don't know this key */
                         return NULL;
@@ -696,9 +707,10 @@ void pmix_hash_register_key(uint32_t inid,
 
 // skg: Note that one may have to add a TMA wrapper for this call if changes are
 // made to how pmix_hash operates. Something for developers to keep in mind.
-pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
-                                           const char *key,
-                                           pmix_keyindex_t *kidx)
+static pmix_regattr_input_t* lookup_key(uint32_t inid,
+                                        const char *key,
+                                        pmix_keyindex_t *kidx,
+                                        bool register_if_missing)
 {
     int id;
     pmix_regattr_input_t *ptr = NULL;
@@ -716,6 +728,12 @@ pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
                     return ptr;
                 }
             }
+        }
+
+        if (!register_if_missing) {
+            /* the caller only wanted to know whether this key is known,
+             * so tell them it isn't rather than minting an index for it */
+            return NULL;
         }
 
         /* we didn't find it - register it */
@@ -737,6 +755,20 @@ pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
      * found or not - we don't register it if not found. */
     ptr = pmix_pointer_array_get_item(keyindex->table, inid);
     return ptr;
+}
+
+pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
+                                           const char *key,
+                                           pmix_keyindex_t *kidx)
+{
+    return lookup_key(inid, key, kidx, true);
+}
+
+pmix_regattr_input_t* pmix_hash_find_key(uint32_t inid,
+                                         const char *key,
+                                         pmix_keyindex_t *kidx)
+{
+    return lookup_key(inid, key, kidx, false);
 }
 
 static void erase_qualifiers(pmix_proc_data_t *proc,

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -778,13 +778,33 @@ static pmix_regattr_input_t* lookup_key(uint32_t inid,
             return NULL;
         }
 
-        /* we didn't find it - register it */
-        ptr = (pmix_regattr_input_t*)pmix_malloc(sizeof(pmix_regattr_input_t));
-        ptr->name = strdup(key);
-        ptr->string = strdup(key);
+        /* We didn't find it - register it.
+         *
+         * Allocate through the keyindex's own allocator, not the heap.
+         * A keyindex can live in a shared-memory segment (gds/shmem3
+         * keeps one beside the modex data it describes), and every
+         * pointer reachable from it is read by other processes that
+         * mapped that segment. A heap pointer stored here is valid only
+         * in the process that minted it, so a reader dereferences an
+         * address that means nothing in its own space. The TMA helpers
+         * fall back to plain malloc/strdup when there is no allocator,
+         * which is the ordinary process-global case - and this is what
+         * keyindex_destruct() has always assumed, since it frees these
+         * with pmix_tma_free(). */
+        pmix_tma_t *const tma = pmix_obj_get_tma(&keyindex->super);
+
+        ptr = (pmix_regattr_input_t*)pmix_tma_malloc(tma, sizeof(pmix_regattr_input_t));
+        if (PMIX_UNLIKELY(NULL == ptr)) {
+            return NULL;
+        }
+        ptr->name = pmix_tma_strdup(tma, key);
+        ptr->string = pmix_tma_strdup(tma, key);
         ptr->type = PMIX_UNDEF; // we don't know what type the user will set
-        ptr->description = (char**)pmix_malloc(2 * sizeof(char*));
-        ptr->description[0] = strdup("USER DEFINED");
+        ptr->description = (char**)pmix_tma_malloc(tma, 2 * sizeof(char*));
+        if (PMIX_UNLIKELY(NULL == ptr->description)) {
+            return NULL;
+        }
+        ptr->description[0] = pmix_tma_strdup(tma, "USER DEFINED");
         ptr->description[1] = NULL;
         pmix_hash_register_key(UINT32_MAX, ptr, keyindex);
         return ptr;

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -680,6 +680,36 @@ static pmix_proc_data_t *lookup_proc(pmix_hash_table_t *jtable, uint32_t id, boo
     return proc_data;
 }
 
+/* Add an entry to the string -> entry side of the index. The entry is
+ * borrowed; keyindex->table owns it. */
+static void add_to_lookup(pmix_keyindex_t *keyindex,
+                          pmix_regattr_input_t *ptr)
+{
+    if (NULL == keyindex->lookup || NULL == ptr->string) {
+        return;
+    }
+    pmix_hash_table_set_value_ptr(keyindex->lookup, ptr->string,
+                                  strlen(ptr->string), ptr);
+}
+
+void pmix_hash_keyindex_rebuild(pmix_keyindex_t *kidx)
+{
+    pmix_keyindex_t *const keyindex = get_keyindex_ptr(kidx);
+    pmix_regattr_input_t *ptr;
+    int id;
+
+    if (NULL == keyindex->lookup) {
+        return;
+    }
+    pmix_hash_table_remove_all(keyindex->lookup);
+    for (id = 0; id < keyindex->table->size; id++) {
+        ptr = pmix_pointer_array_get_item(keyindex->table, id);
+        if (NULL != ptr) {
+            add_to_lookup(keyindex, ptr);
+        }
+    }
+}
+
 void pmix_hash_register_key(uint32_t inid,
                             pmix_regattr_input_t *ptr,
                             pmix_keyindex_t *kidx)
@@ -692,6 +722,7 @@ void pmix_hash_register_key(uint32_t inid,
         pmix_pointer_array_set_item(keyindex->table, (int)keyindex->next_id, ptr);
         ptr->index = keyindex->next_id;
         keyindex->next_id += 1;
+        add_to_lookup(keyindex, ptr);
         return;
     }
 
@@ -703,6 +734,7 @@ void pmix_hash_register_key(uint32_t inid,
     }
     /* store the pointer in the table */
     pmix_pointer_array_set_item(keyindex->table, inid, ptr);
+    add_to_lookup(keyindex, ptr);
 }
 
 // skg: Note that one may have to add a TMA wrapper for this call if changes are
@@ -721,11 +753,21 @@ static pmix_regattr_input_t* lookup_key(uint32_t inid,
             /* they have to give us something! */
             return NULL;
         }
-        for (id = 0; id < keyindex->table->size; id++) {
-            ptr = pmix_pointer_array_get_item(keyindex->table, id);
-            if (NULL != ptr) {
-                if (0 == strcmp(key, ptr->string)) {
-                    return ptr;
+        if (NULL != keyindex->lookup && 0 < strlen(key)) {
+            void *found = NULL;
+            if (PMIX_SUCCESS == pmix_hash_table_get_value_ptr(keyindex->lookup, key,
+                                                              strlen(key), &found)) {
+                return (pmix_regattr_input_t*)found;
+            }
+        } else {
+            /* no lookup side available - fall back on scanning the
+             * table we do have */
+            for (id = 0; id < keyindex->table->size; id++) {
+                ptr = pmix_pointer_array_get_item(keyindex->table, id);
+                if (NULL != ptr && NULL != ptr->string) {
+                    if (0 == strcmp(key, ptr->string)) {
+                        return ptr;
+                    }
                 }
             }
         }

--- a/src/util/pmix_hash.h
+++ b/src/util/pmix_hash.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -55,9 +55,24 @@ PMIX_EXPORT void pmix_hash_register_key(uint32_t inid,
                                         pmix_regattr_input_t *ptr,
                                         pmix_keyindex_t *kidx);
 
+/* Translate a key to its keyindex entry, registering the key (and thus
+ * assigning it an index) if it is not already known. This is the form
+ * the store path wants: storing a value is precisely the point at which
+ * a new key legitimately acquires an index. */
 PMIX_EXPORT pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
                                                        const char *key,
                                                        pmix_keyindex_t *kidx);
+
+/* Same translation, but return NULL instead of registering an unknown
+ * key. This is the form every read-only path wants. Registering on a
+ * lookup would grow the keyindex without bound - one entry for every
+ * key anyone ever asked for and did not find - and would be fatal for a
+ * keyindex living in a shared-memory segment that the caller has mapped
+ * read-only. A key that was never stored cannot be found anyway, so the
+ * answer is the same either way. */
+PMIX_EXPORT pmix_regattr_input_t* pmix_hash_find_key(uint32_t inid,
+                                                     const char *key,
+                                                     pmix_keyindex_t *kidx);
 
 #define PMIX_HASH_TRACE_KEY_ACTUAL(s, r, k, id, tbl, v)                     \
 do {                                                                        \

--- a/src/util/pmix_hash.h
+++ b/src/util/pmix_hash.h
@@ -55,6 +55,12 @@ PMIX_EXPORT void pmix_hash_register_key(uint32_t inid,
                                         pmix_regattr_input_t *ptr,
                                         pmix_keyindex_t *kidx);
 
+/* Repopulate a keyindex's string -> entry lookup from its pointer
+ * array. Call this after modifying the array directly - adding,
+ * removing, or renumbering entries without going through
+ * pmix_hash_register_key() - or the two sides will disagree. */
+PMIX_EXPORT void pmix_hash_keyindex_rebuild(pmix_keyindex_t *kidx);
+
 /* Translate a key to its keyindex entry, registering the key (and thus
  * assigning it an index) if it is not already known. This is the form
  * the store path wants: storing a value is precisely the point at which

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -85,7 +85,11 @@ noinst_SCRIPTS = pmix_client_otheruser.sh \
 	run_tests10.pl \
 	run_tests11.pl \
 	run_tests12.pl \
-	run_tests13.pl
+	run_tests13.pl \
+	run_tests16.pl \
+	run_tests17.pl \
+	run_tests18.pl \
+	run_tests19.pl
 #	run_tests14.pl \
 #	run_tests15.pl
 
@@ -120,6 +124,10 @@ TESTS = \
 	run_tests11.pl \
 	run_tests12.pl \
 	run_tests13.pl \
+	run_tests16.pl \
+	run_tests17.pl \
+	run_tests18.pl \
+	run_tests19.pl \
 	pmix_environ
 #	run_tests14.pl \
 #	run_tests15.pl

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -89,7 +89,9 @@ noinst_SCRIPTS = pmix_client_otheruser.sh \
 	run_tests16.pl \
 	run_tests17.pl \
 	run_tests18.pl \
-	run_tests19.pl
+	run_tests19.pl \
+	run_tests20.pl \
+	run_tests21.pl
 #	run_tests14.pl \
 #	run_tests15.pl
 
@@ -128,6 +130,8 @@ TESTS = \
 	run_tests17.pl \
 	run_tests18.pl \
 	run_tests19.pl \
+	run_tests20.pl \
+	run_tests21.pl \
 	pmix_environ
 #	run_tests14.pl \
 #	run_tests15.pl

--- a/test/run_tests.pl.in
+++ b/test/run_tests.pl.in
@@ -24,7 +24,19 @@ my @tests = ("-n 4 --ns-dist 3:1 --fence \"[db | 0:0-2;1:0]\"",
              "-n 5 --test-replace 100:0,1,10,50,99",
              "-n 5 --test-internal 10",
              "-s 1 -n 2 --job-fence",
-             "-s 1 -n 2 --job-fence -c");
+             "-s 1 -n 2 --job-fence -c",
+             # Repeated modex exchanges across multiple namespaces.
+             # A fence stores its result through the gds module of each
+             # participating namespace, and for a shared-memory module
+             # the key indices in that store cross a process boundary -
+             # so the cases that matter are the ones where a second
+             # fence adds to an already-published store, where the
+             # namespaces involved differ between fences, and where the
+             # server meets the keys in an order no client shares.
+             "-n 6 --ns-dist 3:3 --fence \"[db | 0:;1:][db | 0:;1:]\"",
+             "-n 6 --ns-dist 2:2:2 --fence \"[db | 0:;1:;2:][db | 0:;1:;2:][db | 0:;1:;2:]\"",
+             "-n 6 --ns-dist 2:2:2 --fence \"[db | 0:0-1;1:0][db | 1:;2:]\"",
+             "-n 6 --ns-dist 2:2:2 --fence \"[db | 0:;1:;2:][db | 0:;1:;2:]\" --noise \"[0:0,1]\"");
 #             "-s 2 -n 2 --job-fence",
 #            "-s 2 -n 2 --job-fence -c");
 

--- a/test/run_tests.pl.in
+++ b/test/run_tests.pl.in
@@ -36,7 +36,14 @@ my @tests = ("-n 4 --ns-dist 3:1 --fence \"[db | 0:0-2;1:0]\"",
              "-n 6 --ns-dist 3:3 --fence \"[db | 0:;1:][db | 0:;1:]\"",
              "-n 6 --ns-dist 2:2:2 --fence \"[db | 0:;1:;2:][db | 0:;1:;2:][db | 0:;1:;2:]\"",
              "-n 6 --ns-dist 2:2:2 --fence \"[db | 0:0-1;1:0][db | 1:;2:]\"",
-             "-n 6 --ns-dist 2:2:2 --fence \"[db | 0:;1:;2:][db | 0:;1:;2:]\" --noise \"[0:0,1]\"");
+             "-n 6 --ns-dist 2:2:2 --fence \"[db | 0:;1:;2:][db | 0:;1:;2:]\" --noise \"[0:0,1]\"",
+             # --use-same-keys re-publishes the same key names with new
+             # values before each fence, so this is the case where a key
+             # already has an index and an entry: the store has to update
+             # in place rather than add, and every reader has to end up
+             # with the new value.
+             "-n 6 --ns-dist 3:3 --fence \"[db | 0:;1:][db | 0:;1:]\" --use-same-keys",
+             "-n 6 --ns-dist 2:2:2 --fence \"[db | 0:;1:;2:][db | 0:;1:;2:][db | 0:;1:;2:]\" --use-same-keys");
 #             "-s 2 -n 2 --job-fence",
 #            "-s 2 -n 2 --job-fence -c");
 

--- a/test/run_tests16.pl.in
+++ b/test/run_tests16.pl.in
@@ -1,0 +1,1 @@
+run_tests.pl.in

--- a/test/run_tests17.pl.in
+++ b/test/run_tests17.pl.in
@@ -1,0 +1,1 @@
+run_tests.pl.in

--- a/test/run_tests18.pl.in
+++ b/test/run_tests18.pl.in
@@ -1,0 +1,1 @@
+run_tests.pl.in

--- a/test/run_tests19.pl.in
+++ b/test/run_tests19.pl.in
@@ -1,0 +1,1 @@
+run_tests.pl.in

--- a/test/run_tests20.pl.in
+++ b/test/run_tests20.pl.in
@@ -1,0 +1,1 @@
+run_tests.pl.in

--- a/test/run_tests21.pl.in
+++ b/test/run_tests21.pl.in
@@ -1,0 +1,1 @@
+run_tests.pl.in

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -273,6 +273,7 @@ typedef struct {
         char _key[50];                                                                            \
         pmix_value_t *_val;                                                                       \
         get_cbdata _cbdata;                                                                       \
+        int _mismatch = 0;                                                                        \
         _cbdata.status = PMIX_SUCCESS;                                                            \
         pmix_proc_t _foobar;                                                                      \
         SET_KEY(_key, fence_num, ind, use_same_keys);                                             \
@@ -319,12 +320,22 @@ typedef struct {
                 TEST_ERROR(("%s:%u: from %s:%d Key %s value or type mismatch,"                    \
                             " want type %d get type %d",                                          \
                             my_nspace, my_rank, ns, r, _key, PMIX_VAL_TYPE_##dtype, _val->type)); \
+                _mismatch = 1;                                                                    \
             }                                                                                     \
         }                                                                                         \
         if (PMIX_SUCCESS == rc) {                                                                 \
             TEST_VERBOSE(                                                                         \
                 ("%s:%d: GET OF %s from %s:%d SUCCEEDED", my_nspace, my_rank, _key, ns, r));      \
             PMIX_VALUE_RELEASE(_val);                                                             \
+        }                                                                                         \
+        /* Report a wrong value as a failure. The comparison above used to                        \
+         * print and then leave rc at PMIX_SUCCESS, so every caller's                             \
+         * "if (PMIX_SUCCESS != rc)" check passed and the run finished with                       \
+         * "Test SUCCEEDED!" and an exit status of 0 - which is why a fence                       \
+         * that returned stale data was invisible to make check. Set it                           \
+         * after the release above so the value is still freed. */                                \
+        if (_mismatch) {                                                                          \
+            rc = PMIX_ERROR;                                                                      \
         }                                                                                         \
     } while (0)
 

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -274,13 +274,30 @@ typedef struct {
         pmix_value_t *_val;                                                                       \
         get_cbdata _cbdata;                                                                       \
         int _mismatch = 0;                                                                        \
+        pmix_info_t _ginfo, *_ginfop = NULL;                                                      \
+        size_t _nginfo = 0;                                                                       \
+        bool _grefresh = true;                                                                    \
         _cbdata.status = PMIX_SUCCESS;                                                            \
         pmix_proc_t _foobar;                                                                      \
         SET_KEY(_key, fence_num, ind, use_same_keys);                                             \
+        /* Reusing a key means this fence re-published a value the peer                           \
+         * already gave us, and a plain PMIx_Get is answered out of the                           \
+         * local cache of that peer's data - by design, and exactly what                          \
+         * PMIX_GET_REFRESH_CACHE is documented for: "refresh the existing                        \
+         * local data cache for the process in case new values have been                          \
+         * put and committed by it since the last refresh". Without it this                       \
+         * test reads the previous fence's value and calls the library                            \
+         * wrong. Only ask for the refresh when we actually reused a key,                         \
+         * so the unique-key cases keep exercising the cached path. */                            \
+        if (use_same_keys) {                                                                      \
+            PMIX_INFO_LOAD(&_ginfo, PMIX_GET_REFRESH_CACHE, &_grefresh, PMIX_BOOL);               \
+            _ginfop = &_ginfo;                                                                    \
+            _nginfo = 1;                                                                          \
+        }                                                                                         \
         PMIX_LOAD_PROCID(&_foobar, ns, r);                                                        \
         TEST_VERBOSE(("%s:%d want to get from %s:%d key %s", my_nspace, my_rank, ns, r, _key));   \
         if (blocking) {                                                                           \
-            if (PMIX_SUCCESS != (rc = PMIx_Get(&_foobar, _key, NULL, 0, &_val))) {                \
+            if (PMIX_SUCCESS != (rc = PMIx_Get(&_foobar, _key, _ginfop, _nginfo, &_val))) {       \
                 if (!((rc == PMIX_ERR_NOT_FOUND || rc == PMIX_ERR_NOT_FOUND)           \
                       && ok_notfnd)) {                                                            \
                     TEST_ERROR(("%s:%d: PMIx_Get failed: %s from %s:%d, key %s", my_nspace,       \
@@ -292,7 +309,8 @@ typedef struct {
             PMIX_VALUE_CREATE(_val, 1);                                                           \
             _cbdata.kv = _val;                                                                    \
             if (PMIX_SUCCESS                                                                      \
-                != (rc = PMIx_Get_nb(&_foobar, _key, NULL, 0, get_cb, (void *) &_cbdata))) {      \
+                != (rc = PMIx_Get_nb(&_foobar, _key, _ginfop, _nginfo, get_cb,                     \
+                                     (void *) &_cbdata))) {                                       \
                 TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %s from %s:%d, key=%s", my_nspace,      \
                               my_rank, PMIx_Error_string(rc), ns, r, _key));                      \
             } else {                                                                              \

--- a/test/unit/gds_datastore.c
+++ b/test/unit/gds_datastore.c
@@ -149,6 +149,7 @@ static void test_assign_module(void)
 static size_t modex_nblobs = 0;   /* callbacks carrying a buffer */
 static size_t modex_ndone = 0;    /* callbacks carrying NULL     */
 static pmix_rank_t modex_ranks[8];
+static char modex_nspaces[8][PMIX_MAX_NSLEN + 1];
 static pmix_status_t modex_cb_rc = PMIX_SUCCESS;
 
 static pmix_status_t modex_cb(pmix_proc_t *proc, pmix_buffer_t *pbkt)
@@ -159,9 +160,26 @@ static pmix_status_t modex_cb(pmix_proc_t *proc, pmix_buffer_t *pbkt)
     }
     if (modex_nblobs < sizeof(modex_ranks) / sizeof(modex_ranks[0])) {
         modex_ranks[modex_nblobs] = proc->rank;
+        pmix_strncpy(modex_nspaces[modex_nblobs], proc->nspace, PMIX_MAX_NSLEN);
     }
     ++modex_nblobs;
     return modex_cb_rc;
+}
+
+/* true if every blob the callback saw came from the named nspace */
+static bool modex_all_from(const char *nspace)
+{
+    size_t n, lim = modex_nblobs;
+
+    if (lim > sizeof(modex_ranks) / sizeof(modex_ranks[0])) {
+        lim = sizeof(modex_ranks) / sizeof(modex_ranks[0]);
+    }
+    for (n = 0; n < lim; n++) {
+        if (0 != strcmp(modex_nspaces[n], nspace)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 /* Build the envelope pmix_gds_base_store_modex() expects: an outer byte
@@ -227,6 +245,143 @@ static pmix_status_t build_modex(pmix_buffer_t *out, const char *nspace,
     return rc;
 }
 
+/* Same envelope, but the rank-level block carries procs from more than
+ * one nspace - which is what a fence spanning two local nspaces
+ * produces, and what the nspace filter has to sort out. */
+static pmix_status_t build_modex_mixed(pmix_buffer_t *out,
+                                       pmix_proc_t *procs, size_t nprocs)
+{
+    pmix_buffer_t ranklevel, serverlevel, pbkt;
+    pmix_byte_object_t bo;
+    pmix_status_t rc;
+    uint8_t collect = 1;
+    bool compressed = false;
+    size_t n;
+
+    PMIX_CONSTRUCT(&ranklevel, pmix_buffer_t);
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &ranklevel, &collect, 1, PMIX_BYTE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DESTRUCT(&ranklevel);
+        return rc;
+    }
+    for (n = 0; n < nprocs; n++) {
+        PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &pbkt, &procs[n], 1, PMIX_PROC);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_DESTRUCT(&pbkt);
+            PMIX_DESTRUCT(&ranklevel);
+            return rc;
+        }
+        PMIX_UNLOAD_BUFFER(&pbkt, bo.bytes, bo.size);
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &ranklevel, &bo, 1, PMIX_BYTE_OBJECT);
+        PMIX_BYTE_OBJECT_DESTRUCT(&bo);
+        PMIX_DESTRUCT(&pbkt);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_DESTRUCT(&ranklevel);
+            return rc;
+        }
+    }
+
+    PMIX_CONSTRUCT(&serverlevel, pmix_buffer_t);
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &serverlevel, &compressed, 1, PMIX_BOOL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DESTRUCT(&serverlevel);
+        PMIX_DESTRUCT(&ranklevel);
+        return rc;
+    }
+    PMIX_UNLOAD_BUFFER(&ranklevel, bo.bytes, bo.size);
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &serverlevel, &bo, 1, PMIX_BYTE_OBJECT);
+    PMIX_BYTE_OBJECT_DESTRUCT(&bo);
+    PMIX_DESTRUCT(&ranklevel);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DESTRUCT(&serverlevel);
+        return rc;
+    }
+
+    PMIX_UNLOAD_BUFFER(&serverlevel, bo.bytes, bo.size);
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, out, &bo, 1, PMIX_BYTE_OBJECT);
+    PMIX_BYTE_OBJECT_DESTRUCT(&bo);
+    PMIX_DESTRUCT(&serverlevel);
+    return rc;
+}
+
+/* A fence can span local nspaces that were assigned different gds
+ * modules, so the same payload is walked once per nspace, each pass
+ * storing only that nspace's blobs. Passing NULL still stores
+ * everything, which is what a single-module caller wants. */
+static void test_store_modex_nspace_filter(void)
+{
+    pmix_buffer_t buf;
+    pmix_server_trkr_t trk;
+    pmix_proc_t procs[4];
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- modex walker: per-nspace filtering --\n");
+
+    memset(&trk, 0, sizeof(trk));
+    trk.collect_type = PMIX_COLLECT_YES;
+
+    PMIX_LOAD_PROCID(&procs[0], "gds-modex-nsA", 0);
+    PMIX_LOAD_PROCID(&procs[1], "gds-modex-nsB", 0);
+    PMIX_LOAD_PROCID(&procs[2], "gds-modex-nsA", 1);
+    PMIX_LOAD_PROCID(&procs[3], "gds-modex-nsB", 1);
+
+    /* filtering to one nspace delivers only its blobs, and signals done
+     * once - for that nspace alone */
+    modex_nblobs = modex_ndone = 0;
+    modex_cb_rc = PMIX_SUCCESS;
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    rc = build_modex_mixed(&buf, procs, 4);
+    report("mixed-nspace envelope builds", PMIX_SUCCESS == rc);
+    if (PMIX_SUCCESS == rc) {
+        rc = pmix_gds_base_store_modex(&buf, "gds-modex-nsA", modex_cb, &trk);
+        report("filtered store_modex succeeds", PMIX_SUCCESS == rc);
+        report("filtered store_modex delivers only that nspace's blobs",
+               2 == modex_nblobs);
+        report("filtered store_modex delivers no other nspace",
+               modex_all_from("gds-modex-nsA"));
+        report("filtered store_modex signals done once", 1 == modex_ndone);
+    }
+    PMIX_DESTRUCT(&buf);
+
+    /* the other nspace's blobs are still reachable on its own pass -
+     * i.e. filtering does not consume or skip past them permanently */
+    modex_nblobs = modex_ndone = 0;
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    rc = build_modex_mixed(&buf, procs, 4);
+    if (PMIX_SUCCESS == rc) {
+        rc = pmix_gds_base_store_modex(&buf, "gds-modex-nsB", modex_cb, &trk);
+        report("the second nspace's pass sees its own blobs",
+               PMIX_SUCCESS == rc && 2 == modex_nblobs
+                   && modex_all_from("gds-modex-nsB"));
+    }
+    PMIX_DESTRUCT(&buf);
+
+    /* a NULL filter stores everything, and signals done once per nspace */
+    modex_nblobs = modex_ndone = 0;
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    rc = build_modex_mixed(&buf, procs, 4);
+    if (PMIX_SUCCESS == rc) {
+        rc = pmix_gds_base_store_modex(&buf, NULL, modex_cb, &trk);
+        report("an unfiltered walk delivers every blob",
+               PMIX_SUCCESS == rc && 4 == modex_nblobs);
+        report("an unfiltered walk signals done once per nspace",
+               2 == modex_ndone);
+    }
+    PMIX_DESTRUCT(&buf);
+
+    /* a filter naming an nspace not present delivers nothing at all */
+    modex_nblobs = modex_ndone = 0;
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    rc = build_modex_mixed(&buf, procs, 4);
+    if (PMIX_SUCCESS == rc) {
+        rc = pmix_gds_base_store_modex(&buf, "gds-modex-absent", modex_cb, &trk);
+        report("a filter matching no blob delivers none",
+               PMIX_SUCCESS == rc && 0 == modex_nblobs && 0 == modex_ndone);
+    }
+    PMIX_DESTRUCT(&buf);
+}
+
 static void test_store_modex(void)
 {
     pmix_buffer_t buf;
@@ -246,7 +401,7 @@ static void test_store_modex(void)
     rc = build_modex(&buf, "gds-modex-ns", ranks, 3);
     report("modex envelope builds", PMIX_SUCCESS == rc);
     if (PMIX_SUCCESS == rc) {
-        rc = pmix_gds_base_store_modex(&buf, modex_cb, &trk);
+        rc = pmix_gds_base_store_modex(&buf, NULL, modex_cb, &trk);
         report("store_modex walks the envelope successfully", PMIX_SUCCESS == rc);
         report("store_modex delivers every proc blob", 3 == modex_nblobs);
         report("store_modex delivers rank 0 first",
@@ -268,7 +423,7 @@ static void test_store_modex(void)
     PMIX_CONSTRUCT(&buf, pmix_buffer_t);
     rc = build_modex(&buf, "gds-modex-ns", ranks, 3);
     if (PMIX_SUCCESS == rc) {
-        rc = pmix_gds_base_store_modex(&buf, modex_cb, &trk);
+        rc = pmix_gds_base_store_modex(&buf, NULL, modex_cb, &trk);
         report("a callback that does not report success truncates the walk",
                1 == modex_nblobs);
     }
@@ -695,6 +850,7 @@ int main(int argc, char **argv)
 
     test_assign_module();
     test_store_modex();
+    test_store_modex_nspace_filter();
     test_map_forms();
     test_malformed_job_info();
     test_scope_routing();

--- a/test/unit/util/util_hash.c
+++ b/test/unit/util/util_hash.c
@@ -107,9 +107,50 @@ static void test_lookup_auto_register(void)
            p != NULL && strcmp(p->string, "unit.test.auto.key") == 0);
 }
 
+static void test_find_key_does_not_register(void)
+{
+    uint32_t before, after;
+    pmix_regattr_input_t *p;
+
+    /* A known key is returned just as pmix_hash_lookup_key would. */
+    p = pmix_hash_find_key(UINT32_MAX, PMIX_SERVER_TOOL_SUPPORT, NULL);
+    report("find_key: known key returned", p != NULL);
+
+    /* An unknown key returns NULL and, crucially, leaves the keyindex
+     * alone. Checking the status without checking next_id would pass
+     * against the old auto-registering lookup as well. */
+    before = pmix_globals.keyindex.next_id;
+    p = pmix_hash_find_key(UINT32_MAX, "unit.test.never.registered", NULL);
+    after = pmix_globals.keyindex.next_id;
+    report("find_key: unknown key returns NULL", p == NULL);
+    report("find_key: unknown key did not grow keyindex", before == after);
+}
+
 /* ------------------------------------------------------------------ */
 /* pmix_hash_store / pmix_hash_fetch                                   */
 /* ------------------------------------------------------------------ */
+
+static void test_fetch_does_not_register(void)
+{
+    pmix_hash_table_t *t = new_table();
+    pmix_list_t kvals;
+    pmix_status_t rc;
+    uint32_t before, after;
+
+    /* Fetching a key nobody ever stored must not mint an index for it.
+     * Before this was fixed, every failed fetch grew the process-global
+     * keyindex by one entry that could never be removed - and would
+     * have written into a read-only shared-memory keyindex. */
+    PMIX_CONSTRUCT(&kvals, pmix_list_t);
+    before = pmix_globals.keyindex.next_id;
+    rc = pmix_hash_fetch(t, 0, "unit.test.fetch.unregistered", NULL, 0, &kvals, NULL);
+    after = pmix_globals.keyindex.next_id;
+    report("fetch_no_register: returns ERR_NOT_FOUND", PMIX_ERR_NOT_FOUND == rc);
+    report("fetch_no_register: did not grow keyindex", before == after);
+    drain_list(&kvals);
+    PMIX_DESTRUCT(&kvals);
+    PMIX_RELEASE(t);
+}
 
 static void test_store_fetch_basic(void)
 {
@@ -348,6 +389,8 @@ int main(int argc, char **argv)
 
     test_lookup_known_key();
     test_lookup_auto_register();
+    test_find_key_does_not_register();
+    test_fetch_does_not_register();
     test_store_fetch_basic();
     test_fetch_not_found_empty_table();
     test_fetch_wrong_key();


### PR DESCRIPTION
Enables `gds/shmem3` to store modex data, so local clients share one copy
of a job's remote-proc data instead of each holding their own.

The blocker was the key index. `pmix_hash_store`/`pmix_hash_fetch` key their
entries by a `uint32_t` index, not by the key string, and a non-reserved
key's index is assigned **per process, in order of first encounter**. That
is invisible today because indices never cross a process boundary — every
wire format carries the key string. A shared-memory segment *is* a process
boundary, and the server's indices are what every client would have to read.

Dictating a numbering the way the job segment does cannot work here: the
server meets modex keys in the order the aggregated blob arrives, which no
client can predict, and re-running the job-data fixup after a fence would
renumber indices already recorded in a client's own tables. So the modex
segment carries its own key index, written by the one process that owns it.

## What's here

| Commit | |
|---|---|
| `0a50fd92` | Document the modex data path and the key index |
| `98a70894` | Stop registering keys on the datastore read paths |
| `83dbe0c0` | Index keys by string instead of scanning for them |
| `f307c50b` | Give the shmem3 modex segment its own key index |
| `c96cf5b9` | Store a modex through each participating nspace's module |
| `dfb52ec4` | Let a requester reach data held by another nspace's module |
| `ff50cd08` | Add repeated multi-namespace modex cases to the test suite |
| `0bbd161d` | Allocate key index entries through the index's own allocator |
| `c332de4e` | Report a wrong fence value as a test failure |
| `d4eb2a2d` | Refresh the cache when a fence test reuses its keys |

New documentation page: `docs/how-things-work/modex.rst`.

## Notes for review

**Routing.** The three modex macros took a peer and ignored it, resolving
`pmix_globals.mypeer`'s module — which both the server and client pin to
`"hash"`. That is why shmem3's modex half, though written, had never
executed. They now resolve from the peer they are already given.

**Storing is not a one-module operation.** All local clients of a given
nspace share a module, but clients of *different* nspaces need not, so a
fence spanning two local nspaces has no single module that should receive
the whole payload. `pmix_gds_base_store_modex()` gained an nspace filter and
`_mdxcbfunc` walks the payload once per participating nspace, through a peer
of that nspace. `NULL` keeps the old "store everything" behavior.

**Layout stamp.** `pmix_keyindex_t`, `pmix_regattr_input_t` and
`pmix_pointer_array_t` now live in the segment, so `PMIX_GDS_SHMEM3_LAYOUT_ID`
changes and a peer built before this falls back to `hash` as designed. No
component rename — the stamp is what protects peers here.

**Incidental fix, worth its own look.** `pmix_hash_lookup_key()` registered
any key it did not find, and three read-only callers used it, so every
`PMIx_Get` of a never-stored key permanently grew the process-global
keyindex. Behavior is unchanged — an absent key already returned
`PMIX_ERR_NOT_FOUND` — but the side effect is gone.

**Performance.** The string→index translation was a linear `strcmp` scan of a
table the reserved dictionary already fills with 671 entries, and it runs on
every put, every commit-ingested kval, every modex-stored kval, and every
string fetch. Now a hash lookup: measured over 200 non-reserved keys,
**1729ns → 61ns**.

## Testing

`make check`: **105/105 on macOS and Linux**, warning-free under
`--enable-devel-check` on both.

`contrib/dockerswarm/run-gds-tests.sh`: **20 passed, 0 failed**. This suite
is not optional for this change — `pmix_test` runs a single server, so its
fences are purely local, the host returns no data, and `store_modex` is
never called at all. The swarm caught a segfault in every cross-server
shmem3 case (14 passed / 6 failed at first): entries were being allocated on
the server's heap and their pointers stored into the shared segment, so
clients dereferenced addresses meaningless in their own space. That is
`0bbd161d`.

Two test-suite defects surfaced along the way and are fixed here:

- The `GET` macro printed a value mismatch and left `rc` at `PMIX_SUCCESS`,
  so `pmix_test` could report every value wrong and still exit 0.
- `--use-same-keys` re-publishes keys and then read them with a plain
  `PMIx_Get`, which is answered from the local cache — so it read the
  previous fence's value. The library is correct here;
  `PMIX_GET_REFRESH_CACHE` is documented for exactly this case. With that
  fixed the option works and is now exercised (cases 20 and 21), and it is
  the sharpest case the suite has for this change: a reused key already has
  an index and an entry, so the store must update in place.

## Note

`config/pmix.m4` changed, so this needs `./autogen.pl && ./configure` rather
than a plain `make`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
