### PR TITLE
python: bind the optional-callback form of the remaining server calls

### DIFF
--- a/bindings/python/AGENTS.md
+++ b/bindings/python/AGENTS.md
@@ -86,18 +86,32 @@ from there waits on the event loop it is standing in; the library now
 reports that rather than deadlocking (see §4b). So a handler that wants
 to register or delete a namespace *must* pass a callback.
 
-Five of that family currently take one: `register_nspace`,
-`deregister_nspace`, `register_client`, `deregister_client`, and
-`notify_event`. The rest — `register_resources`,
-`deregister_resources`, `setup_local_support`, `deliver_inventory`,
-`iof_deliver`, `iof_flow_control`, `session_control`,
-`deregister_event_handler`, `iof_deregister`, `iof_push` — are still
-blocking-only, and adding a callback to one follows the same pattern:
-build the caddy with `pypmix_nb_setup`, register the callback, pass
-`pypmix_client_op_cbfunc` and the caddy, and reclaim on a failed
-return. Anything the library holds until completion (an info array, for
-instance — `register_nspace` and `notify_event` both retain theirs) has
-to live in the caddy rather than be freed at return.
+All fifteen of that family now take one: `register_nspace`,
+`deregister_nspace`, `register_client`, `deregister_client`,
+`notify_event`, `register_resources`, `deregister_resources`,
+`setup_local_support`, `deliver_inventory`, `iof_deliver`,
+`iof_flow_control`, `session_control`, `deregister_event_handler`,
+`iof_deregister` and `iof_push`.
+
+Fourteen take the op-style callback, `cbfunc(status, cbdata)`.
+`session_control` is the exception: it reports results, so it takes the
+info-style `cbfunc(status, results, cbdata)` and routes through
+`pypmix_client_info_cbfunc`.
+
+Adding a callback to a further one follows the same pattern: build the
+caddy with `pypmix_nb_setup`, register the callback, pass the right
+trampoline and the caddy, and reclaim on a failed return. **Anything the
+library holds until completion has to live in the caddy** rather than be
+freed at return — an info array (`register_nspace` and `notify_event`
+both retain theirs), a proc array, or a byte object. `pypmix_nb_add_bo`
+exists for the last of those: the IOF payloads cannot be the stack copy
+the blocking forms use.
+
+Which of those a given API retains is not guessable — read it. The
+server calls are split roughly evenly: `register_client` and
+`deregister_client` copy the proc and keep nothing, `setup_local_support`
+strdup's the namespace but holds the info array, and `IOF_deliver` holds
+the source, the payload *and* the directives.
 
 Three more are blocking by construction and cannot simply grow a
 callback: `dmodex_request`, `setup_application` and `collect_inventory`

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -84,6 +84,8 @@ cdef struct nbcbd:
     pmix_resource_unit_t *units  # PyMem_Malloc'd by pmix_alloc_units
     size_t nunits
     pmix_byte_object_t *cred     # PyMem_Malloc'd, as is its payload
+    pmix_byte_object_t *bo       # ditto - the IOF payloads, which the
+                                 #   library holds until it completes
     pmix_cpuset_t cpuset  # constructed only when havecpuset is set
     int havecpuset
     size_t idx            # key into the pynbcbs registry
@@ -153,6 +155,10 @@ cdef void pypmix_nb_cbdata_free(pypmix_nb_cbdata_t *cd):
         if NULL != cd.cred.bytes:
             PyMem_Free(cd.cred.bytes)
         PyMem_Free(cd.cred)
+    if NULL != cd.bo:
+        if NULL != cd.bo.bytes:
+            PyMem_Free(cd.bo.bytes)
+        PyMem_Free(cd.bo)
     if 0 != cd.havecpuset:
         pmix_destruct_cpuset(&cd.cpuset)
     free(cd)
@@ -427,6 +433,36 @@ cdef int pypmix_nb_add_procs(pypmix_nb_cbdata_t *cd, peers, nspace):
         return PMIX_ERR_NOMEM
     pmix_copy_nspace(cd.procs[0].nspace, nspace)
     cd.procs[0].rank = PMIX_RANK_WILDCARD
+    return PMIX_SUCCESS
+
+# Park a byte object in the caddy. The IOF calls hand the library a
+# payload it holds until the operation completes, so it cannot be the
+# stack copy the blocking forms use
+cdef int pypmix_nb_add_bo(pypmix_nb_cbdata_t *cd, pybo):
+    cdef const char *ptr
+    if pybo is None:
+        return PMIX_SUCCESS
+    cd.bo = <pmix_byte_object_t*> PyMem_Malloc(sizeof(pmix_byte_object_t))
+    if not cd.bo:
+        return PMIX_ERR_NOMEM
+    cd.bo.bytes = NULL
+    cd.bo.size = 0
+    pybytes = pybo.get('bytes') if isinstance(pybo, dict) else pybo
+    if pybytes is None:
+        return PMIX_SUCCESS
+    if isinstance(pybytes, str):
+        pybytes = pybytes.encode('ascii')
+    else:
+        pybytes = bytes(pybytes)
+    if 0 == len(pybytes):
+        return PMIX_SUCCESS
+    cd.bo.size = len(pybytes)
+    cd.bo.bytes = <char*> PyMem_Malloc(cd.bo.size)
+    if not cd.bo.bytes:
+        cd.bo.size = 0
+        return PMIX_ERR_NOMEM
+    ptr = <const char*>pybytes
+    memcpy(cd.bo.bytes, ptr, cd.bo.size)
     return PMIX_SUCCESS
 
 # Park a NULL-terminated key array in the caddy. A None/empty list is
@@ -3175,7 +3211,34 @@ cdef class PMIxClient:
         myhdlrs.append({'refid': rc, 'hdlr': hdlr})
         return PMIX_SUCCESS, rc
 
-    def deregister_event_handler(self, ref:int):
+    # cbfunc(status:int, cbdata) - deregistering from inside the very
+    # handler being deregistered is a natural thing to do, and that
+    # handler runs on the progress thread
+    def deregister_event_handler(self, ref:int, cbfunc=None, cbdata=None):
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef size_t cref
+        cdef int prc
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            cref = ref
+            # nothing of ours is retained - the caddy carries only the
+            # registry key
+            cd = pypmix_nb_setup(None, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_Deregister_event_handler(cref,
+                                                    pypmix_client_op_cbfunc,
+                                                    <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
+
         rc = PMIx_Deregister_event_handler(ref, NULL, NULL)
         return rc
 
@@ -4651,10 +4714,31 @@ cdef class PMIxServer(PMIxClient):
         return PMIX_SUCCESS
 
     # Register resources
-    def register_resources(self, directives):
+    # cbfunc(status:int, cbdata) - the non-blocking form, which is the
+    # only one usable from a server module upcall (see deregister_nspace)
+    def register_resources(self, directives, cbfunc=None, cbdata=None):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef int prc
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            # the library holds the info array until it completes
+            cd = pypmix_nb_setup(directives, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_server_register_resources(cd.info, cd.ninfo,
+                         pypmix_client_op_cbfunc, <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
 
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
@@ -4668,10 +4752,31 @@ cdef class PMIxServer(PMIxClient):
         return rc
 
     # Deregister resources
-    def deregister_resources(self, directives):
+    # cbfunc(status:int, cbdata) - the non-blocking form, which is the
+    # only one usable from a server module upcall (see deregister_nspace)
+    def deregister_resources(self, directives, cbfunc=None, cbdata=None):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef int prc
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            # the library holds the info array until it completes
+            cd = pypmix_nb_setup(directives, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_server_deregister_resources(cd.info, cd.ninfo,
+                         pypmix_client_op_cbfunc, <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
 
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
@@ -4909,15 +5014,41 @@ cdef class PMIxServer(PMIxClient):
             pmix_free_info(directives, ndirs)
         return (rc, dataout)
 
-    def deliver_inventory(self, pyinfo, pydirs):
+    # cbfunc(status:int, cbdata) - see deregister_nspace
+    def deliver_inventory(self, pyinfo, pydirs, cbfunc=None, cbdata=None):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t ndirs
         cdef size_t ninfo
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef int prc
         ndirs   = 0
         ninfo   = 0
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            # both arrays are held by the library until it completes
+            cd = pypmix_nb_setup(pyinfo, &prc)
+            if NULL == cd:
+                return prc
+            prc = pypmix_nb_add_dirs(cd, pydirs)
+            if PMIX_SUCCESS != prc:
+                pypmix_nb_cbdata_free(cd)
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_server_deliver_inventory(cd.info, cd.ninfo,
+                                                    cd.dirs, cd.ndirs,
+                                                    pypmix_client_op_cbfunc,
+                                                    <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
 
         # allocate and load pmix info structs from python list of dictionaries
         directives_ptr = &directives
@@ -4940,13 +5071,34 @@ cdef class PMIxServer(PMIxClient):
             pmix_free_info(directives, ndirs)
         return rc
 
-    def setup_local_support(self, ns:str, ilist):
+    # cbfunc(status:int, cbdata) - see deregister_nspace
+    def setup_local_support(self, ns:str, ilist, cbfunc=None, cbdata=None):
         global active
         cdef pmix_nspace_t nspace;
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef int prc
         pmix_copy_nspace(nspace, ns)
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            # the library copies the namespace but holds the info array
+            cd = pypmix_nb_setup(ilist, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_server_setup_local_support(nspace, cd.info, cd.ninfo,
+                                                      pypmix_client_op_cbfunc,
+                                                      <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
         # convert the info list
         info_ptr = &info
         rc = pmix_alloc_info(info_ptr, &sz, ilist)
@@ -4962,9 +5114,48 @@ cdef class PMIxServer(PMIxClient):
             rc = PMIx_server_setup_local_support(nspace, NULL, 0, NULL, NULL);
         return rc
 
-    def iof_deliver(self, pysrc:dict, pychannel:int, pydata:dict, pydirs):
+    # cbfunc(status:int, cbdata) - see deregister_nspace. Delivering
+    # output from inside an IOF or server upcall needs this form
+    def iof_deliver(self, pysrc:dict, pychannel:int, pydata:dict, pydirs,
+                    cbfunc=None, cbdata=None):
         cdef pmix_proc_t source
         cdef pmix_iof_channel_t channel
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef pmix_iof_channel_t cchannel
+        cdef int prc
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            cchannel = pychannel
+            # the library holds the source, the payload and the
+            # directives until it completes, so all three go in the caddy
+            cd = pypmix_nb_setup(None, &prc)
+            if NULL == cd:
+                return prc
+            prc = pypmix_nb_add_procs(cd, [pysrc], self.myproc.nspace)
+            if PMIX_SUCCESS != prc:
+                pypmix_nb_cbdata_free(cd)
+                return prc
+            prc = pypmix_nb_add_bo(cd, pydata)
+            if PMIX_SUCCESS != prc:
+                pypmix_nb_cbdata_free(cd)
+                return prc
+            prc = pypmix_nb_add_dirs(cd, pydirs)
+            if PMIX_SUCCESS != prc:
+                pypmix_nb_cbdata_free(cd)
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_server_IOF_deliver(&cd.procs[0], cchannel, cd.bo,
+                                              cd.dirs, cd.ndirs,
+                                              pypmix_client_op_cbfunc,
+                                              <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
         cdef pmix_byte_object_t bo
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
@@ -4998,7 +5189,9 @@ cdef class PMIxServer(PMIxClient):
             pmix_free_info(directives, ndirs)
         return rc
 
-    def iof_flow_control(self, pysrc, pychannel:int, pyxoff:bool, pydirs):
+    # cbfunc(status:int, cbdata) - see deregister_nspace
+    def iof_flow_control(self, pysrc, pychannel:int, pyxoff:bool, pydirs,
+                         cbfunc=None, cbdata=None):
         # Suspend (pyxoff True) or resume (pyxoff False) the processes
         # feeding stdin to us. A pysrc of None means every one of them,
         # so it is deliberately not annotated "dict" - Cython would
@@ -5011,10 +5204,44 @@ cdef class PMIxServer(PMIxClient):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef size_t ndirs
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef pmix_proc_t *cbsrc
+        cdef int prc
         ndirs   = 0
         channel = pychannel
         xoff    = pyxoff
         srcptr  = NULL
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            cd = pypmix_nb_setup(None, &prc)
+            if NULL == cd:
+                return prc
+            cbsrc = NULL
+            if pysrc is not None:
+                # a None source means "every producer", which the C API
+                # spells as a NULL pointer
+                prc = pypmix_nb_add_procs(cd, [pysrc], self.myproc.nspace)
+                if PMIX_SUCCESS != prc:
+                    pypmix_nb_cbdata_free(cd)
+                    return prc
+                cbsrc = &cd.procs[0]
+            prc = pypmix_nb_add_dirs(cd, pydirs)
+            if PMIX_SUCCESS != prc:
+                pypmix_nb_cbdata_free(cd)
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_server_IOF_flow_control(cbsrc, channel, xoff,
+                                                   cd.dirs, cd.ndirs,
+                                                   pypmix_client_op_cbfunc,
+                                                   <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
 
         # convert pysrc to pmix_proc_t, if one was given
         if pysrc is not None:
@@ -5118,10 +5345,34 @@ cdef class PMIxServer(PMIxClient):
         PMIx_Data_buffer_destruct(&dbuf)
         return (rc, pyblob)
 
-    def session_control(self, sessionID:int, ilist):
+    # cbfunc(status:int, results:list, cbdata) - note that this one
+    # reports results, so it takes the info-style callback rather than
+    # the plain op-style one the other server calls use
+    def session_control(self, sessionID:int, ilist, cbfunc=None, cbdata=None):
         cdef pmix_info_t *info
         cdef pmix_info_t **info_ptr
         cdef size_t sz
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef uint32_t csession
+        cdef int prc
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            csession = sessionID
+            cd = pypmix_nb_setup(ilist, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_Session_control(csession, cd.info, cd.ninfo,
+                                           pypmix_client_info_cbfunc,
+                                           <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
 
         # allocate and load pmix info structs from python list of dictionaries
         info_ptr = &info
@@ -6339,13 +6590,43 @@ cdef class PMIxTool(PMIxServer):
         rc = PMIX_SUCCESS
         return rc, refid
 
-    def iof_deregister(self, regid:int, pydirs):
+    # cbfunc(status:int, cbdata) - dropping an IOF registration from
+    # inside the IOF handler itself is natural, and that handler runs on
+    # the progress thread
+    def iof_deregister(self, regid:int, pydirs, cbfunc=None, cbdata=None):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef size_t ndirs
         cdef size_t iofhdlr
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef int prc
         ndirs       = 0
         iofhdlr     = regid
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            cd = pypmix_nb_setup(pydirs, &prc)
+            if NULL == cd:
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_IOF_deregister(iofhdlr, cd.info, cd.ninfo,
+                                          pypmix_client_op_cbfunc, <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+                return crc
+            # the local record goes with it, exactly as in the blocking
+            # form - the library will not call our handler again
+            n = 0
+            for h in myhdlrs:
+                if iofhdlr == h['refid']:
+                    del myhdlrs[n]
+                    break
+                n = n + 1
+            return crc
 
         # allocate and load pmix info structs from python list of dictionaries
         directives_ptr = &directives
@@ -6372,15 +6653,49 @@ cdef class PMIxTool(PMIxServer):
                 pass
         return rc
 
-    def iof_push(self, pytargets, data:dict, pydirs):
+    # cbfunc(status:int, cbdata) - see deregister_nspace
+    def iof_push(self, pytargets, data:dict, pydirs, cbfunc=None, cbdata=None):
         cdef pmix_info_t *directives
         cdef pmix_info_t **directives_ptr
         cdef pmix_byte_object_t *bo
         cdef pmix_byte_object_t pushbo
         cdef size_t ndirs
         cdef pmix_proc_t *targets
+        cdef pypmix_nb_cbdata_t *cd
+        cdef pmix_status_t crc
+        cdef int prc
         ntargets    = 0
         ndirs       = 0
+
+        if cbfunc is not None:
+            if not callable(cbfunc):
+                return PMIX_ERR_BAD_PARAM
+            # targets, payload and directives are all held by the library
+            # until the push completes
+            cd = pypmix_nb_setup(None, &prc)
+            if NULL == cd:
+                return prc
+            prc = pypmix_nb_add_procs(cd, pytargets, self.myproc.nspace)
+            if PMIX_SUCCESS != prc:
+                pypmix_nb_cbdata_free(cd)
+                return prc
+            prc = pypmix_nb_add_bo(cd, data)
+            if PMIX_SUCCESS != prc:
+                pypmix_nb_cbdata_free(cd)
+                return prc
+            prc = pypmix_nb_add_dirs(cd, pydirs)
+            if PMIX_SUCCESS != prc:
+                pypmix_nb_cbdata_free(cd)
+                return prc
+            cd.idx = pypmix_nb_register(cbfunc, cbdata)
+            with nogil:
+                crc = PMIx_IOF_push(cd.procs, cd.nprocs, cd.bo,
+                                    cd.dirs, cd.ndirs,
+                                    pypmix_client_op_cbfunc, <void *> cd)
+            if PMIX_SUCCESS != crc:
+                if pypmix_nb_take(cd.idx) is not None:
+                    pypmix_nb_cbdata_free(cd)
+            return crc
 
         # convert data to pmix_byte_object_t. The struct lives on the
         # stack - the heap copy the old code made was never released, and

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -259,10 +259,98 @@ def main():
                                                      nbcb, {'label': "deregister_client"}))
     drive("deregister_nspace", foo.deregister_nspace("nbnspace", nbcb,
                                                      {'label': "deregister_nspace"}))
-    # a bad callback is refused before anything is allocated
-    if PMIX_ERR_BAD_PARAM != foo.deregister_nspace("nbnspace", "not callable"):
-        print("A NON-CALLABLE CALLBACK WAS ACCEPTED")
+    # the rest of the optional-callback family, against a live library.
+    # Several of these legitimately answer NOT_SUPPORTED here - there is
+    # no host above us to service them - and what matters is the contract:
+    # a callback fires if and only if the call reported PMIX_SUCCESS.
+    def drive_opt(label, rc):
+        if PMIX_SUCCESS == rc:
+            if not nbdone.wait(timeout=30):
+                print("%s ACCEPTED BUT NEVER COMPLETED" % label)
+                exit(1)
+            if nbresult['cbdata'] != {'label': label}:
+                print("%s RETURNED THE WRONG CBDATA" % label)
+                exit(1)
+            print("  %s: completed asynchronously (%s)"
+                  % (label, foo.error_string(nbresult['status'])))
+            nbdone.clear()
+        else:
+            # refused up front, so no callback may fire
+            if nbdone.is_set():
+                print("%s FIRED A CALLBACK IT DID NOT PROMISE" % label)
+                exit(1)
+            print("  %s: refused up front (%s)" % (label, foo.error_string(rc)))
+
+    src = {'nspace': "testnspace", 'rank': 0}
+    payload = {'bytes': b"async iof payload\n", 'size': 18}
+    drive_opt("register_resources",
+              foo.register_resources([], nbcb, {'label': "register_resources"}))
+    drive_opt("deregister_resources",
+              foo.deregister_resources([], nbcb, {'label': "deregister_resources"}))
+    drive_opt("setup_local_support",
+              foo.setup_local_support("testnspace", [], nbcb,
+                                      {'label': "setup_local_support"}))
+    drive_opt("deliver_inventory",
+              foo.deliver_inventory([], [], nbcb, {'label': "deliver_inventory"}))
+    drive_opt("iof_deliver",
+              foo.iof_deliver(src, PMIX_FWD_STDOUT_CHANNEL, payload, [], nbcb,
+                              {'label': "iof_deliver"}))
+    drive_opt("iof_flow_control",
+              foo.iof_flow_control(None, PMIX_FWD_STDIN_CHANNEL, True, [], nbcb,
+                                   {'label': "iof_flow_control"}))
+    # session_control is the one member of this family that reports
+    # results, so it takes the info-style callback - three arguments, not
+    # two - and needs its own waiter.  A standalone server has no
+    # scheduler above it to service the request, so the library answers
+    # PMIX_ERR_UNREACH through the callback; what is being checked here is
+    # that the callback is reached at all, and with the caller's cbdata.
+    sesdone = threading.Event()
+    sesresult = {}
+
+    def sescb(status, results, cbdata):
+        sesresult['status'] = status
+        sesresult['results'] = results
+        sesresult['cbdata'] = cbdata
+        sesdone.set()
+
+    rc = foo.session_control(1, [], sescb, {'label': "session_control"})
+    if PMIX_SUCCESS != rc:
+        print("session_control NOT ACCEPTED:", foo.error_string(rc))
         exit(1)
+    if not sesdone.wait(timeout=30):
+        print("session_control ACCEPTED BUT NEVER COMPLETED")
+        exit(1)
+    if sesresult['cbdata'] != {'label': "session_control"}:
+        print("session_control RETURNED THE WRONG CBDATA")
+        exit(1)
+    if not isinstance(sesresult['results'], list):
+        print("session_control DID NOT HAND BACK A RESULTS LIST")
+        exit(1)
+    print("  session_control: completed asynchronously (%s)"
+          % foo.error_string(sesresult['status']))
+
+    # a bad callback is refused before anything is allocated, on every one
+    # of them
+    for label, rc in [
+            ("register_nspace", foo.register_nspace("nbnspace", 1, [], 42)),
+            ("deregister_nspace", foo.deregister_nspace("nbnspace", 42)),
+            ("register_client", foo.register_client(src, 0, 0, 42)),
+            ("deregister_client", foo.deregister_client(src, 42)),
+            ("notify_event", foo.notify_event(PMIX_ERR_JOB_TERMINATED, src,
+                                              PMIX_RANGE_LOCAL, [], 42)),
+            ("register_resources", foo.register_resources([], 42)),
+            ("deregister_resources", foo.deregister_resources([], 42)),
+            ("setup_local_support", foo.setup_local_support("n", [], 42)),
+            ("deliver_inventory", foo.deliver_inventory([], [], 42)),
+            ("iof_deliver", foo.iof_deliver(src, PMIX_FWD_STDOUT_CHANNEL,
+                                            payload, [], 42)),
+            ("iof_flow_control", foo.iof_flow_control(None,
+                                                      PMIX_FWD_STDIN_CHANNEL,
+                                                      True, [], 42)),
+            ("session_control", foo.session_control(1, [], 42))]:
+        if PMIX_ERR_BAD_PARAM != rc:
+            print("%s ACCEPTED A NON-CALLABLE CALLBACK" % label)
+            exit(1)
     print("Non-blocking server registration calls: OK")
 
     # print a value and an info the way the library itself renders them

--- a/test/python/test_bindings.py
+++ b/test/python/test_bindings.py
@@ -1499,30 +1499,77 @@ class TestOptionalCallbackForms(unittest.TestCase):
     """
 
     def setUp(self):
-        self.server = pmix.PMIxServer()
+        # a tool inherits every client and server method, so one object
+        # reaches all fifteen - iof_deregister and iof_push are tool-role
+        self.server = pmix.PMIxTool()
+
+    #: name -> a call of that method with 'cb' in the callback position
+    def _calls(self, cb):
+        proc = {'nspace': "testns", 'rank': 0}
+        payload = {'bytes': b"hello", 'size': 5}
+        return {
+            'register_nspace':
+                lambda: self.server.register_nspace("testns", 1, [], cb),
+            'deregister_nspace':
+                lambda: self.server.deregister_nspace("testns", cb),
+            'register_client':
+                lambda: self.server.register_client(proc, 0, 0, cb),
+            'deregister_client':
+                lambda: self.server.deregister_client(proc, cb),
+            'notify_event':
+                lambda: self.server.notify_event(pmix.PMIX_ERR_JOB_TERMINATED,
+                                                 proc, pmix.PMIX_RANGE_LOCAL,
+                                                 [], cb),
+            'register_resources':
+                lambda: self.server.register_resources([], cb),
+            'deregister_resources':
+                lambda: self.server.deregister_resources([], cb),
+            'setup_local_support':
+                lambda: self.server.setup_local_support("testns", [], cb),
+            'deliver_inventory':
+                lambda: self.server.deliver_inventory([], [], cb),
+            'iof_deliver':
+                lambda: self.server.iof_deliver(proc,
+                                                pmix.PMIX_FWD_STDOUT_CHANNEL,
+                                                payload, [], cb),
+            'iof_flow_control':
+                lambda: self.server.iof_flow_control(proc,
+                                                     pmix.PMIX_FWD_STDIN_CHANNEL,
+                                                     True, [], cb),
+            'session_control':
+                lambda: self.server.session_control(1, [], cb),
+            'deregister_event_handler':
+                lambda: self.server.deregister_event_handler(0, cb),
+            'iof_deregister':
+                lambda: self.server.iof_deregister(0, [], cb),
+            'iof_push':
+                lambda: self.server.iof_push([proc], payload, [], cb),
+        }
+
+    def test_every_optional_callback_api_is_covered(self):
+        # if a new one is bound, add it here - the whole point of this
+        # class is that the list does not drift
+        self.assertEqual(len(self._calls(lambda *a: None)), 15)
 
     def test_non_callable_callback_is_refused(self):
         # a callback that cannot be called would strand the operation's
         # caddy for the life of the process, so it is checked before
         # anything is allocated
-        proc = {'nspace': "testns", 'rank': 0}
         for bad in (42, "not callable", [], {}):
-            self.assertEqual(
-                self.server.register_nspace("testns", 1, [], bad),
-                pmix.PMIX_ERR_BAD_PARAM, "register_nspace took %r" % (bad,))
-            self.assertEqual(
-                self.server.deregister_nspace("testns", bad),
-                pmix.PMIX_ERR_BAD_PARAM, "deregister_nspace took %r" % (bad,))
-            self.assertEqual(
-                self.server.register_client(proc, 0, 0, bad),
-                pmix.PMIX_ERR_BAD_PARAM, "register_client took %r" % (bad,))
-            self.assertEqual(
-                self.server.deregister_client(proc, bad),
-                pmix.PMIX_ERR_BAD_PARAM, "deregister_client took %r" % (bad,))
-            self.assertEqual(
-                self.server.notify_event(pmix.PMIX_ERR_JOB_TERMINATED, proc,
-                                         pmix.PMIX_RANGE_LOCAL, [], bad),
-                pmix.PMIX_ERR_BAD_PARAM, "notify_event took %r" % (bad,))
+            for name, call in self._calls(bad).items():
+                self.assertEqual(call(), pmix.PMIX_ERR_BAD_PARAM,
+                                 "%s accepted %r as a callback" % (name, bad))
+
+    def test_accepting_a_callable_does_not_raise(self):
+        # before init the library refuses every one of these, but the
+        # binding must marshal the arguments and answer a status rather
+        # than raise - a shape error here is a TypeError, not an rc
+        def cb(*args):
+            pass
+
+        for name, call in self._calls(cb).items():
+            rc = call()
+            self.assertIsInstance(rc, int, "%s did not answer a status" % name)
 
     def test_blocking_form_is_still_the_default(self):
         # omitting the callback must keep the behavior every existing


### PR DESCRIPTION
Completes the family started in #4084, now rebased onto master since that
merged.

PMIx spells "non-blocking" two ways: a separate `*_nb` function, which is the
client family, and an optional trailing `cbfunc`/`cbdata` on the same entry
point, which is mostly the server family. All 25 of the first kind were
already bound. #4084 bound five of the second. This binds the remaining ten:

| | | |
|---|---|---|
| `register_resources` | `deliver_inventory` | `iof_deregister` |
| `deregister_resources` | `iof_deliver` | `iof_push` |
| `setup_local_support` | `iof_flow_control` | |
| `session_control` | `deregister_event_handler` | |

That is all fifteen. Fourteen take the op-style callback,
`cbfunc(status, cbdata)`; `session_control` reports results, so it takes the
info-style `cbfunc(status, results, cbdata)` and routes through
`pypmix_client_info_cbfunc`.

## Why it matters

Every server-module upcall, event handler and completion callback runs on the
progress thread, where the blocking form waits on the event loop it is
standing in. Several of these are things a handler naturally wants to do —
dropping an IOF registration from inside the IOF handler, pushing output from
inside an upcall, deregistering an event handler from the handler itself.
Before this, none of them had a form that works from there.

## What each API retains is not guessable

So each was read rather than assumed. `register_client` and
`deregister_client` copy the proc and keep nothing; `setup_local_support`
strdup's the namespace but holds the info array; `IOF_deliver` holds the
source, the payload *and* the directives. Everything the library keeps until
completion goes in the caddy, which grows a byte-object slot and
`pypmix_nb_add_bo` for the IOF payloads — those cannot be the stack copy the
blocking forms use.

`iof_deregister` drops its local handler record on the asynchronous path too,
as the blocking form does.

## Testing

`test_bindings.py` builds its cases from one table so coverage cannot drift —
a test asserts the table holds all fifteen, and every entry is checked for
both argument validation and marshalling. `server.py` drives ten of them
through real asynchronous completions against a live library, checking the
status and the round-tripped `cbdata`:

```
  register_nspace: completed asynchronously
  register_client: completed asynchronously
  deregister_client: completed asynchronously
  deregister_nspace: completed asynchronously
  register_resources: completed asynchronously (PMIX_SUCCESS)
  deregister_resources: completed asynchronously (PMIX_SUCCESS)
  setup_local_support: completed asynchronously (PMIX_SUCCESS)
  deliver_inventory: completed asynchronously (PMIX_SUCCESS)
  iof_deliver: completed asynchronously (PMIX_SUCCESS)
  iof_flow_control: completed asynchronously (PMIX_SUCCESS)
```

`make check` is 110 tests, all passing.

## A note on `session_control`

It is the one member of the family that reports results, so its callback
takes three arguments rather than two and it needs its own waiter in the
test. A standalone server has no scheduler above it to service the request,
so the library answers `PMIX_ERR_UNREACH` **through the callback** — the
contract working exactly as documented, which is what the test now asserts:

```
  session_control: completed asynchronously (PMIX_ERR_UNREACH)
```

An earlier revision of this PR claimed that call hung and was a pre-existing
C API defect. That was wrong: the test had passed it a two-argument
callback, so the trampoline raised inside the completion and the waiter
never fired. Verified against the C API directly — it reports `UNREACH`
through the callback as it should.

## Still not bound

`dmodex_request`, `setup_application` and `collect_inventory` cannot simply
grow a callback: they drive an internal C callback and wait on the
module-global `active` lock, so they need that non-reentrancy fixed first.
That is a real piece of work, not a follow-on line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
