### PR TITLE
Deep review of the Python bindings, plus two libpmix fixes it uncovered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,10 @@ bindings/python/pmix_constants.pxi
 bindings/python/pmix_constants.stamp
 bindings/python/dist/
 bindings/python/pypmix.egg-info/
+# test/python/test_construct.py imports construct.py from here, so a
+# "make check" leaves the interpreter's byte-code cache behind
+bindings/python/__pycache__/
+test/python/__pycache__/
 
 examples/python/__pycache__/
 examples/alloc

--- a/bindings/AGENTS.md
+++ b/bindings/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md: PMIx Language Bindings (`bindings/`)
+
+Orientation for AI and human contributors working on the PMIx language
+bindings. This is a *map*, not the rulebook — the top-level
+[`CLAUDE.md`/`AGENTS.md`](../CLAUDE.md) at the repo root and the docs under
+[`docs/`](../docs/) are authoritative. When this file and those disagree,
+they win — and please fix this file.
+
+---
+
+## What lives here
+
+This directory holds bindings of the PMIx C API to other programming
+languages. Today there is exactly one:
+
+| Directory | Binding | Guide |
+|-----------|---------|-------|
+| [`python/`](python/) | A Cython extension module named `pmix` | [`python/AGENTS.md`](python/AGENTS.md) |
+
+`Makefile.am` here does nothing but list `SUBDIRS`. Adding a binding for
+another language means adding a directory, listing it there, and wiring
+its `configure` support in the usual way (see the top-level guidance on
+[modifying the configure / build system](../CLAUDE.md)).
+
+**Work on the Python bindings belongs in
+[`python/AGENTS.md`](python/AGENTS.md)** — it is far more detailed than
+this file and covers the conversion layer, the threading model, and the
+defects that recur there.
+
+---
+
+## The one rule that governs every binding
+
+From [`README`](README):
+
+> You can wrap a framework, but you cannot wrap a specific plugin within
+> that framework.
+
+Plugins are reached only through their framework's interface, and which
+plugin is active is a runtime selection the caller does not control.
+Binding `pmix_preg_raw_generate_regex` rather than `PMIx_generate_regex2`
+would produce something that silently does the wrong thing the moment a
+different `preg` component wins selection. There is no restriction on how
+many bindings exist, or on what kind of function they wrap, beyond that.
+
+Two consequences worth stating plainly, because they are what the rule is
+protecting:
+
+- **Bind the public API, not the internals.** The `PMIx_*` entry points in
+  [`include/`](../include/) are the surface that is frozen across releases
+  (see the top-level *Backward Compatibility* section). Anything under
+  `src/` is not, and a binding that reaches into it will break without
+  warning.
+- **A binding must actually reach a `PMIx_*` entry point.** A method that
+  builds up arguments and returns success without calling the library is
+  worse than a missing one: the caller believes it worked. This has
+  happened here before; see §8 of the Python guide.
+
+---
+
+## Where the tests are
+
+Deliberately **not** in this directory. The tests for a binding live with
+the rest of the project's tests:
+
+| What | Where |
+|------|-------|
+| Python unit tests + connected round trips | [`test/python/`](../test/python/) |
+| Python multi-node tests | [`contrib/dockerswarm/python/`](../contrib/dockerswarm/python/) |
+| Runnable Python examples | [`examples/python/`](../examples/python/) |
+
+Keeping them out of `bindings/` is a deliberate correction: a copy of the
+test scripts used to live under `bindings/python/tests/`, only CI ran it,
+and it drifted out of sync with the bindings it was supposed to be
+testing. One home per test.
+
+## Building
+
+The bindings are **not** built by default. `configure` must be told to
+want them — for Python, `--enable-python-bindings`, which also requires a
+Python 3 with Cython and setuptools. Everything under this directory is
+inside a `WANT_<LANGUAGE>_BINDINGS` Automake conditional, so on a tree
+configured without them, a change here compiles nothing at all and a
+clean `make` proves nothing.
+
+**Check that your configured tree is actually building what you changed**
+before believing a green build. For Python:
+
+```sh
+grep WANT_PYTHON_BINDINGS_TRUE config.status   # "" means yes, "#" means no
+```

--- a/bindings/CLAUDE.md
+++ b/bindings/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/bindings/python/AGENTS.md
+++ b/bindings/python/AGENTS.md
@@ -20,7 +20,7 @@ change is silently discarded on the next build.
 | File | Role | Edit? |
 |------|------|-------|
 | `pmix.pyx` | **Source.** The four role classes and all module-level callback trampolines. The heart of the bindings. | ✅ |
-| `pmix.pxi` | **Source.** Cython `include`d by `pmix.pyx`. All the Python↔C conversion helpers (`pmix_load_*`, `pmix_unload_*`, `pmix_free_*`), the `myLock` class, and the `pmix_pyshift_t` caddy. | ✅ |
+| `pmix.pxi` | **Source.** Cython `include`d by `pmix.pyx`. All the Python↔C conversion helpers (`pmix_load_*`, `pmix_unload_*`, `pmix_free_*`) and the `myLock` class. | ✅ |
 | `construct.py` | **Source.** A code generator: harvests `#define`/enum/typedef constants and API/type names from the installed C headers and emits `pmix_constants.pxi` and `pmix_constants.pxd`. | ✅ |
 | `setup.py` | **Source.** setuptools/Cython build driver. Reads `PMIX_BINDINGS_TOP_{BUILDDIR,SRCDIR}` env vars to find `pmix.pyx` and the include dirs; derives the version from `include/pmix_version.h`. | ✅ |
 | `Makefile.am` | **Source.** Automake wiring: runs `construct.py`, then `setup.py`, and installs the egg. | ✅ |
@@ -31,8 +31,9 @@ change is silently discarded on the next build.
 | `Makefile`, `Makefile.in` | **Generated** by Autotools. | ❌ |
 | `build/`, `pypmix.egg-info/` | **Generated** build products. | ❌ |
 
-**All of the tests live in the top-level
-[`test/python/`](../../test/python/) directory** (see §7) — that is the
+**All of the in-tree tests live in the top-level
+[`test/python/`](../../test/python/) directory** (see §7, and
+[`test/python/AGENTS.md`](../../test/python/AGENTS.md)) — that is the
 one place to add or fix one. There is deliberately nothing under
 `bindings/python/tests/`: it held duplicate copies of the connected
 scripts that drifted out of sync with the bindings (only CI ran them, so
@@ -40,6 +41,9 @@ a change could pass `make check` and still break CI), plus a Cython
 round-trip smoke test that nothing compiled or ran. The conversion cases
 that smoke test carried now live in `test/python/test_bindings.py`,
 reachable from Python through the `pmix_value_roundtrip` hook (§7).
+
+Multi-node coverage lives in
+[`contrib/dockerswarm/python/`](../../contrib/dockerswarm/python/) (§7).
 
 ---
 
@@ -123,7 +127,14 @@ field names, so the mapping is mechanical:
 {'type': PMIX_DEVTYPE_GPU, 'count': 4}            # pmix_resource_unit_t
 {'bytes': b'...', 'bytes_used': 43,               # pmix_data_buffer_t
  'bytes_unpacked': 22}                            #   (§8b)
+{'view': 1, 'coord': b'\x01\x00\x00\x00',        # pmix_coord_t
+ 'dims': 1}                                       #   (§8c)
 ```
+
+A coordinate's `coord` is the raw `uint32` vector as **bytes**, and
+`dims` counts coordinates, not bytes — so the payload is always four
+times as long. A `pmix_geometry_t` carries a list of them under `coords`
+plus their count under `ncoords`.
 
 The regex2 `bytes` are *not* necessarily NUL-terminated, which is why the
 struct carries a length and the dict keeps it — treat the payload as
@@ -150,6 +161,20 @@ status). Methods that also produce data return a **tuple**, e.g.
 - `pmix_load_regex2` / `pmix_unload_regex2` — regex dict ↔ `pmix_regex2_t`.
   The loader constructs the struct first, so the caller can (and must)
   `PMIx_Regex2_destruct` it on every path, including a partial failure.
+- `pmix_load_bo` / `pmix_unload_bo` — byte-object dict ↔
+  `pmix_byte_object_t`. **This is the only correct way to move a payload
+  across**: it takes its length from the bytes it was actually handed, not
+  from the dict's `size`. Every arm that copies a blob goes through it.
+- `pmix_load_coord` / `pmix_unload_coord` — coordinate dict ↔
+  `pmix_coord_t`, likewise refusing a `dims` larger than the vector.
+- `pmix_decode_str` — a `char *` the library is allowed to leave NULL,
+  answered as `str` or `None`. Casting a NULL `char *` to `<bytes>` walks
+  address zero; several unload arms used to.
+- `pmix_darray_alloc` / `pmix_darray_nomem` — the block behind a data
+  array, zeroed, with an empty array answered as NULL rather than as a
+  `malloc(0)` whose return value is not portable.
+- `pmix_value_alloc` — one zeroed struct for a `pmix_value_t` to point at
+  (§8, "Zero before you fill").
 - `pmix_load_procs` / `pmix_unload_procs`, `pmix_load_pdata`, `pmix_load_apps`,
   etc. — the remaining structured types.
 
@@ -205,9 +230,19 @@ every server operation (client connected, fence, publish, …). The chain:
 Event and IOF handlers work similarly through the module-global list
 `myhdlrs` (a list of `{'refid', 'hdlr'}` dicts). `pyeventhandler` /
 `pyiofhandler` find the matching handler by `refid`. If the handler isn't
-registered yet (a race with registration), they stash the event in a
-`pmix_pyshift_t` caddy wrapped in a `PyCapsule` and retry via a
+registered yet (a race with registration), they retry via a
 `threading.Timer(0.001, …)`.
+
+**Only Python objects may cross that delay.** Everything the library
+hands an upcall — the `pmix_info_t` array, the results array, the
+payload — is released the instant the upcall returns, so the retry
+carries the *converted* dicts and lists, never the pointers. This used to
+stash the library's own arrays in a C caddy and free them from the timer:
+a use-after-free followed by a double free, plus a leak of the caddy. And
+the library's completion callback cannot be deferred with the rest — it
+must fire before the upcall returns, or the event chain stalls — so
+`pyeventhandler` completes the event with `PMIX_EVENT_NO_ACTION_TAKEN`
+and lets the retry deliver it to the handler for its own sake.
 
 **Server-module keys** accepted by `setmodulefn` are the strings in its
 `permitted` list; the *wiring* names checked in `server_module_init` must
@@ -215,6 +250,31 @@ match exactly (adding a key to one list without the other silently drops the
 callback — that class of mismatch bit the `notifyevent` key historically). A
 Python server registers them via `PMIxServer.init(info, module_map)` where
 `module_map` is `{'clientconnected': fn, 'fencenb': fn, ...}`.
+
+`setmodulefn` **returns a status** — `PMIX_ERR_BAD_PARAM` for a key it
+does not recognize or a handler that is not callable — and both callers
+check it. They used to guard the call with `except KeyError`, which it
+cannot raise, so an unrecognized key was accepted silently, never wired
+in, and the caller's handler was simply never invoked.
+
+### The upcall trampolines must not let an exception escape
+
+Every `cdef int` trampoline is stored in `pmix_server_module_t` and called
+by `libpmix` **across a C frame**, so an exception raised by the Python
+handler has nowhere to propagate. Each one is therefore declared
+`noexcept with gil` **and** wraps its whole body in `try`/`except`,
+reporting the traceback and answering `PMIX_ERROR`.
+
+Both halves are needed. Without `noexcept`, Cython returns −1 and leaves
+the error indicator set, and the generated code then releases the GIL with
+it still set — so the next Python code to run anywhere in the process
+trips over an exception raised inside an unrelated upcall. With `noexcept`
+alone, Cython prints the exception and returns **0**, which is
+`PMIX_SUCCESS` — telling the library a completion callback is coming that
+never will, and hanging the request. A new trampoline needs both.
+
+The same reasoning is why a `cdef int` upcall must not fall off the end of
+its body: that returns 0, i.e. success. `resourceblock` did.
 
 ### 4c. Downcalls: a client `_nb` API → a Python callback
 
@@ -280,8 +340,8 @@ Full write-up, including how to add a further `_nb` binding:
 - Trampolines that only touch C state and release into `libpmix` use
   `with nogil` around the actual C callback invocation (see
   `pypmix_op_cbfunc`).
-- Do not add work between allocating a `pmix_pyshift_t` caddy and wrapping it
-  in its capsule; the capsule owns the lifetime.
+- An upcall that defers work to a timer may carry only Python objects
+  across the delay — see §4b.
 - Match the existing free discipline: whoever allocs the `pmix_info_t[]` /
   procs / caddy is responsible for freeing it after the C call returns or in
   the release callback.
@@ -302,8 +362,28 @@ re-ran `construct.py`.
 `construct.py` classifies each harvested line as a string constant, numeric
 constant, error code, typedef, or API declaration, and emits the appropriate
 Cython. Its parsing is textual and line-oriented, so unusual formatting in a
-header (multi-line macros, unusual comments) can trip it — keep new header
-entries in the conventional one-line style.
+header (multi-line macros) can trip it — keep new header entries in the
+conventional one-line style.
+
+Two things it now handles that it used to get silently wrong, and which
+are worth knowing because the failure mode is a constant with the *wrong
+value* rather than a build error:
+
+- **Enum bodies.** Comments and blank lines inside a `typedef enum` are
+  skipped rather than taken for enumerators, and an explicit `= <value>`
+  is honored, with counting continuing from it. An unparsable value stops
+  the build rather than emitting a wrong one.
+- **A header that fails to parse stops the build.** The return of every
+  `harvest_constants` call is checked; it used to be ignored for every
+  file but the first, quietly producing bindings with that header's
+  constants missing.
+
+`construct.py` has its own unit suite,
+[`test/python/test_construct.py`](../../test/python/test_construct.py),
+which needs neither the extension nor the library. Add to it when you
+touch the generator — its output is what every Python constant *is*, so a
+parsing mistake is not visible until a comparison silently never matches
+at run time.
 
 ---
 
@@ -338,21 +418,48 @@ The `.so` embeds an absolute path to `libpmix` (via the linker), so once built
 it imports without setting `DYLD_LIBRARY_PATH`/`LD_LIBRARY_PATH` — only
 `PYTHONPATH` to the `build/lib.*` directory is needed.
 
+**The module defines `__all__`, and it is computed at import time** at the
+bottom of `pmix.pyx`: everything public except the modules `pmix.pyx`
+imports for its own use and the few names it pulls in with `from X import
+Y`. The documented usage is `from pmix import *`, so without it a caller
+who wrote `import time` before that line silently got the extension's
+`time` instead of their own — and likewise `os`, `sys`, `array`, `queue`,
+`signal`, `threading`, `ctypes` and `traceback`. It is computed rather
+than listed because the bulk of the module is the thousand-odd generated
+`PMIX_*` constants, and a hand-written list would go stale on the first
+new attribute. If you add a module-level import, nothing needs doing; if
+you add a `from X import Y`, add `Y` to the `borrowed` tuple.
+
 ---
 
 ## 7. Testing
 
-Two flavors of test live in [`test/python/`](../../test/python/):
+Full detail is in [`test/python/AGENTS.md`](../../test/python/AGENTS.md);
+this is the summary.
 
-- **Connected/integration:** `server.py` launches `client.py` under a real
-  PMIx server; `sched.py` exercises the scheduler role. Wired into
-  `make check` as `run_server.sh` / `run_sched.sh`. These need a working
-  server environment.
-- **Standalone unit tests:** `test_bindings.py` — a `unittest` suite covering
-  everything that needs **no** server: import, the class hierarchy, constant
-  definitions, and the stateless `*_string` converters. It self-locates the
-  built extension and exits 77 (automake SKIP) if `pmix` can't be imported, so
-  it is safe to run anywhere. Also wired into `make check`.
+Three flavors, at three levels of what they can reach:
+
+- **Standalone unit tests** in [`test/python/`](../../test/python/):
+  `test_bindings.py` covers everything that needs **no** server — import,
+  the class hierarchy, constants, the stateless `*_string` converters, the
+  struct pretty-printers, and the whole conversion layer through the
+  `pmix_value_roundtrip` hook. `test_construct.py` covers the constants
+  generator and needs not even the extension. Both self-locate what they
+  need and exit 77 (automake SKIP) if it is missing, so they are safe to
+  run anywhere.
+- **Connected/integration** in the same directory: `server.py` launches
+  `client.py` under a real PMIx server and is the only script that drives
+  the *server* bindings and the upcall path; `sched.py` exercises the
+  scheduler role. Wired into `make check` as `run_server.sh` /
+  `run_sched.sh`.
+- **Multi-node** in
+  [`contrib/dockerswarm/python/`](../../contrib/dockerswarm/python/),
+  driven by `run-python.sh` — `swarm_client.py`, `swarm_group.py`,
+  `swarm_cpuset.py`, `swarm_datatypes.py`, `swarm_nonblocking.py`.
+
+All four in-tree tests run against the **build** tree, not the installed
+egg. Keep it that way if you add a wrapper script; §3 of
+[`test/python/AGENTS.md`](../../test/python/AGENTS.md) explains why.
 
 Run the unit tests directly:
 
@@ -378,25 +485,41 @@ against an unbuilt module list.
 
 A round trip through the hook is *necessary but not sufficient*: it
 exercises the loader and the unloader against each other, so a mistake
-both of them make — the element **size** of an array, say — cancels out
-and looks correct. The authority for a layout is the C side that will
-read it (`pmix_bfrops_base_pack_*`), not the other half of the binding.
+both of them make — the element **size** of an array, say, or the byte
+order of a coordinate vector — cancels out and looks correct. The
+authority for a layout is the C side that will read it
+(`pmix_bfrops_base_pack_*`), not the other half of the binding.
 Anything the library itself must interpret still wants a connected
-round trip (put→get, publish→lookup) in the integration scripts.
+round trip (put→get, publish→lookup) in the integration scripts, and
+`swarm_datatypes.py` sends every supported type to a peer for exactly
+that reason.
+
+**Two things only a multi-node run can reach**, which is why the swarm
+tests exist rather than being duplicated in-tree:
+
+- A same-host `PMIx_Get` is answered out of the local datastore, so it
+  never travels through the bindings' remote-fetch path.
+- A non-blocking request answered locally completes before the method has
+  returned, so nothing the keepalive caddy holds actually has to survive.
+  A lifetime bug there is invisible until the request is genuinely
+  outstanding — which needs a peer behind a different PMIx server.
 
 When adding a new stateless helper, prefer exposing enough of it to add a
-`test_bindings.py` case.
+`test_bindings.py` case. Prefer boundaries to typical values: the defects
+this code has produced cluster at the largest representable value, the
+empty list, a declared size larger than the payload, an optional string
+the C side left NULL, and a payload full of NUL and high bytes.
+`TestConversionBoundaries` is that set.
 
 ---
 
 ## 8. Defects found and fixed, and gotchas
 
-A deep review (2026-07) found ~22 real bugs in the conversion and method
-code; all were fixed, most in one pass and the cpuset stubs in a follow-on
-that had to build the conversion layer they depended on (§8a). The
-per-defect catalogue lives in the git history of that work. The patterns
-that caused them are worth internalizing so they are not reintroduced —
-they map the fragile spots in this code:
+Two deep reviews have been run over this code: 2026-07 (~22 defects) and
+2026-08 (~40 more, across five passes). The per-defect catalogue lives in
+the git history of each. What is worth keeping here is the *patterns* —
+they map the fragile spots in this code, and every one of them has now
+produced a defect more than once:
 
 - **A `cdef class` method needs an explicit `self`.** Several methods were
   declared `def foo(arg):` and raised `TypeError` when called. Cython does not
@@ -459,6 +582,58 @@ they map the fragile spots in this code:
   not an API of its own. If a method you are about to add has no
   `PMIx_*` entry point behind it, that is the signal to look for the
   attribute that already covers it.
+
+- **A bounds check written as arithmetic is a bounds check nobody read.**
+  Several were `(65536*65536)` or `(2147483647*2147483647)` and simply had
+  the wrong value: a uint16 rejected 65535 but accepted 65536 and let the
+  C store truncate it to zero, while int64 and uint64 refused three
+  quarters of their range. Write the literal — `4294967295` — and check
+  both ends; the unsigned arms had no lower bound at all, so a negative
+  reached the field as an enormous positive.
+- **Trust the payload, not the declared size.** A byte object, an
+  endpoint, a coordinate all carry both bytes and a count, and a caller
+  can hand you a count larger than the bytes. Copying `size` bytes out of
+  the Python object then reads off the end of it. `pmix_load_bo` and
+  `pmix_load_coord` exist so no arm has to get this right on its own.
+- **Zero before you fill, on the heap and on the stack.** A loader that
+  fails partway leaves the caller holding a value it will destruct, and
+  the destructor frees every pointer it finds. That means the struct a
+  `pmix_value_t` points at (use `pmix_value_alloc`), the block behind a
+  data array (`pmix_darray_alloc`), *and* the stack `pmix_value_t` a
+  method loads into — four methods loaded into an unzeroed stack value
+  and destructed it on failure.
+- **A count the destructor walks must be set as you go.** The geometry
+  loader filled in its coordinates and set `ncoords` at the end, then
+  returned an error before reaching it; the destructor walked whatever the
+  allocation happened to hold.
+- **`malloc(0)` may portably answer NULL**, so "did the allocation fail?"
+  cannot be `if not ptr`. An empty array allocates nothing and stays NULL.
+- **A `cdef dict` function must return a dict.** Every arm of
+  `pmix_unload_darray` answered `PMIX_ERR_NOMEM` — an int — when the block
+  was NULL, which raises TypeError. Report failure as `None` and let the
+  caller check.
+- **Binary is not a string, in either direction.** `strdup` on a modex
+  blob truncates it at the first NUL; letting Cython convert a bare
+  `char *` runs `strlen` over an IOF stream; `sizeof(pyobj)` is the size
+  of a pointer, not of the credential; and `<void*>pyobj` is the PyObject
+  header, not its payload. All four shipped.
+- **Everything the library hands an upcall dies when the upcall returns.**
+  Convert it before you defer, before you release, before anything.
+- **An exception has nowhere to go across a C frame** — see the
+  trampoline rules in §4b.
+- **Check what a conversion returned.** `pmix_alloc_info` left its caller
+  holding a freed pointer and a non-zero count on failure, and a dozen
+  methods passed that straight to the library. It now clears both, and
+  the callers check — a sweep for an unchecked `pmix_alloc_info` is a
+  cheap way to find the next one.
+- **Return the same shape on every path.** A method that answers
+  `(rc, results)` on success and a bare `rc` on one error path breaks the
+  caller's tuple unpacking at exactly the moment things are already going
+  wrong. Several did.
+- **Report what the library said.** `register_attributes` called
+  `PMIx_Register_attributes` and then returned `PMIX_SUCCESS` regardless.
+- **A library must not touch the caller's namespace** — see the `__all__`
+  note in §6.
 
 Do **not** work around a defect by weakening a test — fix the code (see the
 top-level guidance on never bending a test to a bug).
@@ -529,6 +704,37 @@ Three things to respect:
 `data_unload` is the one method whose semantics differ from a plain "give
 me the bytes": the library hands back only the portion that has *not* been
 unpacked, and consumes the buffer in the process.
+
+### 8c. Coordinate and geometry conversion
+
+A `pmix_coord_t` is a view, a vector of `uint32` coordinates, and the
+number of them. Python sees the vector as **raw bytes** — there is no
+list form — so a coord dict is
+
+```python
+{'view': PMIX_COORD_VIEW_LOGICAL, 'coord': b'\x01\x00\x00\x00', 'dims': 1}
+```
+
+and `dims` counts coordinates, so `len(coord)` is always `4 * dims`.
+`pmix_load_coord` / `pmix_unload_coord` in `pmix.pxi` are the conversion;
+what comes out of the unloader can be passed straight back in.
+
+A `pmix_geometry_t` is a fabric index, a uuid, an OS name, and a list of
+coords under `coords` with their count under `ncoords`. Two things to
+respect:
+
+- **`ncoords` is what the library's destructor walks.** Set it as each
+  coordinate is built, not after the loop — a loader that fails partway
+  and returns leaves the destructor reading past the end of the block
+  otherwise. That is exactly what this arm used to do.
+- **`dims` is not a byte count.** Believing a `dims` larger than the
+  vector actually provided reads off the end of the Python object;
+  `pmix_load_coord` refuses it.
+
+Note that `PMIX_TOPO` and `PMIX_PROC_CPUSET` values remain unconvertible
+(`PMIX_ERR_NOT_SUPPORTED` on load, `None` on unload) — both are opaque
+provider objects. The cpuset has a string form the bindings use instead
+(§8a); the topology does not.
 
 ### Style / conventions specific to these bindings
 

--- a/bindings/python/AGENTS.md
+++ b/bindings/python/AGENTS.md
@@ -64,10 +64,46 @@ their C-level state (`pmix_proc_t myproc`, `pmix_server_module_t myserver`,
 
 ### What is bound, and what deliberately is not
 
-**Every operational C API is bound**, in both its blocking and its
-non-blocking form. Before concluding something is missing, check
-`pmix.pyx` — and read the two exclusions below, because they are
-choices, not gaps.
+**Every operational C API is bound.** Before concluding something is
+missing, check `pmix.pyx` — and read the two exclusions below, because
+they are choices, not gaps.
+
+**PMIx spells "non-blocking" two different ways, and both are bound —
+but not identically.**
+
+- A **separate `*_nb` function**, which is the client family: 25 of
+  them, from `fence_nb` through `resource_block_nb`. Each is its own
+  Python method (§4c).
+- An **optional trailing `cbfunc`/`cbdata` on the same entry point**,
+  which is mostly the server family. These are bound as optional
+  arguments on the existing method — `deregister_nspace(ns)` blocks,
+  `deregister_nspace(ns, cbfunc, cbdata)` does not — mirroring the C
+  rather than inventing an `_nb` name the library does not have.
+
+The second kind is not a nicety. Every server-module upcall and event
+handler runs **on the progress thread**, and the blocking form called
+from there waits on the event loop it is standing in; the library now
+reports that rather than deadlocking (see §4b). So a handler that wants
+to register or delete a namespace *must* pass a callback.
+
+Five of that family currently take one: `register_nspace`,
+`deregister_nspace`, `register_client`, `deregister_client`, and
+`notify_event`. The rest — `register_resources`,
+`deregister_resources`, `setup_local_support`, `deliver_inventory`,
+`iof_deliver`, `iof_flow_control`, `session_control`,
+`deregister_event_handler`, `iof_deregister`, `iof_push` — are still
+blocking-only, and adding a callback to one follows the same pattern:
+build the caddy with `pypmix_nb_setup`, register the callback, pass
+`pypmix_client_op_cbfunc` and the caddy, and reclaim on a failed
+return. Anything the library holds until completion (an info array, for
+instance — `register_nspace` and `notify_event` both retain theirs) has
+to live in the caddy rather than be freed at return.
+
+Three more are blocking by construction and cannot simply grow a
+callback: `dmodex_request`, `setup_application` and `collect_inventory`
+drive an internal C callback and wait on the module-global `active`
+lock, so making them asynchronous means first fixing the
+non-reentrancy that lock imposes (§4a).
 
 **Struct and utility helper families are out of scope.** They are *not*
 missing bindings and should not be added: `PMIx_Argv_*`, `PMIx_Setenv`,

--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -412,10 +412,14 @@ def harvest_constants(options, src, constants, definitions):
         if not constsrc:
             constants.write("# " + src + "\n")
             constsrc = True
-        # pretty-print the numeric constants
+        # pretty-print the numeric constants.  Pad against nconstlen, which
+        # is what was measured for them - padding against strconstlen left
+        # them unaligned, and unpadded altogether ("PMIX_A= 0") in a header
+        # with no string constants at all
+        width = max(strconstlen, nconstlen)
         for num in nconsts:
             constants.write(num[0])
-            for i in range (4 + strconstlen - len(num[0])):
+            for i in range (4 + width - len(num[0])):
                 constants.write(" ")
             constants.write("= " + num[1] + "\n")
         # add some space

--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -39,8 +39,18 @@ def harvest_constants(options, src, constants, definitions):
     nconstlen = 0
     typedefs = []
     apis = []
-    # loop over the lines
-    for n in range(len(lines)):
+    # Loop over the lines.
+    #
+    # This is a while loop rather than "for n in range(len(lines))" because
+    # several of the branches below consume additional lines - a multi-line
+    # API declaration, a struct body, an enum - by advancing n themselves.
+    # A for loop would reset n on every pass and re-scan every line those
+    # branches had already swallowed.
+    n = -1
+    while True:
+        n += 1
+        if n >= len(lines):
+            break
         line = lines[n]
         # remove white space at front and back
         myline = line.strip()
@@ -48,7 +58,6 @@ def harvest_constants(options, src, constants, definitions):
         if "/*" in myline or "*/" in myline or myline.startswith("*"):
             if "DUPLICATES" in myline:
                 break
-            n += 1
             continue
         # if the line starts with #define, then we want it
         if takeconst and myline.startswith("#define"):
@@ -135,24 +144,55 @@ def harvest_constants(options, src, constants, definitions):
             #
             # start with the fourth option by looking for "enum"
             if "enum" in myline:
-                # each line after this one should contain a name
-                # so we just assign a value sequentially.
+                # Walk the body, assigning each enumerator the value the C
+                # compiler would give it: one past the previous one, unless
+                # this enumerator names its own with "= <value>".
+                #
+                # Three things this used to get wrong.  It took every line
+                # in the body for an enumerator, so a comment - or a blank
+                # line - became a bogus constant; pmix_common.h carries a
+                # warning telling contributors not to write one, which is
+                # the wrong way round.  It ignored an explicit "= value",
+                # silently renumbering the whole enum from that point on.
+                # And it stored the name and value through "tokens", a list
+                # left over from the last #define seen in this file, which
+                # raises NameError if an enum comes first.
                 counter = 0
                 n += 1
-                value = lines[n].strip()
-                if ',' in value:
-                    value = value[:-1]
-                while '}' not in value and n < len(lines):
-                    tokens[0] = value
-                    tokens[1] = str(counter)
-                    counter += 1
-                    nconsts.append([tokens[0], tokens[1]])
-                    if len(tokens[0]) > nconstlen:
-                        nconstlen = len(tokens[0])
-                    n += 1
+                while n < len(lines):
                     value = lines[n].strip()
-                    if ',' in value:
-                        value = value[:-1]
+                    if '}' in value:
+                        break
+                    n += 1
+                    # skip comments and blank lines - they are not
+                    # enumerators
+                    if '' == value or value.startswith("/*") \
+                       or value.startswith("*") or value.startswith("//"):
+                        continue
+                    if ',' == value[-1:]:
+                        value = value[:-1].strip()
+                    # honor an explicitly assigned value, and continue
+                    # counting from it
+                    if '=' in value:
+                        ename, _eq, eval_ = value.partition('=')
+                        ename = ename.strip()
+                        eval_ = eval_.strip()
+                        try:
+                            counter = int(eval_, 0)
+                        except ValueError:
+                            print("CANNOT PARSE ENUM VALUE", value, "in", src)
+                            return -1
+                    else:
+                        ename = value
+                    if '' == ename:
+                        continue
+                    nconsts.append([ename, str(counter)])
+                    if len(ename) > nconstlen:
+                        nconstlen = len(ename)
+                    counter += 1
+                if n >= len(lines):
+                    print("UNTERMINATED ENUM in", src)
+                    return -1
                 # the termination line contains the type name
                 # for this enum - declare it as integer here
                 value = "typedef int " + value[2:]
@@ -163,13 +203,11 @@ def harvest_constants(options, src, constants, definitions):
             elif ";" in myline and not "fn_t" in myline and not "cbfunc_t" in myline:
                 value = myline[:-1]
                 # check for bool type - must be converted to bint
-                if "bool" in value:
-                    value.replace("bool ", "bint ")
+                value = value.replace("bool ", "bint ")
                 # check for pre-declaration statements of form
                 # typedef struct foo foo
                 ck = value.split()
                 if len(ck) == 4 and ck[1] == "struct" and ck[2] == ck[3]:
-                    n += 1
                     continue
                 else:
                     # check for a typedef that includes a named value
@@ -190,22 +228,19 @@ def harvest_constants(options, src, constants, definitions):
                     # this is a one-line function definition
                     value = myline[:-1]
                     # check for bool type - must be converted to bint
-                    if "bool" in value:
-                        value.replace("bool ", "bint ")
+                    value = value.replace("bool ", "bint ")
                     typedefs.append([value])
                 else:
                     # this is a multi-line function definition
                     # check for bool type - must be converted to bint
-                    if "bool" in myline:
-                        myline.replace("bool ", "bint ")
+                    myline = myline.replace("bool ", "bint ")
                     newdef = [myline]
                     defrunning = True
                     while defrunning:
                         n += 1
                         value = lines[n].strip()
                         # check for bool type - must be converted to bint
-                        if "bool" in value:
-                            value.replace("bool ", "bint ")
+                        value = value.replace("bool ", "bint ")
                         if ";" in value:
                             defrunning = False
                             value = value[:-1]
@@ -220,7 +255,6 @@ def harvest_constants(options, src, constants, definitions):
                 value = myline
                 ck = value.split()
                 if len(ck) == 4 and ck[1] == "struct" and ck[2] == ck[3]:
-                    n += 1
                     continue
                 else:
                     newdef = []
@@ -525,19 +559,23 @@ def main():
         sys.exit(1)
     definitions.write("\n\n")
     constants.write("\n\n")
-    harvest_constants(options, "pmix.h", constants, definitions)
+    if harvest_constants(options, "pmix.h", constants, definitions) != 0:
+        sys.exit(1)
     # add some space
     definitions.write("\n\n")
     constants.write("\n\n")
-    harvest_constants(options, "pmix_server.h", constants, definitions)
+    if harvest_constants(options, "pmix_server.h", constants, definitions) != 0:
+        sys.exit(1)
     # add some space
     definitions.write("\n\n")
     constants.write("\n\n")
-    harvest_constants(options, "pmix_tool.h", constants, definitions)
+    if harvest_constants(options, "pmix_tool.h", constants, definitions) != 0:
+        sys.exit(1)
     # add some space
     definitions.write("\n\n")
     constants.write("\n\n")
-    harvest_constants(options, "pmix_deprecated.h", constants, definitions)
+    if harvest_constants(options, "pmix_deprecated.h", constants, definitions) != 0:
+        sys.exit(1)
     # close the files to ensure all output is written
     constants.close()
     definitions.close()

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -7,7 +7,6 @@ from libc.string cimport memset, strncpy, strcpy, strlen, strdup
 from libc.stdlib cimport malloc, realloc, free
 from libc.string cimport memcpy
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
-from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
 
 # pull in all the constant definitions - we
 # store them in a separate file for neatness
@@ -22,6 +21,7 @@ class myLock(threading.Event):
         self.status = PMIX_ERR_NOT_SUPPORTED
         self.sz = 0
         self.info = []
+        self.data = bytearray(0)
 
     def set(self, status):
         self.status = status
@@ -37,14 +37,19 @@ class myLock(threading.Event):
         return self.status
 
     def cache_data(self, data, sz):
-        self.data = array.array('B', data[0])
-        # need to copy the data bytes as the
-        # PMIx server will free it upon return
-        n = 1
-        while n < sz:
-            self.data.append(data[n])
-            n += 1
-        self.sz = sz
+        # 'data' arrives already converted to a Python bytes/bytearray by
+        # the caller, which must copy it: the storage behind it belongs to
+        # the PMIx server and is released as soon as the callback returns.
+        #
+        # The version this replaces tried to build the copy with
+        # array.array('B', data[0]) - in Python 3 an index into a bytes
+        # object is an int, and array() rejects one - so a direct modex
+        # request raised TypeError inside the C callback every time.
+        if data is None:
+            self.data = bytearray(0)
+        else:
+            self.data = bytearray(data)
+        self.sz = len(self.data)
 
     def fetch_data(self):
         return (self.data, self.sz)
@@ -61,61 +66,38 @@ class myLock(threading.Event):
         for x in self.info:
             info.append(x)
 
-ctypedef struct pmix_pyshift_t:
-    char *op
-    pmix_byte_object_t payload
-    size_t idx
-    pmix_modex_cbfunc_t modex
-    pmix_status_t status
-    pmix_byte_object_t bo
-    pmix_byte_object_t *cred
-    pmix_iof_channel_t channel
-    pmix_nspace_t nspace
-    pmix_proc_t source
-    pmix_proc_t *proc
-    pmix_pdata_t *pdata
-    pmix_info_t *results
-    size_t nresults
-    pmix_info_t *info
-    const char *data
-    size_t ndata
-    pmix_op_cbfunc_t op_cbfunc
-    pmix_iof_cbfunc_t iof
-    pmix_info_cbfunc_t query
-    pmix_spawn_cbfunc_t spawn
-    pmix_lookup_cbfunc_t lookup
-    pmix_release_cbfunc_t release_fn
-    pmix_event_notification_cbfunc_fn_t event_handler
-    pmix_tool_connection_cbfunc_t toolconnected
-    pmix_credential_cbfunc_t getcredential
-    pmix_validation_cbfunc_t validationcredential
-    pmix_info_cbfunc_t allocate
-    pmix_info_cbfunc_t sessioncontrol
-    void *notification_cbdata
-    void *cbdata
-
-cdef void iofhdlr_cache(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    cdef pmix_byte_object_t *bo
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "iofhdlr_cache")
-    if NULL == shifter[0].payload.bytes:
-        bo = NULL
-    else:
-        bo = &shifter[0].payload
-    pyiofhandler(shifter[0].idx, shifter[0].channel, &shifter[0].source,
-                 bo, shifter[0].info, shifter[0].ndata)
-    if 0 < shifter[0].ndata:
-        pmix_free_info(shifter[0].info, shifter[0].ndata)
-    free(shifter[0].payload.bytes)
+# Deliver an IOF event that arrived before its handler had finished
+# registering. Everything here is a plain Python object, converted by
+# pyiofhandler before it returned: the C structures the library handed it
+# were released the moment it did, so nothing may reference them by the
+# time this runs. (This used to stash the library's own pmix_info_t array
+# in a caddy and free it here - a use-after-free followed by a double
+# free - and leaked the caddy and its label besides.)
+def iofhdlr_cache(pyev, ret):
+    for h in myhdlrs:
+        if pyev['refid'] == h['refid']:
+            try:
+                h['hdlr'](pyev['refid'], pyev['channel'], pyev['source'],
+                          pyev['payload'], pyev['info'])
+            except:
+                traceback.print_exc()
+            return
+    # still not registered - the handler was never going to take it
     return
 
-cdef void event_cache_cb(capsule, ret):
-    cdef pmix_pyshift_t *shifter
-    shifter = <pmix_pyshift_t*>PyCapsule_GetPointer(capsule, "event_handler")
-    pyeventhandler(shifter[0].idx, shifter[0].status, &shifter[0].source,
-                   shifter[0].info, shifter[0].ndata,
-                   shifter[0].results, shifter[0].nresults,
-                   shifter[0].event_handler, shifter[0].notification_cbdata)
+# The event counterpart of iofhdlr_cache. The library's completion
+# callback was already executed by pyeventhandler before it deferred, so
+# this only delivers the event to the Python handler
+def event_cache_cb(pyev, ret):
+    for h in myhdlrs:
+        if pyev['refid'] == h['refid']:
+            try:
+                h['hdlr'](pyev['refid'], pyev['status'], pyev['source'],
+                          pyev['info'], pyev['results'])
+            except:
+                traceback.print_exc()
+            return
+    return
 
 cdef void pmix_convert_locality(pmix_locality_t loc, pyloc:list):
     if PMIX_LOCALITY_NONLOCAL & loc:
@@ -271,12 +253,21 @@ cdef void pmix_unload_argv(char **keys, argv:list):
         n += 1
 
 cdef int pmix_load_argv(char **keys, argv:list):
+    # the caller allocates len(argv)+1 entries and zeroes them, so a
+    # failure partway leaves a well-formed, shorter argv that
+    # pmix_free_argv can walk
     n = 0
     for a in argv:
         pya = a
         if isinstance(a, str):
             pya = a.encode('ascii')
-        keys[n] = strdup(pya)
+        try:
+            keys[n] = strdup(pya)
+        except:
+            keys[n] = NULL
+            return PMIX_ERR_TYPE_MISMATCH
+        if NULL == keys[n]:
+            return PMIX_ERR_NOMEM
         n += 1
     keys[n] = NULL
     return PMIX_SUCCESS
@@ -294,35 +285,130 @@ cdef void pmix_free_argv(char **argv):
         n += 1
     free(argv)
 
+# Allocate the block behind a data array. Every arm of pmix_load_darray
+# needs the same two guards, and getting either wrong is invisible until
+# it bites: malloc(0) is allowed to answer NULL, which the "did the
+# allocation fail?" test below would then report as PMIX_ERR_NOMEM on a
+# perfectly legal empty array, and an array the loader may abandon partway
+# has to be safe for the caller to destruct. So an empty array stays NULL
+# (its size is zero, so nothing reads it) and every block is zeroed.
+cdef void* pmix_darray_alloc(size_t nmemb, size_t esize):
+    cdef void *ptr
+    if 0 == nmemb or 0 == esize:
+        return NULL
+    ptr = malloc(nmemb * esize)
+    if NULL != ptr:
+        memset(ptr, 0, nmemb * esize)
+    return ptr
+
+# True when pmix_darray_alloc failed rather than declining to allocate an
+# empty array
+cdef int pmix_darray_nomem(void *ptr, size_t nmemb):
+    if NULL == ptr and 0 < nmemb:
+        return 1
+    return 0
+
+# Build a pmix_coord_t from the Python coord dict,
+#
+#     {'view': int, 'coord': bytes, 'dims': int}
+#
+# whose 'coord' entry is the raw uint32 vector as bytes, exactly as
+# pmix_unload_value hands it back. 'dims' counts coordinates, not bytes,
+# so the payload must be four times as long - a dims larger than the bytes
+# actually provided used to be taken at face value and read off the end of
+# the Python object
+cdef int pmix_load_coord(pmix_coord_t *coord, pycoord):
+    cdef const char *ptr
+    cdef size_t nbytes
+
+    coord[0].view = PMIX_COORD_VIEW_UNDEF
+    coord[0].coord = NULL
+    coord[0].dims = 0
+    if not isinstance(pycoord, dict):
+        return PMIX_ERR_BAD_PARAM
+    view = pycoord.get('view', PMIX_COORD_VIEW_UNDEF)
+    if not isinstance(view, pmix_int_types):
+        return PMIX_ERR_TYPE_MISMATCH
+    coord[0].view = view
+    pybytes = pycoord.get('coord')
+    if pybytes is None:
+        return PMIX_SUCCESS
+    if isinstance(pybytes, str):
+        pybytes = pybytes.encode('ascii')
+    else:
+        pybytes = bytes(pybytes)
+    dims = pycoord.get('dims', len(pybytes) // sizeof(uint32_t))
+    if not isinstance(dims, pmix_int_types) or 0 > dims:
+        return PMIX_ERR_BAD_PARAM
+    nbytes = dims * sizeof(uint32_t)
+    if len(pybytes) < nbytes:
+        return PMIX_ERR_BAD_PARAM
+    if 0 == nbytes:
+        return PMIX_SUCCESS
+    coord[0].coord = <uint32_t*> malloc(nbytes)
+    if NULL == coord[0].coord:
+        return PMIX_ERR_NOMEM
+    ptr = <const char*>pybytes
+    memcpy(coord[0].coord, ptr, nbytes)
+    coord[0].dims = dims
+    return PMIX_SUCCESS
+
+# Render a pmix_coord_t back into its Python dict. The vector is handed
+# back as raw bytes, which is what pmix_load_coord takes, so a coord that
+# comes out of here can be passed straight back in. A NULL vector is legal
+cdef dict pmix_unload_coord(const pmix_coord_t *coord):
+    cdef size_t nbytes
+    if NULL == coord:
+        return {'view': PMIX_COORD_VIEW_UNDEF, 'coord': b'', 'dims': 0}
+    if NULL == coord[0].coord or 0 == coord[0].dims:
+        return {'view': coord[0].view, 'coord': b'', 'dims': 0}
+    nbytes = coord[0].dims * sizeof(uint32_t)
+    return {'view': coord[0].view,
+            'coord': (<char*>coord[0].coord)[:nbytes],
+            'dims': coord[0].dims}
+
+# Allocate and zero one struct for a pmix_value_t to point at. The loaders
+# below fill these in field by field and can fail partway - an unconvertible
+# member is enough - and the caller then hands the whole value to the
+# library's destructor, which frees every pointer it finds. Zeroing first is
+# what makes those untouched members NULL rather than stack garbage.
+cdef void* pmix_value_alloc(size_t sz):
+    cdef void *ptr
+    ptr = malloc(sz)
+    if NULL != ptr:
+        memset(ptr, 0, sz)
+    return ptr
+
 cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
     cdef pmix_info_t *infoptr;
     cdef pmix_value_t *valptr;
+    cdef size_t mysize
     mysize = len(mylist)
     # start from a NULL array. Every arm below can fail - an unconvertible
     # element is enough, and an unrecognized type never allocates at all -
     # and the caller then destructs the value, so what it finds here has to
-    # be releasable. The arms that fill in pointers zero their allocation
-    # for the same reason
+    # be releasable. The allocator zeroes every block for that reason, and
+    # answers NULL for an empty array rather than handing back a malloc(0)
+    # whose return value is not portable
     array[0].array = NULL
     if PMIX_INFO == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_info_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_info_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         infoptr = <pmix_info_t*>array[0].array
         rc = pmix_load_info(infoptr, mylist)
     elif PMIX_VALUE == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_value_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_value_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
-        memset(array[0].array, 0, mysize * sizeof(pmix_value_t))
         valptr = <pmix_value_t*>array[0].array
         rc = pmix_load_value(valptr, mylist)
     elif PMIX_BOOL == mytype:
         # a bool array is bool-sized, not int-sized - see the c_bool note
         # in pmix.pyx
-        array[0].array = malloc(mysize * sizeof(c_bool))
+        array[0].array = pmix_darray_alloc(mysize, sizeof(c_bool))
         n = 0
-        if not array[0].array:
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         boolptr = <c_bool*>array[0].array
         for item in mylist:
@@ -332,26 +418,25 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             boolptr[n] = int_bool
             n += 1
     elif PMIX_BYTE == mytype:
-        array[0].array = malloc(mysize * sizeof(uint8_t))
+        array[0].array = pmix_darray_alloc(mysize, sizeof(uint8_t))
         n = 0
         # byte val is uint8 type
-        if not array[0].array:
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         bptr = <uint8_t*> array[0].array
         for item in mylist:
             if not isinstance(item, pmix_int_types):
                 print("uint8 value declared but non-integer provided")
                 return PMIX_ERR_TYPE_MISMATCH
-            if item > 255:
+            if item > 255 or item < 0:
                 print("uint8 value is out of bounds")
                 return PMIX_ERR_BAD_PARAM
             bptr[n] = int(item)
             n += 1
     elif PMIX_STRING == mytype:
-        array[0].array = malloc(mysize * sizeof(char*))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(char*))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
-        memset(array[0].array, 0, mysize * sizeof(char*))
         n = 0
         strptr = <char**> array[0].array
         for item in mylist:
@@ -370,8 +455,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
                     return PMIX_ERR_TYPE_MISMATCH
             n += 1
     elif PMIX_SIZE == mytype:
-        array[0].array = malloc(mysize * sizeof(size_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(size_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         sptr = <size_t*> array[0].array
@@ -382,8 +467,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             sptr[n] = int(item)
             n += 1
     elif PMIX_PID == mytype:
-        array[0].array = malloc(mysize * sizeof(pid_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pid_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         pidptr = <pid_t*> array[0].array
@@ -394,8 +479,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             pidptr[n] = int(item)
             n += 1
     elif PMIX_INT == mytype or PMIX_UINT == mytype:
-        array[0].array = malloc(mysize * sizeof(int))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(int))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         iptr = <int*> array[0].array
@@ -406,8 +491,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             iptr[n] = int(item)
             n += 1
     elif PMIX_INT8 == mytype or PMIX_UINT8 == mytype:
-        array[0].array = malloc(mysize * sizeof(int8_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(int8_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         i8ptr = <int8_t*> array[0].array
@@ -418,8 +503,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             i8ptr[n] = int(item)
             n += 1
     elif PMIX_INT16 == mytype or PMIX_UINT16 == mytype:
-        array[0].array = malloc(mysize * sizeof(int16_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(int16_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         i16ptr = <int16_t*> array[0].array
@@ -430,8 +515,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             i16ptr[n] = int(item)
             n += 1
     elif PMIX_INT32 == mytype or PMIX_UINT32 == mytype:
-        array[0].array = malloc(mysize * sizeof(int32_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(int32_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         i32ptr = <int32_t*> array[0].array
@@ -442,8 +527,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             i32ptr[n] = int(item)
             n += 1
     elif PMIX_INT64 == mytype or PMIX_UINT64 == mytype:
-        array[0].array = malloc(mysize * sizeof(int64_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(int64_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         i64ptr = <int64_t*> array[0].array
@@ -454,8 +539,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             i64ptr[n] = int(item)
             n += 1
     elif PMIX_FLOAT == mytype:
-        array[0].array = malloc(mysize * sizeof(float))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(float))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         fptr = <float*> array[0].array
@@ -463,8 +548,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             fptr[n] = float(item)
             n += 1
     elif PMIX_DOUBLE == mytype:
-        array[0].array = malloc(mysize * sizeof(double))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(double))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         dptr = <double*> array[0].array
@@ -474,8 +559,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
     elif PMIX_TIMEVAL == mytype:
         # TODO: Not clear that "timeval" has the same size as
         # "struct timeval"
-        array[0].array = malloc(mysize * sizeof(timeval))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(timeval))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         tvptr = <timeval*> array[0].array
@@ -484,8 +569,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             tvptr[n].tv_usec = item['usec']
             n += 1
     elif PMIX_TIME == mytype:
-        array[0].array = malloc(mysize * sizeof(time_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(time_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         tmptr = <time_t*> array[0].array
@@ -493,8 +578,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             tmptr[n] = item
             n += 1
     elif PMIX_STATUS == mytype:
-        array[0].array = malloc(mysize * sizeof(int))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(int))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         stptr = <int*> array[0].array
@@ -502,8 +587,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             stptr[n] = item
             n += 1
     elif PMIX_PROC_RANK == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_rank_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_rank_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         rkptr = <pmix_rank_t*> array[0].array
@@ -511,8 +596,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             rkptr[n] = item
             n += 1
     elif PMIX_PROC == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_proc_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_proc_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         prcptr = <pmix_proc_t*> array[0].array
@@ -521,24 +606,23 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             prcptr[n].rank = item['rank']
             n += 1
     elif PMIX_BYTE_OBJECT == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_byte_object_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_byte_object_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
-        memset(array[0].array, 0, mysize * sizeof(pmix_byte_object_t))
         n = 0
         boptr = <pmix_byte_object_t*>array[0].array
         for item in mylist:
-            boptr[n].size = item['size']
-            boptr[n].bytes = <char*> malloc(boptr[n].size)
-            if not boptr[n].bytes:
-                return PMIX_ERR_NOMEM
-            pyarr = bytes(item['bytes'])
-            pyptr = <const char*> pyarr
-            memcpy(boptr[n].bytes, pyptr, boptr[n].size)
+            # the payload, not the declared size, is the authority for how
+            # much there is to copy - trusting a 'size' larger than the
+            # bytes actually handed to us reads off the end of the Python
+            # object. An empty payload legitimately produces a NULL entry
+            rc = pmix_load_bo(&boptr[n], item)
+            if PMIX_SUCCESS != rc:
+                return rc
             n += 1
     elif PMIX_PERSIST == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_persistence_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_persistence_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         perptr = <pmix_persistence_t*> array[0].array
@@ -546,8 +630,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             perptr[n] = item
             n += 1
     elif PMIX_SCOPE == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_scope_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_scope_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         scptr = <pmix_scope_t*> array[0].array
@@ -555,8 +639,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             scptr[n] = item
             n += 1
     elif PMIX_DATA_RANGE == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_data_range_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_data_range_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         rgptr = <pmix_data_range_t*> array[0].array
@@ -564,8 +648,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             rgptr[n] = item
             n += 1
     elif PMIX_PROC_STATE == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_proc_state_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_proc_state_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         psptr = <pmix_proc_state_t*> array[0].array
@@ -573,10 +657,9 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             psptr[n] = item
             n += 1
     elif PMIX_PROC_INFO == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_proc_info_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_proc_info_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
-        memset(array[0].array, 0, mysize * sizeof(pmix_proc_info_t))
         n = 0
         piptr = <pmix_proc_info_t*> array[0].array
         for item in mylist:
@@ -601,10 +684,9 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             piptr[n].state = item['state']
             n += 1
     elif PMIX_DATA_ARRAY == mytype:
-        array[0].array = <pmix_data_array_t*> malloc(mysize * sizeof(pmix_data_array_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_data_array_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
-        memset(array[0].array, 0, mysize * sizeof(pmix_data_array_t))
         daptr = <pmix_data_array_t*>array[0].array
         n = 0
         for item in mylist:
@@ -621,8 +703,8 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
                 return PMIX_ERR_NOT_SUPPORTED
             n += 1
     elif PMIX_ALLOC_DIRECTIVE == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_alloc_directive_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_alloc_directive_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
         n = 0
         aldptr = <pmix_alloc_directive_t*> array[0].array
@@ -630,10 +712,9 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
             aldptr[n] = item
             n += 1
     elif PMIX_ENVAR == mytype:
-        array[0].array = malloc(mysize * sizeof(pmix_envar_t))
-        if not array[0].array:
+        array[0].array = pmix_darray_alloc(mysize, sizeof(pmix_envar_t))
+        if pmix_darray_nomem(array[0].array, mysize):
             return PMIX_ERR_NOMEM
-        memset(array[0].array, 0, mysize * sizeof(pmix_envar_t))
         n = 0
         envptr = <pmix_envar_t*> array[0].array
         for item in mylist:
@@ -670,6 +751,11 @@ cdef int pmix_load_darray(pmix_data_array_t *array, mytype, mylist:list):
 #
 cdef dict pmix_unload_darray(pmix_data_array_t *array):
     cdef pmix_info_t *infoptr;
+    # an empty array legitimately carries no block at all - every arm
+    # below indexes into array[0].array, so answer here rather than
+    # letting each of them re-derive the same check
+    if NULL == array[0].array or 0 == array[0].size:
+        return {'type':array.type, 'array':[]}
     if PMIX_INFO == array.type:
         ilist = []
         n = 0
@@ -678,8 +764,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':ilist}
         return darray
     elif PMIX_BOOL == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         boolptr = <c_bool*>array[0].array
         list = []
         n = 0
@@ -691,8 +775,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         return darray
     elif PMIX_BYTE == array.type:
         # byte val is uint8 type
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         bptr = <uint8_t*> array[0].array
         list = []
         n = 0
@@ -702,8 +784,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_STRING == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         strptr = <char**> array[0].array
         strlist = []
@@ -718,8 +798,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':strlist}
         return darray
     elif PMIX_SIZE == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         sptr = <size_t*> array[0].array
         list = []
@@ -729,8 +807,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_PID == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         pidptr = <pid_t*> array[0].array
         list = []
@@ -740,8 +816,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_INT == array.type or PMIX_UINT == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         iptr = <int*> array[0].array
         list = []
@@ -751,8 +825,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_INT8 == array.type or PMIX_UINT8 == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         i8ptr = <int8_t*> array[0].array
         list = []
@@ -762,8 +834,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_INT16 == array.type or PMIX_UINT16 == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         i16ptr = <int16_t*> array[0].array
         list = []
@@ -773,8 +843,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_INT32 == array.type or PMIX_UINT32 == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         i32ptr = <int32_t*> array[0].array
         list = []
@@ -784,8 +852,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_INT64 == array.type or PMIX_UINT64 == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         i64ptr = <int64_t*> array[0].array
         list = []
@@ -795,8 +861,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_FLOAT == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         fptr = <float*> array[0].array
         list = []
@@ -806,8 +870,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_DOUBLE == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         dptr = <double*> array[0].array
         list = []
@@ -819,8 +881,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
     elif PMIX_TIMEVAL == array.type:
         # TODO: Not clear that "timeval" has the same size as
         # "struct timeval"
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         tvptr = <timeval*> array[0].array
         list = []
@@ -831,8 +891,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_TIME == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         tmptr = <time_t*> array[0].array
         list = []
@@ -842,8 +900,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_STATUS == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         stptr = <int*> array[0].array
         list = []
@@ -853,8 +909,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_PROC_RANK == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         rkptr = <pmix_rank_t*> array[0].array
         list = []
@@ -864,8 +918,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_PROC == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         prcptr = <pmix_proc_t*> array[0].array
         list = []
@@ -879,8 +931,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_BYTE_OBJECT == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         boptr = <pmix_byte_object_t*>array[0].array
         list = []
@@ -904,8 +954,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_PERSIST == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         perptr = <pmix_persistence_t*> array[0].array
         list = []
@@ -915,8 +963,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_SCOPE == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         scptr = <pmix_scope_t*> array[0].array
         list = []
@@ -926,8 +972,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_DATA_RANGE == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         rgptr = <pmix_data_range_t*> array[0].array
         list = []
@@ -937,8 +981,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_PROC_STATE == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         psptr = <pmix_proc_state_t*> array[0].array
         list = []
@@ -948,8 +990,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_PROC_INFO == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         piptr = <pmix_proc_info_t*> array[0].array
         list = []
@@ -967,25 +1007,20 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_DATA_ARRAY == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         daptr = <pmix_data_array_t*>array[0].array
         n = 0
         list = []
         while n < array.size:
             # each element is a complete data array stored inline in the
             # block - an empty one legitimately carries a NULL array
-            try:
-                d = pmix_unload_darray(&daptr[n])
-            except:
-                return PMIX_ERR_NOT_SUPPORTED
+            d = pmix_unload_darray(&daptr[n])
+            if d is None:
+                return None
             list.append(d)
             n += 1
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_ALLOC_DIRECTIVE == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         aldptr = <pmix_alloc_directive_t*> array[0].array
         list = []
@@ -995,8 +1030,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_ENVAR == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         n = 0
         envptr = <pmix_envar_t*> array[0].array
         list = []
@@ -1015,8 +1048,6 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         darray = {'type':array.type, 'array':list}
         return darray
     elif PMIX_VALUE == array.type:
-        if not array[0].array:
-            return PMIX_ERR_NOMEM
         list = []
         n = 0
         valptr = <pmix_value_t*>array[0].array
@@ -1028,7 +1059,7 @@ cdef dict pmix_unload_darray(pmix_data_array_t *array):
         return darray
     else:
         print("UNRECOGNIZED DATA TYPE IN ARRAY: "+str(array[0].type))
-        return PMIX_ERR_NOT_SUPPORTED
+        return None
 
 # provide conversion programs that translate incoming
 # PMIx structures into Python dictionaries, and incoming
@@ -1086,30 +1117,26 @@ cdef void pmix_copy_key(pmix_key_t key, ky):
     memset(key, 0, PMIX_MAX_KEYLEN+1)
     memcpy(key, pykeyptr, klen)
 
-# loads a python pmix regex into a python bytearray
+# Convert a regular expression the library handed back into a Python
+# bytearray.
+#
+# The deprecated PMIx_generate_regex/PMIx_generate_ppn interface answers a
+# NUL-terminated string in every case the library actually produces:
+# "pmix[...]" from the native generator and "blob:<len>:<payload>" from the
+# compressing one, whose payload is base64 and therefore also free of NUL
+# bytes. So the whole string is the value, and the length is strlen.
+#
+# (The version this replaced tried to parse the blob header by indexing a
+# bytes object - regex[1] is an int in Python 3, and len() of an int raises
+# TypeError - and computed a length from that plus the string's own length,
+# which would have read past the allocation had it ever got that far. It
+# also called .replace()/.split() and discarded the results.)
 cdef bytearray pmix_convert_regex(char *regex):
-    if "pmix" == regex[:4].decode("ascii"):
-        # remove null characters
-        if b'\x00' in regex:
-            regex.replace(b'\x00', '')
-        ba = bytearray(regex)
-    elif "blob" == regex[:4].decode("ascii"):
-        sz_str    = len(regex)
-        sz_prefix = 5
-        # extract length of bytearray
-        regex.split(b'\x00')
-        len_bytearray = regex[1]
-        length = len(len_bytearray) + sz_prefix + sz_str
-        ba = bytearray(length)
-        pyregex = <bytes> regex[:length]
-        index = 0
-        while index < length:
-            ba[index] = pyregex[index]
-            index += 1
-    else:
-        # last case with no ':' in string
-        ba = bytearray(regex)
-    return ba
+    cdef size_t length
+    if NULL == regex:
+        return bytearray(0)
+    length = strlen(regex)
+    return bytearray(regex[:length])
 
 # The pmix_regex2_t crosses to Python as a dict carrying the three fields
 # of the struct:
@@ -1200,7 +1227,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("uint8 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 255:
+        if val['value'] > 255 or val['value'] < 0:
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.byte = val['value']
@@ -1225,6 +1252,9 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("size_t value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
+        if val['value'] < 0 or val['value'] > 18446744073709551615:
+            print("size_t value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
         value[0].data.size = val['value']
 
     elif val['val_type'] == PMIX_PID:
@@ -1240,6 +1270,9 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("integer value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
+        if val['value'] > 2147483647 or val['value'] < -2147483648:
+            print("integer value is out of bounds")
+            return PMIX_ERR_BAD_PARAM
         value[0].data.integer = val['value']
 
     elif val['val_type'] == PMIX_INT8:
@@ -1273,7 +1306,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("int64 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > (2147483647*2147483647) or val['value'] < -(2147483648*2147483648):
+        if val['value'] > 9223372036854775807 or val['value'] < -9223372036854775808:
             print("int64 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.int64 = val['value']
@@ -1282,7 +1315,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("integer value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] < 0:
+        if val['value'] > 4294967295 or val['value'] < 0:
             print("uint value out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.uint = val['value']
@@ -1300,7 +1333,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("uint16 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 65536 or val['value'] < 0:
+        if val['value'] > 65535 or val['value'] < 0:
             print("uint16 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.uint16 = val['value']
@@ -1309,7 +1342,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("uint32 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > (65536*65536) or val['value'] < 0:
+        if val['value'] > 4294967295 or val['value'] < 0:
             print("uint32 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.uint32 = val['value']
@@ -1318,7 +1351,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("int64 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > (2147483648*2147483648):
+        if val['value'] > 18446744073709551615 or val['value'] < 0:
             print("uint64 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.uint64 = val['value']
@@ -1351,19 +1384,19 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
     elif val['val_type'] == PMIX_PROC_RANK:
         if not isinstance(val['value'], int):
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > (65536*65536) or val['value'] < 0:
+        if val['value'] > 4294967295 or val['value'] < 0:
             print("uint32 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.rank = val['value']
 
     elif val['val_type'] == PMIX_PROC_NSPACE:
-        value[0].data.nspace = <pmix_nspace_t*> malloc(sizeof(pmix_nspace_t))
+        value[0].data.nspace = <pmix_nspace_t*> pmix_value_alloc(sizeof(pmix_nspace_t))
         if not value[0].data.nspace:
             return PMIX_ERR_NOMEM
         pmix_copy_nspace(value[0].data.nspace[0], val['value'])
 
     elif val['val_type'] == PMIX_PROC:
-        value[0].data.proc = <pmix_proc_t*> malloc(sizeof(pmix_proc_t))
+        value[0].data.proc = <pmix_proc_t*> pmix_value_alloc(sizeof(pmix_proc_t))
         if not value[0].data.proc:
             return PMIX_ERR_NOMEM
         # TODO: check nspace val is a char here
@@ -1372,32 +1405,29 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value']['rank'], pmix_int_types):
             print("uint32 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value']['rank'] > (65536*65536):
+        if val['value']['rank'] > 4294967295 or val['value']['rank'] < 0:
             print("uint32 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.proc[0].rank = val['value']['rank']
 
-    # TODO: pmix byte object conversion isn't working
     elif val['val_type'] == PMIX_BYTE_OBJECT:
-        value[0].data.bo.size = val['value']['size']
-        value[0].data.bo.bytes = <char*> malloc(value[0].data.bo.size)
-        if not value[0].data.bo.bytes:
-            return PMIX_ERR_NOMEM
-        pyptr = <char*>val['value']['bytes']
-        memcpy(value[0].data.bo.bytes, pyptr, value[0].data.bo.size)
+        # the payload is the authority for how much there is to copy. A
+        # 'size' larger than the bytes actually handed to us used to be
+        # taken at face value and read off the end of the Python object
+        rc = pmix_load_bo(&value[0].data.bo, val['value'])
+        if PMIX_SUCCESS != rc:
+            return rc
 
-    # regex is can be a string or a byte object
+    # a regex is carried in a byte object; the value may be given either as
+    # the raw bytes or as the byte-object dict pmix_unload_value hands back
     elif val['val_type'] == PMIX_REGEX:
         regex = val['value']
-        ba = pmix_convert_regex(regex)
-        if not isinstance(ba, bytearray):
-            return PMIX_ERR_TYPE_MISMATCH
-        value[0].data.bo.size  = len(val['value'])
-        value[0].data.bo.bytes = <char*> malloc(value[0].data.bo.size)
-        if not value[0].data.bo.bytes:
-            return PMIX_ERR_NOMEM
-        pyptr = <char*>ba
-        memcpy(value[0].data.bo.bytes, pyptr, value[0].data.bo.size)
+        if isinstance(regex, dict):
+            rc = pmix_load_bo(&value[0].data.bo, regex)
+        else:
+            rc = pmix_load_bo(&value[0].data.bo, {'bytes': regex})
+        if PMIX_SUCCESS != rc:
+            return rc
 
     elif val['val_type'] == PMIX_PERSIST:
         # pmix_persistence_t is defined as uint8
@@ -1414,7 +1444,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("uint8 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 255:
+        if val['value'] > 255 or val['value'] < 0:
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.scope = val['value']
@@ -1424,7 +1454,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("uint8 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 255:
+        if val['value'] > 255 or val['value'] < 0:
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.range = val['value']
@@ -1434,13 +1464,13 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("uint8 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 255:
+        if val['value'] > 255 or val['value'] < 0:
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.state = val['value']
 
     elif val['val_type'] == PMIX_PROC_INFO:
-        value[0].data.pinfo = <pmix_proc_info_t*> malloc(sizeof(pmix_proc_info_t))
+        value[0].data.pinfo = <pmix_proc_info_t*> pmix_value_alloc(sizeof(pmix_proc_info_t))
         if not value[0].data.pinfo:
             return PMIX_ERR_NOMEM
         # TODO: verify nspace is copied correctly
@@ -1448,7 +1478,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value']['proc']['rank'], pmix_int_types):
             print("uint32 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value']['proc']['rank'] > (65536*65536):
+        if val['value']['proc']['rank'] > 4294967295 or val['value']['proc']['rank'] < 0:
             print("uint32 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.pinfo[0].proc.rank = val['value']['proc']['rank']
@@ -1475,13 +1505,13 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value']['state'], pmix_int_types):
             print("uint8 value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value']['state'] > 255:
+        if val['value']['state'] > 255 or val['value']['state'] < 0:
             print("uint8 value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.pinfo[0].state = val['value']['state']
 
     elif val['val_type'] == PMIX_DATA_ARRAY:
-        value[0].data.darray = <pmix_data_array_t*> malloc(sizeof(pmix_data_array_t))
+        value[0].data.darray = <pmix_data_array_t*> pmix_value_alloc(sizeof(pmix_data_array_t))
         if not value[0].data.darray:
             return PMIX_ERR_NOMEM
         value[0].data.darray[0].type = val['value']['type']
@@ -1502,7 +1532,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("allocdirective value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 255:
+        if val['value'] > 255 or val['value'] < 0:
             print("allocdirective value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.adir = val['value']
@@ -1511,8 +1541,8 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("resblockdirective value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 255:
-            print("allocdirective value is out of bounds")
+        if val['value'] > 255 or val['value'] < 0:
+            print("resblockdirective value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.rbdir = val['value']
 
@@ -1539,23 +1569,18 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             value[0].data.envar.separator = ord(enval)
 
     elif val['val_type'] == PMIX_COORD:
-        value[0].data.coord = <pmix_coord_t*> malloc(sizeof(pmix_coord_t))
+        value[0].data.coord = <pmix_coord_t*> pmix_value_alloc(sizeof(pmix_coord_t))
         if not value[0].data.coord:
             return PMIX_ERR_NOMEM
-        value[0].data.coord[0].view = val['value']['view']
-        dims = val['value']['dims']
-        value[0].data.coord[0].coord = <uint32_t*> malloc(dims * sizeof(uint32_t))
-        if not value[0].data.coord[0].coord:
-            return PMIX_ERR_NOMEM
-        pyptr = <char*> val['value']['coord']
-        memcpy(value[0].data.coord[0].coord, pyptr, dims * sizeof(uint32_t))
-        value[0].data.coord[0].dims = dims
+        rc = pmix_load_coord(value[0].data.coord, val['value'])
+        if PMIX_SUCCESS != rc:
+            return rc
 
     elif val['val_type'] == PMIX_LINK_STATE:
         if not isinstance(val['value'], pmix_int_types):
             print("linkstate value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 255:
+        if val['value'] > 255 or val['value'] < 0:
             print("linkstate value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.linkstate = val['value']
@@ -1564,8 +1589,8 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("jobstate value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 255:
-            print("linkstate value is out of bounds")
+        if val['value'] > 255 or val['value'] < 0:
+            print("jobstate value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.jstate = val['value']
 
@@ -1579,13 +1604,13 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         if not isinstance(val['value'], pmix_int_types):
             print("locality value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 65535:
+        if val['value'] > 65535 or val['value'] < 0:
             print("locality value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.locality = val['value']
 
     elif val['val_type'] == PMIX_GEOMETRY:
-        value[0].data.geometry = <pmix_geometry_t*> malloc(sizeof(pmix_geometry_t))
+        value[0].data.geometry = <pmix_geometry_t*> pmix_value_alloc(sizeof(pmix_geometry_t))
         if not value[0].data.geometry:
             return PMIX_ERR_NOMEM
         value[0].data.geometry[0].fabric = val['value']['fabric']
@@ -1603,34 +1628,38 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             pyosname = osname
         pyosnameptr = <const char *>(pyosname)
         value[0].data.geometry[0].osname = strdup(pyosnameptr)
-        ncoords = val['value']['ncoords']
-        value[0].data.geometry[0].coordinates = <pmix_coord_t*> malloc(ncoords * sizeof(pmix_coord_t))
-        if not value[0].data.geometry[0].coordinates:
+        # ncoords must be set as each coordinate is built, not after the
+        # loop: the library's destructor walks exactly that many entries,
+        # and this arm used to leave it as whatever the allocation held
+        # and then report failure, so the caller's destruct ran off the
+        # end of the block
+        pycoords = val['value'].get('coords')
+        if pycoords is None:
+            pycoords = []
+        ncoords = len(pycoords)
+        value[0].data.geometry[0].coordinates = <pmix_coord_t*> pmix_darray_alloc(ncoords, sizeof(pmix_coord_t))
+        if pmix_darray_nomem(value[0].data.geometry[0].coordinates, ncoords):
             return PMIX_ERR_NOMEM
         n = 0
-        for k in val['value']['coords']:
-            value[0].data.geometry[0].coordinates[n].view = k['view']
-            dims = k['dims']
-            value[0].data.geometry[0].coordinates[n].coord = <uint32_t*> malloc(dims * sizeof(uint32_t))
-            if not value[0].data.geometry[0].coordinates[n].coord:
-                return PMIX_ERR_NOMEM
-            pyptr = <char*> k['coord']
-            memcpy(value[0].data.geometry[0].coordinates[n].coord, pyptr, dims * sizeof(uint32_t))
-            value[0].data.geometry[0].coordinates[n].dims = dims
+        for k in pycoords:
+            value[0].data.geometry[0].ncoords = n + 1
+            rc = pmix_load_coord(&value[0].data.geometry[0].coordinates[n], k)
+            if PMIX_SUCCESS != rc:
+                return rc
             n = n + 1
-        return PMIX_ERR_NOT_SUPPORTED
+        value[0].data.geometry[0].ncoords = ncoords
 
     elif val['val_type'] == PMIX_DEVTYPE:
         if not isinstance(val['value'], pmix_int_types):
             print("devtype value declared but non-integer provided")
             return PMIX_ERR_TYPE_MISMATCH
-        if val['value'] > 18446744073709551615:
+        if val['value'] > 18446744073709551615 or val['value'] < 0:
             print("devtype value is out of bounds")
             return PMIX_ERR_BAD_PARAM
         value[0].data.devtype = val['value']
 
     elif val['val_type'] == PMIX_DEVICE:
-        value[0].data.device = <pmix_device_t*> malloc(sizeof(pmix_device_t))
+        value[0].data.device = <pmix_device_t*> pmix_value_alloc(sizeof(pmix_device_t))
         if not value[0].data.device:
             return PMIX_ERR_NOMEM
         uuid = val['value']['uuid']
@@ -1656,7 +1685,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.device[0].type = val['value']['type']
 
     elif val['val_type'] == PMIX_DEVICE_DIST:
-        value[0].data.devdist = <pmix_device_distance_t*> malloc(sizeof(pmix_device_distance_t))
+        value[0].data.devdist = <pmix_device_distance_t*> pmix_value_alloc(sizeof(pmix_device_distance_t))
         if not value[0].data.devdist:
             return PMIX_ERR_NOMEM
         uuid = val['value']['uuid']
@@ -1689,7 +1718,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.devdist[0].maxdist = val['value']['maxdist']
 
     elif val['val_type'] == PMIX_ENDPOINT:
-        value[0].data.endpoint = <pmix_endpoint_t*> malloc(sizeof(pmix_endpoint_t))
+        value[0].data.endpoint = <pmix_endpoint_t*> pmix_value_alloc(sizeof(pmix_endpoint_t))
         if not value[0].data.endpoint:
             return PMIX_ERR_NOMEM
         uuid = val['value']['uuid']
@@ -1706,18 +1735,15 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
             pyosname = osname
         pyosnameptr = <const char *>(pyosname)
         value[0].data.endpoint[0].osname = strdup(pyosnameptr)
-        value[0].data.endpoint[0].endpt.size = val['value']['endpt']['size']
-        value[0].data.endpoint[0].endpt.bytes = <char*> malloc(value[0].data.endpoint[0].endpt.size)
-        if not value[0].data.endpoint[0].endpt.bytes:
-            return PMIX_ERR_NOMEM
-        pyptr = <char*>val['value']['endpt']['bytes']
-        memcpy(value[0].data.endpoint[0].endpt.bytes, pyptr, value[0].data.endpoint[0].endpt.size)
+        rc = pmix_load_bo(&value[0].data.endpoint[0].endpt, val['value'].get('endpt'))
+        if PMIX_SUCCESS != rc:
+            return rc
 
     elif val['val_type'] == PMIX_DATA_BUFFER:
         return PMIX_ERR_NOT_SUPPORTED
 
     elif val['val_type'] == PMIX_RESOURCE_UNIT:
-        value[0].data.resunit = <pmix_resource_unit_t*> malloc(sizeof(pmix_resource_unit_t))
+        value[0].data.resunit = <pmix_resource_unit_t*> pmix_value_alloc(sizeof(pmix_resource_unit_t))
         if not value[0].data.resunit:
             return PMIX_ERR_NOMEM
         if not isinstance(val['value']['type'], pmix_int_types):
@@ -1736,7 +1762,7 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.resunit[0].count = val['value']['count']
 
     elif val['val_type'] == PMIX_NODE_PID:
-        value[0].data.nodepid = <pmix_node_pid_t*> malloc(sizeof(pmix_node_pid_t))
+        value[0].data.nodepid = <pmix_node_pid_t*> pmix_value_alloc(sizeof(pmix_node_pid_t))
         if not value[0].data.nodepid:
             return PMIX_ERR_NOMEM
         hostname = val['value']['hostname']
@@ -1765,6 +1791,14 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         print("UNRECOGNIZED VALUE TYPE: "+str(val['val_type']))
         return PMIX_ERR_NOT_SUPPORTED
     return PMIX_SUCCESS
+
+# Decode a C string that the library is allowed to leave NULL. Casting a
+# NULL char* to <bytes> walks address zero, which is how several unload
+# arms used to crash on a struct whose optional name was simply not set
+cdef object pmix_decode_str(const char *ptr):
+    if NULL == ptr:
+        return None
+    return (<bytes>ptr).decode('UTF-8')
 
 cdef dict pmix_unload_value(const pmix_value_t *value):
 
@@ -1883,8 +1917,8 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
     elif PMIX_PROC_INFO == value[0].type:
         pins = (<bytes>value[0].data.pinfo[0].proc.nspace).decode('UTF-8')
         pirk = value[0].data.pinfo[0].proc.rank
-        pihost = (<bytes>value[0].data.pinfo[0].hostname).decode('UTF-8')
-        pexec = (<bytes>value[0].data.pinfo[0].executable_name).decode('UTF-8')
+        pihost = pmix_decode_str(value[0].data.pinfo[0].hostname)
+        pexec = pmix_decode_str(value[0].data.pinfo[0].executable_name)
         pipid = value[0].data.pinfo[0].pid
         piex = value[0].data.pinfo[0].exit_code
         pist = value[0].data.pinfo[0].state
@@ -1897,9 +1931,11 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
             # it should return with an error code inside that
             # function if there is one
             darray = pmix_unload_darray(value[0].data.darray)
+            if darray is None:
+                return {'value': None, 'val_type': PMIX_UNDEF}
             return {'value':darray, 'val_type':PMIX_DATA_ARRAY}
         except:
-            return PMIX_ERR_NOT_SUPPORTED
+            return {'value': None, 'val_type': PMIX_UNDEF}
 
     elif PMIX_ALLOC_DIRECTIVE == value[0].type:
         return {'value':value[0].data.adir, 'val_type':PMIX_ALLOC_DIRECTIVE}
@@ -1910,19 +1946,14 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
     elif PMIX_ENVAR == value[0].type:
         # either string may be NULL, and the separator goes back as the
         # one-character string the loader expects rather than its ordinal
-        pyenv = (<bytes>value[0].data.envar.envar).decode('UTF-8') \
-            if NULL != value[0].data.envar.envar else None
-        pyval = (<bytes>value[0].data.envar.value).decode('UTF-8') \
-            if NULL != value[0].data.envar.value else None
+        pyenv = pmix_decode_str(value[0].data.envar.envar)
+        pyval = pmix_decode_str(value[0].data.envar.value)
         pysep = chr(value[0].data.envar.separator)
         pyenvans = {'envar': pyenv, 'value': pyval, 'separator': pysep}
         return {'value':pyenvans, 'val_type':PMIX_ENVAR}
 
     elif PMIX_COORD == value[0].type:
-        pyview = value[0].data.coord[0].view
-        pydims = value[0].data.coord[0].dims
-        mybytes = (<char*>value[0].data.coord[0].coord)[:pydims * sizeof(uint32_t)]
-        return {'value': {'view': pyview, 'coord': mybytes, 'dims': pydims}, 'val_type': PMIX_COORD}
+        return {'value': pmix_unload_coord(value[0].data.coord), 'val_type': PMIX_COORD}
 
     elif PMIX_LINK_STATE == value[0].type:
         return {'value': value[0].data.linkstate, 'val_type': PMIX_LINK_STATE}
@@ -1941,36 +1972,35 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
 
     elif PMIX_GEOMETRY == value[0].type:
         pyfabric = value[0].data.geometry[0].fabric
-        pyuuid = (<bytes>value[0].data.geometry[0].uuid).decode('UTF-8')
-        pyosname = (<bytes>value[0].data.geometry[0].osname).decode('UTF-8')
+        pyuuid = pmix_decode_str(value[0].data.geometry[0].uuid)
+        pyosname = pmix_decode_str(value[0].data.geometry[0].osname)
         pyncoord = value[0].data.geometry[0].ncoords
         pylist = []
-        for n in range(pyncoord):
-            pyview = value[0].data.geometry.coordinates[n].view
-            pydims = value[0].data.geometry.coordinates[n].dims
-            mybytes = (<char*>value[0].data.geometry.coordinates[n].coord)[:pydims * sizeof(uint32_t)]
-            pyc = {'view': pyview, 'coord': mybytes, 'dims': pydims}
-            pylist.append(pyc)
-        return {'value': {'fabric': pyfabric, 'uuid': pyuuid, 'osname': pyosname, 'coords': pylist}, 'val_type': PMIX_GEOMETRY}
+        if NULL != value[0].data.geometry[0].coordinates:
+            for n in range(pyncoord):
+                pylist.append(pmix_unload_coord(&value[0].data.geometry[0].coordinates[n]))
+        return {'value': {'fabric': pyfabric, 'uuid': pyuuid, 'osname': pyosname,
+                          'ncoords': pyncoord, 'coords': pylist},
+                'val_type': PMIX_GEOMETRY}
 
     elif PMIX_DEVTYPE == value[0].type:
         return {'value': value[0].data.devtype, 'val_type': PMIX_DEVTYPE}
 
     elif PMIX_DEVICE == value[0].type:
-        pyuuid = (<bytes>value[0].data.device[0].uuid).decode('UTF-8')
-        pyosname = (<bytes>value[0].data.device[0].osname).decode('UTF-8')
+        pyuuid = pmix_decode_str(value[0].data.device[0].uuid)
+        pyosname = pmix_decode_str(value[0].data.device[0].osname)
         pyval = {'uuid': pyuuid, 'osname': pyosname, 'type': value[0].data.device[0].type}
         return {'value': pyval, 'val_type': PMIX_DEVICE}
 
     elif PMIX_DEVICE_DIST == value[0].type:
-        pyuuid = (<bytes>value[0].data.devdist[0].uuid).decode('UTF-8')
-        pyosname = (<bytes>value[0].data.devdist[0].osname).decode('UTF-8')
+        pyuuid = pmix_decode_str(value[0].data.devdist[0].uuid)
+        pyosname = pmix_decode_str(value[0].data.devdist[0].osname)
         pyval = {'uuid': pyuuid, 'osname': pyosname, 'mindist': value[0].data.devdist[0].mindist, 'maxdist': value[0].data.devdist[0].maxdist}
         return {'value': pyval, 'val_type': PMIX_DEVICE_DIST}
 
     elif PMIX_ENDPOINT == value[0].type:
-        pyuuid = (<bytes>value[0].data.endpoint[0].uuid).decode('UTF-8')
-        pyosname = (<bytes>value[0].data.endpoint[0].osname).decode('UTF-8')
+        pyuuid = pmix_decode_str(value[0].data.endpoint[0].uuid)
+        pyosname = pmix_decode_str(value[0].data.endpoint[0].osname)
         pysize = value[0].data.endpoint[0].endpt.size
         if NULL == value[0].data.endpoint[0].endpt.bytes:
             mybytes = b''
@@ -1983,7 +2013,7 @@ cdef dict pmix_unload_value(const pmix_value_t *value):
         return {'value': {'type': value[0].data.resunit[0].type, 'count': value[0].data.resunit[0].count}, 'val_type': PMIX_RESOURCE_UNIT}
 
     elif PMIX_NODE_PID == value[0].type:
-        pyhostname = (<bytes>value[0].data.nodepid[0].hostname).decode('UTF-8')
+        pyhostname = pmix_decode_str(value[0].data.nodepid[0].hostname)
         return {'value': {'hostname': pyhostname, 'nodeid': value[0].data.nodepid[0].nodeid, 'pid': value[0].data.nodepid[0].pid}, 'val_type': PMIX_NODE_PID}
 
     else:
@@ -2056,23 +2086,27 @@ cdef int pmix_load_info(pmix_info_t *array, dicts:list):
 # callers are explicitly allowed to pass None to mean "no attributes" -
 # the branch below depends on it
 cdef int pmix_alloc_info(pmix_info_t **info_ptr, size_t *ninfo, dicts):
+    # Start from an empty array, and leave it that way on every failure
+    # path. Callers routinely pass the result straight into a PMIx call,
+    # and a failure that left the freed pointer and its old count in place
+    # handed the library memory it had just released
+    info_ptr[0] = NULL
+    ninfo[0] = 0
     # Convert any provided dictionary to an array of pmix_info_t
-    if dicts is not None:
-        ninfo[0] = len(dicts)
-        if 0 < ninfo[0]:
-            info_ptr[0] = <pmix_info_t*>malloc(ninfo[0] * sizeof(pmix_info_t))
-            if not info_ptr[0]:
-                return PMIX_ERR_NOMEM
-            rc = pmix_load_info(info_ptr[0], dicts)
-            if PMIX_SUCCESS != rc:
-                pmix_free_info(info_ptr[0], ninfo[0])
-                return rc
-        else:
-            info_ptr[0] = NULL
-            ninfo[0] = 0
-    else:
+    if dicts is None:
+        return PMIX_SUCCESS
+    n = len(dicts)
+    if 0 == n:
+        return PMIX_SUCCESS
+    info_ptr[0] = <pmix_info_t*>malloc(n * sizeof(pmix_info_t))
+    if not info_ptr[0]:
+        return PMIX_ERR_NOMEM
+    rc = pmix_load_info(info_ptr[0], dicts)
+    if PMIX_SUCCESS != rc:
+        pmix_free_info(info_ptr[0], n)
         info_ptr[0] = NULL
-        ninfo[0] = 0
+        return rc
+    ninfo[0] = n
     return PMIX_SUCCESS
 
 cdef int pmix_unload_info(const pmix_info_t *info, size_t ninfo, ilist:list):
@@ -2194,6 +2228,9 @@ cdef void pmix_free_units(pmix_resource_unit_t *array, size_t sz):
 #            dictionary has a key, value, val_type,
 #            and proc keys
 cdef int pmix_load_pdata(pmix_pdata_t *array, data:list):
+    # zero first, for the same reason pmix_load_info does: this can fail
+    # partway through and the caller then releases the whole array
+    memset(array, 0, len(data) * sizeof(pmix_pdata_t))
     n = 0
     for d in data:
         pmix_copy_key(array[n].key, d['key'])
@@ -2492,24 +2529,35 @@ cdef void pmix_free_apps(pmix_app_t *array, size_t sz):
         n += 1
     PyMem_Free(array)
 
+# Render an array of pmix_app_t into the list of app dicts that spawn()
+# takes, so a server's 'spawn' handler sees the apps in exactly the shape
+# a Python caller would have built them
 cdef void pmix_unload_apps(const pmix_app_t *apps, size_t napps, pyapps:list):
     cdef size_t n = 0
+    if NULL == apps:
+        return
     while n < napps:
         myapp = {}
-        myapp['cmd'] = str(apps[n].cmd)
+        # decode - str() of a C string yields the repr of a bytes object,
+        # "b'/bin/true'", which is not a command anything can run
+        myapp['cmd'] = pmix_decode_str(apps[n].cmd)
         myargv = []
         if NULL != apps[n].argv:
             pmix_unload_argv(apps[n].argv, myargv)
-            myapp['argv'] = myargv
+        myapp['argv'] = myargv
         myenv = []
         if NULL != apps[n].env:
             pmix_unload_argv(apps[n].env, myenv)
-            myapp['env'] = myenv
+        myapp['env'] = myenv
+        myapp['cwd'] = pmix_decode_str(apps[n].cwd)
         myapp['maxprocs'] = apps[n].maxprocs
-        keyvals = {}
-        if NULL != apps[n].info:
+        # the info array unloads into a LIST of info dicts - handing
+        # pmix_unload_info a dict raised AttributeError on its first append
+        # and took the whole upcall with it
+        keyvals = []
+        if NULL != apps[n].info and 0 < apps[n].ninfo:
             pmix_unload_info(apps[n].info, apps[n].ninfo, keyvals)
-            myapp['info'] = keyvals
+        myapp['info'] = keyvals
         pyapps.append(myapp)
         n += 1
 

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -2570,11 +2570,20 @@ cdef int pmix_load_apps(pmix_app_t *apps, pyapps:list):
     memset(apps, 0, len(pyapps) * sizeof(pmix_app_t))
     n = 0
     for p in pyapps:
-        pycmd = str(p['cmd']).encode('ascii')
+        # str() of a bytes object is its repr, "b'/bin/true'" - which is
+        # not a command anything can run. Take bytes as they come, and
+        # encode only a str
+        mycmd = p['cmd']
+        if isinstance(mycmd, str):
+            pycmd = mycmd.encode('ascii')
+        else:
+            pycmd = mycmd
         try:
             apps[n].cmd = strdup(pycmd)
         except:
             return PMIX_ERR_TYPE_MISMATCH
+        if NULL == apps[n].cmd:
+            return PMIX_ERR_NOMEM
 
         try:
             if p['argv'] is not None and 0 < len(p['argv']):
@@ -2611,11 +2620,15 @@ cdef int pmix_load_apps(pmix_app_t *apps, pyapps:list):
             pass
 
         try:
-            pycwd = str(p['cwd']).encode('ascii')
+            mycwd = p['cwd']
+            if isinstance(mycwd, str):
+                pycwd = mycwd.encode('ascii')
+            else:
+                pycwd = mycwd
             apps[n].cwd = strdup(pycwd)
         except:
-            pycwd = os.getcwd()
-            pycwd = pycwd.encode('ascii')
+            # no cwd given - the process should start where we are
+            pycwd = os.getcwd().encode('ascii')
             apps[n].cwd = strdup(pycwd)
 
         apps[n].info = NULL

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -2034,21 +2034,24 @@ cdef class PMIxClient:
 
         # convert group name
         pygrp = group.encode('ascii')
-        # convert list of procs to array of pmix_proc_t's
-        if peers is not None:
+        # convert list of procs to array of pmix_proc_t's. Every exit from
+        # here reports (rc, results) - a bare status on these two paths
+        # broke the caller's tuple unpacking. An empty list means "my whole
+        # job", as it does everywhere else, rather than a zero-length array
+        if peers is not None and 0 < len(peers):
             nprocs = len(peers)
             procs = <pmix_proc_t*> PyMem_Malloc(nprocs * sizeof(pmix_proc_t))
             if not procs:
-                return PMIX_ERR_NOMEM
+                return PMIX_ERR_NOMEM, []
             rc = pmix_load_procs(procs, peers)
             if PMIX_SUCCESS != rc:
                 pmix_free_procs(procs, nprocs)
-                return rc
+                return rc, []
         else:
             nprocs = 1
             procs = <pmix_proc_t*> PyMem_Malloc(nprocs * sizeof(pmix_proc_t))
             if not procs:
-                return PMIX_ERR_NOMEM
+                return PMIX_ERR_NOMEM, []
             pmix_copy_nspace(procs[0].nspace, self.myproc.nspace)
             procs[0].rank = PMIX_RANK_WILDCARD
 
@@ -2099,21 +2102,24 @@ cdef class PMIxClient:
 
         # convert group name
         pygrp = group.encode('ascii')
-        # convert list of procs to array of pmix_proc_t's
-        if peers is not None:
+        # convert list of procs to array of pmix_proc_t's. Every exit from
+        # here reports (rc, results) - a bare status on these two paths
+        # broke the caller's tuple unpacking. An empty list means "my whole
+        # job", as it does everywhere else, rather than a zero-length array
+        if peers is not None and 0 < len(peers):
             nprocs = len(peers)
             procs = <pmix_proc_t*> PyMem_Malloc(nprocs * sizeof(pmix_proc_t))
             if not procs:
-                return PMIX_ERR_NOMEM
+                return PMIX_ERR_NOMEM, []
             rc = pmix_load_procs(procs, peers)
             if PMIX_SUCCESS != rc:
                 pmix_free_procs(procs, nprocs)
-                return rc
+                return rc, []
         else:
             nprocs = 1
             procs = <pmix_proc_t*> PyMem_Malloc(nprocs * sizeof(pmix_proc_t))
             if not procs:
-                return PMIX_ERR_NOMEM
+                return PMIX_ERR_NOMEM, []
             pmix_copy_nspace(procs[0].nspace, self.myproc.nspace)
             procs[0].rank = PMIX_RANK_WILDCARD
 

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -3179,17 +3179,42 @@ cdef class PMIxClient:
         rc = PMIx_Deregister_event_handler(ref, NULL, NULL)
         return rc
 
-    def notify_event(self, status:int, pysrc:dict, range, pyinfo):
+    # cbfunc(status:int, cbdata) - reporting an event from inside an
+    # event handler or a server module upcall needs the non-blocking
+    # form, as both run on the progress thread
+    def notify_event(self, status:int, pysrc:dict, range, pyinfo,
+                     cbfunc=None, cbdata=None):
         cdef pmix_proc_t proc
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t ninfo
         cdef pmix_data_range_t crange = range
         cdef pmix_status_t cstatus = status
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef int prc
 
         # convert the proc
         pmix_copy_nspace(proc.nspace, pysrc['nspace'])
         proc.rank = pysrc['rank']
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            # the library holds the info array until the event has been
+            # delivered, so it goes in the caddy
+            cd = pypmix_nb_setup(pyinfo, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_Notify_event(cstatus, &proc, crange,
+                                        cd.info, cd.ninfo,
+                                        pypmix_client_op_cbfunc, <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
 
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
@@ -4531,14 +4556,48 @@ cdef class PMIxServer(PMIxClient):
     #            defined as such:
     #            [{key:y, value:val, val_type:ty}, … ]
     #
-    def register_nspace(self, ns:str, nlocalprocs:int, dicts):
+    def register_nspace(self, ns:str, nlocalprocs:int, dicts,
+                        cbfunc=None, cbdata=None):
         cdef pmix_nspace_t nspace
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef int prc
+        cdef int cnlocal
         global active
         # convert the args into the necessary C-arguments
         pmix_copy_nspace(nspace, ns)
+        cnlocal = nlocalprocs
+
+        # Non-blocking form. The C API expresses it with an optional
+        # callback on the same entry point rather than with a separate
+        # _nb function, but the machinery is the one every _nb binding
+        # uses - see section 4c of the bindings AGENTS.md.
+        #
+        # This is the only form that works from inside a server module
+        # upcall: those run on the progress thread, and the blocking form
+        # would there be waiting on the event loop it is standing in.
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            # the library holds the info array until it completes, so it
+            # goes in the caddy rather than being freed at return
+            cd = pypmix_nb_setup(dicts, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_server_register_nspace(nspace, cnlocal,
+                                                  cd.info, cd.ninfo,
+                                                  pypmix_client_op_cbfunc,
+                                                  <void *> cd)
+            if PMIX_SUCCESS != crc:
+                # no callback will be executed, so reclaim it here
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
 
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
@@ -4561,13 +4620,35 @@ cdef class PMIxServer(PMIxClient):
     # @ns [INPUT]
     #     - Namespace of job (string)
     #
-    def deregister_nspace(self, ns:str):
+    # Deleting a namespace from inside a server module upcall - when the
+    # last client finalizes, say - is the natural thing to write, and the
+    # upcall runs on the progress thread. Pass a callback for that case:
+    # the blocking form there would be waiting on the event loop it is
+    # standing in, which the library now reports rather than hanging on.
+    #
+    # cbfunc(status:int, cbdata)
+    def deregister_nspace(self, ns:str, cbfunc=None, cbdata=None):
         cdef pmix_nspace_t nspace
+        cdef pypmix_nb_cbdata_t *cd
+        cdef int prc
         global active
         # convert the args into the necessary C-arguments
         pmix_copy_nspace(nspace, ns)
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            cd = pypmix_nb_setup(None, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                PMIx_server_deregister_nspace(nspace, pypmix_client_op_cbfunc,
+                                              <void *> cd)
+            return PMIX_SUCCESS
+
         PMIx_server_deregister_nspace(nspace, NULL, NULL)
-        return
+        return PMIX_SUCCESS
 
     # Register resources
     def register_resources(self, directives):
@@ -4614,11 +4695,42 @@ cdef class PMIxServer(PMIxClient):
     # @gid [INPUT]
     #      - Group ID (gid) of the client (int)
     #
-    def register_client(self, proc:dict, uid:int, gid:int):
+    # cbfunc(status:int, cbdata) - see deregister_nspace for why the
+    # non-blocking form matters. Registering a namespace and its clients
+    # from inside a 'spawn' upcall is the ordinary way a host services a
+    # spawn request, and that upcall runs on the progress thread.
+    def register_client(self, proc:dict, uid:int, gid:int,
+                        cbfunc=None, cbdata=None):
         global active
         cdef pmix_proc_t p;
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef int prc
+        cdef uid_t cuid
+        cdef gid_t cgid
         pmix_copy_nspace(p.nspace, proc['nspace'])
         p.rank = proc['rank']
+        cuid = uid
+        cgid = gid
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            # the library copies the proc before it returns, so the caddy
+            # carries nothing but the registry key
+            cd = pypmix_nb_setup(None, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_server_register_client(&p, cuid, cgid, NULL,
+                                                  pypmix_client_op_cbfunc,
+                                                  <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
+
         rc = PMIx_server_register_client(&p, uid, gid, NULL, NULL, NULL)
         return rc
 
@@ -4627,13 +4739,29 @@ cdef class PMIxServer(PMIxClient):
     # @proc [INPUT]
     #       - namespace and rank of the client (dict)
     #
-    def deregister_client(self, proc:dict):
+    # cbfunc(status:int, cbdata) - see deregister_nspace
+    def deregister_client(self, proc:dict, cbfunc=None, cbdata=None):
         global active
         cdef pmix_proc_t p;
+        cdef pypmix_nb_cbdata_t *cd
+        cdef int prc
         pmix_copy_nspace(p.nspace, proc['nspace'])
         p.rank = proc['rank']
-        rc = PMIx_server_deregister_client(&p, NULL, NULL)
-        return rc
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            cd = pypmix_nb_setup(None, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                PMIx_server_deregister_client(&p, pypmix_client_op_cbfunc,
+                                              <void *> cd)
+            return PMIX_SUCCESS
+
+        PMIx_server_deregister_client(&p, NULL, NULL)
+        return PMIX_SUCCESS
 
     # Setup the environment of a child process that is to be forked
     # by the host

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -5004,555 +5004,771 @@ cdef class PMIxServer(PMIxClient):
         return rc
 
 cdef int clientconnected(pmix_proc_t *proc, void *server_object,
-                         pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'clientconnected' in keys:
-        if not proc:
-            return PMIX_ERR_BAD_PARAM
-        myproc = []
-        pmix_unload_procs(proc, 1, myproc)
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['clientconnected'](myproc[0], pypmix_op_cbfunc, cbdata_dict)
+                         pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'clientconnected' in keys:
+            if not proc:
+                return PMIX_ERR_BAD_PARAM
+            myproc = []
+            pmix_unload_procs(proc, 1, myproc)
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['clientconnected'](myproc[0], pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_FOUND
+        return PMIX_ERR_NOT_FOUND
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int clientconnected2(pmix_proc_t *proc, void *server_object,
                           pmix_info_t info[], size_t ninfo,
-                          pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'clientconnected2' in keys:
-        if not proc:
-            return PMIX_ERR_BAD_PARAM
-        args = {}
-        myproc = []
-        pmix_unload_procs(proc, 1, myproc)
-        args['proc'] = myproc[0]
-        ilist = []
-        if NULL != info:
-            rc = pmix_unload_info(info, ninfo, ilist)
-            if PMIX_SUCCESS != rc:
-                return rc
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['clientconnected2'](args, pypmix_op_cbfunc, cbdata_dict)
+                          pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'clientconnected2' in keys:
+            if not proc:
+                return PMIX_ERR_BAD_PARAM
+            args = {}
+            myproc = []
+            pmix_unload_procs(proc, 1, myproc)
+            args['proc'] = myproc[0]
+            ilist = []
+            if NULL != info:
+                rc = pmix_unload_info(info, ninfo, ilist)
+                if PMIX_SUCCESS != rc:
+                    return rc
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['clientconnected2'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_FOUND
+        return PMIX_ERR_NOT_FOUND
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int clientfinalized(pmix_proc_t *proc, void *server_object,
-                         pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'clientfinalized' in keys:
-        if not proc:
-            return PMIX_ERR_BAD_PARAM
-        myproc = []
-        pmix_unload_procs(proc, 1, myproc)
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['clientfinalized'](myproc[0], pypmix_op_cbfunc, cbdata_dict)
+                         pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'clientfinalized' in keys:
+            if not proc:
+                return PMIX_ERR_BAD_PARAM
+            myproc = []
+            pmix_unload_procs(proc, 1, myproc)
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['clientfinalized'](myproc[0], pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int clientaborted(const pmix_proc_t *proc, void *server_object,
                        int status, const char msg[],
                        pmix_proc_t procs[], size_t nprocs,
-                       pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'abort' in keys:
-        args = {}
-        myproc = []
-        myprocs = []
-        # convert the caller's name
-        pmix_unload_procs(proc, 1, myproc)
-        args['caller'] = myproc[0]
-        # record the status
-        args['status'] = status
-        # record the msg, if given
-        if NULL != msg:
-            args['msg'] = pmix_decode_str(msg)
-        # convert any provided array of procs to be aborted
-        if NULL != procs:
-            pmix_unload_procs(procs, nprocs, myprocs)
-            args['targets'] = myprocs
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        # upcall it
-        return pmixservermodule['abort'](args, pypmix_op_cbfunc, cbdata_dict)
+                       pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'abort' in keys:
+            args = {}
+            myproc = []
+            myprocs = []
+            # convert the caller's name
+            pmix_unload_procs(proc, 1, myproc)
+            args['caller'] = myproc[0]
+            # record the status
+            args['status'] = status
+            # record the msg, if given
+            if NULL != msg:
+                args['msg'] = pmix_decode_str(msg)
+            # convert any provided array of procs to be aborted
+            if NULL != procs:
+                pmix_unload_procs(procs, nprocs, myprocs)
+                args['targets'] = myprocs
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            # upcall it
+            return pmixservermodule['abort'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int fencenb(const pmix_proc_t procs[], size_t nprocs,
                  const pmix_info_t info[], size_t ninfo,
                  char *data, size_t ndata,
-                 pmix_modex_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'fencenb' in keys:
-        args = {}
-        myprocs = []
-        blist = []
-        ilist = []
-        barray = None
+                 pmix_modex_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'fencenb' in keys:
+            args = {}
+            myprocs = []
+            blist = []
+            ilist = []
+            barray = None
 
-        if NULL == procs:
-            myprocs.append({'nspace': myname.get('nspace', ''), 'rank': PMIX_RANK_WILDCARD})
-        else:
-            pmix_unload_procs(procs, nprocs, myprocs)
-        args['procs'] = myprocs
-        if NULL != info:
-            rc = pmix_unload_info(info, ninfo, ilist)
-            if PMIX_SUCCESS != rc:
-                return rc
-            args['directives'] = ilist
-        if NULL != data:
-            pmix_unload_bytes(data, ndata, blist)
-            barray = bytearray(blist)
-            args['data'] = barray
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['fencenb'](args, pypmix_modex_cbfunc, cbdata_dict)
+            if NULL == procs:
+                myprocs.append({'nspace': myname.get('nspace', ''), 'rank': PMIX_RANK_WILDCARD})
+            else:
+                pmix_unload_procs(procs, nprocs, myprocs)
+            args['procs'] = myprocs
+            if NULL != info:
+                rc = pmix_unload_info(info, ninfo, ilist)
+                if PMIX_SUCCESS != rc:
+                    return rc
+                args['directives'] = ilist
+            if NULL != data:
+                pmix_unload_bytes(data, ndata, blist)
+                barray = bytearray(blist)
+                args['data'] = barray
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['fencenb'](args, pypmix_modex_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 
 
 cdef int directmodex(const pmix_proc_t *proc,
                      const pmix_info_t info[], size_t ninfo,
-                     pmix_modex_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'directmodex' in keys:
-        args = {}
-        myprocs = []
-        ilist = []
-        pmix_unload_procs(proc, 1, myprocs)
-        args['proc'] = myprocs[0]
-        if NULL != info:
-            pmix_unload_info(info, ninfo, ilist)
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['directmodex'](args, pypmix_modex_cbfunc, cbdata_dict)
+                     pmix_modex_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'directmodex' in keys:
+            args = {}
+            myprocs = []
+            ilist = []
+            pmix_unload_procs(proc, 1, myprocs)
+            args['proc'] = myprocs[0]
+            if NULL != info:
+                pmix_unload_info(info, ninfo, ilist)
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['directmodex'](args, pypmix_modex_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int publish(const pmix_proc_t *proc,
                  const pmix_info_t info[], size_t ninfo,
-                 pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'publish' in keys:
-        args = {}
-        myprocs = []
-        ilist = []
-        pmix_unload_procs(proc, 1, myprocs)
-        args['proc'] = myprocs[0]
-        if NULL != info:
-            pmix_unload_info(info, ninfo, ilist)
-        args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['publish'](args, pypmix_op_cbfunc, cbdata_dict)
+                 pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'publish' in keys:
+            args = {}
+            myprocs = []
+            ilist = []
+            pmix_unload_procs(proc, 1, myprocs)
+            args['proc'] = myprocs[0]
+            if NULL != info:
+                pmix_unload_info(info, ninfo, ilist)
+            args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['publish'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int lookup(const pmix_proc_t *proc, char **keys,
                 const pmix_info_t info[], size_t ninfo,
-                pmix_lookup_cbfunc_t cbfunc, void *cbdata) with gil:
-    srvkeys = pmixservermodule.keys()
-    if 'lookup' in srvkeys:
-        args = {}
-        pdata   = []
-        myprocs = []
-        ilist = []
-        pykeys = []
-        pmix_unload_procs(proc, 1, myprocs)
-        args['proc'] = myprocs[0]
-        # decode, as the unpublish upcall and the query builder do - a
-        # handler must not have to guess whether its keys are str or bytes
-        if NULL != keys:
-            pmix_unload_argv(keys, pykeys)
-        args['keys'] = pykeys
-        if NULL != info:
-            pmix_unload_info(info, ninfo, ilist)
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['lookup'](args, pypmix_lookup_cbfunc, cbdata_dict)
+                pmix_lookup_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        srvkeys = pmixservermodule.keys()
+        if 'lookup' in srvkeys:
+            args = {}
+            pdata   = []
+            myprocs = []
+            ilist = []
+            pykeys = []
+            pmix_unload_procs(proc, 1, myprocs)
+            args['proc'] = myprocs[0]
+            # decode, as the unpublish upcall and the query builder do - a
+            # handler must not have to guess whether its keys are str or bytes
+            if NULL != keys:
+                pmix_unload_argv(keys, pykeys)
+            args['keys'] = pykeys
+            if NULL != info:
+                pmix_unload_info(info, ninfo, ilist)
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['lookup'](args, pypmix_lookup_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int unpublish(const pmix_proc_t *proc, char **keys,
                    const pmix_info_t info[], size_t ninfo,
-                   pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    srvkeys = pmixservermodule.keys()
-    if 'unpublish' in srvkeys:
-        args = {}
-        myprocs = []
-        ilist = []
-        pykeys = []
-        pmix_unload_procs(proc, 1, myprocs)
-        args['proc'] = myprocs[0]
-        if NULL != keys:
-            pmix_unload_argv(keys, pykeys)
-            args['keys'] = pykeys
-        if NULL != info:
-            pmix_unload_info(info, ninfo, ilist)
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['unpublish'](args, pypmix_op_cbfunc, cbdata_dict)
+                   pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        srvkeys = pmixservermodule.keys()
+        if 'unpublish' in srvkeys:
+            args = {}
+            myprocs = []
+            ilist = []
+            pykeys = []
+            pmix_unload_procs(proc, 1, myprocs)
+            args['proc'] = myprocs[0]
+            if NULL != keys:
+                pmix_unload_argv(keys, pykeys)
+                args['keys'] = pykeys
+            if NULL != info:
+                pmix_unload_info(info, ninfo, ilist)
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['unpublish'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int spawn(const pmix_proc_t *proc,
                const pmix_info_t job_info[], size_t ninfo,
                const pmix_app_t apps[], size_t napps,
-               pmix_spawn_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'spawn' in keys:
-        args = {}
-        myprocs = []
-        ilist = []
-        pyapps = []
-        pmix_unload_procs(proc, 1, myprocs)
-        args['proc'] = myprocs[0]
-        if NULL != job_info:
-            pmix_unload_info(job_info, ninfo, ilist)
-            args['jobinfo'] = ilist
-        pmix_unload_apps(apps, napps, pyapps)
-        args['apps'] = pyapps
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['spawn'](args, pypmix_spawn_cbfunc, cbdata_dict)
+               pmix_spawn_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'spawn' in keys:
+            args = {}
+            myprocs = []
+            ilist = []
+            pyapps = []
+            pmix_unload_procs(proc, 1, myprocs)
+            args['proc'] = myprocs[0]
+            if NULL != job_info:
+                pmix_unload_info(job_info, ninfo, ilist)
+                args['jobinfo'] = ilist
+            pmix_unload_apps(apps, napps, pyapps)
+            args['apps'] = pyapps
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['spawn'](args, pypmix_spawn_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 
 cdef int connect(const pmix_proc_t procs[], size_t nprocs,
                  const pmix_info_t info[], size_t ninfo,
-                 pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'connect' in keys:
-        args = {}
-        myprocs = []
-        ilist = []
-        if NULL != procs:
-            pmix_unload_procs(procs, nprocs, myprocs)
-            args['procs'] = myprocs
-        if NULL != info:
-            pmix_unload_info(info, ninfo, ilist)
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['connect'](args, pypmix_op_cbfunc, cbdata_dict)
+                 pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'connect' in keys:
+            args = {}
+            myprocs = []
+            ilist = []
+            if NULL != procs:
+                pmix_unload_procs(procs, nprocs, myprocs)
+                args['procs'] = myprocs
+            if NULL != info:
+                pmix_unload_info(info, ninfo, ilist)
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['connect'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int disconnect(const pmix_proc_t procs[], size_t nprocs,
                     const pmix_info_t info[], size_t ninfo,
-                    pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'disconnect' in keys:
-        args = {}
-        myprocs = []
-        ilist = []
-        if NULL != procs:
-            pmix_unload_procs(procs, nprocs, myprocs)
-            args['procs'] = myprocs
-        if NULL != info:
-            pmix_unload_info(info, ninfo, ilist)
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['disconnect'](args, pypmix_op_cbfunc, cbdata_dict)
+                    pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'disconnect' in keys:
+            args = {}
+            myprocs = []
+            ilist = []
+            if NULL != procs:
+                pmix_unload_procs(procs, nprocs, myprocs)
+                args['procs'] = myprocs
+            if NULL != info:
+                pmix_unload_info(info, ninfo, ilist)
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['disconnect'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int registerevents(pmix_status_t *codes, size_t ncodes,
                         const pmix_info_t info[], size_t ninfo,
-                        pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'registerevents' in keys:
-        args = {}
-        mycodes = []
-        ilist = []
-        if NULL != codes:
-            n = 0
-            while n < ncodes:
-                mycodes.append(codes[n])
-                n += 1
-            args['codes'] = mycodes
-        if NULL != info:
-            pmix_unload_info(info, ninfo, ilist)
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['registerevents'](args, pypmix_op_cbfunc, cbdata_dict)
+                        pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'registerevents' in keys:
+            args = {}
+            mycodes = []
+            ilist = []
+            if NULL != codes:
+                n = 0
+                while n < ncodes:
+                    mycodes.append(codes[n])
+                    n += 1
+                args['codes'] = mycodes
+            if NULL != info:
+                pmix_unload_info(info, ninfo, ilist)
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['registerevents'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int deregisterevents(pmix_status_t *codes, size_t ncodes,
-                          pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'deregisterevents' in keys:
-        args = {}
-        mycodes = []
-        if NULL != codes:
-            n = 0
-            while n < ncodes:
-                mycodes.append(codes[n])
-                n += 1
-            args['codes'] = mycodes
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['deregisterevents'](args, pypmix_op_cbfunc, cbdata_dict)
+                          pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'deregisterevents' in keys:
+            args = {}
+            mycodes = []
+            if NULL != codes:
+                n = 0
+                while n < ncodes:
+                    mycodes.append(codes[n])
+                    n += 1
+                args['codes'] = mycodes
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['deregisterevents'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 
 cdef int notifyevent(pmix_status_t code,
                      const pmix_proc_t *source,
                      pmix_data_range_t drange,
                      pmix_info_t info[], size_t ninfo,
-                     pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'notifyevent' in keys:
-        args = {}
-        ilist = []
-        myproc = []
-        args['code'] = code
-        pmix_unload_procs(source, 1, myproc)
-        args['source'] = myproc[0]
-        args['range'] = drange
-        if NULL != info:
-            pmix_unload_info(info, ninfo, ilist)
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['notifyevent'](args, pypmix_op_cbfunc, cbdata_dict)
+                     pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'notifyevent' in keys:
+            args = {}
+            ilist = []
+            myproc = []
+            args['code'] = code
+            pmix_unload_procs(source, 1, myproc)
+            args['source'] = myproc[0]
+            args['range'] = drange
+            if NULL != info:
+                pmix_unload_info(info, ninfo, ilist)
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['notifyevent'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 
 cdef int query(pmix_proc_t *source,
                pmix_query_t *queries, size_t nqueries,
                pmix_info_cbfunc_t cbfunc,
-               void *cbdata) with gil:
-    pyqueries = []
-    keys = pmixservermodule.keys()
-    if 'query' in keys:
-        args = {}
-        myproc = []
-        if NULL == queries or NULL == source:
-            return PMIX_ERR_BAD_PARAM
-        pmix_unload_queries(queries, nqueries, pyqueries)
-        args['queries'] = pyqueries
-        pmix_unload_procs(source, 1, myproc)
-        args['source'] = myproc[0]
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['query'](args, pypmix_info_cbfunc, cbdata_dict)
+               void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        pyqueries = []
+        keys = pmixservermodule.keys()
+        if 'query' in keys:
+            args = {}
+            myproc = []
+            if NULL == queries or NULL == source:
+                return PMIX_ERR_BAD_PARAM
+            pmix_unload_queries(queries, nqueries, pyqueries)
+            args['queries'] = pyqueries
+            pmix_unload_procs(source, 1, myproc)
+            args['source'] = myproc[0]
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['query'](args, pypmix_info_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef void toolconnected(pmix_info_t *info, size_t ninfo,
                         pmix_tool_connection_cbfunc_t cbfunc,
                         void *cbdata) noexcept with gil:
-    keys = pmixservermodule.keys()
-    ret_proc = {'nspace': "UNDEF", 'rank': PMIX_RANK_UNDEF}
-    if 'toolconnected' in keys:
-        args = {}
-        ilist = []
-        if NULL != info:
-            pmix_unload_info(info, ninfo, ilist)
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        pmixservermodule['toolconnected'](args, pypmix_tool_connection_cbfunc, cbdata_dict)
+    # as in the cdef int trampolines: libpmix calls this across a C frame,
+    # so report a handler that raises rather than letting the exception
+    # surface later as an unattributed "Exception ignored in"
+    try:
+        keys = pmixservermodule.keys()
+        if 'toolconnected' in keys:
+            args = {}
+            ilist = []
+            if NULL != info:
+                pmix_unload_info(info, ninfo, ilist)
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            pmixservermodule['toolconnected'](args, pypmix_tool_connection_cbfunc, cbdata_dict)
+    except:
+        traceback.print_exc()
 
 cdef void log(const pmix_proc_t *client,
               const pmix_info_t data[], size_t ndata,
               const pmix_info_t directives[], size_t ndirs,
               pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
-    keys = pmixservermodule.keys()
-    if 'log' in keys:
-        args = {}
-        ilist = []
-        myproc = []
-        mydirs = []
-        if NULL == client:
-            return
-        pmix_unload_procs(client, 1, myproc)
-        args['source'] = myproc[0]
-        if NULL != data:
-            pmix_unload_info(data, ndata, ilist)
-            args['data'] = ilist
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, mydirs)
-            args['directives'] = mydirs
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        pmixservermodule['log'](args, pypmix_op_cbfunc, cbdata_dict)
+    # see toolconnected above
+    try:
+        keys = pmixservermodule.keys()
+        if 'log' in keys:
+            args = {}
+            ilist = []
+            myproc = []
+            mydirs = []
+            if NULL == client:
+                return
+            pmix_unload_procs(client, 1, myproc)
+            args['source'] = myproc[0]
+            if NULL != data:
+                pmix_unload_info(data, ndata, ilist)
+                args['data'] = ilist
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, mydirs)
+                args['directives'] = mydirs
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            pmixservermodule['log'](args, pypmix_op_cbfunc, cbdata_dict)
+    except:
+        traceback.print_exc()
 
 cdef int allocate(const pmix_proc_t *client,
                   pmix_alloc_directive_t action,
                   const pmix_info_t directives[], size_t ndirs,
-                  pmix_info_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'allocate' in keys:
-        args = {}
-        myproc = []
-        keyvals = []
-        if NULL == client:
-            return PMIX_ERR_BAD_PARAM
-        pmix_unload_procs(client, 1, myproc)
-        args['source'] = myproc[0]
-        args['action'] = action
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, keyvals)
-            args['directives'] = keyvals
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['allocate'](args, pypmix_info_cbfunc, cbdata_dict)
+                  pmix_info_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'allocate' in keys:
+            args = {}
+            myproc = []
+            keyvals = []
+            if NULL == client:
+                return PMIX_ERR_BAD_PARAM
+            pmix_unload_procs(client, 1, myproc)
+            args['source'] = myproc[0]
+            args['action'] = action
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, keyvals)
+                args['directives'] = keyvals
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['allocate'](args, pypmix_info_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 
 cdef int jobcontrol(const pmix_proc_t *requestor,
                     const pmix_proc_t targets[], size_t ntargets,
                     const pmix_info_t directives[], size_t ndirs,
-                    pmix_info_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'jobcontrol' in keys:
-        args = {}
-        myproc = []
-        mytargets = []
-        mydirs = []
-        if NULL != requestor:
-            pmix_unload_procs(requestor, 1, myproc)
-            args['source'] = myproc[0]
-        if NULL != targets:
-            pmix_unload_procs(targets, ntargets, mytargets)
-            args['targets'] = mytargets
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, mydirs)
-            args['directives'] = mydirs
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['jobcontrol'](args, pypmix_info_cbfunc, cbdata_dict)
+                    pmix_info_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'jobcontrol' in keys:
+            args = {}
+            myproc = []
+            mytargets = []
+            mydirs = []
+            if NULL != requestor:
+                pmix_unload_procs(requestor, 1, myproc)
+                args['source'] = myproc[0]
+            if NULL != targets:
+                pmix_unload_procs(targets, ntargets, mytargets)
+                args['targets'] = mytargets
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, mydirs)
+                args['directives'] = mydirs
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['jobcontrol'](args, pypmix_info_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int monitor(const pmix_proc_t *requestor,
                  const pmix_info_t *monitor, pmix_status_t error,
                  const pmix_info_t directives[], size_t ndirs,
-                 pmix_info_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'monitor' in keys:
-        args = {}
-        mymon = []
-        myproc = []
-        mydirs = []
-        blist = []
-        if NULL == monitor:
-            return PMIX_ERR_BAD_PARAM
-        if NULL != requestor:
-            pmix_unload_procs(requestor, 1, myproc)
-            args['source'] = myproc[0]
-        pmix_unload_info(monitor, 1, mymon)
-        args['monitor'] = mymon[0]
-        args['error'] = error
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, mydirs)
-            args['directives'] = mydirs
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['monitor'](args, pypmix_info_cbfunc, cbdata_dict)
+                 pmix_info_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'monitor' in keys:
+            args = {}
+            mymon = []
+            myproc = []
+            mydirs = []
+            blist = []
+            if NULL == monitor:
+                return PMIX_ERR_BAD_PARAM
+            if NULL != requestor:
+                pmix_unload_procs(requestor, 1, myproc)
+                args['source'] = myproc[0]
+            pmix_unload_info(monitor, 1, mymon)
+            args['monitor'] = mymon[0]
+            args['error'] = error
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, mydirs)
+                args['directives'] = mydirs
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['monitor'](args, pypmix_info_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int getcredential(const pmix_proc_t *proc,
                        const pmix_info_t directives[], size_t ndirs,
-                       pmix_credential_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'getcredential' in keys:
-        args = {}
-        myproc = []
-        mydirs = []
-        if NULL != proc:
-            pmix_unload_procs(proc, 1, myproc)
-            args['source'] = myproc[0]
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, mydirs)
-            args['directives'] = mydirs
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['getcredential'](args, pypmix_credential_cbfunc, cbdata_dict)
+                       pmix_credential_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'getcredential' in keys:
+            args = {}
+            myproc = []
+            mydirs = []
+            if NULL != proc:
+                pmix_unload_procs(proc, 1, myproc)
+                args['source'] = myproc[0]
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, mydirs)
+                args['directives'] = mydirs
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['getcredential'](args, pypmix_credential_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int validatecredential(const pmix_proc_t *proc,
                             const pmix_byte_object_t *cred,
                             const pmix_info_t directives[], size_t ndirs,
-                            pmix_validation_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'validatecredential' in keys:
-        args = {}
-        keyvals = {}
-        myproc = []
-        mydirs = []
-        blist = []
-        pycred = {}
-        if NULL != proc:
-            pmix_unload_procs(proc, 1, myproc)
-            args['source'] = myproc[0]
-        if NULL != cred:
-            pmix_unload_bytes(cred[0].bytes, cred[0].size, blist)
-            barray = bytearray(blist)
-            pycred['bytes'] = barray
-            pycred['size'] = cred[0].size
-            args['credential'] = pycred
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, mydirs)
-            args['directives'] = mydirs
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['validatecredential'](args, pypmix_validation_cbfunc, cbdata_dict)
+                            pmix_validation_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'validatecredential' in keys:
+            args = {}
+            keyvals = {}
+            myproc = []
+            mydirs = []
+            blist = []
+            pycred = {}
+            if NULL != proc:
+                pmix_unload_procs(proc, 1, myproc)
+                args['source'] = myproc[0]
+            if NULL != cred:
+                pmix_unload_bytes(cred[0].bytes, cred[0].size, blist)
+                barray = bytearray(blist)
+                pycred['bytes'] = barray
+                pycred['size'] = cred[0].size
+                args['credential'] = pycred
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, mydirs)
+                args['directives'] = mydirs
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['validatecredential'](args, pypmix_validation_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int iofpull(const pmix_proc_t procs[], size_t nprocs,
                  const pmix_info_t directives[], size_t ndirs,
                  pmix_iof_channel_t channels,
-                 pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'iofpull' in keys:
-        args = {}
-        keyvals = {}
-        myprocs = []
-        mydirs = []
-        pychannels = int(channels)
-        args['channels'] = channels
-        if NULL != procs:
-            pmix_unload_procs(procs, nprocs, myprocs)
-            args['sources'] = myprocs
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, mydirs)
-            args['directives'] = mydirs
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['iofpull'](args, pypmix_op_cbfunc, cbdata_dict)
+                 pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'iofpull' in keys:
+            args = {}
+            keyvals = {}
+            myprocs = []
+            mydirs = []
+            pychannels = int(channels)
+            args['channels'] = channels
+            if NULL != procs:
+                pmix_unload_procs(procs, nprocs, myprocs)
+                args['sources'] = myprocs
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, mydirs)
+                args['directives'] = mydirs
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['iofpull'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int pushstdin(const pmix_proc_t *source,
                    const pmix_proc_t targets[], size_t ntargets,
                    const pmix_info_t directives[], size_t ndirs,
                    const pmix_byte_object_t *bo,
-                   pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'pushstdin' in keys:
-        args = {}
-        keyvals = {}
-        myproc = []
-        mytargets = []
-        mydirs = []
-        blist = []
-        pyload = {}
-        if NULL != source:
-            pmix_unload_procs(source, 1, myproc)
-            args['source'] = myproc[0]
-        if NULL != targets:
-            pmix_unload_procs(targets, ntargets, mytargets)
-            args['targets'] = mytargets
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, mydirs)
-            args['directives'] = mydirs
-        if NULL != bo:
-            pmix_unload_bytes(bo[0].bytes, bo[0].size, blist)
-            barray = bytearray(blist)
-            pyload['bytes'] = barray
-            pyload['size'] = bo[0].size
-            args['payload'] = pyload
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['pushstdin'](args, pypmix_op_cbfunc, cbdata_dict)
+                   pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'pushstdin' in keys:
+            args = {}
+            keyvals = {}
+            myproc = []
+            mytargets = []
+            mydirs = []
+            blist = []
+            pyload = {}
+            if NULL != source:
+                pmix_unload_procs(source, 1, myproc)
+                args['source'] = myproc[0]
+            if NULL != targets:
+                pmix_unload_procs(targets, ntargets, mytargets)
+                args['targets'] = mytargets
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, mydirs)
+                args['directives'] = mydirs
+            if NULL != bo:
+                pmix_unload_bytes(bo[0].bytes, bo[0].size, blist)
+                barray = bytearray(blist)
+                pyload['bytes'] = barray
+                pyload['size'] = bo[0].size
+                args['payload'] = pyload
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['pushstdin'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 
 # The server library requires that the host complete a group operation by
@@ -5570,152 +5786,206 @@ cdef int pushstdin(const pmix_proc_t *source,
 cdef int group(pmix_group_operation_t op, char grp[],
                const pmix_proc_t procs[], size_t nprocs,
                const pmix_info_t directives[], size_t ndirs,
-               pmix_info_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'group' in keys:
-        args = {}
-        myprocs = []
-        mydirs = []
-        args['op'] = op
-        if NULL == grp:
-            return PMIX_ERR_BAD_PARAM
-        args['group'] = grp.decode('ascii')
-        if NULL != procs:
-            pmix_unload_procs(procs, nprocs, myprocs)
-        args['procs'] = myprocs
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, mydirs)
-            args['directives'] = mydirs
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['group'](args, pypmix_info_cbfunc, cbdata_dict)
+               pmix_info_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'group' in keys:
+            args = {}
+            myprocs = []
+            mydirs = []
+            args['op'] = op
+            if NULL == grp:
+                return PMIX_ERR_BAD_PARAM
+            args['group'] = grp.decode('ascii')
+            if NULL != procs:
+                pmix_unload_procs(procs, nprocs, myprocs)
+            args['procs'] = myprocs
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, mydirs)
+                args['directives'] = mydirs
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['group'](args, pypmix_info_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int fabric(const pmix_proc_t *requestor,
                 pmix_fabric_operation_t op,
                 const pmix_info_t directives[],
                 size_t ndirs,
                 pmix_info_cbfunc_t cbfunc,
-                void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'fabric' in keys:
-        args = {}
-        keyvals = {}
-        myprocs = []
-        mydirs = []
-        args['op'] = op
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, mydirs)
-            args['directives'] = mydirs
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['fabric'](args, pypmix_info_cbfunc, cbdata_dict)
+                void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'fabric' in keys:
+            args = {}
+            keyvals = {}
+            myprocs = []
+            mydirs = []
+            args['op'] = op
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, mydirs)
+                args['directives'] = mydirs
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['fabric'](args, pypmix_info_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int toolconnected2(pmix_info_t *info, size_t ninfo,
                         pmix_tool_connection_cbfunc_t cbfunc,
                         void *cbdata) noexcept with gil:
-    keys = pmixservermodule.keys()
-    ret_proc = {'nspace': "UNDEF", 'rank': PMIX_RANK_UNDEF}
-    if 'toolconnected2' in keys:
-        args = {}
-        ilist = []
-        if NULL != info:
-            pmix_unload_info(info, ninfo, ilist)
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['toolconnected2'](args, pypmix_tool_connection_cbfunc, cbdata_dict)
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        ret_proc = {'nspace': "UNDEF", 'rank': PMIX_RANK_UNDEF}
+        if 'toolconnected2' in keys:
+            args = {}
+            ilist = []
+            if NULL != info:
+                pmix_unload_info(info, ninfo, ilist)
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['toolconnected2'](args, pypmix_tool_connection_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int log2(const pmix_proc_t *client,
               const pmix_info_t data[], size_t ndata,
               const pmix_info_t directives[], size_t ndirs,
               pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
-    keys = pmixservermodule.keys()
-    if 'log2' in keys:
-        args = {}
-        ilist = []
-        myproc = []
-        mydirs = []
-        if NULL == client:
-            return PMIX_ERR_BAD_PARAM
-        pmix_unload_procs(client, 1, myproc)
-        args['source'] = myproc[0]
-        if NULL != data:
-            pmix_unload_info(data, ndata, ilist)
-            args['data'] = ilist
-        if NULL != directives:
-            pmix_unload_info(directives, ndirs, mydirs)
-            args['directives'] = mydirs
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['log2'](args, pypmix_op_cbfunc, cbdata_dict)
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'log2' in keys:
+            args = {}
+            ilist = []
+            myproc = []
+            mydirs = []
+            if NULL == client:
+                return PMIX_ERR_BAD_PARAM
+            pmix_unload_procs(client, 1, myproc)
+            args['source'] = myproc[0]
+            if NULL != data:
+                pmix_unload_info(data, ndata, ilist)
+                args['data'] = ilist
+            if NULL != directives:
+                pmix_unload_info(directives, ndirs, mydirs)
+                args['directives'] = mydirs
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['log2'](args, pypmix_op_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int sessioncontrol(const pmix_proc_t *requestor,
                         uint32_t sessionID,
                         const pmix_info_t directives[], size_t ndirs,
-                        pmix_info_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'sessioncontrol' in keys:
-        args = {}
-        myproc = []
-        blist = []
-        ilist = []
-        barray = None
+                        pmix_info_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'sessioncontrol' in keys:
+            args = {}
+            myproc = []
+            blist = []
+            ilist = []
+            barray = None
 
-        if NULL == requestor:
-            return PMIX_ERR_BAD_PARAM
-        pmix_unload_procs(requestor, 1, myproc)
-        args['requestor'] = myproc[0]
-        args['sessionID'] = sessionID
-        if NULL != directives:
-            rc = pmix_unload_info(directives, ndirs, ilist)
-            if PMIX_SUCCESS != rc:
-                return rc
-            args['directives'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['sessioncontrol'](args, pypmix_info_cbfunc, cbdata_dict)
+            if NULL == requestor:
+                return PMIX_ERR_BAD_PARAM
+            pmix_unload_procs(requestor, 1, myproc)
+            args['requestor'] = myproc[0]
+            args['sessionID'] = sessionID
+            if NULL != directives:
+                rc = pmix_unload_info(directives, ndirs, ilist)
+                if PMIX_SUCCESS != rc:
+                    return rc
+                args['directives'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['sessioncontrol'](args, pypmix_info_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 cdef int resourceblock(const pmix_proc_t *requestor,
                        pmix_resource_block_directive_t directive,
                        const char *block,
                        const pmix_resource_unit_t *units, size_t nunits,
                        const pmix_info_t *info, size_t ninfo,
-                       pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
-    keys = pmixservermodule.keys()
-    if 'resourceblock' in keys:
-        args = {}
-        myproc = []
-        blist = []
-        ulist = []
-        ilist = []
-        barray = None
+                       pmix_op_cbfunc_t cbfunc, void *cbdata) noexcept with gil:
+    # libpmix calls this across a C frame, so an exception
+    # raised by the handler has nowhere to propagate to.
+    # Without this, Cython returned -1 and left the error
+    # indicator set for whatever Python code ran next in
+    # this process to trip over.
+    try:
+        keys = pmixservermodule.keys()
+        if 'resourceblock' in keys:
+            args = {}
+            myproc = []
+            blist = []
+            ulist = []
+            ilist = []
+            barray = None
 
-        if NULL == requestor:
-            return PMIX_ERR_BAD_PARAM
-        if NULL == units:
-            return PMIX_ERR_BAD_PARAM
-        pmix_unload_procs(requestor, 1, myproc)
-        args['requestor'] = myproc[0]
-        args['directive'] = directive
-        args['block'] = pmix_decode_str(block)
-        rc = pmix_unload_units(units, nunits, ulist)
-        if PMIX_SUCCESS != rc:
-            return rc
-        args['units'] = ulist
-        if NULL != info:
-            rc = pmix_unload_info(info, ninfo, ilist)
+            if NULL == requestor:
+                return PMIX_ERR_BAD_PARAM
+            if NULL == units:
+                return PMIX_ERR_BAD_PARAM
+            pmix_unload_procs(requestor, 1, myproc)
+            args['requestor'] = myproc[0]
+            args['directive'] = directive
+            args['block'] = pmix_decode_str(block)
+            rc = pmix_unload_units(units, nunits, ulist)
             if PMIX_SUCCESS != rc:
                 return rc
-            args['info'] = ilist
-        cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
-        return pmixservermodule['resourceblock'](args, pypmix_info_cbfunc, cbdata_dict)
+            args['units'] = ulist
+            if NULL != info:
+                rc = pmix_unload_info(info, ninfo, ilist)
+                if PMIX_SUCCESS != rc:
+                    return rc
+                args['info'] = ilist
+            cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
+            return pmixservermodule['resourceblock'](args, pypmix_info_cbfunc, cbdata_dict)
 
-    return PMIX_ERR_NOT_SUPPORTED
+        return PMIX_ERR_NOT_SUPPORTED
+    except:
+        traceback.print_exc()
+        return PMIX_ERROR
 
 
 cdef class PMIxTool(PMIxServer):

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -2055,6 +2055,9 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            pmix_free_procs(procs, nprocs)
+            return rc, []
 
         # Call the library
         # the library only sets these on success, so start them
@@ -2117,6 +2120,9 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            pmix_free_procs(procs, nprocs)
+            return rc, []
 
         # Call the library
         # the library only sets these on success, so start them
@@ -2169,6 +2175,8 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            return rc, []
 
         # Call the library
         # the library only sets these on success, so start them
@@ -2208,6 +2216,8 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            return rc
 
         # Call the library
         _grp = <char *>pygrp
@@ -2236,6 +2246,8 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            return rc
 
         # Call the library
         _grp = <char *>pygrp
@@ -3958,6 +3970,8 @@ cdef class PMIxClient:
         if 0 == self.fabric_set:
             return (PMIX_ERR_INIT, None)
         rc = PMIx_Fabric_update(&self.myfabric)
+        if PMIX_SUCCESS != rc:
+            return (rc, fabricinfo)
         # convert the fabric info array for return
         if 0 < self.myfabric.ninfo:
             pmix_unload_info(self.myfabric.info, self.myfabric.ninfo, fabricinfo)
@@ -5896,6 +5910,9 @@ cdef class PMIxTool(PMIxServer):
         # allocate and load pmix info structs from python list of dictionaries
         directives_ptr = &directives
         rc = pmix_alloc_info(directives_ptr, &ndirs, pydirs)
+        if PMIX_SUCCESS != rc:
+            pmix_free_procs(procs, nprocs)
+            return rc, -1
 
         # Call the library
         with nogil:
@@ -5929,6 +5946,8 @@ cdef class PMIxTool(PMIxServer):
         # allocate and load pmix info structs from python list of dictionaries
         directives_ptr = &directives
         rc = pmix_alloc_info(directives_ptr, &ndirs, pydirs)
+        if PMIX_SUCCESS != rc:
+            return rc
 
         # call the library
         rc = PMIx_IOF_deregister(iofhdlr, directives, ndirs, NULL, NULL)
@@ -5969,20 +5988,27 @@ cdef class PMIxTool(PMIxServer):
                 return rc
             bo = &pushbo
 
-        # convert list of proc targets to array of pmix_proc_t's
-        if pytargets is not None:
+        # convert list of proc targets to array of pmix_proc_t's. Every
+        # failure from here on has the payload to give back
+        if pytargets is not None and 0 < len(pytargets):
             ntargets = len(pytargets)
             targets = <pmix_proc_t*>PyMem_Malloc(ntargets * sizeof(pmix_proc_t))
             if not targets:
+                if NULL != bo:
+                    free(bo.bytes)
                 return PMIX_ERR_NOMEM
             rc = pmix_load_procs(targets, pytargets)
             if PMIX_SUCCESS != rc:
                 pmix_free_procs(targets, ntargets)
+                if NULL != bo:
+                    free(bo.bytes)
                 return rc
         else:
             ntargets = 1
             targets = <pmix_proc_t*>PyMem_Malloc(ntargets * sizeof(pmix_proc_t))
             if not targets:
+                if NULL != bo:
+                    free(bo.bytes)
                 return PMIX_ERR_NOMEM
             pmix_copy_nspace(targets[0].nspace, self.myproc.nspace)
             targets[0].rank = PMIX_RANK_WILDCARD
@@ -5990,6 +6016,11 @@ cdef class PMIxTool(PMIxServer):
         # allocate and load pmix info structs from python list of dictionaries
         directives_ptr = &directives
         rc = pmix_alloc_info(directives_ptr, &ndirs, pydirs)
+        if PMIX_SUCCESS != rc:
+            pmix_free_procs(targets, ntargets)
+            if NULL != bo:
+                free(bo.bytes)
+            return rc
 
         # Call the library
         rc = PMIx_IOF_push(targets, ntargets, bo, directives, ndirs, NULL, NULL)
@@ -6063,3 +6094,37 @@ cdef class PMIxScheduler(PMIxTool):
         rc = PMIx_tool_finalize()
         return rc
 
+
+
+# The documented way to use these bindings is "from pmix import *", which
+# without an __all__ hands the caller every name at module scope - and
+# that includes the modules this file imports for its own use.  A program
+# that did
+#
+#     import time
+#     from pmix import *
+#
+# silently got the extension's "time" instead of its own, and the same for
+# os, sys, array, queue, signal, threading, ctypes and traceback.  Rebinding
+# a caller's imports is not something a library may do.
+#
+# Build the export list at import time rather than maintaining it by hand:
+# the whole point of the module is the several thousand PMIX_* constants
+# construct.py generates, and enumerating those would go stale on the first
+# new attribute.  So export everything public except the modules and the
+# handful of symbols pulled in by "from X import Y".
+def _pmix_build_all():
+    import types as _types
+    borrowed = ('Callable', 'Timer', 'addressof', 'c_int', 'address')
+    names = []
+    for name, obj in globals().items():
+        if name.startswith('_'):
+            continue
+        if name in borrowed:
+            continue
+        if isinstance(obj, _types.ModuleType):
+            continue
+        names.append(name)
+    return sorted(names)
+
+__all__ = _pmix_build_all()

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -542,17 +542,32 @@ def pypmix_info_cbfunc(int rc, list refarginfo, dict cbdata_dict):
 
 def pypmix_modex_cbfunc(int status, bytearray ret_data, dict cbdata_dict):
     cdef char *data
-    cdef size_t size = len(ret_data)
+    cdef const char *src
+    cdef size_t size
     cdef pmix_modex_cbfunc_t cbfunc = <pmix_modex_cbfunc_t> <uintptr_t> cbdata_dict['cbfunc']
     cdef void* cbdata = <void*> <uintptr_t> cbdata_dict['cbdata']
+    cdef pypmix_modex_cbdata_t *mcbd
 
     if NULL == cbfunc:
         return
 
-    data = strdup(ret_data)
+    # a modex payload is packed binary, not a string. strdup stopped at the
+    # first NUL byte, which for anything but an all-ASCII blob silently
+    # handed the peer a truncated - usually empty - modex
+    pybytes = bytes(ret_data)
+    size = len(pybytes)
+    data = NULL
+    if 0 < size:
+        data = <char *> malloc(size)
+        if NULL == data:
+            print("Error allocating modex payload")
+            return
+        src = <const char*>pybytes
+        memcpy(data, src, size)
     mcbd = <pypmix_modex_cbdata_t *> malloc(sizeof(pypmix_modex_cbdata_t))
     if mcbd == NULL:
         print("Error allocating pypmix_modex_cbdata_t")
+        free(data)
         return
     mcbd.data = data
     mcbd.size = size
@@ -565,32 +580,34 @@ def pypmix_lookup_cbfunc(int rc, list pdata, dict cbdata_dict):
     cdef void* cbdata = <void*> <uintptr_t> cbdata_dict['cbdata']
     cdef pmix_pdata_t *pd;
     cdef size_t ndata = 0;
-    cdef pypmix_modex_cbdata_t *pcbd = NULL
 
     if NULL == cbfunc:
         return
 
-    if pdata is not None:
+    pd = NULL
+    if pdata is not None and 0 < len(pdata):
         ndata = len(pdata)
-        if 0 < ndata:
-            pd = <pmix_pdata_t*> malloc(ndata * sizeof(pmix_pdata_t))
-            if not pdata:
-                return
-            prc = pmix_load_pdata(pd, pdata)
-            if PMIX_SUCCESS != prc:
-                pmix_free_pdata(pd, ndata)
-                return
-        else:
-            pd = NULL
-    else:
-        pd = NULL
+        # pmix_free_pdata releases this with the Python allocator, so it
+        # has to come from there. The test that guarded the allocation
+        # also checked the wrong variable ("pdata", the caller's list,
+        # which is never NULL) and so never caught a failure
+        pd = <pmix_pdata_t*> PyMem_Malloc(ndata * sizeof(pmix_pdata_t))
+        if NULL == pd:
+            return
+        prc = pmix_load_pdata(pd, pdata)
+        if PMIX_SUCCESS != prc:
+            pmix_free_pdata(pd, ndata)
+            return
 
     with nogil:
         cbfunc(rc, pd, ndata, cbdata)
 
-    PyMem_Free(pd)
+    # the pdata carry loaded values, so release them rather than just
+    # freeing the block
+    if NULL != pd:
+        pmix_free_pdata(pd, ndata)
 
-def pypmix_spawn_cbfunc(int rc, str nspace, dict cbdata_dict):
+def pypmix_spawn_cbfunc(int rc, nspace, dict cbdata_dict):
     cdef pmix_spawn_cbfunc_t cbfunc = <pmix_spawn_cbfunc_t> <uintptr_t> cbdata_dict['cbfunc']
     cdef void* cbdata = <void*> <uintptr_t> cbdata_dict['cbdata']
     cdef pmix_nspace_t c_nspace
@@ -598,8 +615,13 @@ def pypmix_spawn_cbfunc(int rc, str nspace, dict cbdata_dict):
     if NULL == cbfunc:
         return
 
-    if PMIX_SUCCESS == rc:
-        strcpy(c_nspace, nspace)
+    # always start from an empty namespace: a failed spawn has none to
+    # report, and the array is passed to the library either way, so it
+    # must never be left holding stack garbage. pmix_copy_nspace also
+    # accepts a str (strcpy did not) and clamps to the field width
+    memset(c_nspace, 0, sizeof(pmix_nspace_t))
+    if PMIX_SUCCESS == rc and nspace is not None:
+        pmix_copy_nspace(c_nspace, nspace)
 
     with nogil:
         cbfunc(rc, c_nspace, cbdata)
@@ -623,7 +645,6 @@ def pypmix_tool_connection_cbfunc(int rc, dict proc, dict cbdata_dict):
 def pypmix_credential_cbfunc(int rc, dict byteobject, list info, dict cbdata_dict):
     cdef pmix_credential_cbfunc_t cbfunc = <pmix_credential_cbfunc_t> <uintptr_t> cbdata_dict['cbfunc']
     cdef void* cbdata = <void*> <uintptr_t> cbdata_dict['cbdata']
-    cdef int size = 0
     cdef size_t ninfo = 0
     cdef pmix_byte_object_t c_byteobject
     cdef pmix_info_t *c_info = NULL
@@ -631,21 +652,31 @@ def pypmix_credential_cbfunc(int rc, dict byteobject, list info, dict cbdata_dic
     if NULL == cbfunc:
         return
 
+    # construct unconditionally - a failed request has no credential to
+    # report, and the struct is passed to the library on that path too
+    c_byteobject.bytes = NULL
+    c_byteobject.size = 0
     if PMIX_SUCCESS == rc:
-        size = byteobject['size']
-        c_byteobject.size = size
-        c_byteobject.bytes = <char *> malloc(size)
-        memcpy(c_byteobject.bytes, <void *> byteobject['bytes'], size)
+        # pmix_load_bo reads the payload out of the Python object. The
+        # code this replaces cast the object itself to void* and memcpy'd
+        # from there, so what reached the peer was the first 'size' bytes
+        # of the PyObject header rather than the credential
+        prc = pmix_load_bo(&c_byteobject, byteobject)
+        if PMIX_SUCCESS != prc:
+            print("Error transferring credential to C:", prc)
+            return prc
 
         prc = pmix_alloc_info(&c_info, &ninfo, info)
         if PMIX_SUCCESS != prc:
             print("Error transferring info to C:", prc)
+            if NULL != c_byteobject.bytes:
+                free(c_byteobject.bytes)
             return prc
 
     with nogil:
         cbfunc(rc, &c_byteobject, c_info, ninfo, cbdata)
 
-    if 0 < size:
+    if NULL != c_byteobject.bytes:
         free(c_byteobject.bytes)
     if 0 < ninfo:
         pmix_free_info(c_info, ninfo)
@@ -676,10 +707,15 @@ def pypmix_validation_cbfunc(int rc, dict byteobject, list info, dict cbdata_dic
 
 cdef void dmodx_cbfunc(pmix_status_t status,
                        char *data, size_t sz,
-                       void *cbdata) noexcept:
+                       void *cbdata) noexcept with gil:
     global active
-    if PMIX_SUCCESS == status:
-        active.cache_data(data, sz)
+    # the blob is packed binary and the library frees it on our return, so
+    # slice it to its recorded length and copy it now. Letting Cython
+    # convert the bare char* would run strlen over it
+    if PMIX_SUCCESS == status and NULL != data and 0 < sz:
+        active.cache_data(data[:sz], sz)
+    else:
+        active.cache_data(None, 0)
     active.set(status)
     return
 
@@ -731,12 +767,13 @@ cdef void pyiofhandler(size_t iofhdlr_id, pmix_iof_channel_t channel,
     pyinfo = []
     pmix_unload_info(info, ninfo, pyinfo)
 
-    # convert payload to python byteobject
-    pybytes = {}
+    # convert payload to python byteobject. IOF data is a raw stream, not
+    # a string: letting Cython convert the bare char* runs strlen over it,
+    # which truncates any payload carrying a NUL and reads past the end of
+    # one that carries none
+    pybytes = {'bytes': b'', 'size': 0}
     if NULL != payload:
-        pybytes['bytes'] = payload[0].bytes
-        pybytes['size']  = payload[0].size
-
+        pmix_unload_bo(payload, pybytes)
 
     # find the handler being called
     found = False
@@ -748,30 +785,17 @@ cdef void pyiofhandler(size_t iofhdlr_id, pmix_iof_channel_t channel,
                 # call user iof python handler
                 h['hdlr'](pyiof_id, pychannel, pysource, pybytes, pyinfo)
         except:
-            pass
+            traceback.print_exc()
 
-    # if we didn't find the handler, cache this event in a timeshift
-    # and try it again
+    # If we didn't find the handler, this event arrived before its
+    # registration completed - retry it in a moment. Everything the retry
+    # needs is converted to Python first: the info array belongs to the
+    # library and is gone the instant we return, so the caddy carries the
+    # converted list rather than the pointer
     if not found:
-        mycaddy    = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
-        mycaddy.op = strdup("iofhdlr_cache")
-        mycaddy.idx                 = iofhdlr_id
-        mycaddy.channel             = channel
-        memset(mycaddy.source.nspace, 0, PMIX_MAX_NSLEN+1)
-        memcpy(mycaddy.source.nspace, source[0].nspace, PMIX_MAX_NSLEN)
-        mycaddy.source.rank         = source[0].rank
-        if payload != NULL:
-            mycaddy.payload.bytes       = <char *>malloc(payload[0].size)
-            memset(mycaddy.payload.bytes, 0, payload[0].size)
-            memcpy(mycaddy.payload.bytes, payload[0].bytes, payload[0].size)
-            mycaddy.payload.size        = payload[0].size
-        else:
-            mycaddy.payload.bytes   = <char *>NULL
-            mycaddy.payload.size    = 0
-        mycaddy.info                = info
-        mycaddy.ndata               = ninfo
-        cb = PyCapsule_New(mycaddy, "iofhdlr_cache", NULL)
-        threading.Timer(0.001, iofhdlr_cache, [cb, rc]).start()
+        pyretry = {'refid': pyiof_id, 'channel': pychannel,
+                   'source': pysource, 'payload': pybytes, 'info': pyinfo}
+        threading.Timer(0.001, iofhdlr_cache, [pyretry, rc]).start()
     return
 
 cdef void pyeventhandler(size_t evhdlr_registration_id,
@@ -787,6 +811,7 @@ cdef void pyeventhandler(size_t evhdlr_registration_id,
     cdef char* kystr
     cdef pmix_nspace_t srcnspace
     cdef pmix_status_t ret_status
+    cdef pmix_status_t noaction
     cdef pypmix_info_cbdata_t *icbd
 
     # convert the source to python
@@ -841,25 +866,24 @@ cdef void pyeventhandler(size_t evhdlr_registration_id,
         except:
             pass
 
-    # if we didn't find the handler, delay a little and try again
+    # If we didn't find the handler, this event arrived before its
+    # registration completed - retry it in a moment. As in pyiofhandler,
+    # only Python objects are carried across the delay: the info and
+    # results arrays belong to the library and are released as soon as
+    # this upcall returns.
+    #
+    # The library's completion callback cannot be deferred with them - it
+    # must be executed before we return, or the event chain stalls - so
+    # complete the event here with no results and let the retry deliver it
+    # to the handler for its own sake.
     if not found:
-        mycaddy    = <pmix_pyshift_t*> PyMem_Malloc(sizeof(pmix_pyshift_t))
-        mycaddy.op = strdup("event_handler")
-        mycaddy.idx                 = evhdlr_registration_id
-        mycaddy.status              = status
-        memset(mycaddy.source.nspace, 0, PMIX_MAX_NSLEN+1)
-        memcpy(mycaddy.source.nspace, source[0].nspace, PMIX_MAX_NSLEN)
-        mycaddy.source.rank         = source[0].rank
-        mycaddy.info                = info
-        mycaddy.ndata               = ninfo
-        mycaddy.results             = results
-        mycaddy.nresults            = nresults
-        mycaddy.op_cbfunc           = NULL
-        mycaddy.cbdata              = NULL
-        mycaddy.notification_cbdata = cbdata
-        mycaddy.event_handler       = cbfunc
-        cb = PyCapsule_New(mycaddy, "event_handler", NULL)
-        threading.Timer(0.001, event_cache_cb, [cb, rc]).start()
+        if NULL != cbfunc:
+            noaction = PMIX_EVENT_NO_ACTION_TAKEN
+            with nogil:
+                cbfunc(noaction, NULL, 0, NULL, NULL, cbdata)
+        pyretry = {'refid': pyev_id, 'status': status, 'source': pysource,
+                   'info': pyinfo, 'results': pyresults}
+        threading.Timer(0.001, event_cache_cb, [pyretry, rc]).start()
     return
 
 # Round-trip a value dict through the C conversion layer and back.
@@ -950,6 +974,8 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &klen, dicts)
+        if PMIX_SUCCESS != rc:
+            return rc, myname
         rc = PMIx_Init(&self.myproc, info, klen)
         if 0 < klen:
             pmix_free_info(info, klen)
@@ -967,13 +993,12 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &klen, dicts)
+        if PMIX_SUCCESS != rc:
+            return rc
         rc = PMIx_Finalize(info, klen)
         if 0 < klen:
             pmix_free_info(info, klen)
         return rc
-
-    def initialized(self):
-        return PMIx_Initialized()
 
     # Request that the provided array of procs be aborted, returning the
     # provided _status_ and printing the provided message.
@@ -1191,6 +1216,8 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+        if PMIX_SUCCESS != rc:
+            return rc, None
 
         val = None
 
@@ -1229,6 +1256,8 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
+        if PMIX_SUCCESS != rc:
+            return rc
 
         # pass it into the publish API
         # release the GIL across the collective. These block until the
@@ -1278,11 +1307,14 @@ cdef class PMIxClient:
             keys = NULL
 
         # allocate and load pmix info structs from python list of dictionaries
+        info = NULL
         if dicts is not None:
             info_ptr = &info
             rc = pmix_alloc_info(info_ptr, &ninfo, dicts)
-        else:
-            info = NULL
+            if PMIX_SUCCESS != rc:
+                if NULL != keys:
+                    pmix_free_argv(keys)
+                return rc
 
         # pass it into the unpublish API
         # release the GIL across the collective. These block until the
@@ -1386,12 +1418,13 @@ cdef class PMIxClient:
             return PMIX_ERR_BAD_PARAM, None
 
         # allocate and load pmix info structs from python list of dictionaries
+        jinfo = NULL
+        ninfo = 0
         if jobInfo is not None:
             jinfo_ptr = &jinfo
             rc = pmix_alloc_info(jinfo_ptr, &ninfo, jobInfo)
-        else:
-            jinfo = NULL
-            ninfo = 0
+            if PMIX_SUCCESS != rc:
+                return rc, None
 
         # convert the list of apps to an array of pmix_app_t
         napps = len(pyapps)
@@ -1458,6 +1491,9 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            pmix_free_procs(procs, nprocs)
+            return rc
 
         # Call the library
         # release the GIL across the collective. These block until the
@@ -1512,6 +1548,9 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            pmix_free_procs(procs, nprocs)
+            return rc
 
         # Call the library
         # release the GIL across the collective. These block until the
@@ -1542,15 +1581,26 @@ cdef class PMIxClient:
         nodename = NULL
         memset(nspace, 0, sizeof(nspace))
         procs = NULL
+        nprocs = 0
         if pynode is not None:
-            pyn = pynode.encode('ascii')
+            if isinstance(pynode, str):
+                pyn = pynode.encode('ascii')
+            else:
+                pyn = pynode
             nodename = strdup(pyn)
+            if NULL == nodename:
+                return PMIX_ERR_NOMEM, peers
         if pyns is not None:
             pmix_copy_nspace(nspace, pyns)
         rc = PMIx_Resolve_peers(nodename, nspace, &procs, &nprocs)
+        # the node name was ours, not the library's, and it did not retain it
+        if NULL != nodename:
+            free(nodename)
         if PMIX_SUCCESS == rc and 0 < nprocs:
             rc = pmix_unload_procs(procs, nprocs, peers)
-            pmix_free_procs(procs, nprocs)
+            # the proc array came from the library's allocator, so it goes
+            # back to the library
+            PMIx_Proc_free(procs, nprocs)
         return rc, peers
 
     # NOTE: pyns is deliberately left unannotated - see resolve_peers above.
@@ -1601,7 +1651,8 @@ cdef class PMIxClient:
                 for q in pyq:
                     queries[n].keys       = NULL
                     queries[n].qualifiers = NULL
-                    nstrings = len(q['keys'])
+                    qkeys = q.get('keys')
+                    nstrings = 0 if qkeys is None else len(qkeys)
                     if 0 < nstrings:
                         # the entries are strdup'd, so the array must come
                         # from the C allocator as well
@@ -1609,14 +1660,18 @@ cdef class PMIxClient:
                         if not queries[n].keys:
                             pmix_free_queries(queries, nqueries)
                             return PMIX_ERR_NOMEM,pyresults
-                        rc = pmix_load_argv(queries[n].keys, q['keys'])
+                        memset(queries[n].keys, 0, (nstrings+1) * sizeof(char*))
+                        rc = pmix_load_argv(queries[n].keys, qkeys)
                         if PMIX_SUCCESS != rc:
                             pmix_free_queries(queries, nqueries)
                             return rc,pyresults
                     # allocate and load pmix info structs from python list of dictionaries
                     queries[n].nqual = 0
                     qual_ptr         = &(queries[n].qualifiers)
-                    rc               = pmix_alloc_info(qual_ptr, &(queries[n].nqual), q['qualifiers'])
+                    rc               = pmix_alloc_info(qual_ptr, &(queries[n].nqual), q.get('qualifiers'))
+                    if PMIX_SUCCESS != rc:
+                        pmix_free_queries(queries, nqueries)
+                        return rc, pyresults
                     n += 1
             else:
                 nqueries = 0
@@ -1647,11 +1702,18 @@ cdef class PMIxClient:
         data_ptr = &data
         directives_ptr = &directives
         rc = pmix_alloc_info(data_ptr, &ndata, pydata)
+        if PMIX_SUCCESS != rc:
+            return rc
         rc = pmix_alloc_info(directives_ptr, &ndirs, pydirs)
+        if PMIX_SUCCESS != rc:
+            if 0 < ndata:
+                pmix_free_info(data, ndata)
+            return rc
 
         # call the API
         rc = PMIx_Log(data, ndata, directives, ndirs)
-        pmix_free_info(data, ndata)
+        if 0 < ndata:
+            pmix_free_info(data, ndata)
         if 0 < ndirs:
             pmix_free_info(directives, ndirs)
         return rc
@@ -1672,6 +1734,8 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            return rc, pyres
 
         # call the API
         _directive = directive
@@ -1797,7 +1861,7 @@ cdef class PMIxClient:
         if PMIX_SUCCESS != rc:
             if 0 < ntargets:
                 pmix_free_procs(targets, ntargets)
-            return rc
+            return rc, pyres
 
         # call the API
         # release the GIL across the collective. These block until the
@@ -1837,17 +1901,15 @@ cdef class PMIxClient:
         monitor_info_ptr = &monitor_info
         rc = pmix_alloc_info(monitor_info_ptr, &nmonitor, pymonitor_info)
         if PMIX_SUCCESS != rc:
-            if 0 < nmonitor:
-                pmix_free_info(monitor_info, nmonitor)
-            return rc
+            return rc, pyres
 
         # allocate and load pmix info structs from python list of dictionaries
         directives_ptr = &directives
         rc = pmix_alloc_info(directives_ptr, &ndirs, pydirs)
         if PMIX_SUCCESS != rc:
-            if 0 < ndirs:
-                pmix_free_info(directives, ndirs)
-            return rc
+            if 0 < nmonitor:
+                pmix_free_info(monitor_info, nmonitor)
+            return rc, pyres
 
         # call the API
         _code = code
@@ -1892,9 +1954,7 @@ cdef class PMIxClient:
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
         if PMIX_SUCCESS != rc:
-            if 0 < ninfo:
-                pmix_free_info(info, ninfo)
-            return rc
+            return rc, {}
 
         # call the API
         boptr = &bo
@@ -1911,10 +1971,12 @@ cdef class PMIxClient:
             cred['size'] = bo.size
         return rc, cred
 
-    def validate_credential(self, pycred:dict, pyinfo):
+    # NOTE: pycred is deliberately left unannotated so the body can report
+    # PMIX_ERR_BAD_PARAM on None rather than having Cython reject it
+    def validate_credential(self, pycred, pyinfo):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
-        cdef pmix_byte_object_t *bo
+        cdef pmix_byte_object_t bo
         cdef size_t ninfo
         cdef pmix_info_t *results
         cdef size_t nresults
@@ -1923,28 +1985,28 @@ cdef class PMIxClient:
         nresults = 0
         pyres = []
 
-        # convert pycred to pmix_byte_object_t
-        bo = <pmix_byte_object_t*>PyMem_Malloc(sizeof(pmix_byte_object_t))
-        if not bo:
-            return PMIX_ERR_NOMEM
-        cred = bytes(pycred['bytes'], 'ascii')
-        bo.size = sizeof(cred)
-        bo.bytes = <char*> PyMem_Malloc(bo.size)
-        if not bo.bytes:
-            return PMIX_ERR_NOMEM
-        pyptr = <const char*>cred
-        memcpy(bo.bytes, pyptr, bo.size)
+        # convert pycred to pmix_byte_object_t. The credential is binary,
+        # and its length is len(), not sizeof() - the latter measures the
+        # Python object reference and so always said 8, truncating every
+        # credential to its first eight bytes. The struct itself lives on
+        # the stack; there is no reason to heap-allocate one, and the heap
+        # copy the old code made was never released
+        rc = pmix_load_bo(&bo, pycred)
+        if PMIX_SUCCESS != rc:
+            return rc, pyres
 
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
         if PMIX_SUCCESS != rc:
-            if 0 < ninfo:
-                pmix_free_info(info, ninfo)
-            return rc
+            if NULL != bo.bytes:
+                free(bo.bytes)
+            return rc, pyres
 
         # call the API
-        rc = PMIx_Validate_credential(bo, info, ninfo, &results, &nresults)
+        rc = PMIx_Validate_credential(&bo, info, ninfo, &results, &nresults)
+        if NULL != bo.bytes:
+            free(bo.bytes)
         if 0 < ninfo:
             pmix_free_info(info, ninfo)
         if PMIX_SUCCESS == rc and 0 < nresults:
@@ -3052,28 +3114,30 @@ cdef class PMIxClient:
         cdef size_t ninfo
 
         # convert the codes to an array of ints
-        if pycodes is not None:
+        codes = NULL
+        ncodes = 0
+        info = NULL
+        ninfo = 0
+        if pycodes is not None and 0 < len(pycodes):
             ncodes = len(pycodes)
             codes = <int*> PyMem_Malloc(ncodes * sizeof(int))
             if not codes:
-                return PMIX_ERR_NOMEM
+                # every other exit reports (rc, refid) - a bare status here
+                # broke the caller's tuple unpacking
+                return PMIX_ERR_NOMEM, -1
             n = 0
             for c in pycodes:
                 codes[n] = c
                 n += 1
-        else:
-            codes = NULL
-            ncodes = 0
         # allocate and load pmix info structs from python list of dictionaries
         if pyinfo is not None:
             info_ptr = &info
             rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
             if PMIX_SUCCESS != rc:
                 print("Error converting info array:", self.error_string(rc))
+                if 0 < ncodes:
+                    PyMem_Free(codes)
                 return rc, -1
-        else:
-            info = NULL
-            ninfo = 0
 
         # pass our hdlr switchyard to the API
         with nogil:
@@ -3112,6 +3176,8 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            return rc
 
         # call the library
         with nogil:
@@ -3124,14 +3190,17 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Error_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
-        val = pystr.decode('ascii')
-        return val
+        return pystr.decode('ascii')
 
     def proc_state_string(self, pystat:int):
         cdef char *string
 
         string = <char*>PMIx_Proc_state_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3139,6 +3208,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Scope_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3146,6 +3217,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Persistence_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3153,6 +3226,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Data_range_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3160,6 +3235,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Info_directives_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3167,6 +3244,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Data_type_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3174,6 +3253,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Alloc_directive_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3181,6 +3262,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_IOF_channel_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3188,6 +3271,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Job_state_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3195,6 +3280,8 @@ cdef class PMIxClient:
         cdef char *string
         pyrep = rep.encode('ascii')
         string = <char*>PMIx_Get_attribute_string(pyrep)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3202,6 +3289,8 @@ cdef class PMIxClient:
         cdef char *string
         pyrep = rep.encode('ascii')
         string = <char*>PMIx_Get_attribute_name(pyrep)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3209,6 +3298,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Link_state_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3216,6 +3307,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Device_type_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3223,6 +3316,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Value_comparison_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3230,6 +3325,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Group_operation_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3237,6 +3334,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Resource_block_directive_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3244,6 +3343,8 @@ cdef class PMIxClient:
         cdef char *string
 
         string = <char*>PMIx_Alloc_inheritance_string(pystat)
+        if NULL == string:
+            return None
         pystr = string
         return pystr.decode('ascii')
 
@@ -3300,6 +3401,11 @@ cdef class PMIxClient:
             pfx = <char*>pypfx
 
         if PMIX_VALUE == data_type:
+            # zero first: a load that fails partway is destructed below,
+            # and the destructor frees whatever pointers it finds in the
+            # struct - which on an unzeroed stack value is whatever the
+            # previous frame left there
+            memset(&value, 0, sizeof(pmix_value_t))
             rc = pmix_load_value(&value, pysrc)
             if PMIX_SUCCESS != rc:
                 pmix_destruct_value(&value)
@@ -3362,6 +3468,8 @@ cdef class PMIxClient:
 
         if not isinstance(pyval, dict):
             return (PMIX_ERR_BAD_PARAM, None)
+        # zero first - see data_print
+        memset(&value, 0, sizeof(pmix_value_t))
         rc = pmix_load_value(&value, pyval)
         if PMIX_SUCCESS != rc:
             pmix_destruct_value(&value)
@@ -3497,6 +3605,8 @@ cdef class PMIxClient:
             return (rc, pybuf)
 
         if PMIX_VALUE == data_type:
+            # zero first - see data_print
+            memset(&value, 0, sizeof(pmix_value_t))
             rc = pmix_load_value(&value, pysrc)
             if PMIX_SUCCESS == rc:
                 rc = PMIx_Data_pack(tgt, &buf, <void*>&value, 1, PMIX_VALUE)
@@ -3600,6 +3710,8 @@ cdef class PMIxClient:
                 data_type = PMIX_VALUE
 
         if PMIX_VALUE == data_type:
+            # zero first - see data_print
+            memset(&value, 0, sizeof(pmix_value_t))
             rc = pmix_load_value(&value, pysrc)
             if PMIX_SUCCESS != rc:
                 pmix_destruct_value(&value)
@@ -3826,6 +3938,8 @@ cdef class PMIxClient:
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &sz, dicts)
+        if PMIX_SUCCESS != rc:
+            return (rc, None)
 
         if sz > 0:
             rc = PMIx_Fabric_register(&self.myfabric, info, sz)
@@ -4032,8 +4146,12 @@ def setmodulefn(k, f):
                  'toolconnected2', 'log2', 'sessioncontrol', 'resourceblock']
     if k not in permitted:
         return PMIX_ERR_BAD_PARAM
-    if not k in pmixservermodule:
-        pmixservermodule[k] = f
+    if not callable(f):
+        return PMIX_ERR_BAD_PARAM
+    # last registration wins: a server that re-inits with a different
+    # handler for a key used to keep silently calling the first one
+    pmixservermodule[k] = f
+    return PMIX_SUCCESS
 
 cdef class PMIxServer(PMIxClient):
     cdef pmix_server_module_t myserver
@@ -4066,9 +4184,7 @@ cdef class PMIxServer(PMIxClient):
             return PMIX_ERR_INIT
         kvkeys = list(map.keys())
         for key in kvkeys:
-            try:
-                setmodulefn(key, map[key])
-            except KeyError:
+            if PMIX_SUCCESS != setmodulefn(key, map[key]):
                 print("SERVER MODULE FUNCTION ", key, " IS NOT RECOGNIZED")
                 return PMIX_ERR_INIT
 
@@ -4078,8 +4194,11 @@ cdef class PMIxServer(PMIxClient):
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &sz, dicts)
+        if PMIX_SUCCESS != rc:
+            return rc
         if sz > 0:
             rc = PMIx_server_init(&self.myserver, info, sz)
+            pmix_free_info(info, sz)
         else:
             rc = PMIx_server_init(&self.myserver, NULL, 0)
         return rc
@@ -4173,6 +4292,8 @@ cdef class PMIxServer(PMIxClient):
             return (rc, bytearray(0))
         # load regex appropriately into python bytearray
         ba = pmix_convert_regex(regex)
+        # the library allocated it, so hand it back
+        free(regex)
         return (rc, ba)
 
     # Compress a list of node names into the current regular expression
@@ -4284,26 +4405,11 @@ cdef class PMIxServer(PMIxClient):
         # the library leaves the output pointer untouched when it fails
         if PMIX_SUCCESS != rc or NULL == ppn:
             return (rc, bytearray(0))
-        if "pmix" == ppn[:4].decode("ascii"):
-            if b'\x00' in ppn:
-                ppn.replace(b'\x00', '')
-            ba = bytearray(ppn)
-        elif "blob" == ppn[:4].decode("ascii"):
-            sz_str    = len(ppn)
-            sz_prefix = 5
-            # extract length of bytearray
-            ppn.split(b'\x00')
-            len_bytearray = ppn[1]
-            length = len(len_bytearray) + sz_prefix + sz_str
-            ba = bytearray(length)
-            index = 0
-            pyppn = <bytes> ppn[:length]
-            while index < length:
-                ba[index] = pyppn[index]
-                index += 1
-        else:
-            # last case with no ':' in string
-            ba = bytearray(ppn)
+        # the generator answers a NUL-terminated string in every form the
+        # library produces, so the whole string is the value
+        ba = pmix_convert_regex(ppn)
+        # the library allocated it, so hand it back
+        free(ppn)
         return (rc, ba)
 
     # Render a Python cpuset dict into the library's cpuset string, the
@@ -4417,9 +4523,15 @@ cdef class PMIxServer(PMIxClient):
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &sz, dicts)
+        if PMIX_SUCCESS != rc:
+            return rc
 
+        # the blocking form copies whatever it needs before it returns, so
+        # the array is ours to release - it used to be leaked on every
+        # namespace registration
         if sz > 0:
             rc = PMIx_server_register_nspace(nspace, nlocalprocs, info, sz, NULL, NULL)
+            pmix_free_info(info, sz)
         else:
             rc = PMIx_server_register_nspace(nspace, nlocalprocs, NULL, 0, NULL, NULL)
         return rc
@@ -4450,6 +4562,8 @@ cdef class PMIxServer(PMIxClient):
             return rc
 
         rc = PMIx_server_register_resources(info, sz, NULL, NULL)
+        if 0 < sz:
+            pmix_free_info(info, sz)
         return rc
 
     # Deregister resources
@@ -4465,6 +4579,8 @@ cdef class PMIxServer(PMIxClient):
             return rc
 
         rc = PMIx_server_deregister_resources(info, sz, NULL, NULL)
+        if 0 < sz:
+            pmix_free_info(info, sz)
         return rc
 
     # Register a client process
@@ -4524,8 +4640,12 @@ cdef class PMIxServer(PMIxClient):
             while NULL != penv[n]:
                 ln = strlen(penv[n])
                 pstring = penv[n].decode('ascii')
-                kv = pstring.split('=')
-                envin[kv[0]] = kv[1]
+                # split once: PATH-like values routinely contain '=', and
+                # splitting on every one of them dropped everything past
+                # the second
+                kv = pstring.split('=', 1)
+                if 2 == len(kv):
+                    envin[kv[0]] = kv[1]
                 free(penv[n])
                 n += 1
             free(penv)
@@ -4558,6 +4678,8 @@ cdef class PMIxServer(PMIxClient):
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &sz, dicts)
+        if PMIX_SUCCESS != rc:
+            return (rc, dataout)
 
         active.clear()
         rc = PMIx_server_setup_application(nspace, info, sz, setupapp_cbfunc, NULL);
@@ -4565,39 +4687,53 @@ cdef class PMIxServer(PMIxClient):
             active.wait()
             # transfer the data to the dictionary
             active.fetch_info(dataout)
+            rc = active.get_status()
+        if 0 < sz:
+            pmix_free_info(info, sz)
         return (rc, dataout)
 
-    def register_attributes(self, function:str, attrs):
+    def register_attributes(self, function, attrs):
         cdef size_t nattrs
         cdef char *func
         cdef char **attarray
         nattrs    = 0
-        func      = strdup(function)
 
-        if attrs is not None:
-            nattrs = len(attrs)
-            if 0 < nattrs:
-                # allocate and load list of strings into regattrs struct
-                attarray = <char **> PyMem_Malloc((nattrs+1) * sizeof(char*))
-                if not attarray:
-                    return PMIX_ERR_NOMEM
-                rc = pmix_load_argv(attarray, attrs)
-                if PMIX_SUCCESS != rc:
-                    PyMem_Free(attarray)
-                    return rc
-            else:
-                return PMIX_SUCCESS
-        else:
+        if function is None:
+            return PMIX_ERR_BAD_PARAM
+        if attrs is None or 0 == len(attrs):
             return PMIX_SUCCESS
+        # strdup takes bytes; handing it the str raised TypeError inside a
+        # cdef function, where the exception was swallowed
+        if isinstance(function, str):
+            pyfunc = function.encode('ascii')
+        else:
+            pyfunc = function
+        func = strdup(pyfunc)
+        if NULL == func:
+            return PMIX_ERR_NOMEM
+
+        nattrs = len(attrs)
+        # the entries are strdup'd, so the array must come from the C
+        # allocator too - the old code freed a strdup'd string and a
+        # PyMem array through the wrong allocators in both directions
+        attarray = <char **> malloc((nattrs+1) * sizeof(char*))
+        if not attarray:
+            free(func)
+            return PMIX_ERR_NOMEM
+        memset(attarray, 0, (nattrs+1) * sizeof(char*))
+        rc = pmix_load_argv(attarray, attrs)
+        if PMIX_SUCCESS != rc:
+            pmix_free_argv(attarray)
+            free(func)
+            return rc
 
         # call Server API
         rc = PMIx_Register_attributes(func, attarray)
 
-        if 0 < nattrs:
-            PyMem_Free(attarray)
-        if func != NULL:
-            PyMem_Free(func)
-        return PMIX_SUCCESS
+        pmix_free_argv(attarray)
+        free(func)
+        # report what the library said, rather than claiming success
+        return rc
 
     def collect_inventory(self, pydirs):
         cdef pmix_info_t *directives
@@ -4609,6 +4745,8 @@ cdef class PMIxServer(PMIxClient):
         # allocate and load pmix info structs from python list of dictionaries
         directives_ptr = &directives
         rc = pmix_alloc_info(directives_ptr, &ndirs, pydirs)
+        if PMIX_SUCCESS != rc:
+            return (rc, dataout)
 
         # call the API
         active.clear()
@@ -4618,6 +4756,9 @@ cdef class PMIxServer(PMIxClient):
             active.wait()
             # transfer the data to the dictionary
             active.fetch_info(dataout)
+            rc = active.get_status()
+        if 0 < ndirs:
+            pmix_free_info(directives, ndirs)
         return (rc, dataout)
 
     def deliver_inventory(self, pyinfo, pydirs):
@@ -4633,12 +4774,22 @@ cdef class PMIxServer(PMIxClient):
         # allocate and load pmix info structs from python list of dictionaries
         directives_ptr = &directives
         rc = pmix_alloc_info(directives_ptr, &ndirs, pydirs)
+        if PMIX_SUCCESS != rc:
+            return rc
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &ninfo, pyinfo)
+        if PMIX_SUCCESS != rc:
+            if 0 < ndirs:
+                pmix_free_info(directives, ndirs)
+            return rc
 
         # call the API
         rc = PMIx_server_deliver_inventory(info, ninfo, directives, ndirs,
                                            NULL, NULL)
+        if 0 < ninfo:
+            pmix_free_info(info, ninfo)
+        if 0 < ndirs:
+            pmix_free_info(directives, ndirs)
         return rc
 
     def setup_local_support(self, ns:str, ilist):
@@ -4653,12 +4804,14 @@ cdef class PMIxServer(PMIxClient):
         rc = pmix_alloc_info(info_ptr, &sz, ilist)
         if PMIX_SUCCESS != rc:
             return rc
+        # the blocking form completes before it returns, so there is no
+        # callback to wait on - the wait that used to be here was on the
+        # module-global lock nothing on this path ever sets
         if sz > 0:
             rc = PMIx_server_setup_local_support(nspace, info, sz, NULL, NULL);
+            pmix_free_info(info, sz)
         else:
             rc = PMIx_server_setup_local_support(nspace, NULL, 0, NULL, NULL);
-        if PMIX_SUCCESS == rc:
-            active.wait()
         return rc
 
     def iof_deliver(self, pysrc:dict, pychannel:int, pydata:dict, pydirs):
@@ -4676,22 +4829,23 @@ cdef class PMIxServer(PMIxClient):
         source.rank = pysrc['rank']
 
         # convert pydata to pmix_byte_object_t
-        data = bytes(pydata['bytes'], 'ascii')
-        bo.size = len(data)
-        bo.bytes = <char*> PyMem_Malloc(bo.size)
-        if not bo.bytes:
-            return PMIX_ERR_NOMEM
-        pyptr = <const char*>data
-        memcpy(bo.bytes, pyptr, bo.size)
+        rc = pmix_load_bo(&bo, pydata)
+        if PMIX_SUCCESS != rc:
+            return rc
 
         # allocate and load pmix info structs from python list of dictionaries
         directives_ptr = &directives
         rc = pmix_alloc_info(directives_ptr, &ndirs, pydirs)
+        if PMIX_SUCCESS != rc:
+            if NULL != bo.bytes:
+                free(bo.bytes)
+            return rc
 
         # call API
         rc = PMIx_server_IOF_deliver(&source, channel, &bo, directives, ndirs,
                                      NULL, NULL)
-        PyMem_Free(bo.bytes)
+        if NULL != bo.bytes:
+            free(bo.bytes)
         if 0 < ndirs:
             pmix_free_info(directives, ndirs)
         return rc
@@ -4899,7 +5053,7 @@ cdef int clientaborted(const pmix_proc_t *proc, void *server_object,
         args['status'] = status
         # record the msg, if given
         if NULL != msg:
-            args['msg'] = str(msg)
+            args['msg'] = pmix_decode_str(msg)
         # convert any provided array of procs to be aborted
         if NULL != procs:
             pmix_unload_procs(procs, nprocs, myprocs)
@@ -4923,7 +5077,7 @@ cdef int fencenb(const pmix_proc_t procs[], size_t nprocs,
         barray = None
 
         if NULL == procs:
-            myprocs.append({'nspace': myname.nspace, 'rank': PMIX_RANK_WILDCARD})
+            myprocs.append({'nspace': myname.get('nspace', ''), 'rank': PMIX_RANK_WILDCARD})
         else:
             pmix_unload_procs(procs, nprocs, myprocs)
         args['procs'] = myprocs
@@ -5534,7 +5688,7 @@ cdef int resourceblock(const pmix_proc_t *requestor,
         pmix_unload_procs(requestor, 1, myproc)
         args['requestor'] = myproc[0]
         args['directive'] = directive
-        args['block'] = block
+        args['block'] = pmix_decode_str(block)
         rc = pmix_unload_units(units, nunits, ulist)
         if PMIX_SUCCESS != rc:
             return rc
@@ -5546,6 +5700,8 @@ cdef int resourceblock(const pmix_proc_t *requestor,
             args['info'] = ilist
         cbdata_dict = {'cbdata' : <uintptr_t> cbdata, 'cbfunc' : <uintptr_t> cbfunc}
         return pmixservermodule['resourceblock'](args, pypmix_info_cbfunc, cbdata_dict)
+
+    return PMIX_ERR_NOT_SUPPORTED
 
 
 cdef class PMIxTool(PMIxServer):
@@ -5619,10 +5775,13 @@ cdef class PMIxTool(PMIxServer):
         cdef pmix_info_t **info_ptr
         cdef size_t sz
         cdef pmix_proc_t srvr
+        global myname
 
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &sz, dicts)
+        if PMIX_SUCCESS != rc:
+            return rc, None, None
 
         if sz > 0:
             rc = PMIx_tool_attach_to_server(&self.myproc, &srvr, info, sz)
@@ -5642,11 +5801,16 @@ cdef class PMIxTool(PMIxServer):
         cdef size_t nservers
 
         pysrvrs = []
+        servers = NULL
+        nservers = 0
         rc = PMIx_tool_get_servers(&servers, &nservers)
-        if PMIX_SUCCESS != rc:
+        if PMIX_SUCCESS != rc or NULL == servers:
             return rc, pysrvrs
         rc = pmix_unload_procs(servers, nservers, pysrvrs)
-        PyMem_Free(servers)
+        # the array came from the library's allocator (PMIX_PROC_CREATE),
+        # so handing it to Python's allocator was a mismatch that can abort
+        # the process
+        PMIx_Proc_free(servers, nservers)
         return rc, pysrvrs
 
     def set_server(self, server:dict, pyinfo):
@@ -5688,9 +5852,7 @@ cdef class PMIxTool(PMIxServer):
             return PMIX_ERR_INIT
         kvkeys = list(map.keys())
         for key in kvkeys:
-            try:
-                setmodulefn(key, map[key])
-            except KeyError:
+            if PMIX_SUCCESS != setmodulefn(key, map[key]):
                 print("SERVER MODULE FUNCTION ", key, " IS NOT RECOGNIZED")
                 return PMIX_ERR_INIT
         self.server_module_init(kvkeys)
@@ -5791,30 +5953,26 @@ cdef class PMIxTool(PMIxServer):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef pmix_byte_object_t *bo
+        cdef pmix_byte_object_t pushbo
         cdef size_t ndirs
         cdef pmix_proc_t *targets
         ntargets    = 0
         ndirs       = 0
 
-        # convert data to pmix_byte_object_t
+        # convert data to pmix_byte_object_t. The struct lives on the
+        # stack - the heap copy the old code made was never released, and
+        # bytes(x, 'ascii') raised on a payload that already was bytes
+        bo = NULL
         if data:
-            bo = <pmix_byte_object_t*>malloc(sizeof(pmix_byte_object_t))
-            if not bo:
-                return PMIX_ERR_NOMEM
-            cred = bytes(data['bytes'], 'ascii')
-            bo.size = len(cred)
-            bo.bytes = <char*> malloc(bo.size)
-            if not bo.bytes:
-                return PMIX_ERR_NOMEM
-            pyptr = <const char*>cred
-            memcpy(bo.bytes, pyptr, bo.size)
-        else:
-            bo = NULL
+            rc = pmix_load_bo(&pushbo, data)
+            if PMIX_SUCCESS != rc:
+                return rc
+            bo = &pushbo
 
         # convert list of proc targets to array of pmix_proc_t's
         if pytargets is not None:
             ntargets = len(pytargets)
-            targets = <pmix_proc_t*>malloc(ntargets * sizeof(pmix_proc_t))
+            targets = <pmix_proc_t*>PyMem_Malloc(ntargets * sizeof(pmix_proc_t))
             if not targets:
                 return PMIX_ERR_NOMEM
             rc = pmix_load_procs(targets, pytargets)
@@ -5823,7 +5981,7 @@ cdef class PMIxTool(PMIxServer):
                 return rc
         else:
             ntargets = 1
-            targets = <pmix_proc_t*>malloc(ntargets * sizeof(pmix_proc_t))
+            targets = <pmix_proc_t*>PyMem_Malloc(ntargets * sizeof(pmix_proc_t))
             if not targets:
                 return PMIX_ERR_NOMEM
             pmix_copy_nspace(targets[0].nspace, self.myproc.nspace)
@@ -5835,6 +5993,8 @@ cdef class PMIxTool(PMIxServer):
 
         # Call the library
         rc = PMIx_IOF_push(targets, ntargets, bo, directives, ndirs, NULL, NULL)
+        if NULL != bo and NULL != bo.bytes:
+            free(bo.bytes)
         if 0 < ntargets:
             pmix_free_procs(targets, ntargets)
         if 0 < ndirs:

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -43,23 +43,22 @@ def getVersion():
             print("Error: pmix_version.h does not exist at path: ",vers_path)
             sys.exit(1)
 
+    fields = {}
     with open(vers_path) as verFile:
-        lines = verFile.readlines()
-        for l in lines:
-            if 'MAJOR' in l:
-                major = l.split()[2]
-                major = major[:-1]
-            elif 'MINOR' in l:
-                minor = l.split()[2]
-                minor = minor[:-1]
-            elif 'RELEASE' in l:
-                release = l.split()[2]
-                release = release[:-1]
-        vers = [major, minor, release]
-        version = ".".join(vers)
-        return version
+        for l in verFile.readlines():
+            for name in ('MAJOR', 'MINOR', 'RELEASE'):
+                if ('PMIX_VERSION_' + name) in l:
+                    # the value carries an L suffix - "#define
+                    # PMIX_VERSION_MAJOR 7L"
+                    fields[name] = l.split()[2].rstrip('Ll')
+    missing = [n for n in ('MAJOR', 'MINOR', 'RELEASE') if n not in fields]
+    if missing:
+        print("Error: %s does not define PMIX_VERSION_%s"
+              % (vers_path, ", PMIX_VERSION_".join(missing)))
+        sys.exit(1)
+    return ".".join(fields[n] for n in ('MAJOR', 'MINOR', 'RELEASE'))
 
-def package_setup(package_name, package_vers):
+def package_setup():
     '''
     Package setup routine.
     '''
@@ -106,7 +105,9 @@ def package_setup(package_name, package_vers):
                 'Programming Language :: Python :: 3.9',
                 'Programming Language :: Python :: 3.10',
                 'Programming Language :: Python :: 3.11',
-                'Programming Language :: Python :: 3.12'],
+                'Programming Language :: Python :: 3.12',
+                'Programming Language :: Python :: 3.13',
+                'Programming Language :: Python :: 3.14'],
         keywords = ['PMI', 'PMIx', 'HPC', 'MPI', 'SHMEM' ],
         platforms = 'any',
         install_requires = ["cython"],
@@ -123,12 +124,10 @@ def main():
     '''
     The main entry point for this program.
     '''
-    package_name = 'pypmix'
-    package_vers = getVersion()
+    package_setup()
 
-    package_setup(package_name, package_vers)
-
-    return os.EX_OK
+    # os.EX_OK is not defined everywhere Python runs
+    return 0
 
 
 if __name__ == '__main__':

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -35,7 +35,7 @@ is only the nickname.
 | `run-mca-tests.sh` | Runs `test/unit/mca` plus the hostile MCA-parameter cases in the `--enable-mca-dso` configuration, where the component repository is actually exercised. See §14. |
 | `run-bfrops-tests.sh` | Runs the `src/mca/bfrops` unit programs on Linux in an optimized `--enable-mca-dso` build, **and** moves one value of every PMIx data type between ranks on *different* nodes. The only place the peer-assigned bfrops module and the negotiated buffer type are observable at all. See §15. |
 | `swarm-common.sh` | Sourced by all seven scripts above: which swarm to drive (`PMIX_SWARM`), how to reach a node, and how to clean one. The three runners each carried their own copy of that once, and the copies drifted. |
-| `python/` | The swarm's own Python clients (`swarm_client.py`, `swarm_group.py`, `swarm_cpuset.py`). |
+| `python/` | The swarm's own Python clients (`swarm_client.py`, `swarm_group.py`, `swarm_cpuset.py`, `swarm_datatypes.py`, `swarm_nonblocking.py`). |
 | `Dockerfile` | Base image: toolchain, PRRTE master *source* (autogen'd), SSH wiring, node entrypoint. It contains **no** PMIx and **no** built PRRTE. |
 | `docker-compose.yml` | The ten nodes `pmix-node1`..`pmix-node10`, each mounting the shared `pmix-build` volume. Every one of those names derives from `$PMIX_SWARM`, so two clones can each run a swarm — see §4. |
 
@@ -369,6 +369,8 @@ do. `swarm_client.py` exercises them for real here.
 | `python/swarm_client.py` | multi-node client: `put`/`commit`/`fence`/`get` of every peer's data across nodes, then the client-role topology calls — `load_topology`, `get_cpuset`, `compute_distances`, `parse_cpuset_string`, `get_relative_locality` |
 | `python/swarm_cpuset.py` | the **server-role** cpuset calls against real hwloc — `generate_cpuset_string`, `generate_locality_string` — which a launched client rank cannot reach (they wrap `PMIx_server_generate_*`), plus their malformed-input guards. Runs standalone, no launcher |
 | `python/swarm_group.py` | multi-node groups from Python, both `group_construct`/`_destruct` and the non-blocking `_nb` forms whose callbacks run on the progress thread |
+| `python/swarm_datatypes.py` | every data type the conversion layer supports, written by one rank and read by a peer behind a different prted, plus a `data_pack`/`data_unpack` round trip of the same values. The in-tree unit suite runs the loader against the unloader, so a mistake *both* make — the element size of an array, the byte order of a coordinate — cancels out; the library's packer does not forgive it |
+| `python/swarm_nonblocking.py` | the `_nb` family (fence, get, publish/lookup/unpublish, connect/disconnect, query, log, job_control) against a remote server. A request answered out of the local datastore completes before the method returns, so nothing the keepalive caddy holds has to survive — only a remote peer makes it outstanding |
 
 Each swarm client prints one `PMIXPY <rank> <PASS|FAIL> <name>` line per check
 and a final `PMIXPY <rank> DONE <nfail>`; a client exits non-zero if any check

--- a/contrib/dockerswarm/python/swarm_datatypes.py
+++ b/contrib/dockerswarm/python/swarm_datatypes.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Push every data type the Python conversion layer supports through a real
+# multi-node put/commit/fence/get, and check that what a peer reads back is
+# what was written.
+#
+# Why this cannot be a unit test.  test_bindings.py exercises the loader and
+# the unloader against each other through the pmix_value_roundtrip hook, which
+# is necessary but not sufficient: a mistake both halves make - the element
+# *size* of an array, say, or the byte order of a coordinate vector - cancels
+# out and looks like a clean round trip.  The authority for a layout is the C
+# side that has to read it.  Sending a value to a peer behind a *different*
+# prted forces it through pmix_bfrops_base_pack_*/unpack_*, so a layout the
+# bindings got wrong stops matching.
+#
+# The cases here are chosen to be the ones that would silently pass a
+# same-process round trip:
+#
+#   * binary payloads - byte objects carrying NUL and high bytes, which a
+#     converter that treats them as C strings truncates
+#   * every width at its largest representable value, which a bounds check
+#     written with the wrong constant either refuses or silently truncates
+#   * data arrays, including empty ones and nested ones
+#   * the structured types (proc, proc_info, envar, coord) whose members are
+#     read back by field
+#
+# Prints "PMIXPY <rank> <PASS|FAIL> <name>" per check and a final DONE line,
+# exactly as the other swarm clients do.  Exits non-zero if any check failed.
+
+from pmix import *
+import sys
+
+myrank = -1
+nfail = 0
+
+
+def check(name, ok, detail=""):
+    global nfail
+    if not ok:
+        nfail += 1
+    print("PMIXPY %d %s %s%s" % (myrank, "PASS" if ok else "FAIL", name,
+                                 ("  [" + str(detail) + "]") if detail else ""),
+          flush=True)
+
+
+# A coordinate vector crosses as the raw uint32 block, so build it the way
+# the bindings hand it back
+def coord(*vals):
+    return {'view': 1,
+            'coord': b''.join(v.to_bytes(4, sys.byteorder) for v in vals),
+            'dims': len(vals)}
+
+
+# key suffix, value dict.  The key is qualified with the writing rank so
+# every rank publishes its own copy and no two collide.
+CASES = (
+    ("bool", {'value': True, 'val_type': PMIX_BOOL}),
+    ("byte", {'value': 200, 'val_type': PMIX_BYTE}),
+    ("string", {'value': "a string", 'val_type': PMIX_STRING}),
+    ("size", {'value': 1 << 40, 'val_type': PMIX_SIZE}),
+    ("int", {'value': -7, 'val_type': PMIX_INT}),
+    ("int8", {'value': -128, 'val_type': PMIX_INT8}),
+    ("int16", {'value': 32767, 'val_type': PMIX_INT16}),
+    ("int32", {'value': -2147483648, 'val_type': PMIX_INT32}),
+    # the int64/uint64 bounds checks used to be written as products that
+    # were nowhere near the real limits, so the top of the range was
+    # refused outright
+    ("int64", {'value': 9223372036854775807, 'val_type': PMIX_INT64}),
+    ("uint", {'value': 4294967295, 'val_type': PMIX_UINT}),
+    ("uint8", {'value': 255, 'val_type': PMIX_UINT8}),
+    ("uint16", {'value': 65535, 'val_type': PMIX_UINT16}),
+    ("uint32", {'value': 4294967295, 'val_type': PMIX_UINT32}),
+    ("uint64", {'value': 18446744073709551615, 'val_type': PMIX_UINT64}),
+    ("double", {'value': 3.140625, 'val_type': PMIX_DOUBLE}),
+    ("timeval", {'value': {'sec': 12, 'usec': 34}, 'val_type': PMIX_TIMEVAL}),
+    ("status", {'value': PMIX_ERR_NOT_FOUND, 'val_type': PMIX_STATUS}),
+    ("rank", {'value': 3, 'val_type': PMIX_PROC_RANK}),
+    ("proc", {'value': {'nspace': "somens", 'rank': 2},
+              'val_type': PMIX_PROC}),
+    # a byte object whose payload is neither NUL-free nor NUL-terminated -
+    # the shape a converter that runs strlen over it gets wrong
+    ("bo-binary", {'value': {'bytes': bytes(range(256)), 'size': 256},
+                   'val_type': PMIX_BYTE_OBJECT}),
+    ("bo-empty", {'value': {'bytes': b'', 'size': 0},
+                  'val_type': PMIX_BYTE_OBJECT}),
+    ("envar", {'value': {'envar': "SWARM_VAR", 'value': "one:two",
+                         'separator': ':'}, 'val_type': PMIX_ENVAR}),
+    ("procinfo", {'value': {'proc': {'nspace': "somens", 'rank': 1},
+                            'hostname': "somehost",
+                            'executable': "someexec",
+                            'pid': 4321, 'exitcode': 0, 'state': 2},
+                  'val_type': PMIX_PROC_INFO}),
+    ("coord", {'value': coord(1, 2, 3), 'val_type': PMIX_COORD}),
+    # arrays, including the empty one that used to raise TypeError coming
+    # back out of the unloader
+    ("array-int", {'value': {'type': PMIX_INT32, 'array': [1, -2, 3]},
+                   'val_type': PMIX_DATA_ARRAY}),
+    ("array-string", {'value': {'type': PMIX_STRING, 'array': ["a", "bb"]},
+                      'val_type': PMIX_DATA_ARRAY}),
+    ("array-bool", {'value': {'type': PMIX_BOOL, 'array': [True, False, True]},
+                    'val_type': PMIX_DATA_ARRAY}),
+    ("array-size", {'value': {'type': PMIX_SIZE, 'array': [0, 1 << 32]},
+                    'val_type': PMIX_DATA_ARRAY}),
+    ("array-empty", {'value': {'type': PMIX_INT, 'array': []},
+                     'val_type': PMIX_DATA_ARRAY}),
+    ("array-proc", {'value': {'type': PMIX_PROC,
+                              'array': [{'nspace': "n1", 'rank': 0},
+                                        {'nspace': "n2", 'rank': 1}]},
+                    'val_type': PMIX_DATA_ARRAY}),
+    ("array-bo", {'value': {'type': PMIX_BYTE_OBJECT,
+                            'array': [{'bytes': b'\x00\xff', 'size': 2},
+                                      {'bytes': b'abc', 'size': 3}]},
+                  'val_type': PMIX_DATA_ARRAY}),
+    ("array-nested", {'value': {'type': PMIX_DATA_ARRAY, 'array': [
+                          {'type': PMIX_INT, 'array': [1, 2]},
+                          {'type': PMIX_STRING, 'array': ["x"]}]},
+                      'val_type': PMIX_DATA_ARRAY}),
+)
+
+
+def same(want, got):
+    """Compare a written value with what came back.
+
+    Two allowances, both of them the library's doing rather than the
+    bindings': a string may arrive as bytes, and a byte object reports the
+    length of the payload it actually carries.
+    """
+    if isinstance(want, bytes) and isinstance(got, str):
+        got = got.encode('ascii')
+    if isinstance(want, str) and isinstance(got, bytes):
+        got = got.decode('ascii')
+    if isinstance(want, dict) and isinstance(got, dict):
+        if set(want.keys()) != set(got.keys()):
+            return False
+        return all(same(want[k], got[k]) for k in want)
+    if isinstance(want, list) and isinstance(got, list):
+        if len(want) != len(got):
+            return False
+        return all(same(a, b) for a, b in zip(want, got))
+    return want == got
+
+
+def main():
+    global myrank
+
+    client = PMIxClient()
+    rc, myproc = client.init([])
+    if PMIX_SUCCESS != rc:
+        print("PMIXPY -1 FAIL init [%d]" % rc, flush=True)
+        return 1
+    myrank = myproc['rank']
+    nspace = myproc['nspace']
+    check("init", True, "%s:%d" % (nspace, myrank))
+
+    jobproc = {'nspace': nspace, 'rank': PMIX_RANK_WILDCARD}
+    rc, val = client.get(jobproc, PMIX_JOB_SIZE, [])
+    if PMIX_SUCCESS != rc or val is None:
+        check("get PMIX_JOB_SIZE", False, rc)
+        client.finalize([])
+        return 1
+    nprocs = val['value']
+    check("job size >= 2 (multi-rank run)", nprocs >= 2, nprocs)
+
+    # publish one key per case, under global scope so peers can read them
+    put_ok = True
+    for name, value in CASES:
+        rc = client.put(PMIX_GLOBAL, "swarm.dt.%s" % name, dict(value))
+        if PMIX_SUCCESS != rc:
+            put_ok = False
+            check("put %s" % name, False, rc)
+    check("put every data type", put_ok, "%d types" % len(CASES))
+
+    rc = client.commit()
+    check("commit", PMIX_SUCCESS == rc, rc)
+    rc = client.fence([{'nspace': nspace, 'rank': PMIX_RANK_WILDCARD}], [])
+    check("fence", PMIX_SUCCESS == rc, rc)
+
+    # Read every case back from every OTHER rank.  A peer behind a different
+    # prted is the whole point: that value was packed by the library, sent
+    # over the wire, and unpacked on this side.
+    for name, value in CASES:
+        ok = True
+        detail = ""
+        for peer in range(nprocs):
+            if peer == myrank:
+                continue
+            p = {'nspace': nspace, 'rank': peer}
+            rc, got = client.get(p, "swarm.dt.%s" % name, [])
+            if PMIX_SUCCESS != rc or got is None:
+                ok = False
+                detail = "peer %d rc=%d" % (peer, rc)
+                break
+            if not same(value['value'], got['value']):
+                ok = False
+                detail = "peer %d wanted %r got %r" % (peer, value['value'],
+                                                       got['value'])
+                break
+        check("remote get %s" % name, ok, detail)
+
+    # Serialization of the same values, which is the other consumer of the
+    # conversion layer.  data_pack hands the value to the library's packer
+    # directly, so a layout mistake shows up here without a peer at all -
+    # but it needs an initialized library, which is why it lives beside the
+    # connected checks rather than in the unit suite.
+    pack_ok = True
+    detail = ""
+    for name, value in CASES:
+        rc, buf = client.data_pack(None, dict(value), PMIX_VALUE)
+        if PMIX_SUCCESS != rc:
+            pack_ok = False
+            detail = "%s pack rc=%d" % (name, rc)
+            break
+        rc, got = client.data_unpack(buf, PMIX_VALUE)
+        if PMIX_SUCCESS != rc or got is None:
+            pack_ok = False
+            detail = "%s unpack rc=%d" % (name, rc)
+            break
+        if not same(value['value'], got['value']):
+            pack_ok = False
+            detail = "%s wanted %r got %r" % (name, value['value'],
+                                              got['value'])
+            break
+    check("pack/unpack every data type", pack_ok, detail)
+
+    # the same payloads through the compressor, which is the one consumer
+    # that cares about every byte rather than about the type
+    rc, comp = client.data_compress(bytes(range(256)) * 64)
+    if PMIX_SUCCESS == rc:
+        rc2, back = client.data_decompress(comp)
+        check("compress/decompress round trip",
+              PMIX_SUCCESS == rc2 and back == bytes(range(256)) * 64,
+              "rc=%d" % rc2)
+    else:
+        # no compression component built is a legitimate answer
+        check("compress declined cleanly", PMIX_ERR_NOT_AVAILABLE == rc, rc)
+
+    rc = client.finalize([])
+    check("finalize", PMIX_SUCCESS == rc, rc)
+    print("PMIXPY %d DONE %d" % (myrank, nfail), flush=True)
+    return 1 if nfail else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/contrib/dockerswarm/python/swarm_nonblocking.py
+++ b/contrib/dockerswarm/python/swarm_nonblocking.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Drive the non-blocking client bindings against a real, remote PMIx server.
+#
+# swarm_group.py already covers group_construct_nb/_destruct_nb.  This covers
+# the rest of the _nb family - fence, get, publish/lookup/unpublish, connect/
+# disconnect, query, log, job_control - because that machinery is where the
+# bindings do their most delicate work and the least of it is reachable
+# without a server:
+#
+#   * the caddy keeps the C input arrays alive past the method's return,
+#     since PMIx does not copy them.  A lifetime bug there is a
+#     use-after-free that only bites once the request is genuinely
+#     outstanding - which it is not when the local datastore answers
+#     immediately.  A peer behind a different prted makes it outstanding.
+#   * the callback and its cbdata live in a module-global registry, and the
+#     registry entry is the ownership token for the caddy.  Whether the
+#     trampoline and the method's error path can both try to free it is only
+#     visible under real completions.
+#   * the trampolines run on the library's progress thread and must take the
+#     GIL.  A missing "with gil" deadlocks or crashes there, not here.
+#
+# Every operation is run enough times to shake out a leak or a double free
+# that a single call would not.
+#
+# Prints "PMIXPY <rank> <PASS|FAIL> <name>" per check and a final DONE line.
+# Exits non-zero if any check on this rank failed.
+
+from pmix import *
+import sys
+import threading
+
+myrank = -1
+nfail = 0
+
+#: how many times to repeat each operation - enough that a caddy leak or a
+#: double free has somewhere to show itself
+REPEAT = 20
+
+#: how long to wait for a completion before calling it hung
+TIMEOUT = 60
+
+
+def check(name, ok, detail=""):
+    global nfail
+    if not ok:
+        nfail += 1
+    print("PMIXPY %d %s %s%s" % (myrank, "PASS" if ok else "FAIL", name,
+                                 ("  [" + str(detail) + "]") if detail else ""),
+          flush=True)
+
+
+class Completion(object):
+    """Collect what a non-blocking callback was handed.
+
+    The callback runs on the library's progress thread, so it must not do
+    anything but record and wake - certainly not call back into a blocking
+    PMIx operation.
+    """
+
+    def __init__(self):
+        self.done = threading.Event()
+        self.status = None
+        self.results = None
+        self.cbdata = None
+
+    def op(self, status, cbdata):
+        self.status = status
+        self.cbdata = cbdata
+        self.done.set()
+
+    def info(self, status, results, cbdata):
+        self.status = status
+        self.results = results
+        self.cbdata = cbdata
+        self.done.set()
+
+    def value(self, status, val, cbdata):
+        self.status = status
+        self.results = val
+        self.cbdata = cbdata
+        self.done.set()
+
+    def wait(self):
+        return self.done.wait(TIMEOUT)
+
+
+def run(name, start, accept, token):
+    """Start one non-blocking operation and wait for its completion.
+
+    'start' is called with the callback and the cbdata token; 'accept' is
+    the set of statuses the completion may legitimately report.  Returns
+    (ok, detail).
+    """
+    comp = Completion()
+    rc = start(comp, token)
+    if PMIX_SUCCESS != rc:
+        # the contract is that a callback fires if and only if the request
+        # was accepted, so a refusal here is a clean outcome as long as the
+        # status is one we expect
+        if rc in accept:
+            return True, "refused with %d (no callback)" % rc
+        return False, "%s returned %d" % (name, rc)
+    if not comp.wait():
+        return False, "%s never completed" % name
+    if comp.cbdata is not token:
+        return False, "%s handed back the wrong cbdata" % name
+    if comp.status not in accept:
+        return False, "%s completed with %d" % (name, comp.status)
+    return True, ""
+
+
+def repeat(name, start, accept):
+    """Run an operation REPEAT times, stopping at the first failure."""
+    for i in range(REPEAT):
+        token = {'iteration': i, 'name': name}
+        ok, detail = run(name, start, accept, token)
+        if not ok:
+            check(name, False, "pass %d: %s" % (i, detail))
+            return False
+    check(name, True, "%d completions" % REPEAT)
+    return True
+
+
+def main():
+    global myrank
+
+    client = PMIxClient()
+    rc, myproc = client.init([])
+    if PMIX_SUCCESS != rc:
+        print("PMIXPY -1 FAIL init [%d]" % rc, flush=True)
+        return 1
+    myrank = myproc['rank']
+    nspace = myproc['nspace']
+    check("init", True, "%s:%d" % (nspace, myrank))
+
+    jobproc = {'nspace': nspace, 'rank': PMIX_RANK_WILDCARD}
+    rc, val = client.get(jobproc, PMIX_JOB_SIZE, [])
+    if PMIX_SUCCESS != rc or val is None:
+        check("get PMIX_JOB_SIZE", False, rc)
+        client.finalize([])
+        return 1
+    nprocs = val['value']
+    check("job size >= 2 (multi-rank run)", nprocs >= 2, nprocs)
+
+    everyone = [{'nspace': nspace, 'rank': PMIX_RANK_WILDCARD}]
+
+    # --- a bad callback must be refused before anything is allocated ------
+    #
+    # A callback that can never run would strand the caddy for the life of
+    # the process, so the methods check first
+    for name, call in (
+            ("fence_nb", lambda: client.fence_nb(everyone, [], None)),
+            ("get_nb", lambda: client.get_nb(jobproc, PMIX_JOB_SIZE, [], 42)),
+            ("publish_nb", lambda: client.publish_nb([], "not callable")),
+            ("query_nb", lambda: client.query_nb([], None))):
+        check("%s rejects a non-callable callback" % name,
+              PMIX_ERR_BAD_PARAM == call())
+
+    # --- fence_nb ---------------------------------------------------------
+    #
+    # A collective across every rank, so this one genuinely blocks on the
+    # other nodes.  Note that every rank must post the same number of
+    # fences in the same order for the collective to match up.
+    ok = True
+    for i in range(REPEAT):
+        comp = Completion()
+        token = {'iteration': i}
+        rc = client.fence_nb(everyone, [], comp.op, token)
+        if PMIX_SUCCESS != rc:
+            check("fence_nb", False, "pass %d returned %d" % (i, rc))
+            ok = False
+            break
+        if not comp.wait():
+            check("fence_nb", False, "pass %d never completed" % i)
+            ok = False
+            break
+        if PMIX_SUCCESS != comp.status or comp.cbdata is not token:
+            check("fence_nb", False,
+                  "pass %d status=%s" % (i, comp.status))
+            ok = False
+            break
+    if ok:
+        check("fence_nb across all ranks", True, "%d completions" % REPEAT)
+
+    # --- put/commit, then get_nb of a peer's key --------------------------
+    #
+    # This is the remote fetch: the value lives behind another prted, so the
+    # request is genuinely outstanding when get_nb returns and the caddy has
+    # to keep the proc and the key alive until the callback fires.
+    rc = client.put(PMIX_GLOBAL, "swarm.nb.rank",
+                    {'value': myrank, 'val_type': PMIX_INT32})
+    check("put", PMIX_SUCCESS == rc, rc)
+    rc = client.put(PMIX_GLOBAL, "swarm.nb.blob",
+                    {'value': {'bytes': bytes(range(256)), 'size': 256},
+                     'val_type': PMIX_BYTE_OBJECT})
+    check("put byte object", PMIX_SUCCESS == rc, rc)
+    rc = client.commit()
+    check("commit", PMIX_SUCCESS == rc, rc)
+    rc = client.fence(everyone, [])
+    check("fence", PMIX_SUCCESS == rc, rc)
+
+    peer = (myrank + 1) % nprocs
+    peerproc = {'nspace': nspace, 'rank': peer}
+
+    ok = True
+    for i in range(REPEAT):
+        comp = Completion()
+        token = {'iteration': i}
+        rc = client.get_nb(peerproc, "swarm.nb.rank", [], comp.value, token)
+        if PMIX_SUCCESS != rc or not comp.wait():
+            check("get_nb of a peer's key", False,
+                  "pass %d rc=%d completed=%s" % (i, rc, comp.done.is_set()))
+            ok = False
+            break
+        if PMIX_SUCCESS != comp.status or comp.results is None \
+           or comp.results.get('value') != peer:
+            check("get_nb of a peer's key", False,
+                  "pass %d status=%s val=%s" % (i, comp.status, comp.results))
+            ok = False
+            break
+        if comp.cbdata is not token:
+            check("get_nb of a peer's key", False, "wrong cbdata")
+            ok = False
+            break
+    if ok:
+        check("get_nb of a peer's key", True, "%d completions" % REPEAT)
+
+    # the same, for a binary payload - the value trampoline converts the
+    # library's pmix_value_t before the library releases it, and a payload
+    # full of NUL and high bytes is where treating it as a string shows
+    comp = Completion()
+    rc = client.get_nb(peerproc, "swarm.nb.blob", [], comp.value, None)
+    if PMIX_SUCCESS == rc and comp.wait() and PMIX_SUCCESS == comp.status:
+        got = comp.results['value'] if comp.results else None
+        payload = got.get('bytes') if isinstance(got, dict) else None
+        check("get_nb of a binary byte object",
+              payload == bytes(range(256)),
+              "%d bytes" % (len(payload) if payload is not None else -1))
+    else:
+        check("get_nb of a binary byte object", False,
+              "rc=%d status=%s" % (rc, comp.status))
+
+    # a key that does not exist must report NOT_FOUND through the callback
+    # rather than hanging or handing back a value
+    comp = Completion()
+    rc = client.get_nb(peerproc, "swarm.nb.absent",
+                       [{'key': PMIX_TIMEOUT, 'value': 5,
+                         'val_type': PMIX_INT}], comp.value, None)
+    if PMIX_SUCCESS == rc:
+        completed = comp.wait()
+        check("get_nb of a missing key reports an error",
+              completed and PMIX_SUCCESS != comp.status, comp.status)
+    else:
+        check("get_nb of a missing key reports an error",
+              PMIX_SUCCESS != rc, rc)
+
+    # --- publish / lookup / unpublish, non-blocking -----------------------
+    #
+    # These go to the server and back, and lookup_nb is the only user of the
+    # pdata trampoline
+    key = "swarm.nb.pub.%d" % myrank
+    comp = Completion()
+    rc = client.publish_nb([{'key': key, 'value': "published-%d" % myrank,
+                             'val_type': PMIX_STRING}], comp.op)
+    published = (PMIX_SUCCESS == rc and comp.wait()
+                 and PMIX_SUCCESS == comp.status)
+    check("publish_nb", published, "rc=%d status=%s" % (rc, comp.status))
+
+    rc = client.fence(everyone, [])
+    check("fence after publish", PMIX_SUCCESS == rc, rc)
+
+    if published:
+        peerkey = "swarm.nb.pub.%d" % peer
+        comp = Completion()
+        rc = client.lookup_nb([peerkey],
+                              [{'key': PMIX_WAIT, 'value': 1,
+                                'val_type': PMIX_INT}], comp.info)
+        if PMIX_SUCCESS == rc and comp.wait() and PMIX_SUCCESS == comp.status:
+            got = None
+            for entry in (comp.results or []):
+                if entry.get('key') == peerkey:
+                    got = entry.get('value')
+            if isinstance(got, bytes):
+                got = got.decode('ascii')
+            check("lookup_nb finds a peer's published key",
+                  got == "published-%d" % peer, got)
+        else:
+            check("lookup_nb finds a peer's published key", False,
+                  "rc=%d status=%s" % (rc, comp.status))
+
+        comp = Completion()
+        rc = client.unpublish_nb([key], [], comp.op)
+        check("unpublish_nb",
+              PMIX_SUCCESS == rc and comp.wait() and PMIX_SUCCESS == comp.status,
+              "rc=%d status=%s" % (rc, comp.status))
+
+    rc = client.fence(everyone, [])
+    check("fence after unpublish", PMIX_SUCCESS == rc, rc)
+
+    # --- query_nb ---------------------------------------------------------
+    #
+    # This one carries no info array of its own; the qualifiers ride inside
+    # each query, and the caddy owns the whole pmix_query_t array
+    repeat("query_nb",
+           lambda c, t: client.query_nb(
+               [{'keys': [PMIX_QUERY_NAMESPACES], 'qualifiers': []}],
+               c.info, t),
+           (PMIX_SUCCESS, PMIX_ERR_NOT_FOUND, PMIX_ERR_NOT_SUPPORTED))
+
+    # a query with no qualifiers key at all - the builder used to index the
+    # dict directly and raise KeyError
+    ok, detail = run("query_nb without qualifiers",
+                     lambda c, t: client.query_nb(
+                         [{'keys': [PMIX_QUERY_NAMESPACES]}], c.info, t),
+                     (PMIX_SUCCESS, PMIX_ERR_NOT_FOUND,
+                      PMIX_ERR_NOT_SUPPORTED),
+                     {'token': 1})
+    check("query_nb without a qualifiers key", ok, detail)
+
+    # --- log_nb -----------------------------------------------------------
+    repeat("log_nb",
+           lambda c, t: client.log_nb(
+               [{'key': PMIX_LOG_STDERR, 'value': "swarm nb log\n",
+                 'val_type': PMIX_STRING}], [], c.op, t),
+           (PMIX_SUCCESS, PMIX_ERR_NOT_SUPPORTED))
+
+    # --- job_control_nb ---------------------------------------------------
+    #
+    # carries two info arrays and a proc array in the same caddy
+    repeat("job_control_nb",
+           lambda c, t: client.job_control_nb(
+               [{'nspace': nspace, 'rank': myrank}],
+               [{'key': PMIX_JOB_CTRL_ID, 'value': "swarm-nb",
+                 'val_type': PMIX_STRING}], c.info, t),
+           (PMIX_SUCCESS, PMIX_ERR_NOT_SUPPORTED, PMIX_ERR_NOT_FOUND,
+            PMIX_ERR_BAD_PARAM))
+
+    # --- connect_nb / disconnect_nb ---------------------------------------
+    #
+    # collectives again, so every rank must post them in the same order
+    comp = Completion()
+    rc = client.connect_nb(everyone, [], comp.op)
+    connected = (PMIX_SUCCESS == rc and comp.wait()
+                 and comp.status in (PMIX_SUCCESS, PMIX_ERR_NOT_SUPPORTED))
+    check("connect_nb", connected, "rc=%d status=%s" % (rc, comp.status))
+    if connected and PMIX_SUCCESS == comp.status:
+        comp = Completion()
+        rc = client.disconnect_nb(everyone, [], comp.op)
+        check("disconnect_nb",
+              PMIX_SUCCESS == rc and comp.wait() and PMIX_SUCCESS == comp.status,
+              "rc=%d status=%s" % (rc, comp.status))
+
+    # --- an empty attribute list must reach the library as NULL -----------
+    #
+    # A non-NULL info array with a count of zero tells the library the array
+    # is terminated by an end marker, and it walks off the allocation
+    # looking for one
+    ok, detail = run("fence_nb with an empty info list",
+                     lambda c, t: client.fence_nb(everyone, [], c.op, t),
+                     (PMIX_SUCCESS,), {'token': 2})
+    check("fence_nb with an empty info list", ok, detail)
+    ok, detail = run("fence_nb with a None info list",
+                     lambda c, t: client.fence_nb(everyone, None, c.op, t),
+                     (PMIX_SUCCESS,), {'token': 3})
+    check("fence_nb with a None info list", ok, detail)
+
+    rc = client.finalize([])
+    check("finalize", PMIX_SUCCESS == rc, rc)
+    print("PMIXPY %d DONE %d" % (myrank, nfail), flush=True)
+    return 1 if nfail else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/contrib/dockerswarm/run-python.sh
+++ b/contrib/dockerswarm/run-python.sh
@@ -159,6 +159,28 @@ test_linux() {
                     python3 $PYDIR/swarm_group.py 2>&1")"
     tally "$OUT" "swarm_group.py: group construct/destruct across nodes" 4
     cleanup_swarm
+
+    banner "multi-node Python data types"
+    cleanup_swarm
+    # Every type the conversion layer supports, written by one rank and read
+    # by a peer behind a different prted.  The in-tree unit suite round-trips
+    # the loader against the unloader, which cannot catch a mistake both of
+    # them make; going through the library's packer can.
+    OUT="$(RUN "prterun --host node1:2,node2:2 -np 4 --map-by node --timeout 180 \
+                    python3 $PYDIR/swarm_datatypes.py 2>&1")"
+    tally "$OUT" "swarm_datatypes.py: every data type across nodes" 4
+    cleanup_swarm
+
+    banner "multi-node Python non-blocking operations"
+    cleanup_swarm
+    # The _nb family against a remote server, which is the only place the
+    # keepalive caddy and the callback registry are under real load: a
+    # request answered out of the local datastore completes before the
+    # method has returned, so nothing has to survive.
+    OUT="$(RUN "prterun --host node1:2,node2:2 -np 4 --map-by node --timeout 180 \
+                    python3 $PYDIR/swarm_nonblocking.py 2>&1")"
+    tally "$OUT" "swarm_nonblocking.py: the _nb family across nodes" 4
+    cleanup_swarm
 }
 
 ########################################################################

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -2000,9 +2000,7 @@ typedef enum {
 
 /* Group operations. New values must be appended after the existing ones to
  * preserve their numeric values - this enum crosses the PMIx-to-host callback
- * boundary (pmix_server_module_t.group). Keep the body free of comment lines:
- * the Python bindings generator (bindings/python/construct.py) treats every
- * line inside a typedef enum as an enumerator. */
+ * boundary (pmix_server_module_t.group). */
 typedef enum {
     PMIX_GROUP_CONSTRUCT,
     PMIX_GROUP_DESTRUCT,

--- a/src/runtime/help-pmix-runtime.txt
+++ b/src/runtime/help-pmix-runtime.txt
@@ -101,3 +101,28 @@ upcall module. This is not allowed - the server module can
 only be provided once and cannot be overwritten.
 
 Please correct your program and try again.
+#
+[blocking-call-from-progress-thread]
+A blocking call to %s was made from the PMIx progress thread.
+
+Blocking PMIx APIs hand their work to the progress thread and then wait
+for it to complete. Calling one FROM that thread cannot work: the work is
+posted to the very event loop the caller is standing in, and that loop
+cannot run it until the caller returns. The call would never return, and
+the process would hang.
+
+The usual way to reach this is to call a blocking PMIx API from inside a
+server module upcall, an event handler, or the completion callback of a
+non-blocking operation - all of which the library dispatches from the
+progress thread.
+
+Use the non-blocking form of the call instead. It hands the request to
+the library and returns immediately, and the library will execute your
+callback when the operation completes. If you need the operation to
+finish before you proceed, have your callback wake a different thread.
+
+The call has not been allowed to hang. An API that reports a status has
+returned PMIX_ERR_WOULD_BLOCK without performing the operation. An API
+that reports no status has instead completed the operation
+asynchronously, which is indistinguishable to the caller except that it
+did not wait.

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -34,6 +34,7 @@
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_fd.h"
+#include "src/util/pmix_show_help.h"
 
 /* create a tracking object for progress threads */
 typedef struct {
@@ -91,6 +92,42 @@ static struct timeval long_timeout = {.tv_sec = 3600, .tv_usec = 0};
 static const char *shared_thread_name = "PMIX-wide async progress thread";
 static pmix_progress_tracker_t *shared_thread_tracker = NULL;
 
+/* Identity of the thread currently running the shared progress loop.
+ *
+ * Only that thread ever writes this, which is what makes reading it
+ * without a lock correct for the one question it is asked. A thread
+ * comparing itself against it either wrote the value itself - and so
+ * reads its own write, getting a true answer - or is some other thread,
+ * which correctly fails to match. A stale value can therefore never
+ * produce a false "yes", only a false "no", and a false "no" just leaves
+ * the caller with the behavior it had before this check existed.
+ *
+ * The sentinel follows the convention already used for pmix_thread_t in
+ * src/threads/thread.c.
+ */
+static pthread_t shared_loop_thread = (pthread_t) -1;
+
+bool pmix_progress_thread_is_current(void)
+{
+    pthread_t owner = shared_loop_thread;
+
+    if ((pthread_t) -1 == owner) {
+        /* nobody is in the loop */
+        return false;
+    }
+    return (0 != pthread_equal(owner, pthread_self()));
+}
+
+bool pmix_progress_thread_check_blocking(const char *api)
+{
+    if (!pmix_progress_thread_is_current()) {
+        return false;
+    }
+    pmix_show_help("help-pmix-runtime.txt", "blocking-call-from-progress-thread",
+                   true, (NULL == api) ? "a blocking PMIx API" : api);
+    return true;
+}
+
 /*
  * If this event is fired, just restart it so that this event base
  * continues to have something to block on.
@@ -110,9 +147,22 @@ static void *progress_engine(pmix_object_t *obj)
 {
     pmix_thread_t *t = (pmix_thread_t *) obj;
     pmix_progress_tracker_t *trk = (pmix_progress_tracker_t *) t->t_arg;
+    bool shared = (NULL != trk->name && 0 == strcmp(trk->name, shared_thread_name));
+
+    /* record who we are, so a blocking PMIx API called from inside one of
+     * the callbacks this loop dispatches can tell that it is about to wait
+     * on itself. Only the shared loop is tracked - it is the one
+     * PMIX_THREADSHIFT posts to */
+    if (shared) {
+        shared_loop_thread = pthread_self();
+    }
 
     while (trk->ev_active) {
         pmix_event_loop(trk->ev_base, PMIX_EVLOOP_ONCE);
+    }
+
+    if (shared) {
+        shared_loop_thread = (pthread_t) -1;
     }
 
     return PMIX_THREAD_CANCELLED;
@@ -120,10 +170,19 @@ static void *progress_engine(pmix_object_t *obj)
 
 void PMIx_Progress(void)
 {
+    pthread_t save;
+
     if (NULL == shared_thread_tracker) {
         return;
     }
+    /* the host is driving progress itself, so for the duration of this
+     * pass *we* are the progress thread - see progress_engine above.
+     * Restore rather than clear: a host that calls this from inside a
+     * callback of its own would otherwise erase the real owner */
+    save = shared_loop_thread;
+    shared_loop_thread = pthread_self();
     pmix_event_loop(shared_thread_tracker->ev_base, PMIX_EVLOOP_ONCE);
+    shared_loop_thread = save;
 }
 
 static void stop_progress_engine(pmix_progress_tracker_t *trk)

--- a/src/runtime/pmix_progress_threads.h
+++ b/src/runtime/pmix_progress_threads.h
@@ -72,4 +72,41 @@ PMIX_EXPORT pmix_status_t pmix_progress_thread_pause(const char *name);
  */
 PMIX_EXPORT pmix_status_t pmix_progress_thread_resume(const char *name);
 
+/**
+ * Is the calling thread the one currently running the shared progress
+ * loop?
+ *
+ * This answers the question a blocking PMIx API has to ask before it
+ * thread-shifts its work and waits for the result: am I about to post
+ * that work to the very event loop I am standing in?  If so, waiting
+ * for it can never succeed - the loop cannot service the new event
+ * until the current one returns, and the current one is us.  See the
+ * PMIX_CHECK_NOT_PROGRESS_THREAD comment in src/include/pmix_globals.h.
+ *
+ * True for the dedicated progress thread while it is inside the event
+ * loop, and for whatever thread is inside PMIx_Progress() when the host
+ * has taken over driving progress itself (PMIX_EXTERNAL_PROGRESS).
+ * False everywhere else, including before the thread is started and
+ * after it has been stopped.
+ */
+PMIX_EXPORT bool pmix_progress_thread_is_current(void);
+
+/**
+ * Guard the entry to a blocking PMIx API.
+ *
+ * Returns true - and reports the error to the user - when the caller is
+ * on the progress thread, meaning the call it is about to make would
+ * wait for an event loop that cannot run until the caller returns.  The
+ * caller must then answer without waiting: PMIX_ERR_WOULD_BLOCK for an
+ * API that reports a status, or by handing the work to the progress
+ * thread asynchronously for one that does not.
+ *
+ * Note that this refuses nothing that used to work: every such call
+ * deadlocks when made from the progress thread, so an error here can
+ * only ever replace a hang.
+ *
+ * @param api  name of the API being guarded, for the diagnostic
+ */
+PMIX_EXPORT bool pmix_progress_thread_check_blocking(const char *api);
+
 #endif

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1411,6 +1411,14 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const pmix_nspace_t nspace
     /* if the provided callback is NULL, then substitute
      * our own internal cbfunc and block here */
     if (NULL == cbfunc) {
+        if (pmix_progress_thread_check_blocking("PMIx_server_register_nspace")) {
+            /* we are ON the progress thread, so waiting for the event we
+             * would post is waiting for ourselves - answer rather than
+             * hang. The caller wanted the blocking form; the non-blocking
+             * one works fine from here */
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_WOULD_BLOCK;
+        }
         PMIX_CONSTRUCT_LOCK(&mylock);
         cd->opcbfunc = opcbfunc;
         cd->cbdata = &mylock;
@@ -1746,8 +1754,12 @@ static void _deregister_nspace(int sd, short args, void *cbdata)
     PMIX_RELEASE(nptr);
 
 cleanup:
-    /* release the caller */
-    cd->opcbfunc(rc, cd->cbdata);
+    /* release the caller, if there is one waiting - a request that had to
+     * be completed asynchronously because it came from the progress
+     * thread carries no callback */
+    if (NULL != cd->opcbfunc) {
+        cd->opcbfunc(rc, cd->cbdata);
+    }
     PMIX_RELEASE(cd);
 }
 
@@ -1780,6 +1792,24 @@ PMIX_EXPORT void PMIx_server_deregister_nspace(const pmix_nspace_t nspace, pmix_
     /* if the provided callback is NULL, then substitute
      * our own internal cbfunc and block here */
     if (NULL == cbfunc) {
+        if (pmix_progress_thread_check_blocking("PMIx_server_deregister_nspace")) {
+            /* We are ON the progress thread - the host called us from
+             * inside one of its own upcalls. We cannot wait for the event
+             * we are about to post, because the loop that would run it is
+             * the one we are standing in.
+             *
+             * Complete asynchronously instead. Nothing observable is lost:
+             * this API reports no status, and every other PMIx operation
+             * is serialized through the same loop, so it will see the
+             * namespace gone exactly as it would have. Running the handler
+             * inline is NOT an option - it releases peers and the
+             * namespace object itself, which the callback we are nested
+             * inside may still be holding.
+             */
+            cd->opcbfunc = NULL;
+            PMIX_THREADSHIFT(cd, _deregister_nspace);
+            return;
+        }
         PMIX_CONSTRUCT_LOCK(&mylock);
         cd->opcbfunc = opcbfunc;
         cd->cbdata = &mylock;
@@ -1988,6 +2018,14 @@ pmix_status_t PMIx_server_register_resources(pmix_info_t info[], size_t ninfo,
     /* if the provided callback is NULL, then substitute
      * our own internal cbfunc and block here */
     if (NULL == cbfunc) {
+        if (pmix_progress_thread_check_blocking("PMIx_server_register_resources")) {
+            /* we are ON the progress thread, so waiting for the event we
+             * would post is waiting for ourselves - answer rather than
+             * hang. The caller wanted the blocking form; the non-blocking
+             * one works fine from here */
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_WOULD_BLOCK;
+        }
         PMIX_CONSTRUCT_LOCK(&mylock);
         cd->opcbfunc = opcbfunc;
         cd->cbdata = &mylock;
@@ -2057,6 +2095,14 @@ pmix_status_t PMIx_server_deregister_resources(pmix_info_t info[], size_t ninfo,
     /* if the provided callback is NULL, then substitute
      * our own internal cbfunc and block here */
     if (NULL == cbfunc) {
+        if (pmix_progress_thread_check_blocking("PMIx_server_deregister_resources")) {
+            /* we are ON the progress thread, so waiting for the event we
+             * would post is waiting for ourselves - answer rather than
+             * hang. The caller wanted the blocking form; the non-blocking
+             * one works fine from here */
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_WOULD_BLOCK;
+        }
         PMIX_CONSTRUCT_LOCK(&mylock);
         cd->opcbfunc = opcbfunc;
         cd->cbdata = &mylock;
@@ -2398,6 +2444,14 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_client(const pmix_proc_t *proc, u
     /* if the provided callback is NULL, then substitute
      * our own internal cbfunc and block here */
     if (NULL == cbfunc) {
+        if (pmix_progress_thread_check_blocking("PMIx_server_register_client")) {
+            /* we are ON the progress thread, so waiting for the event we
+             * would post is waiting for ourselves - answer rather than
+             * hang. The caller wanted the blocking form; the non-blocking
+             * one works fine from here */
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_WOULD_BLOCK;
+        }
         PMIX_CONSTRUCT_LOCK(&mylock);
         cd->opcbfunc = opcbfunc;
         cd->cbdata = &mylock;
@@ -2446,7 +2500,11 @@ static void _deregister_client(int sd, short args, void *cbdata)
     remove_client(nptr, &cd->proc);
 
 cleanup:
-    cd->opcbfunc(PMIX_SUCCESS, cd->cbdata);
+    /* release the caller, if there is one waiting - see the matching
+     * comment in _deregister_nspace */
+    if (NULL != cd->opcbfunc) {
+        cd->opcbfunc(PMIX_SUCCESS, cd->cbdata);
+    }
     PMIX_RELEASE(cd);
 }
 
@@ -2486,6 +2544,14 @@ PMIX_EXPORT void PMIx_server_deregister_client(const pmix_proc_t *proc, pmix_op_
     /* if the provided callback is NULL, then substitute
      * our own internal cbfunc and block here */
     if (NULL == cbfunc) {
+        if (pmix_progress_thread_check_blocking("PMIx_server_deregister_client")) {
+            /* on the progress thread - complete asynchronously rather
+             * than wait on the loop we are standing in. See the matching
+             * comment in PMIx_server_deregister_nspace */
+            cd->opcbfunc = NULL;
+            PMIX_THREADSHIFT(cd, _deregister_client);
+            return;
+        }
         PMIX_CONSTRUCT_LOCK(&mylock);
         cd->opcbfunc = opcbfunc;
         cd->cbdata = &mylock;
@@ -2790,6 +2856,12 @@ PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc, const cha
         return PMIX_ERR_BAD_PARAM;
     }
 
+    if (pmix_progress_thread_check_blocking("PMIx_Store_internal")) {
+        /* this call always waits for the progress thread to do the store,
+         * so it cannot be made from that thread */
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     /* setup to thread shift this request */
     cd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == cd) {
@@ -3045,6 +3117,14 @@ pmix_status_t PMIx_server_setup_local_support(const pmix_nspace_t nspace, pmix_i
     /* if the provided callback is NULL, then substitute
      * our own internal cbfunc and block here */
     if (NULL == cbfunc) {
+        if (pmix_progress_thread_check_blocking("PMIx_server_setup_local_support")) {
+            /* we are ON the progress thread, so waiting for the event we
+             * would post is waiting for ourselves - answer rather than
+             * hang. The caller wanted the blocking form; the non-blocking
+             * one works fine from here */
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_WOULD_BLOCK;
+        }
         PMIX_CONSTRUCT_LOCK(&mylock);
         cd->opcbfunc = opcbfunc;
         cd->cbdata = &mylock;
@@ -3206,6 +3286,14 @@ pmix_status_t PMIx_server_IOF_deliver(const pmix_proc_t *source, pmix_iof_channe
     /* if the provided callback is NULL, then substitute
      * our own internal cbfunc and block here */
     if (NULL == cbfunc) {
+        if (pmix_progress_thread_check_blocking("PMIx_server_IOF_deliver")) {
+            /* we are ON the progress thread, so waiting for the event we
+             * would post is waiting for ourselves - answer rather than
+             * hang. The caller wanted the blocking form; the non-blocking
+             * one works fine from here */
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_WOULD_BLOCK;
+        }
         PMIX_CONSTRUCT_LOCK(&mylock);
         cd->opcbfunc = opcbfunc;
         cd->cbdata = &mylock;
@@ -3288,6 +3376,14 @@ pmix_status_t PMIx_server_IOF_flow_control(const pmix_proc_t *source,
     /* if the provided callback is NULL, then substitute
      * our own internal cbfunc and block here */
     if (NULL == cbfunc) {
+        if (pmix_progress_thread_check_blocking("PMIx_server_IOF_flow_control")) {
+            /* we are ON the progress thread, so waiting for the event we
+             * would post is waiting for ourselves - answer rather than
+             * hang. The caller wanted the blocking form; the non-blocking
+             * one works fine from here */
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_WOULD_BLOCK;
+        }
         PMIX_CONSTRUCT_LOCK(&mylock);
         cd->opcbfunc = opcbfunc;
         cd->cbdata = &mylock;
@@ -3440,6 +3536,14 @@ pmix_status_t PMIx_server_deliver_inventory(pmix_info_t info[], size_t ninfo,
     /* if the provided callback is NULL, then substitute
      * our own internal cbfunc and block here */
     if (NULL == cbfunc) {
+        if (pmix_progress_thread_check_blocking("PMIx_server_deliver_inventory")) {
+            /* we are ON the progress thread, so waiting for the event we
+             * would post is waiting for ourselves - answer rather than
+             * hang. The caller wanted the blocking form; the non-blocking
+             * one works fine from here */
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_WOULD_BLOCK;
+        }
         PMIX_CONSTRUCT_LOCK(&mylock);
         cd->cbfunc.opcbfn = opcbfunc;
         cd->cbdata = &mylock;
@@ -3566,6 +3670,14 @@ pmix_status_t PMIx_server_define_process_set(const pmix_proc_t *members, size_t 
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    if (pmix_progress_thread_check_blocking("PMIx_server_define_process_set")) {
+        /* the caddy below lives on OUR stack and is safe only because
+         * PMIX_WAIT_THREAD holds this frame until the handler wakes it.
+         * We cannot wait from the progress thread, and we cannot let the
+         * request outlive the frame, so refuse */
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     /* need to threadshift this request */
     PMIX_CONSTRUCT(&cd, pmix_setup_caddy_t);
     cd.nspace = (char*)pset_name;
@@ -3622,6 +3734,14 @@ pmix_status_t PMIx_server_delete_process_set(char *pset_name)
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    if (pmix_progress_thread_check_blocking("PMIx_server_delete_process_set")) {
+        /* the caddy below lives on OUR stack and is safe only because
+         * PMIX_WAIT_THREAD holds this frame until the handler wakes it.
+         * We cannot wait from the progress thread, and we cannot let the
+         * request outlive the frame, so refuse */
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* need to threadshift this request */

--- a/test/python/AGENTS.md
+++ b/test/python/AGENTS.md
@@ -1,0 +1,177 @@
+# AGENTS.md: PMIx Python Binding Tests (`test/python/`)
+
+Orientation for AI and human contributors working on the tests for the
+PMIx Python bindings. This is a *map*, not the rulebook — the top-level
+[`CLAUDE.md`/`AGENTS.md`](../../CLAUDE.md) at the repo root is
+authoritative, and the bindings themselves are documented in
+[`bindings/python/AGENTS.md`](../../bindings/python/AGENTS.md). When this
+file and those disagree, they win — and please fix this file.
+
+**This is the one place in-tree tests for the Python bindings live.**
+There is deliberately nothing under `bindings/python/tests/`: it held
+duplicate copies of these scripts that drifted out of sync, and only CI
+ran them, so a change could pass `make check` and still break CI.
+
+---
+
+## 1. What is here
+
+| File | Role | In `make check`? |
+|------|------|------------------|
+| `test_bindings.py` | `unittest` suite for everything that needs **no** server: import, the class hierarchy, constants, the stateless `*_string` converters, and the conversion layer via the `pmix_value_roundtrip` hook | ✅ |
+| `test_construct.py` | `unittest` suite for `bindings/python/construct.py`, the constants generator. Needs neither the extension nor the library | ✅ |
+| `server.py` | Stands up a PMIx server with Python handlers, forks `client.py` under it, and drives the server-role API. The only script that exercises the **upcall** path | ✅ via `run_server.sh` |
+| `client.py` | The client `server.py` launches. Blocking and non-blocking client operations against a live server | (run by `server.py`) |
+| `sched.py` | The scheduler role — session control, resource blocks | ✅ via `run_sched.sh` |
+| `tool.py` | The tool role: attach, spawn. Needs a launcher, so it is **not** in `make check` — run it by hand against a live RM | ❌ |
+| `run_server.sh.in`, `run_sched.sh.in` | Automake-substituted wrappers that put the built extension on `PYTHONPATH` (§3) | — |
+
+Multi-node coverage lives elsewhere, in
+[`contrib/dockerswarm/python/`](../../contrib/dockerswarm/python/) — see §4.
+
+---
+
+## 2. Running them
+
+```sh
+cd test/python
+make check                 # all four, the way CI runs them
+./test_bindings.py         # directly; it finds the built .so itself
+./test_bindings.py -v      # per-test names
+./test_construct.py        # needs only Python
+```
+
+`test_bindings.py` self-locates the extension: it tries `import pmix`,
+then falls back to globbing `bindings/python/build/lib.*` relative to the
+repo root. If it still cannot import, it exits **77** — Automake's SKIP —
+so it is safe to run in a tree built without the bindings. Keep that
+property when you edit it.
+
+Both suites print a certain amount of expected noise on stderr
+("uint8 value is out of bounds", "SERVER REQUIRES AT LEAST ONE MODULE
+FUNCTION TO OPERATE"). That is the conversion layer reporting refusals the
+tests deliberately provoke; `OK` on the last line is the result.
+
+---
+
+## 3. `make check` runs against the BUILD tree
+
+`run_server.sh` and `run_sched.sh` put
+`<builddir>/bindings/python/build/lib.*` on `PYTHONPATH` first, and fall
+back to the installed egg path only if that directory does not exist.
+
+This is load-bearing and easy to undo by accident. They originally pointed
+`PYTHONPATH` at the install prefix's `site-packages`, which meant `make
+check` tested whatever version happened to be installed there — so a
+newly bound method made `run_server.sh` fail against a months-old egg
+while the code under test was correct, and a tree that had never been
+installed failed outright. The rest of the PMIx test suite runs against
+the build tree by design; these must too.
+
+If you add another wrapper script here, copy that arrangement.
+
+---
+
+## 4. What can be tested where
+
+This is the part worth internalizing before adding a test, because a case
+put at the wrong level either cannot run or cannot fail.
+
+**No server needed — put it in `test_bindings.py`.** The `*_string`
+converters, the constants, the class hierarchy, the struct
+pretty-printers, and — through the `pmix_value_roundtrip` hook that
+`pmix.pyx` exposes for exactly this — every arm of `pmix_load_value` /
+`pmix_unload_value`. That hook is what makes the `PMIX_DATA_ARRAY` arms
+testable at all: Cython silently converts a C struct to a dict, so a
+struct-member typo in an unload arm compiles cleanly and fails only at
+run time.
+
+**But a round trip through the hook is necessary, not sufficient.** It
+runs the loader against the unloader, so a mistake *both* of them make —
+the element size of an array, the byte order of a coordinate vector —
+cancels out and looks correct. The authority for a layout is the C side
+that has to read it (`pmix_bfrops_base_pack_*`), not the other half of the
+binding. Anything the library itself must interpret needs a connected
+test.
+
+**Needs a live library but not a launcher — `server.py`.** Serialization
+(`data_pack`/`data_unpack`), the regex generators, `collect_job_info`, the
+cpuset string generators, and the whole server-module upcall path.
+`server.py` forks `client.py`, so a put on one side and a get on the other
+is a real round trip through the library.
+
+**Needs more than one node — the dockerswarm harness.** A same-host
+put/get is answered out of the local datastore, so it never touches the
+bindings' remote-fetch path, and a non-blocking request completes before
+the method has returned, so nothing the caddy holds has to survive. Both
+of those only become real when the peer is behind a *different* PMIx
+server. See
+[`contrib/dockerswarm/AGENTS.md`](../../contrib/dockerswarm/AGENTS.md) and
+`run-python.sh`.
+
+**Two things macOS cannot test at all:** `get_cpuset` and
+`compute_distances`. Darwin has no CPU-binding API behind
+`hwloc_get_cpubind`, so they answer `PMIX_ERR_NOT_FOUND` /
+`PMIX_ERR_UNREACH` no matter what the bindings do. Test those on Linux.
+
+---
+
+## 5. Conventions for a new test
+
+- **Say what the case is protecting.** Every non-obvious case here carries
+  a comment naming the defect it would catch. A test whose reason is not
+  written down gets weakened the first time it fails.
+- **Never bend a test to a bug.** If a case fails, the default assumption
+  is that the code is wrong. See the top-level guidance.
+- **Prefer `make check`-able over manual.** A test nothing runs is not
+  coverage.
+- **Exercise boundaries, not typical values.** The defects found in these
+  bindings clustered there: the largest value a field can hold, an empty
+  list, a declared size larger than the payload, an optional string the C
+  side left NULL, a payload full of NUL and high bytes. `TestConversionBoundaries`
+  in `test_bindings.py` is that set.
+- **Repeat allocating operations.** A leak or a double free will not show
+  up in one call. Several classes carry a
+  `test_repeated_calls_are_stable` for this; add to one rather than
+  inventing a new pattern.
+- **A new script must go in `TESTS` and `noinst_SCRIPTS`** in
+  `Makefile.am`, and be executable. Adding it to only one of those is the
+  usual way a test ends up never running.
+- **Adding a `.py` here needs no `autogen.pl`** — editing `Makefile.am`
+  alone is enough; a plain `make` regenerates the `Makefile`. Changing
+  `configure.ac` or a `run_*.sh.in` substitution does need the full
+  `./autogen.pl && ./configure` cycle for the substitution, though
+  `./config.status <file>` is enough to re-expand an existing one.
+
+---
+
+## 6. The upcall protocol, as these scripts use it
+
+`server.py` and `sched.py` are the worked examples of writing a PMIx
+server in Python, so their shape is the documentation for it.
+
+A server-module handler is registered by name in the map passed to
+`PMIxServer.init(info, map)`, and is called with three arguments:
+
+```python
+def clientconnected(proc, cbfunc, cbdata):
+    cbfunc(PMIX_SUCCESS, cbdata)      # complete the operation
+    return PMIX_SUCCESS               # ... and say a completion is coming
+```
+
+- The **first** argument is the converted request: a proc dict for the
+  simple ones, an `args` dict for the rest.
+- **`cbfunc`** is a Python wrapper around the C completion callback, and
+  **`cbdata`** is an opaque dict holding only integers — so it may be
+  saved and used after the handler returns, from another thread.
+- The **return** value tells the library what to expect:
+  `PMIX_SUCCESS` means "I will invoke `cbfunc` exactly once",
+  `PMIX_OPERATION_SUCCEEDED` means "done already, do not wait for me", and
+  an error means the request failed. Returning `PMIX_SUCCESS` without ever
+  calling `cbfunc` hangs the request.
+
+A handler that raises is caught by the trampoline, reported, and turned
+into `PMIX_ERROR` — but do not rely on that to paper over a bug.
+
+Event handlers are different: they return a `(status, results)` tuple, not
+a bare status.

--- a/test/python/AGENTS.md
+++ b/test/python/AGENTS.md
@@ -173,5 +173,28 @@ def clientconnected(proc, cbfunc, cbdata):
 A handler that raises is caught by the trampoline, reported, and turned
 into `PMIX_ERROR` — but do not rely on that to paper over a bug.
 
+**A handler runs on the progress thread, so it must never make a
+blocking PMIx call.** The blocking form of any API hands its work to
+that same thread and waits for it, which from inside a handler means
+waiting on the event loop the handler is standing in — the thread waits
+on itself. Deleting a namespace from `clientfinalized` is the usual way
+to discover this. The library reports it now (`PMIX_ERR_WOULD_BLOCK`,
+plus a `show_help` explaining it) rather than hanging, but the fix is to
+pass a completion callback:
+
+```python
+def deletion_done(status, cbdata):     # on the progress thread
+    ...
+
+def clientfinalized(proc, cbfunc, cbdata):
+    cbfunc(PMIX_SUCCESS, cbdata)                       # complete the upcall
+    srv.deregister_nspace(proc['nspace'], deletion_done, None)
+    return PMIX_SUCCESS
+```
+
+The same applies to a `_nb` completion callback and to an event handler.
+If you need a result before proceeding, wake a different thread and do
+the work there.
+
 Event handlers are different: they return a `(status, results)` tuple, not
 a bare status.

--- a/test/python/CLAUDE.md
+++ b/test/python/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/test/python/Makefile.am
+++ b/test/python/Makefile.am
@@ -17,7 +17,8 @@ noinst_SCRIPTS = \
     sched.py \
     client.py \
     tool.py \
-    test_bindings.py
+    test_bindings.py \
+    test_construct.py
 
 #########################
 # Support for "make check"
@@ -26,10 +27,13 @@ if WANT_PYTHON_BINDINGS
 
 # test_bindings.py is a self-contained unittest suite that needs no live
 # server; it locates the built extension itself and SKIPs (exit 77) if the
-# pmix module cannot be imported.  run_server.sh / run_sched.sh exercise the
-# connected client/server/scheduler round-trip paths.
+# pmix module cannot be imported.  test_construct.py checks the constants
+# generator and needs neither the extension nor the library, only Python.
+# run_server.sh / run_sched.sh exercise the connected
+# client/server/scheduler round-trip paths.
 TESTS = \
     test_bindings.py \
+    test_construct.py \
     run_server.sh \
     run_sched.sh
 

--- a/test/python/run_sched.sh.in
+++ b/test/python/run_sched.sh.in
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-# PMIX_PYTHON_EGG_PATH is derived from Automake's $pythondir, which is
-# expressed in terms of ${prefix} and so reaches us still unexpanded.
-# Define the variables it refers to and let the shell finish the job.
+# Run the scheduler-role test against the extension in the BUILD tree.
+# See run_server.sh.in for why the build tree comes first.
 prefix=@prefix@
 exec_prefix=@exec_prefix@
-export PYTHONPATH=@PMIX_PYTHON_EGG_PATH@
+egg=@PMIX_PYTHON_EGG_PATH@
+
+builddir=$(echo @PMIX_TOP_BUILDDIR@/bindings/python/build/lib.*)
+if [ -d "$builddir" ]; then
+    export PYTHONPATH="$builddir${egg:+:$egg}"
+else
+    export PYTHONPATH="$egg"
+fi
 
 ./sched.py

--- a/test/python/run_server.sh.in
+++ b/test/python/run_server.sh.in
@@ -1,10 +1,28 @@
 #!/bin/bash
 
-# PMIX_PYTHON_EGG_PATH is derived from Automake's $pythondir, which is
-# expressed in terms of ${prefix} and so reaches us still unexpanded.
-# Define the variables it refers to and let the shell finish the job.
+# Run the connected client/server round-trip against the extension in the
+# BUILD tree.
+#
+# "make check" is supposed to exercise what was just built, and pointing
+# PYTHONPATH at the install prefix does not: it tests whatever version was
+# last installed there, or fails outright when the tree has never been
+# installed.  That is not a hypothetical - a binding added to pmix.pyx made
+# this test fail against a months-old installed egg while the freshly built
+# one had it.
+#
+# So prefer the build tree, and fall back to the egg path (derived from
+# Automake's $pythondir, which is expressed in terms of ${prefix} and so
+# reaches us still unexpanded - define what it refers to and let the shell
+# finish the job) for an installed-only tree.
 prefix=@prefix@
 exec_prefix=@exec_prefix@
-export PYTHONPATH=@PMIX_PYTHON_EGG_PATH@
+egg=@PMIX_PYTHON_EGG_PATH@
+
+builddir=$(echo @PMIX_TOP_BUILDDIR@/bindings/python/build/lib.*)
+if [ -d "$builddir" ]; then
+    export PYTHONPATH="$builddir${egg:+:$egg}"
+else
+    export PYTHONPATH="$egg"
+fi
 
 ./server.py

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -216,6 +216,55 @@ def main():
         print("COLLECT_JOB_INFO RETURNED NO DATA")
         exit(1)
 
+    # Exercise the non-blocking form of the server registration calls.
+    # PMIx spells this one as an optional callback on the same entry
+    # point rather than as a separate _nb function, and it is the only
+    # form usable from inside a server module upcall - those run on the
+    # progress thread, where the blocking form would be waiting on the
+    # event loop it is standing in.
+    print("Testing the non-blocking server registration calls")
+    nbdone = threading.Event()
+    nbresult = {}
+
+    def nbcb(status, cbdata):
+        # runs on the PMIx progress thread
+        nbresult['status'] = status
+        nbresult['cbdata'] = cbdata
+        nbdone.set()
+
+    def drive(label, rc):
+        # a callback fires if and only if the request was accepted
+        if PMIX_SUCCESS != rc:
+            print("%s NOT ACCEPTED: %s" % (label, foo.error_string(rc)))
+            exit(1)
+        if not nbdone.wait(timeout=30):
+            print("%s CALLBACK NEVER FIRED" % label)
+            exit(1)
+        if PMIX_SUCCESS != nbresult['status']:
+            print("%s COMPLETED WITH %s" % (label,
+                                            foo.error_string(nbresult['status'])))
+            exit(1)
+        if nbresult['cbdata'] != {'label': label}:
+            print("%s RETURNED THE WRONG CBDATA: %s" % (label, nbresult['cbdata']))
+            exit(1)
+        print("  %s: completed asynchronously" % label)
+        nbdone.clear()
+
+    drive("register_nspace", foo.register_nspace("nbnspace", 1, kvals,
+                                                 nbcb, {'label': "register_nspace"}))
+    drive("register_client", foo.register_client({'nspace': "nbnspace", 'rank': 0},
+                                                 os.geteuid(), os.getegid(),
+                                                 nbcb, {'label': "register_client"}))
+    drive("deregister_client", foo.deregister_client({'nspace': "nbnspace", 'rank': 0},
+                                                     nbcb, {'label': "deregister_client"}))
+    drive("deregister_nspace", foo.deregister_nspace("nbnspace", nbcb,
+                                                     {'label': "deregister_nspace"}))
+    # a bad callback is refused before anything is allocated
+    if PMIX_ERR_BAD_PARAM != foo.deregister_nspace("nbnspace", "not callable"):
+        print("A NON-CALLABLE CALLBACK WAS ACCEPTED")
+        exit(1)
+    print("Non-blocking server registration calls: OK")
+
     # print a value and an info the way the library itself renders them
     (rc, txt) = foo.data_print("VALUE: ", {'value': 42, 'val_type': PMIX_INT32})
     print("DataPrint: ", foo.error_string(rc), txt)

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -1481,6 +1481,71 @@ class TestToolServerModule(unittest.TestCase):
         self.assertEqual(tool.set_server_module(None), pmix.PMIX_ERR_INIT)
 
 
+class TestOptionalCallbackForms(unittest.TestCase):
+    """The server calls that take an optional completion callback.
+
+    PMIx expresses "non-blocking" two ways: a separate *_nb function (the
+    client family), and an optional trailing cbfunc/cbdata on the same
+    entry point (mostly the server family).  These bindings used to hard-
+    code NULL for the second kind, so the only behavior reachable from
+    Python was the blocking one - which cannot be used from a server
+    module upcall, because those run on the progress thread and the
+    blocking form would there be waiting on the event loop it is standing
+    in.
+
+    Only the argument checking is testable without a live server; the
+    round trip is exercised in server.py, and from inside an actual
+    upcall by test/unit/progress_threads.c.
+    """
+
+    def setUp(self):
+        self.server = pmix.PMIxServer()
+
+    def test_non_callable_callback_is_refused(self):
+        # a callback that cannot be called would strand the operation's
+        # caddy for the life of the process, so it is checked before
+        # anything is allocated
+        proc = {'nspace': "testns", 'rank': 0}
+        for bad in (42, "not callable", [], {}):
+            self.assertEqual(
+                self.server.register_nspace("testns", 1, [], bad),
+                pmix.PMIX_ERR_BAD_PARAM, "register_nspace took %r" % (bad,))
+            self.assertEqual(
+                self.server.deregister_nspace("testns", bad),
+                pmix.PMIX_ERR_BAD_PARAM, "deregister_nspace took %r" % (bad,))
+            self.assertEqual(
+                self.server.register_client(proc, 0, 0, bad),
+                pmix.PMIX_ERR_BAD_PARAM, "register_client took %r" % (bad,))
+            self.assertEqual(
+                self.server.deregister_client(proc, bad),
+                pmix.PMIX_ERR_BAD_PARAM, "deregister_client took %r" % (bad,))
+            self.assertEqual(
+                self.server.notify_event(pmix.PMIX_ERR_JOB_TERMINATED, proc,
+                                         pmix.PMIX_RANGE_LOCAL, [], bad),
+                pmix.PMIX_ERR_BAD_PARAM, "notify_event took %r" % (bad,))
+
+    def test_blocking_form_is_still_the_default(self):
+        # omitting the callback must keep the behavior every existing
+        # caller depends on - a status, not a promise of one
+        rc = self.server.deregister_nspace("no-such-nspace")
+        self.assertIsInstance(rc, int)
+
+    def test_callback_is_optional_positionally_and_by_keyword(self):
+        # the parameter was appended, so existing positional calls keep
+        # working and the new one can be passed either way
+        def cb(status, cbdata):
+            pass
+
+        for call in (lambda: self.server.deregister_nspace("n", cb),
+                     lambda: self.server.deregister_nspace("n", cbfunc=cb),
+                     lambda: self.server.deregister_nspace("n", cb, {'x': 1}),
+                     lambda: self.server.deregister_nspace(
+                         "n", cbfunc=cb, cbdata={'x': 1})):
+            # before init the library refuses, but the binding must accept
+            # the shape rather than raise TypeError
+            self.assertIsInstance(call(), int)
+
+
 class TestServerModuleRegistration(unittest.TestCase):
     """setmodulefn, the gate on the server-module map.
 

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -1456,5 +1456,60 @@ class TestToolServerModule(unittest.TestCase):
         self.assertEqual(tool.set_server_module(None), pmix.PMIX_ERR_INIT)
 
 
+class TestServerModuleRegistration(unittest.TestCase):
+    """setmodulefn, the gate on the server-module map.
+
+    A key it does not recognize is never wired into pmix_server_module_t,
+    so accepting one silently means the caller's handler is never called
+    and nothing says so.  init() used to guard this with "except KeyError",
+    which setmodulefn cannot raise - it returns a status.
+    """
+
+    @staticmethod
+    def _handler(request, cbfunc, cbdata):
+        return pmix.PMIX_SUCCESS
+
+    def test_known_key_is_accepted(self):
+        self.assertEqual(pmix.setmodulefn('clientconnected', self._handler),
+                         pmix.PMIX_SUCCESS)
+
+    def test_unknown_key_is_refused(self):
+        self.assertEqual(pmix.setmodulefn('nosuchhandler', self._handler),
+                         pmix.PMIX_ERR_BAD_PARAM)
+
+    def test_non_callable_is_refused(self):
+        # a handler that cannot be called would fail inside the upcall, on
+        # the library's progress thread, where there is nothing useful to
+        # report it to
+        for bad in (None, 42, "a string", []):
+            self.assertEqual(pmix.setmodulefn('clientfinalized', bad),
+                             pmix.PMIX_ERR_BAD_PARAM,
+                             "accepted %r as a handler" % (bad,))
+
+    def test_server_init_refuses_an_unknown_key(self):
+        server = pmix.PMIxServer()
+        rc = server.init([], {'nosuchhandler': self._handler})
+        self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+
+    def test_server_init_refuses_a_non_callable(self):
+        server = pmix.PMIxServer()
+        rc = server.init([], {'clientconnected': "not callable"})
+        self.assertEqual(rc, pmix.PMIX_ERR_INIT)
+
+    def test_registration_replaces_a_previous_handler(self):
+        # the map is module-global, so a second server (or a re-init) has
+        # to be able to change a handler - it used to keep the first one
+        def first(request, cbfunc, cbdata):
+            return pmix.PMIX_SUCCESS
+
+        def second(request, cbfunc, cbdata):
+            return pmix.PMIX_SUCCESS
+
+        pmix.setmodulefn('monitor', first)
+        self.assertIs(pmix.pmixservermodule['monitor'], first)
+        pmix.setmodulefn('monitor', second)
+        self.assertIs(pmix.pmixservermodule['monitor'], second)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -1122,6 +1122,200 @@ class TestDataArrayConversion(unittest.TestCase):
                 self.assertEqual(rc, pmix.PMIX_SUCCESS)
 
 
+class TestConversionBoundaries(unittest.TestCase):
+    """The edges of the conversion layer: widths, empties, and NULLs.
+
+    Every case here stands for a defect the 2026-08 review found.  They are
+    grouped separately from TestValueConversion because what they check is
+    not "does this type round-trip" but "does the boundary behave" - the
+    largest value a field can hold, the smallest array, an optional string
+    the C side left unset.  Those are exactly the inputs a round-trip suite
+    built from typical values never reaches.
+    """
+
+    #: val_type, largest value the field can hold, first value past it
+    WIDTHS = (
+        ("uint8", pmix.PMIX_UINT8, 255, 256),
+        ("uint16", pmix.PMIX_UINT16, 65535, 65536),
+        ("uint32", pmix.PMIX_UINT32, 4294967295, 4294967296),
+        ("uint64", pmix.PMIX_UINT64, 18446744073709551615,
+         18446744073709551616),
+        ("rank", pmix.PMIX_PROC_RANK, 4294967294, 4294967296),
+        ("int8", pmix.PMIX_INT8, 127, 128),
+        ("int16", pmix.PMIX_INT16, 32767, 32768),
+        ("int32", pmix.PMIX_INT32, 2147483647, 2147483648),
+        ("int64", pmix.PMIX_INT64, 9223372036854775807,
+         9223372036854775808),
+    )
+
+    def test_largest_value_is_accepted(self):
+        # the bounds checks were written as products (65536*65536) and
+        # simply had the wrong value in several arms, so the top of the
+        # range was refused - or, worse, one past the top was accepted and
+        # silently truncated by the C store
+        for name, vtype, top, _over in self.WIDTHS:
+            rc, got = pmix.pmix_value_roundtrip({'value': top,
+                                                 'val_type': vtype})
+            self.assertEqual(rc, pmix.PMIX_SUCCESS,
+                             "%s refused its largest value: %s" % (name, rc))
+            self.assertEqual(got['value'], top,
+                             "%s did not survive the round trip" % name)
+
+    def test_out_of_range_is_refused(self):
+        for name, vtype, _top, over in self.WIDTHS:
+            rc, got = pmix.pmix_value_roundtrip({'value': over,
+                                                 'val_type': vtype})
+            self.assertNotEqual(rc, pmix.PMIX_SUCCESS,
+                                "%s accepted %d" % (name, over))
+            self.assertIsNone(got)
+
+    def test_negative_is_refused_by_unsigned_types(self):
+        for vtype in (pmix.PMIX_UINT, pmix.PMIX_UINT8, pmix.PMIX_UINT16,
+                      pmix.PMIX_UINT32, pmix.PMIX_UINT64, pmix.PMIX_SIZE,
+                      pmix.PMIX_PROC_RANK, pmix.PMIX_BYTE, pmix.PMIX_SCOPE,
+                      pmix.PMIX_DATA_RANGE, pmix.PMIX_PERSIST,
+                      pmix.PMIX_PROC_STATE):
+            rc, got = pmix.pmix_value_roundtrip({'value': -1,
+                                                 'val_type': vtype})
+            self.assertNotEqual(rc, pmix.PMIX_SUCCESS,
+                                "type %d accepted -1" % vtype)
+            self.assertIsNone(got)
+
+    def test_empty_array_of_every_type(self):
+        # An empty array carries no block at all.  Every unload arm used to
+        # test the block for NULL and, finding one, "return PMIX_ERR_NOMEM"
+        # - an int, from a function declared to return a dict, which raises
+        # TypeError.  So an empty array of any type blew up rather than
+        # converting to [].
+        for vtype in (pmix.PMIX_INT, pmix.PMIX_STRING, pmix.PMIX_BOOL,
+                      pmix.PMIX_BYTE, pmix.PMIX_SIZE, pmix.PMIX_PROC,
+                      pmix.PMIX_INFO, pmix.PMIX_BYTE_OBJECT,
+                      pmix.PMIX_ENVAR, pmix.PMIX_PROC_INFO,
+                      pmix.PMIX_DATA_ARRAY, pmix.PMIX_FLOAT,
+                      pmix.PMIX_DOUBLE, pmix.PMIX_PROC_RANK):
+            rc, got = pmix.pmix_value_roundtrip(
+                {'value': {'type': vtype, 'array': []},
+                 'val_type': pmix.PMIX_DATA_ARRAY})
+            self.assertEqual(rc, pmix.PMIX_SUCCESS,
+                             "empty array of type %d failed: %s" % (vtype, rc))
+            self.assertEqual(got['value'], {'type': vtype, 'array': []})
+
+    def test_byte_object_trusts_the_payload_not_the_count(self):
+        # a 'size' larger than the bytes actually provided used to be taken
+        # at face value and memcpy'd, reading off the end of the object
+        rc, got = pmix.pmix_value_roundtrip(
+            {'value': {'bytes': b'\x01\x02', 'size': 4096},
+             'val_type': pmix.PMIX_BYTE_OBJECT})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertEqual(got['value'], {'bytes': b'\x01\x02', 'size': 2})
+
+    def test_byte_object_keeps_high_bytes_and_nuls(self):
+        payload = bytes(range(256))
+        rc, got = pmix.pmix_value_roundtrip(
+            {'value': {'bytes': payload, 'size': len(payload)},
+             'val_type': pmix.PMIX_BYTE_OBJECT})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertEqual(got['value']['bytes'], payload)
+        self.assertEqual(got['value']['size'], 256)
+
+    def test_empty_byte_object(self):
+        rc, got = pmix.pmix_value_roundtrip(
+            {'value': {'bytes': b'', 'size': 0},
+             'val_type': pmix.PMIX_BYTE_OBJECT})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertEqual(got['value'], {'bytes': b'', 'size': 0})
+
+    #: a coord's vector is the raw uint32 block, carried as bytes
+    @staticmethod
+    def _coord(*vals):
+        return {'view': 1,
+                'coord': b''.join(v.to_bytes(4, sys.byteorder) for v in vals),
+                'dims': len(vals)}
+
+    def test_coord_round_trip(self):
+        given = self._coord(1, 2, 3)
+        rc, got = pmix.pmix_value_roundtrip({'value': given,
+                                             'val_type': pmix.PMIX_COORD})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertEqual(got['value'], given)
+
+    def test_coord_dims_larger_than_the_vector_is_refused(self):
+        # 'dims' counts coordinates, so the payload must be four times as
+        # long; a larger dims used to be believed and read past the end
+        bad = {'view': 1, 'coord': (1).to_bytes(4, sys.byteorder), 'dims': 64}
+        rc, got = pmix.pmix_value_roundtrip({'value': bad,
+                                             'val_type': pmix.PMIX_COORD})
+        self.assertNotEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertIsNone(got)
+
+    def test_empty_coord(self):
+        rc, got = pmix.pmix_value_roundtrip(
+            {'value': {'view': 0, 'coord': b'', 'dims': 0},
+             'val_type': pmix.PMIX_COORD})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertEqual(got['value']['dims'], 0)
+
+    def test_geometry_round_trip(self):
+        # the geometry loader never set 'ncoords', and the library's
+        # destructor walks exactly that many coordinates - so releasing a
+        # geometry ran off the end of the block.  It also reported
+        # PMIX_ERR_NOT_SUPPORTED after building the whole struct.
+        given = {'fabric': 2, 'uuid': "fab-uuid", 'osname': "ib0",
+                 'ncoords': 2,
+                 'coords': [self._coord(1, 2), self._coord(9)]}
+        rc, got = pmix.pmix_value_roundtrip({'value': given,
+                                             'val_type': pmix.PMIX_GEOMETRY})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS,
+                         "geometry failed to convert: %s" % rc)
+        self.assertEqual(got['value'], given)
+
+    def test_geometry_with_no_coordinates(self):
+        given = {'fabric': 0, 'uuid': "u", 'osname': "o",
+                 'ncoords': 0, 'coords': []}
+        rc, got = pmix.pmix_value_roundtrip({'value': given,
+                                             'val_type': pmix.PMIX_GEOMETRY})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertEqual(got['value'], given)
+
+    def test_endpoint_round_trip(self):
+        given = {'uuid': "ep-uuid", 'osname': "eth0",
+                 'endpt': {'bytes': b'\x00\xff\x10', 'size': 3}}
+        rc, got = pmix.pmix_value_roundtrip({'value': given,
+                                             'val_type': pmix.PMIX_ENDPOINT})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertEqual(got['value'], given)
+
+    def test_nested_data_arrays(self):
+        given = {'type': pmix.PMIX_DATA_ARRAY, 'array': [
+            {'type': pmix.PMIX_INT, 'array': [1, 2, 3]},
+            {'type': pmix.PMIX_STRING, 'array': ["a", None]},
+            {'type': pmix.PMIX_INT, 'array': []},
+        ]}
+        rc, got = pmix.pmix_value_roundtrip({'value': given,
+                                            'val_type': pmix.PMIX_DATA_ARRAY})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertEqual(got['value'], given)
+
+    def test_boundary_cases_are_stable(self):
+        # each of these allocates, and a leak or a double free only shows up
+        # when the same conversion is run many times over
+        cases = [{'value': top, 'val_type': vtype}
+                 for _n, vtype, top, _o in self.WIDTHS]
+        cases.append({'value': self._coord(1, 2, 3),
+                      'val_type': pmix.PMIX_COORD})
+        cases.append({'value': {'fabric': 0, 'uuid': "u", 'osname': "o",
+                                'ncoords': 1, 'coords': [self._coord(4)]},
+                      'val_type': pmix.PMIX_GEOMETRY})
+        cases.append({'value': {'bytes': bytes(range(256)), 'size': 256},
+                      'val_type': pmix.PMIX_BYTE_OBJECT})
+        cases.append({'value': {'type': pmix.PMIX_INT, 'array': []},
+                      'val_type': pmix.PMIX_DATA_ARRAY})
+        for _ in range(200):
+            for case in cases:
+                rc, _got = pmix.pmix_value_roundtrip(case)
+                self.assertEqual(rc, pmix.PMIX_SUCCESS)
+
+
 class TestDataBindings(unittest.TestCase):
     """The serialization family.
 

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -863,6 +863,31 @@ class TestStructPrinters(unittest.TestCase):
         self.assertEqual(rc, pmix.PMIX_ERR_BAD_PARAM)
         self.assertIsNone(txt)
 
+    def test_app_accepts_bytes_for_its_strings(self):
+        # the loader ran str() over the command, so a bytes command became
+        # the repr "b'/bin/true'" - not a program anything can run.  These
+        # bindings take str or bytes everywhere else, and callers do hand
+        # back what an upcall gave them.
+        rc, txt = self.client.app_string({'cmd': b"/bin/true",
+                                          'argv': [b"true"], 'maxprocs': 1})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertIn("/bin/true", txt)
+        self.assertNotIn("b'", txt)
+
+    def test_app_with_only_a_command(self):
+        # argv, env, cwd and info are all optional; argv defaults to the
+        # command itself, as execvp would need
+        rc, txt = self.client.app_string({'cmd': "/bin/true"})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertIn("/bin/true", txt)
+
+    def test_app_with_empty_lists(self):
+        rc, txt = self.client.app_string({'cmd': "/bin/true", 'argv': [],
+                                          'env': [], 'info': [],
+                                          'maxprocs': 1})
+        self.assertEqual(rc, pmix.PMIX_SUCCESS)
+        self.assertIn("/bin/true", txt)
+
     def test_repeated_calls_are_stable(self):
         # each of these builds a struct, renders it, and has to release
         # both the struct and the string the library allocated

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -84,6 +84,35 @@ class TestModule(unittest.TestCase):
             obj = cls()
             self.assertIsNotNone(obj)
 
+    def test_star_import_does_not_rebind_the_callers_modules(self):
+        # "from pmix import *" is the documented way to use these bindings,
+        # so what it exports is part of the interface.  Without an __all__
+        # it handed the caller every name at module scope, including the
+        # modules pmix.pyx imports for its own use - a program that did
+        # "import time" and then "from pmix import *" silently got the
+        # extension's time, and the same for os, sys, array, queue, signal,
+        # threading, ctypes and traceback.
+        import types
+        namespace = {}
+        exec("from pmix import *", namespace)
+        modules = sorted(name for name, obj in namespace.items()
+                         if isinstance(obj, types.ModuleType)
+                         and not name.startswith("_"))
+        self.assertEqual(modules, [],
+                         "star import rebinds the caller's %s" % modules)
+
+    def test_star_import_still_exports_what_it_should(self):
+        namespace = {}
+        exec("from pmix import *", namespace)
+        for name in ("PMIxClient", "PMIxServer", "PMIxTool", "PMIxScheduler",
+                     "PMIX_SUCCESS", "PMIX_RANK_WILDCARD", "PMIX_STRING",
+                     "PMIX_ERR_NOT_FOUND", "PMIX_JOB_SIZE"):
+            self.assertIn(name, namespace, "star import dropped " + name)
+        # the constants are the bulk of the module, so a mistake in the
+        # export list would show up as a collapse in their number
+        constants = [n for n in namespace if n.startswith("PMIX_")]
+        self.assertGreater(len(constants), 500, len(constants))
+
 
 class TestConstants(unittest.TestCase):
     def test_success_is_zero(self):

--- a/test/python/test_construct.py
+++ b/test/python/test_construct.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Unit tests for bindings/python/construct.py, the generator that harvests
+# the C headers into pmix_constants.pxi and pmix_constants.pxd.
+#
+# The generator is plain Python and needs neither a built extension nor a
+# library, so these run anywhere.  They matter because its output is what
+# every Python constant in the bindings *is*: a header the generator
+# mis-parses does not fail the build, it silently produces a constant with
+# the wrong value, and the first symptom is an attribute comparison that
+# never matches at run time.
+#
+# Run directly with:
+#     ./test_construct.py
+
+import os
+import sys
+import tempfile
+import unittest
+
+
+def _load_construct():
+    """Import construct.py from the source tree beside us."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.abspath(os.path.join(here, "..", ".."))
+    path = os.path.join(root, "bindings", "python")
+    if path not in sys.path:
+        sys.path.insert(0, path)
+    import construct
+    return construct
+
+
+try:
+    construct = _load_construct()
+except ImportError:                                  # pragma: no cover
+    print("construct.py not importable - skipping", file=sys.stderr)
+    sys.exit(77)
+
+
+class _Options(object):
+    """The subset of construct.py's option object harvest_constants reads."""
+
+    def __init__(self, directory):
+        self.src = directory
+        self.includedir = directory
+
+
+class _Harvest(unittest.TestCase):
+    """Run the generator over a synthetic header and capture its output."""
+
+    def harvest(self, text, name="pmix_common.h"):
+        import io
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, name), "w") as f:
+                f.write(text)
+            constants = io.StringIO()
+            definitions = io.StringIO()
+            construct.takeconst = True
+            construct.takeapis = True
+            construct.takedtypes = True
+            rc = construct.harvest_constants(_Options(d), name,
+                                             constants, definitions)
+        return rc, constants.getvalue(), definitions.getvalue()
+
+    @staticmethod
+    def _assignments(constants):
+        """The 'NAME = value' lines, as a {name: value} mapping.
+
+        The generator pads the name out to a column, so parse on the '='
+        rather than on whitespace.
+        """
+        out = {}
+        for line in constants.splitlines():
+            if line.startswith("#") or "=" not in line:
+                continue
+            name, _eq, value = line.partition("=")
+            out[name.strip()] = value.strip()
+        return out
+
+    def assertConstant(self, constants, name, value):
+        got = self._assignments(constants)
+        self.assertIn(name, got,
+                      "%s was not generated:\n%s" % (name, constants))
+        self.assertEqual(got[name], value,
+                         "%s came out as %s" % (name, got[name]))
+
+    def assertNoConstant(self, constants, name):
+        self.assertNotIn(name, self._assignments(constants),
+                         "%s should not have been generated:\n%s"
+                         % (name, constants))
+
+
+class TestEnums(_Harvest):
+    """typedef enum bodies.
+
+    The generator assigns each enumerator the value the C compiler would.
+    Getting this wrong is invisible: the constant still exists, it just
+    does not mean what the C side means by it, and these values cross the
+    server-module callback boundary.
+    """
+
+    def test_sequential_values(self):
+        rc, constants, _defs = self.harvest("""
+typedef enum {
+    PMIX_A,
+    PMIX_B,
+    PMIX_C
+} pmix_letter_t;
+""")
+        self.assertEqual(rc, 0)
+        self.assertConstant(constants, "PMIX_A", "0")
+        self.assertConstant(constants, "PMIX_B", "1")
+        self.assertConstant(constants, "PMIX_C", "2")
+
+    def test_comment_lines_are_not_enumerators(self):
+        # a comment inside the body used to become a constant of its own,
+        # and shifted every enumerator after it by one.  pmix_common.h
+        # carries a warning asking contributors not to write one; the
+        # generator should simply cope.
+        rc, constants, _defs = self.harvest("""
+typedef enum {
+    PMIX_A,
+    /* what B is for */
+    PMIX_B,
+
+    // and C
+    PMIX_C
+} pmix_letter_t;
+""")
+        self.assertEqual(rc, 0)
+        self.assertConstant(constants, "PMIX_A", "0")
+        self.assertConstant(constants, "PMIX_B", "1")
+        self.assertConstant(constants, "PMIX_C", "2")
+
+    def test_explicit_values_are_honored(self):
+        # an ignored "= value" renumbers the whole enum from that point on
+        rc, constants, _defs = self.harvest("""
+typedef enum {
+    PMIX_A = 4,
+    PMIX_B,
+    PMIX_C = 0x10,
+    PMIX_D
+} pmix_letter_t;
+""")
+        self.assertEqual(rc, 0)
+        self.assertConstant(constants, "PMIX_A", "4")
+        self.assertConstant(constants, "PMIX_B", "5")
+        self.assertConstant(constants, "PMIX_C", "16")
+        self.assertConstant(constants, "PMIX_D", "17")
+
+    def test_enum_before_any_define(self):
+        # the enumerator name and value used to be stored through "tokens",
+        # a list left over from the last #define seen in the file, so an
+        # enum that came first raised NameError
+        rc, constants, _defs = self.harvest("""
+typedef enum {
+    PMIX_ONLY
+} pmix_only_t;
+#define PMIX_LATER   7
+""")
+        self.assertEqual(rc, 0)
+        self.assertConstant(constants, "PMIX_ONLY", "0")
+        self.assertConstant(constants, "PMIX_LATER", "7")
+
+    def test_enum_type_is_declared(self):
+        _rc, _constants, defs = self.harvest("""
+typedef enum {
+    PMIX_A
+} pmix_letter_t;
+""")
+        self.assertIn("typedef int pmix_letter_t", defs)
+
+    def test_unparsable_value_is_reported(self):
+        # better to stop the build than to emit a constant that is wrong
+        rc, _constants, _defs = self.harvest("""
+typedef enum {
+    PMIX_A = SOME_OTHER_MACRO
+} pmix_letter_t;
+""")
+        self.assertNotEqual(rc, 0)
+
+    def test_unterminated_enum_is_reported(self):
+        rc, _constants, _defs = self.harvest("""
+typedef enum {
+    PMIX_A,
+    PMIX_B
+""")
+        self.assertNotEqual(rc, 0)
+
+
+class TestDefines(_Harvest):
+    """#define constants, in their three flavors."""
+
+    def test_string_constant(self):
+        _rc, constants, defs = self.harvest("""
+#define PMIX_SOMETHING   "pmix.something"
+""")
+        # the Python-visible constant decodes, so it compares equal to the
+        # keys the library hands back
+        self.assertIn("PMIX_SOMETHING", constants)
+        self.assertIn(".decode('ascii')", constants)
+        self.assertIn("cdef const char* _PMIX_SOMETHING", defs)
+
+    def test_numeric_constant(self):
+        _rc, constants, _defs = self.harvest("""
+#define PMIX_COUNT   42
+""")
+        self.assertConstant(constants, "PMIX_COUNT", "42")
+
+    def test_hex_constant(self):
+        _rc, constants, _defs = self.harvest("""
+#define PMIX_FLAG   0x0004
+""")
+        self.assertConstant(constants, "PMIX_FLAG", "0x0004")
+
+    def test_uint32_max_is_converted(self):
+        # Python does not know UINT32_MAX, so the generator substitutes it
+        _rc, constants, _defs = self.harvest("""
+#define PMIX_RANK_UNDEF     UINT32_MAX
+#define PMIX_RANK_WILDCARD  UINT32_MAX-1
+""")
+        self.assertConstant(constants, "PMIX_RANK_UNDEF", "0xffffffff")
+        self.assertConstant(constants, "PMIX_RANK_WILDCARD", "0xfffffffe")
+
+    def test_error_constant(self):
+        _rc, constants, defs = self.harvest("""
+#define PMIX_ERR_BAD   -27
+""")
+        self.assertIn("PMIX_ERR_BAD", constants)
+        self.assertIn("cdef int _PMIX_ERR_BAD", defs)
+
+    def test_function_like_macros_are_skipped(self):
+        # these are not constants, and there is nothing to bind
+        _rc, constants, _defs = self.harvest("""
+#define PMIx_Something(a, b)   do_it(a, b)
+#define PMIX_HAVE_VISIBILITY 1
+""")
+        self.assertNoConstant(constants, "PMIx_Something(a,")
+        self.assertNoConstant(constants, "PMIX_HAVE_VISIBILITY")
+
+
+class TestApis(_Harvest):
+    """PMIX_EXPORT declarations."""
+
+    def test_single_line_api(self):
+        _rc, _constants, defs = self.harvest("""
+PMIX_EXPORT pmix_status_t PMIx_Do_thing(int a);
+""")
+        self.assertIn("pmix_status_t PMIx_Do_thing(int a) nogil", defs)
+
+    def test_void_argument_is_snipped(self):
+        # Cython does not accept "void" as an argument list
+        _rc, _constants, defs = self.harvest("""
+PMIX_EXPORT int PMIx_Initialized(void);
+""")
+        self.assertIn("PMIx_Initialized()", defs)
+        self.assertNotIn("PMIx_Initialized(void)", defs)
+
+    def test_bool_becomes_bint(self):
+        # Cython has no "bool"; leaving one in the .pxd fails the build
+        _rc, _constants, defs = self.harvest("""
+PMIX_EXPORT bool PMIx_Is_thing(bool flag);
+""")
+        self.assertIn("bint", defs)
+        self.assertNotIn("bool", defs)
+
+    def test_multi_line_api_is_collected(self):
+        _rc, _constants, defs = self.harvest("""
+PMIX_EXPORT pmix_status_t PMIx_Do_thing(int a,
+                                        bool b,
+                                        char *c);
+""")
+        self.assertIn("PMIx_Do_thing", defs)
+        self.assertIn("bint b,", defs)
+        self.assertIn("char *c) nogil", defs)
+
+    def test_lines_after_a_multi_line_api_are_not_rescanned(self):
+        # the harvest loop used to be a "for n in range(len(lines))" whose
+        # body advanced n by hand, so every line a multi-line declaration
+        # swallowed was read a second time
+        _rc, constants, defs = self.harvest("""
+PMIX_EXPORT pmix_status_t PMIx_Do_thing(int a,
+                                        int b);
+#define PMIX_AFTER   9
+""")
+        self.assertConstant(constants, "PMIX_AFTER", "9")
+        self.assertEqual(defs.count("PMIx_Do_thing"), 1)
+
+
+class TestTypedefs(_Harvest):
+    """typedef handling, including the struct bodies."""
+
+    def test_simple_typedef(self):
+        _rc, _constants, defs = self.harvest("""
+typedef uint16_t pmix_thing_t;
+""")
+        self.assertIn("ctypedef uint16_t pmix_thing_t", defs)
+
+    def test_bool_typedef_becomes_bint(self):
+        _rc, _constants, defs = self.harvest("""
+typedef bool pmix_flag_t;
+""")
+        self.assertIn("bint", defs)
+        self.assertNotIn("bool", defs)
+
+    def test_predeclaration_is_skipped(self):
+        # "typedef struct foo foo" declares nothing Cython needs
+        _rc, _constants, defs = self.harvest("""
+typedef struct pmix_thing pmix_thing;
+""")
+        self.assertNotIn("pmix_thing pmix_thing", defs)
+
+    def test_struct_body(self):
+        _rc, _constants, defs = self.harvest("""
+typedef struct {
+    char name[PMIX_MAX_NSLEN+1];
+    int rank;
+} pmix_thing_t;
+""")
+        self.assertIn("ctypedef struct pmix_thing_t:", defs)
+        # the dimension has to become a literal - Cython cannot see the
+        # C macro
+        self.assertIn("char name[256]", defs)
+        self.assertIn("int rank", defs)
+
+    def test_missing_file_is_reported(self):
+        with tempfile.TemporaryDirectory() as d:
+            import io
+            rc = construct.harvest_constants(_Options(d), "no_such.h",
+                                             io.StringIO(), io.StringIO())
+        self.assertNotEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/python/tool.py
+++ b/test/python/tool.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from pmix import *
-from os import *
+import os
 import time
 
 def main():
@@ -11,7 +11,10 @@ def main():
     uid = os.geteuid()
     gid = os.getegid()
     basename = os.path.basename(__file__)
-    tmpdir = os.getenv('TMPDIR')
+    # a bare os.getenv('TMPDIR') is None on a machine that does not set it,
+    # and os.path.join(None, ...) raises rather than reporting anything
+    # useful
+    tmpdir = os.getenv('TMPDIR', '/tmp')
     sessiondir = os.path.join(tmpdir, basename + '.session.' + str(uid) + '.' + str(gid))
     info = [{'key':PMIX_LAUNCHER, 'value':True, 'val_type':PMIX_BOOL},
             {'key':PMIX_SERVER_TOOL_SUPPORT, 'value':True, 'val_type':PMIX_BOOL},
@@ -23,7 +26,11 @@ def main():
 
     # construct an application to spawn
     app = {'cmd':'hostname', 'maxprocs':1}
-    foo.spawn(None, [app])
+    rc, nspace = foo.spawn(None, [app])
+    if PMIX_SUCCESS != rc:
+        print("SPAWN FAILED", foo.error_string(rc))
+    else:
+        print("SPAWNED", nspace)
     time.sleep(2.0)
     # finalize
     foo.finalize()

--- a/test/unit/progress_threads.c
+++ b/test/unit/progress_threads.c
@@ -205,6 +205,108 @@ static void test_unknown_name(void)
     report("unknown:resume", PMIX_ERR_NOT_FOUND == pmix_progress_thread_resume(nm));
 }
 
+/* ------------------------------------------------------------------
+ * Blocking calls made FROM the progress thread
+ *
+ * A blocking PMIx API hands its work to the progress thread and waits.
+ * Called from that thread it would post the work to the very event loop
+ * it is standing in, and wait for a loop that cannot run until it
+ * returns - the thread waits on itself, forever.  The way a host reaches
+ * this is ordinary: deleting a namespace from inside its own
+ * client_finalized upcall, for instance, or from an event handler.  Both
+ * are dispatched from the progress thread.
+ *
+ * The guard turns that hang into an answer.  These tests run inside an
+ * event handler - which is dispatched from the progress thread, so it
+ * stands in for any upcall - and would hang the whole suite if the guard
+ * regressed, which is exactly the signal wanted.
+ * ------------------------------------------------------------------ */
+
+static pmix_lock_t reentry_lock;
+static bool reentry_saw_progress_thread = false;
+static pmix_status_t reentry_store_rc = PMIX_SUCCESS;
+static pmix_status_t reentry_pset_rc = PMIX_SUCCESS;
+
+static void reentry_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                            const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    pmix_value_t val;
+    pmix_nspace_t ns;
+
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo, results,
+                            nresults);
+
+    /* we are on the progress thread - the whole point of the exercise */
+    reentry_saw_progress_thread = pmix_progress_thread_is_current();
+
+    /* an API that reports a status must refuse rather than hang */
+    PMIX_VALUE_LOAD(&val, "value", PMIX_STRING);
+    reentry_store_rc = PMIx_Store_internal(&pmix_globals.myid, "ut.reentry.key", &val);
+    PMIX_VALUE_DESTRUCT(&val);
+
+    /* ... including the one whose caddy lives on the caller's stack */
+    reentry_pset_rc = PMIx_server_delete_process_set("ut-no-such-pset");
+
+    /* an API that reports no status completes asynchronously instead.
+     * There is nothing to check here beyond the fact that it returns at
+     * all - which it did not before the guard existed */
+    PMIX_LOAD_NSPACE(ns, "ut-no-such-nspace");
+    PMIx_server_deregister_nspace(ns, NULL, NULL);
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+    PMIX_WAKEUP_THREAD(&reentry_lock);
+}
+
+static void reentry_registered(pmix_status_t status, size_t refid, void *cbdata)
+{
+    pmix_lock_t *lk = (pmix_lock_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(refid);
+    lk->status = status;
+    PMIX_WAKEUP_THREAD(lk);
+}
+
+static void test_blocking_call_from_progress_thread(void)
+{
+    pmix_status_t code = PMIX_ERR_DEBUGGER_RELEASE;
+    pmix_lock_t reglock;
+
+    /* off the progress thread, the predicate must say so */
+    report("reentry:main thread is not the progress thread",
+           !pmix_progress_thread_is_current());
+
+    PMIX_CONSTRUCT_LOCK(&reglock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, reentry_handler, reentry_registered,
+                                &reglock);
+    PMIX_WAIT_THREAD(&reglock);
+    if (PMIX_SUCCESS != reglock.status) {
+        report("reentry:handler registered", false);
+        PMIX_DESTRUCT_LOCK(&reglock);
+        return;
+    }
+    PMIX_DESTRUCT_LOCK(&reglock);
+
+    PMIX_CONSTRUCT_LOCK(&reentry_lock);
+    PMIx_Notify_event(code, &pmix_globals.myid, PMIX_RANGE_LOCAL, NULL, 0, NULL, NULL);
+    /* if the guard regresses, the handler never returns and this never
+     * wakes - the suite hangs, which is the intended alarm */
+    PMIX_WAIT_THREAD(&reentry_lock);
+    PMIX_DESTRUCT_LOCK(&reentry_lock);
+
+    report("reentry:handler ran on the progress thread", reentry_saw_progress_thread);
+    report("reentry:PMIx_Store_internal reports WOULD_BLOCK",
+           PMIX_ERR_WOULD_BLOCK == reentry_store_rc);
+    report("reentry:PMIx_server_delete_process_set reports WOULD_BLOCK",
+           PMIX_ERR_WOULD_BLOCK == reentry_pset_rc);
+
+    /* and the same calls still work normally from this thread */
+    report("reentry:delete_process_set works off the progress thread",
+           PMIX_ERR_WOULD_BLOCK != PMIx_server_delete_process_set("ut-no-such-pset"));
+}
+
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
@@ -224,6 +326,7 @@ int main(int argc, char **argv)
     test_start_progresses();
     test_pause_resume();
     test_unknown_name();
+    test_blocking_call_from_progress_thread();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 


### PR DESCRIPTION
A deep review of `bindings/python`, plus two library fixes it turned up.

## Why this is not only a bindings PR

The review started in the bindings but ended in `src/server`. Two of the
commits here fix `libpmix` itself and affect every host, not just Python:

**A blocking PMIx API called from the progress thread deadlocks.** It posts
its work to the very event loop the caller is standing in, then waits for a
loop that cannot run until it returns — the progress thread waits on itself.
Reaching this is ordinary: every server-module upcall, event handler, and
non-blocking completion callback is dispatched from that thread, so a host
that deletes a namespace from its own `client_finalized` handler hangs the
server with no diagnostic at all. It reproduces 100% of the time:

```
progress_engine
  event_base_loop
    event_process_active_single_queue
      <host's client_finalized handler>
        PMIx_server_deregister_nspace
          _pthread_cond_wait          <- waiting for this very thread
```

`pmix_progress_thread_is_current()` detects it, and the thirteen blocking
public APIs in `src/server` now answer instead of hanging: those that report
a status return `PMIX_ERR_WOULD_BLOCK`, and the two that report none
(`deregister_nspace`, `deregister_client`) complete the operation
asynchronously, which the caller cannot distinguish except that it did not
wait. A `show_help` message explains what happened and what to do instead.

Running the handler inline was the other candidate and is **not** safe: it
releases peers and the namespace object that the callback we are nested
inside may still hold. Posting the work preserves the existing guarantee
that these handlers never interleave with another event callback.

Note that this refuses nothing that used to work — every one of these calls
already deadlocked from the progress thread, so an error can only replace a
hang.

**The bindings had no non-blocking form of the server registration calls.**
PMIx spells non-blocking two ways: a separate `*_nb` function (the client
family, all 25 already bound) and an optional trailing `cbfunc`/`cbdata` on
the same entry point (mostly the server family). Every call site of the
second kind hard-coded `NULL, NULL`, so a Python handler had no working
alternative to the blocking form it must not use. Five now take an optional
callback, mirroring the C rather than inventing an `_nb` name the library
does not have:

```python
srv.deregister_nspace(ns)                     # blocking, as before
srv.deregister_nspace(ns, cbfunc, cbdata)     # completes asynchronously
```

## The bindings review

~40 defects across five passes. Grouped by root cause rather than listed:

- **Wrong widths.** Bounds checks written as arithmetic — `(65536*65536)`,
  `(2147483647*2147483647)` — with the wrong value. A uint16 rejected 65535
  but accepted 65536 and let the C store truncate it to zero; int64 and
  uint64 refused three quarters of their range; the unsigned arms had no
  lower bound, so a negative arrived as an enormous positive.
- **Empty arrays.** Every arm of `pmix_unload_darray` returned
  `PMIX_ERR_NOMEM` — an int — from a function declared to return a dict, so
  an empty array of any type raised `TypeError` instead of converting to
  `[]`.
- **Declared sizes believed over payloads.** The byte-object, endpoint and
  coordinate loaders copied as many bytes as the dict claimed, reading off
  the end of the Python object when the two disagreed.
- **Structs released before they were fully built.** Loaders malloc'd
  without zeroing, so a partial failure handed the destructor stack garbage;
  the geometry arm never set `ncoords` — exactly what the destructor walks.
- **Binary treated as strings.** The modex callback `strdup`'d its payload;
  the IOF upcall ran `strlen` over a raw stream; the credential callback
  cast the Python object to `void*` and copied the PyObject header rather
  than the credential; `validate_credential` used `sizeof` where it meant
  `len`, truncating every credential to eight bytes.
- **Library memory kept past its lifetime.** The event/IOF retry path stashed
  the library's own `pmix_info_t` array in a caddy and freed it later — a
  use-after-free followed by a double free.
- **Allocator mismatches**, **ignored conversion failures**, and a handful of
  methods returning a bare status where the caller unpacks a tuple.

Two more worth calling out on their own:

- A raising server-module handler returned −1 but left Python's error
  indicator set across the GIL release, so unrelated code later tripped over
  an exception raised inside an upcall. All 29 trampolines are now
  `noexcept` with an explicit catch. (`noexcept` alone would be worse: on a
  `cdef int` it returns 0 — `PMIX_SUCCESS` — promising a callback that never
  comes.)
- `from pmix import *`, the documented usage, rebound the caller's `time`,
  `os`, `sys`, `array`, `queue`, `signal`, `threading`, `ctypes` and
  `traceback`. The module now defines `__all__`, computed at import time so
  it cannot go stale against the generated constants.

`construct.py` is also hardened: it took comments and blank lines inside a
`typedef enum` for enumerators and ignored explicit `= value`, either of
which silently produces a constant with the wrong value. Generated output is
byte-for-byte identical on the current headers.

## Testing

- `test/python/test_bindings.py`: 103 → 132 tests, including a
  boundary-focused class covering the shapes these defects lived on.
- `test/python/test_construct.py`: new, 23 tests for the generator. Needs
  neither the extension nor the library.
- `test/unit/progress_threads.c`: 5 checks that run inside an event handler
  — dispatched from the progress thread, so it stands in for any upcall.
  It would **hang the suite** if the deadlock guard regressed, which is the
  intended alarm.
- Two new multi-node tests, `swarm_datatypes.py` and `swarm_nonblocking.py`,
  covering what the unit suite structurally cannot: the loader/unloader
  round trip cancels out mistakes both halves make, and a locally-answered
  non-blocking request completes before the method returns, so nothing the
  caddy holds has to survive.

`make check` is 110 tests, all passing. The full dockerswarm suite is green
across all ten runners.

## Also fixed

`make check` for the bindings pointed `PYTHONPATH` at the install prefix, so
it tested whatever egg happened to be installed there rather than what was
just built — `run_server.sh` was failing against a months-old egg while the
code under test was correct.

## Documentation

`bindings/python/AGENTS.md` is updated throughout, including a correction:
it claimed every operational API was bound "in both its blocking and its
non-blocking form", which was true only of the `_nb` family. New
`bindings/AGENTS.md` and `test/python/AGENTS.md` (with the customary
`CLAUDE.md` symlinks); the latter records what can be tested at which level
and why a handler must never make a blocking call.

## Not addressed

Ten more optional-callback APIs are still blocking-only; the pattern for
adding one is documented. Three others — `dmodex_request`,
`setup_application`, `collect_inventory` — cannot simply grow a callback:
they wait on the module-global `active` lock, so they need that
non-reentrancy fixed first.

Separately, `pmix_server.c` has ~20 sites where the `progress_thread_stopped`
guard returns without invoking `cbfunc`, while the `!initialized` guard
immediately above it correctly does. A host using the non-blocking form waits
forever for a callback that never comes. Left alone here to keep this PR
reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
