### PR TITLE
Report a dropped request through the callback the host supplied

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1781,10 +1781,23 @@ PMIX_EXPORT void PMIx_server_deregister_nspace(const pmix_nspace_t nspace, pmix_
     }
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the request cannot be serviced, and this API reports no status,
+         * so the callback is the only way to say so - a host that was
+         * given one and never hears back waits forever. The initialized
+         * check above has always done this; this one did not */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_ERR_NOT_AVAILABLE, cbdata);
+        }
         return;
     }
 
     cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_ERR_NOMEM, cbdata);
+        }
+        return;
+    }
     PMIX_LOAD_PROCID(&cd->proc, nspace, PMIX_RANK_WILDCARD);
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
@@ -2522,6 +2535,10 @@ PMIX_EXPORT void PMIx_server_deregister_client(const pmix_proc_t *proc, pmix_op_
     }
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* see the matching comment in PMIx_server_deregister_nspace */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_ERR_NOT_AVAILABLE, cbdata);
+        }
         return;
     }
 

--- a/test/unit/progress_threads.c
+++ b/test/unit/progress_threads.c
@@ -307,6 +307,61 @@ static void test_blocking_call_from_progress_thread(void)
            PMIX_ERR_WOULD_BLOCK != PMIx_server_delete_process_set("ut-no-such-pset"));
 }
 
+/* ------------------------------------------------------------------
+ * The void deregistration APIs must report a dropped request
+ *
+ * PMIx_server_deregister_nspace and PMIx_server_deregister_client are
+ * the only two public APIs that take a completion callback and report no
+ * status.  The callback is therefore the ONLY way they can tell a host
+ * that its request will not be serviced - and a host that is given one
+ * and never hears back waits forever.
+ *
+ * Their !initialized guard has always invoked the callback.  The
+ * progress_thread_stopped guard immediately below it used to return
+ * silently, which is the case a host hits while shutting down.
+ * ------------------------------------------------------------------ */
+
+static pmix_status_t dropped_status = PMIX_SUCCESS;
+static int dropped_count = 0;
+
+static void dropped_cb(pmix_status_t status, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(cbdata);
+    dropped_status = status;
+    dropped_count++;
+}
+
+static void test_void_deregisters_report_a_dropped_request(void)
+{
+    pmix_nspace_t ns;
+    pmix_proc_t proc;
+
+    /* stop the shared progress thread, which is what makes the library
+     * refuse to accept new work - the same state a finalizing host is in */
+    PMIx_Progress_thread_stop(NULL, 0);
+
+    PMIX_LOAD_NSPACE(ns, "ut-dropped-nspace");
+    dropped_count = 0;
+    dropped_status = PMIX_SUCCESS;
+    PMIx_server_deregister_nspace(ns, dropped_cb, NULL);
+    report("dropped:deregister_nspace invoked the callback", 1 == dropped_count);
+    report("dropped:deregister_nspace reported NOT_AVAILABLE",
+           PMIX_ERR_NOT_AVAILABLE == dropped_status);
+
+    PMIX_LOAD_PROCID(&proc, "ut-dropped-nspace", 0);
+    dropped_count = 0;
+    dropped_status = PMIX_SUCCESS;
+    PMIx_server_deregister_client(&proc, dropped_cb, NULL);
+    report("dropped:deregister_client invoked the callback", 1 == dropped_count);
+    report("dropped:deregister_client reported NOT_AVAILABLE",
+           PMIX_ERR_NOT_AVAILABLE == dropped_status);
+
+    /* a NULL callback on the same path must simply return */
+    PMIx_server_deregister_nspace(ns, NULL, NULL);
+    PMIx_server_deregister_client(&proc, NULL, NULL);
+    report("dropped:a NULL callback is tolerated", true);
+}
+
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
@@ -327,6 +382,8 @@ int main(int argc, char **argv)
     test_pause_resume();
     test_unknown_name();
     test_blocking_call_from_progress_thread();
+    /* must come last - it stops the shared progress thread */
+    test_void_deregisters_report_a_dropped_request();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 


### PR DESCRIPTION
Rebased onto master now that #4084 has merged; one commit, two files.

`PMIx_server_deregister_nspace` and `PMIx_server_deregister_client` are the
only two public APIs that take a completion callback and return no status.
That callback is therefore the only channel they have for telling a host that
its request will not be serviced.

Both check two things on entry:

```c
    if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
        if (NULL != cbfunc) {
            cbfunc(PMIX_ERR_INIT, cbdata);      /* correct */
        }
        return;
    }

    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
        return;                                 /* silently drops it */
    }
```

The second is exactly the state a finalizing host is in, so a host using the
non-blocking form during shutdown waited forever for a callback that was
never coming. Both now report `PMIX_ERR_NOT_AVAILABLE`, matching the status
their status-returning siblings answer in the same situation.

`PMIx_server_deregister_nspace` also used the caddy it had just allocated
without checking it, unlike its sibling. Fixed while here.

## Scope — smaller than I first said

When I raised this at the end of #4084 I put it at "roughly twenty sites".
That was wrong, and worth correcting rather than quietly shipping the smaller
change.

Every *other* public API that takes a callback also returns a status, and
there an error return already means "no callback will fire" — that is the
library's tri-state convention, documented in `src/server/AGENTS.md`. Those
guards return `PMIX_ERR_NOT_AVAILABLE` and are correct as they stand. The
~20 sites my first scan flagged were mostly the library's own internal
completion callbacks, where dropping work during finalize is intended.

Only the two `void` APIs have no way to report, and only they needed fixing.

## Testing

`test/unit/progress_threads.c` pins the behaviour: with the shared progress
thread stopped, both calls must invoke the callback exactly once with
`NOT_AVAILABLE`, and both must still tolerate a NULL one.

`make check` is 110 tests, all passing; `simptest` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
