### PR TITLE
Fix pmix_mca_base_var_build_env(), sweep asprintf, guard pcompress entry points

### DIFF
--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -56,6 +56,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
 
 #include "src/client/pmix_client_ops.h"
 #include "src/server/pmix_server_ops.h"
@@ -230,7 +231,7 @@ static void resolve_peers(int sd, short args, void *cbdata)
                 continue;
             }
             /* prepend the nspace */
-            if (PMIX_UNLIKELY(0 > asprintf(&prs, "%s:%s", ns->nspace, val->data.string))) {
+            if (PMIX_UNLIKELY(0 > pmix_asprintf(&prs, "%s:%s", ns->nspace, val->data.string))) {
                 PMIX_LIST_DESTRUCT(&cb.kvs);
                 PMIX_CONSTRUCT(&cb.kvs, pmix_list_t);
                 continue;

--- a/src/mca/base/pmix_mca_base_component_compare.c
+++ b/src/mca/base/pmix_mca_base_component_compare.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,6 +24,7 @@
 
 #include "src/mca/base/pmix_base.h"
 #include "src/mca/mca.h"
+#include "src/util/pmix_printf.h"
 
 /*
  * Function for comparing two pmix_mca_base_component_priority_t structs so
@@ -127,7 +128,7 @@ int pmix_mca_base_component_compatible(const pmix_mca_base_component_t *aa,
 char *pmix_mca_base_component_to_string(const pmix_mca_base_component_t *a)
 {
     char *str = NULL;
-    if (0 > asprintf(&str, "%s.%s.%d.%d", a->pmix_mca_type_name, a->pmix_mca_component_name,
+    if (0 > pmix_asprintf(&str, "%s.%s.%d.%d", a->pmix_mca_type_name, a->pmix_mca_component_name,
                      a->pmix_mca_component_major_version, a->pmix_mca_component_minor_version)) {
         return NULL;
     }

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -208,7 +208,7 @@ static int file_exists(const char *filename, const char *ext)
         return access(filename, F_OK) == 0;
     }
 
-    ret = asprintf(&final, "%s.%s", filename, ext);
+    ret = pmix_asprintf(&final, "%s.%s", filename, ext);
     if (0 > ret || NULL == final) {
         return 0;
     }
@@ -522,7 +522,7 @@ int pmix_mca_base_component_repository_open(pmix_mca_base_framework_t *framework
         if (pmix_mca_base_component_track_load_errors) {
             pmix_mca_base_failed_component_t *f_comp = PMIX_NEW(pmix_mca_base_failed_component_t);
             f_comp->comp = ri;
-            if (0 > asprintf(&(f_comp->error_msg), "%s", err_msg)) {
+            if (0 > pmix_asprintf(&(f_comp->error_msg), "%s", err_msg)) {
                 PMIX_RELEASE(f_comp);
                 free(err_msg);
                 return PMIX_ERR_BAD_PARAM;

--- a/src/mca/base/pmix_mca_base_framework.c
+++ b/src/mca/base/pmix_mca_base_framework.c
@@ -4,7 +4,7 @@
  *                         reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,6 +16,7 @@
 
 #include "pmix_common.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
 
 #include "pmix_mca_base_framework.h"
 #include "pmix_mca_base_var.h"
@@ -88,7 +89,7 @@ int pmix_mca_base_framework_register(struct pmix_mca_base_framework_t *framework
             goto error;
         }
 
-        ret = asprintf(&desc,
+        ret = pmix_asprintf(&desc,
                        "Default selection set of components for the %s framework (<none>"
                        " means use all components that can be found)",
                        framework->framework_name);
@@ -106,7 +107,7 @@ int pmix_mca_base_framework_register(struct pmix_mca_base_framework_t *framework
         }
 
         /* register a verbosity variable for this framework */
-        ret = asprintf(&desc, "Verbosity level for the %s framework (default: 0)",
+        ret = pmix_asprintf(&desc, "Verbosity level for the %s framework (default: 0)",
                        framework->framework_name);
         if (0 > ret) {
             ret = PMIX_ERR_OUT_OF_RESOURCE;

--- a/src/mca/base/pmix_mca_base_open.c
+++ b/src/mca/base/pmix_mca_base_open.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -196,7 +196,7 @@ int pmix_mca_base_open(const char *add_path)
         set_defaults(&lds);
     }
     gethostname(hostname, PMIX_MAXHOSTNAMELEN - 1);
-    rc = asprintf(&lds.lds_prefix, "[%s:%05d] ", hostname, getpid());
+    rc = pmix_asprintf(&lds.lds_prefix, "[%s:%05d] ", hostname, getpid());
     if (0 > rc) {
         if (NULL != lds.lds_file_suffix) {
             free(lds.lds_file_suffix);

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -945,6 +945,7 @@ int pmix_mca_base_var_build_env(char ***env, int *num_env)
         ret = pmix_asprintf(&str, "%s%s=%s", var->mbv_prefix, var->mbv_full_name, value_string);
         free(value_string);
         if (0 > ret) {
+            ret = PMIX_ERR_OUT_OF_RESOURCE;
             goto cleanup;
         }
 
@@ -952,16 +953,27 @@ int pmix_mca_base_var_build_env(char ***env, int *num_env)
         free(str);
         str = NULL;
 
-        ret = PMIX_SUCCESS;
+        /* Note: a failure here has to be acted on immediately - the
+         * next trip around the loop overwrites ret, so a value checked
+         * only after the loop says nothing about this iteration */
         switch (var->mbv_source) {
             case PMIX_MCA_BASE_VAR_SOURCE_FILE:
             case PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE:
-                ret = pmix_asprintf(&str, "%sSOURCE_%s=FILE:%s", var->mbv_prefix, var->mbv_full_name,
-                               pmix_mca_base_var_source_file(var));
+                ret = pmix_asprintf(&str, "%sSOURCE_%s=FILE:%s", var->mbv_prefix,
+                                    var->mbv_full_name, pmix_mca_base_var_source_file(var));
+                if (0 > ret) {
+                    ret = PMIX_ERR_OUT_OF_RESOURCE;
+                    goto cleanup;
+                }
                 break;
 
             case PMIX_MCA_BASE_VAR_SOURCE_COMMAND_LINE:
-                ret = pmix_asprintf(&str, "%sSOURCE_%s=COMMAND_LINE", var->mbv_prefix, var->mbv_full_name);
+                ret = pmix_asprintf(&str, "%sSOURCE_%s=COMMAND_LINE", var->mbv_prefix,
+                                    var->mbv_full_name);
+                if (0 > ret) {
+                    ret = PMIX_ERR_OUT_OF_RESOURCE;
+                    goto cleanup;
+                }
                 break;
 
             case PMIX_MCA_BASE_VAR_SOURCE_ENV:
@@ -971,20 +983,19 @@ int pmix_mca_base_var_build_env(char ***env, int *num_env)
                 break;
 
             case PMIX_MCA_BASE_VAR_SOURCE_MAX:
+                ret = PMIX_ERR_NOT_FOUND;
                 goto cleanup;
         }
 
         if (NULL != str) {
             pmix_argv_append(num_env, env, str);
             free(str);
+            str = NULL;
         }
-    }
-    if (ret < 0) {
-        ret = PMIX_ERR_OUT_OF_RESOURCE;
     }
 
     /* All done */
-    return ret;
+    return PMIX_SUCCESS;
 
     /* Error condition */
 
@@ -994,7 +1005,7 @@ cleanup:
         *num_env = 0;
         *env = NULL;
     }
-    return PMIX_ERR_NOT_FOUND;
+    return ret;
 }
 
 /*

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -283,10 +283,10 @@ static void resolve_relative_paths(char **file_prefix, char *file_path, bool rel
         ;
 #endif
     } else {
-        /* Prepend the files to the search list. NOTE: asprintf leaves
-         * its output pointer indeterminate on failure, so it must not
-         * be freed here */
-        if (0 > asprintf(&tmp_str, "%s%c%s", *file_prefix, sep, *files)) {
+        /* Prepend the files to the search list. NOTE: pmix_asprintf
+         * sets its output pointer to NULL on failure, so there is
+         * nothing to free here */
+        if (0 > pmix_asprintf(&tmp_str, "%s%c%s", *file_prefix, sep, *files)) {
             pmix_output(0, "OUT OF MEM");
             free(*files);
             *files = NULL;
@@ -329,12 +329,12 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
     }
 
 #if PMIX_WANT_HOME_CONFIG_FILES
-    ret = asprintf(&pmix_mca_base_var_files,
+    ret = pmix_asprintf(&pmix_mca_base_var_files,
                    "%s" PMIX_PATH_SEP ".pmix" PMIX_PATH_SEP "mca-params.conf%c%s" PMIX_PATH_SEP
                    "pmix-mca-params.conf",
                    home, ',', pmix_pinstall_dirs.sysconfdir);
 #else
-    ret = asprintf(&pmix_mca_base_var_files, "%s" PMIX_PATH_SEP "pmix-mca-params.conf",
+    ret = pmix_asprintf(&pmix_mca_base_var_files, "%s" PMIX_PATH_SEP "pmix-mca-params.conf",
                    pmix_pinstall_dirs.sysconfdir);
 #endif
     if (0 > ret) {
@@ -359,7 +359,7 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
     (void) pmix_mca_base_var_register_synonym(ret, "pmix", "mca", NULL, "param_files",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
-    ret = asprintf(&pmix_mca_base_var_override_file,
+    ret = pmix_asprintf(&pmix_mca_base_var_override_file,
                    "%s" PMIX_PATH_SEP "pmix-mca-params-override.conf",
                    pmix_pinstall_dirs.sysconfdir);
     if (0 > ret) {
@@ -399,7 +399,7 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
         return ret;
     }
 
-   ret = asprintf(&pmix_mca_base_param_file_path, "%s" PMIX_PATH_SEP "amca-param-sets%c%s",
+   ret = pmix_asprintf(&pmix_mca_base_param_file_path, "%s" PMIX_PATH_SEP "amca-param-sets%c%s",
                    pmix_pinstall_dirs.pmixdatadir, PMIX_ENV_SEP, cwd);
     if (0 > ret) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -428,7 +428,7 @@ int pmix_mca_base_var_cache_files(bool rel_path_search)
         if (NULL != pmix_mca_base_param_file_path) {
             char *tmp_str = pmix_mca_base_param_file_path;
 
-            ret = asprintf(&pmix_mca_base_param_file_path, "%s%c%s", force_agg_path, PMIX_ENV_SEP,
+            ret = pmix_asprintf(&pmix_mca_base_param_file_path, "%s%c%s", force_agg_path, PMIX_ENV_SEP,
                            tmp_str);
             free(tmp_str);
             if (0 > ret) {
@@ -546,7 +546,7 @@ static int var_set_string(pmix_mca_base_var_t *var, char *value)
        in the future. */
     if (0 == strncmp(value, "~/", 2)) {
         if (NULL != home) {
-            ret = asprintf(&value, "%s/%s", home, value + 2);
+            ret = pmix_asprintf(&value, "%s/%s", home, value + 2);
             if (0 > ret) {
                 return PMIX_ERROR;
             }
@@ -565,7 +565,7 @@ static int var_set_string(pmix_mca_base_var_t *var, char *value)
         tmp[0] = '\0';
         tmp += 3;
 
-        ret = asprintf(&tmp, "%s:%s%s%s", value, home ? home : "", home ? "/" : "", tmp);
+        ret = pmix_asprintf(&tmp, "%s:%s%s%s", value, home ? home : "", home ? "/" : "", tmp);
 
         free(value);
 
@@ -942,7 +942,7 @@ int pmix_mca_base_var_build_env(char ***env, int *num_env)
             goto cleanup;
         }
 
-        ret = asprintf(&str, "%s%s=%s", var->mbv_prefix, var->mbv_full_name, value_string);
+        ret = pmix_asprintf(&str, "%s%s=%s", var->mbv_prefix, var->mbv_full_name, value_string);
         free(value_string);
         if (0 > ret) {
             goto cleanup;
@@ -956,12 +956,12 @@ int pmix_mca_base_var_build_env(char ***env, int *num_env)
         switch (var->mbv_source) {
             case PMIX_MCA_BASE_VAR_SOURCE_FILE:
             case PMIX_MCA_BASE_VAR_SOURCE_OVERRIDE:
-                ret = asprintf(&str, "%sSOURCE_%s=FILE:%s", var->mbv_prefix, var->mbv_full_name,
+                ret = pmix_asprintf(&str, "%sSOURCE_%s=FILE:%s", var->mbv_prefix, var->mbv_full_name,
                                pmix_mca_base_var_source_file(var));
                 break;
 
             case PMIX_MCA_BASE_VAR_SOURCE_COMMAND_LINE:
-                ret = asprintf(&str, "%sSOURCE_%s=COMMAND_LINE", var->mbv_prefix, var->mbv_full_name);
+                ret = pmix_asprintf(&str, "%sSOURCE_%s=COMMAND_LINE", var->mbv_prefix, var->mbv_full_name);
                 break;
 
             case PMIX_MCA_BASE_VAR_SOURCE_ENV:
@@ -1445,12 +1445,12 @@ static int var_get_env(pmix_mca_base_var_t *var, const char *name, char **source
     char *source_env, *value_env;
     int ret;
 
-    ret = asprintf(&source_env, "%sSOURCE_%s", var->mbv_prefix, name);
+    ret = pmix_asprintf(&source_env, "%sSOURCE_%s", var->mbv_prefix, name);
     if (0 > ret) {
         return PMIX_ERROR;
     }
 
-    ret = asprintf(&value_env, "%s%s", var->mbv_prefix, name);
+    ret = pmix_asprintf(&value_env, "%s%s", var->mbv_prefix, name);
     if (0 > ret) {
         free(source_env);
         return PMIX_ERROR;
@@ -1744,9 +1744,9 @@ static char *source_name(pmix_mca_base_var_t *var)
         int rc;
 
         if (fv) {
-            rc = asprintf(&ret, "file (%s:%d)", fv->mbvfv_file, fv->mbvfv_lineno);
+            rc = pmix_asprintf(&ret, "file (%s:%d)", fv->mbvfv_file, fv->mbvfv_lineno);
         } else {
-            rc = asprintf(&ret, "file (%s)", var->mbv_source_file);
+            rc = pmix_asprintf(&ret, "file (%s)", var->mbv_source_file);
         }
 
         /* some compilers will warn if the return code of asprintf is not checked (even if it is
@@ -1777,29 +1777,29 @@ static int var_value_string(pmix_mca_base_var_t *var, char **value_string)
     if (NULL == var->mbv_enumerator) {
         switch (var->mbv_type) {
         case PMIX_MCA_BASE_VAR_TYPE_INT:
-            ret = asprintf(value_string, "%d", value->intval);
+            ret = pmix_asprintf(value_string, "%d", value->intval);
             break;
         case PMIX_MCA_BASE_VAR_TYPE_UNSIGNED_INT:
-            ret = asprintf(value_string, "%u", value->uintval);
+            ret = pmix_asprintf(value_string, "%u", value->uintval);
             break;
         case PMIX_MCA_BASE_VAR_TYPE_UNSIGNED_LONG:
-            ret = asprintf(value_string, "%lu", value->ulval);
+            ret = pmix_asprintf(value_string, "%lu", value->ulval);
             break;
         case PMIX_MCA_BASE_VAR_TYPE_UNSIGNED_LONG_LONG:
-            ret = asprintf(value_string, "%llu", value->ullval);
+            ret = pmix_asprintf(value_string, "%llu", value->ullval);
             break;
         case PMIX_MCA_BASE_VAR_TYPE_SIZE_T:
-            ret = asprintf(value_string, "%" PRIsize_t, value->sizetval);
+            ret = pmix_asprintf(value_string, "%" PRIsize_t, value->sizetval);
             break;
         case PMIX_MCA_BASE_VAR_TYPE_STRING:
         case PMIX_MCA_BASE_VAR_TYPE_VERSION_STRING:
-            ret = asprintf(value_string, "%s", value->stringval ? value->stringval : "");
+            ret = pmix_asprintf(value_string, "%s", value->stringval ? value->stringval : "");
             break;
         case PMIX_MCA_BASE_VAR_TYPE_BOOL:
-            ret = asprintf(value_string, "%d", value->boolval);
+            ret = pmix_asprintf(value_string, "%d", value->boolval);
             break;
         case PMIX_MCA_BASE_VAR_TYPE_DOUBLE:
-            ret = asprintf(value_string, "%lf", value->lfval);
+            ret = pmix_asprintf(value_string, "%lf", value->lfval);
             break;
         default:
             ret = -1;

--- a/src/mca/base/pmix_mca_base_var_enum.c
+++ b/src/mca/base/pmix_mca_base_var_enum.c
@@ -236,7 +236,7 @@ static int pmix_mca_base_var_enum_verbose_sfv(pmix_mca_base_var_enum_t *self, co
     }
 
     if (string_value) {
-        ret = asprintf(string_value, "%d", value);
+        ret = pmix_asprintf(string_value, "%d", value);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
@@ -664,7 +664,7 @@ static int enum_string_from_value_flag(pmix_mca_base_var_enum_t *self, const int
 
         tmp = out;
 
-        ret = asprintf(&out, "%s%s%s", tmp ? tmp : "", tmp ? "," : "",
+        ret = pmix_asprintf(&out, "%s%s%s", tmp ? tmp : "", tmp ? "," : "",
                        flag_enum->enum_flags[i].string);
         free(tmp);
 

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -1173,6 +1173,35 @@ size_t PMIx_Info_list_get_size(void *ptr)
     return pmix_list_get_size(p);
 }
 
+/* Sizing a compressed blob asks the selected pcompress module how big
+ * the blob inflates to. Every module in this tree answers, but the
+ * module is *copied* out of whichever component the MCA base selected,
+ * and a component is a run-time-loadable plugin: one built against a
+ * libpmix that predates these two entry points leaves the slots NULL,
+ * and the call is then a jump to address zero. That is not a theoretical
+ * mismatch - an installed plugin older than the library it is loaded
+ * into is exactly what a partial upgrade produces, and it is how this
+ * was found.
+ *
+ * Ask through these instead of calling the slot. A module that cannot
+ * answer yields 0, which is what the base default already returns for a
+ * blob it cannot read. */
+static size_t decompressed_size(const pmix_byte_object_t *bo)
+{
+    if (NULL == pmix_compress.get_decompressed_size) {
+        return 0;
+    }
+    return pmix_compress.get_decompressed_size(bo);
+}
+
+static size_t decompressed_strlen(const pmix_byte_object_t *bo)
+{
+    if (NULL == pmix_compress.get_decompressed_strlen) {
+        return 0;
+    }
+    return pmix_compress.get_decompressed_strlen(bo);
+}
+
 static pmix_status_t get_darray_size(pmix_data_array_t *array,
                                      size_t *sz)
 {
@@ -1286,14 +1315,14 @@ static pmix_status_t get_darray_size(pmix_data_array_t *array,
             *sz = array->size * sizeof(void*);
             bo = (pmix_byte_object_t*)array->array;
             for (n=0; n < array->size; n++) {
-                *sz += pmix_compress.get_decompressed_strlen(&bo[n]);
+                *sz += decompressed_strlen(&bo[n]);
             }
             break;
         case PMIX_COMPRESSED_BYTE_OBJECT:
             *sz = array->size * sizeof(void*);
             bo = (pmix_byte_object_t*)array->array;
             for (n=0; n < array->size; n++) {
-                *sz += pmix_compress.get_decompressed_size(&bo[n]);
+                *sz += decompressed_size(&bo[n]);
             }
             break;
         case PMIX_PERSIST:
@@ -1611,10 +1640,10 @@ pmix_status_t PMIx_Value_get_size(const pmix_value_t *v,
             }
             break;
         case PMIX_COMPRESSED_STRING:
-            *sz = pmix_compress.get_decompressed_strlen(&v->data.bo);
+            *sz = decompressed_strlen(&v->data.bo);
             break;
         case PMIX_COMPRESSED_BYTE_OBJECT:
-            *sz = pmix_compress.get_decompressed_size(&v->data.bo);
+            *sz = decompressed_size(&v->data.bo);
             break;
         case PMIX_PERSIST:
             *sz = sizeof(pmix_persistence_t);

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Jeff Squyres  All rights reserved.
  * $COPYRIGHT$
  *
@@ -35,6 +35,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
 
 #include "src/mca/bfrops/base/base.h"
@@ -297,7 +298,7 @@ pmix_status_t pmix_bfrops_base_pack_float(pmix_pointer_array_t *regtypes, pmix_b
     PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
-        ret = asprintf(&convert, "%f", ssrc[i]);
+        ret = pmix_asprintf(&convert, "%f", ssrc[i]);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
@@ -323,7 +324,7 @@ pmix_status_t pmix_bfrops_base_pack_double(pmix_pointer_array_t *regtypes, pmix_
     PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
-        ret = asprintf(&convert, "%f", ssrc[i]);
+        ret = pmix_asprintf(&convert, "%f", ssrc[i]);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
         }

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -97,7 +97,7 @@ int pmix_bfrops_base_print_bool(char **output, char *prefix, bool *src, pmix_dat
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_BOOL\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_BOOL\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -106,7 +106,7 @@ int pmix_bfrops_base_print_bool(char **output, char *prefix, bool *src, pmix_dat
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_BOOL\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_BOOL\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    (*src) ? "TRUE" : "FALSE");
 
@@ -125,7 +125,7 @@ int pmix_bfrops_base_print_byte(char **output, char *prefix, uint8_t *src, pmix_
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_BYTE\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_BYTE\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -134,7 +134,7 @@ int pmix_bfrops_base_print_byte(char **output, char *prefix, uint8_t *src, pmix_
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_BYTE\tValue: %x",
+    ret = pmix_asprintf(output, "%sData type: PMIX_BYTE\tValue: %x",
                    (NULL == prefix) ? " " : prefix, *src);
 
     if (0 > ret) {
@@ -152,7 +152,7 @@ int pmix_bfrops_base_print_string(char **output, char *prefix, char *src, pmix_d
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_STRING\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_STRING\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -161,7 +161,7 @@ int pmix_bfrops_base_print_string(char **output, char *prefix, char *src, pmix_d
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_STRING\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_STRING\tValue: %s",
                    (NULL == prefix) ? " " : prefix, src);
 
     if (0 > ret) {
@@ -179,7 +179,7 @@ int pmix_bfrops_base_print_size(char **output, char *prefix, size_t *src, pmix_d
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_SIZE\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_SIZE\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -188,7 +188,7 @@ int pmix_bfrops_base_print_size(char **output, char *prefix, size_t *src, pmix_d
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_SIZE\tValue: %lu",
+    ret = pmix_asprintf(output, "%sData type: PMIX_SIZE\tValue: %lu",
                    (NULL == prefix) ? " " : prefix,
                    (unsigned long) *src);
 
@@ -207,7 +207,7 @@ int pmix_bfrops_base_print_pid(char **output, char *prefix, pid_t *src, pmix_dat
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_PID\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_PID\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -216,7 +216,7 @@ int pmix_bfrops_base_print_pid(char **output, char *prefix, pid_t *src, pmix_dat
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_PID\tValue: %lu",
+    ret = pmix_asprintf(output, "%sData type: PMIX_PID\tValue: %lu",
                    (NULL == prefix) ? " " : prefix,
                    (unsigned long) *src);
     if (0 > ret) {
@@ -234,7 +234,7 @@ int pmix_bfrops_base_print_int(char **output, char *prefix, int *src, pmix_data_
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_INT\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_INT\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -243,7 +243,7 @@ int pmix_bfrops_base_print_int(char **output, char *prefix, int *src, pmix_data_
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_INT\tValue: %ld",
+    ret = pmix_asprintf(output, "%sData type: PMIX_INT\tValue: %ld",
                    (NULL == prefix) ? " " : prefix, (long) *src);
 
     if (0 > ret) {
@@ -261,7 +261,7 @@ int pmix_bfrops_base_print_uint(char **output, char *prefix, uint *src, pmix_dat
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_UINT\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_UINT\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -270,7 +270,7 @@ int pmix_bfrops_base_print_uint(char **output, char *prefix, uint *src, pmix_dat
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_UINT\tValue: %lu",
+    ret = pmix_asprintf(output, "%sData type: PMIX_UINT\tValue: %lu",
                    (NULL == prefix) ? " " : prefix, (unsigned long) *src);
 
     if (0 > ret) {
@@ -288,7 +288,7 @@ int pmix_bfrops_base_print_uint8(char **output, char *prefix, uint8_t *src, pmix
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_UINT8\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_UINT8\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -297,7 +297,7 @@ int pmix_bfrops_base_print_uint8(char **output, char *prefix, uint8_t *src, pmix
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_UINT8\tValue: %u",
+    ret = pmix_asprintf(output, "%sData type: PMIX_UINT8\tValue: %u",
                    (NULL == prefix) ? " " : prefix, (unsigned int) *src);
 
     if (0 > ret) {
@@ -315,7 +315,7 @@ int pmix_bfrops_base_print_uint16(char **output, char *prefix, uint16_t *src, pm
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_UINT16\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_UINT16\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -324,7 +324,7 @@ int pmix_bfrops_base_print_uint16(char **output, char *prefix, uint16_t *src, pm
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_UINT16\tValue: %u",
+    ret = pmix_asprintf(output, "%sData type: PMIX_UINT16\tValue: %u",
                    (NULL == prefix) ? " " : prefix, (unsigned int) *src);
 
     if (0 > ret) {
@@ -342,7 +342,7 @@ int pmix_bfrops_base_print_uint32(char **output, char *prefix, uint32_t *src, pm
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_UINT32\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_UINT32\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -351,7 +351,7 @@ int pmix_bfrops_base_print_uint32(char **output, char *prefix, uint32_t *src, pm
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_UINT32\tValue: %u",
+    ret = pmix_asprintf(output, "%sData type: PMIX_UINT32\tValue: %u",
                    (NULL == prefix) ? " " : prefix, (unsigned int) *src);
 
     if (0 > ret) {
@@ -369,7 +369,7 @@ int pmix_bfrops_base_print_int8(char **output, char *prefix, int8_t *src, pmix_d
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_INT8\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_INT8\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -378,7 +378,7 @@ int pmix_bfrops_base_print_int8(char **output, char *prefix, int8_t *src, pmix_d
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_INT8\tValue: %d",
+    ret = pmix_asprintf(output, "%sData type: PMIX_INT8\tValue: %d",
                    (NULL == prefix) ? " " : prefix, (int) *src);
 
     if (0 > ret) {
@@ -396,7 +396,7 @@ int pmix_bfrops_base_print_int16(char **output, char *prefix, int16_t *src, pmix
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_INT16\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_INT16\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -405,7 +405,7 @@ int pmix_bfrops_base_print_int16(char **output, char *prefix, int16_t *src, pmix
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_INT16\tValue: %d",
+    ret = pmix_asprintf(output, "%sData type: PMIX_INT16\tValue: %d",
                    (NULL == prefix) ? " " : prefix, (int) *src);
 
     if (0 > ret) {
@@ -423,7 +423,7 @@ int pmix_bfrops_base_print_int32(char **output, char *prefix, int32_t *src, pmix
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_INT32\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_INT32\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -432,7 +432,7 @@ int pmix_bfrops_base_print_int32(char **output, char *prefix, int32_t *src, pmix
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_INT32\tValue: %d",
+    ret = pmix_asprintf(output, "%sData type: PMIX_INT32\tValue: %d",
                    (NULL == prefix) ? " " : prefix, (int) *src);
 
     if (0 > ret) {
@@ -449,7 +449,7 @@ int pmix_bfrops_base_print_uint64(char **output, char *prefix, uint64_t *src, pm
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_UINT64\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_UINT64\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -458,7 +458,7 @@ int pmix_bfrops_base_print_uint64(char **output, char *prefix, uint64_t *src, pm
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_UINT64\tValue: %lu",
+    ret = pmix_asprintf(output, "%sData type: PMIX_UINT64\tValue: %lu",
                    (NULL == prefix) ? " " : prefix, (unsigned long) *src);
     if (0 > ret) {
         return PMIX_ERR_OUT_OF_RESOURCE;
@@ -475,7 +475,7 @@ int pmix_bfrops_base_print_int64(char **output, char *prefix, int64_t *src, pmix
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_INT64\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_INT64\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -484,7 +484,7 @@ int pmix_bfrops_base_print_int64(char **output, char *prefix, int64_t *src, pmix
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_INT64\tValue: %ld",
+    ret = pmix_asprintf(output, "%sData type: PMIX_INT64\tValue: %ld",
                    (NULL == prefix) ? " " : prefix, (long) *src);
 
     if (0 > ret) {
@@ -502,7 +502,7 @@ int pmix_bfrops_base_print_float(char **output, char *prefix, float *src, pmix_d
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_FLOAT\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_FLOAT\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -511,7 +511,7 @@ int pmix_bfrops_base_print_float(char **output, char *prefix, float *src, pmix_d
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_FLOAT\tValue: %f",
+    ret = pmix_asprintf(output, "%sData type: PMIX_FLOAT\tValue: %f",
                    (NULL == prefix) ? " " : prefix, *src);
 
     if (0 > ret) {
@@ -529,7 +529,7 @@ int pmix_bfrops_base_print_double(char **output, char *prefix, double *src, pmix
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_DOUBLE\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_DOUBLE\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -538,7 +538,7 @@ int pmix_bfrops_base_print_double(char **output, char *prefix, double *src, pmix
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_DOUBLE\tValue: %f",
+    ret = pmix_asprintf(output, "%sData type: PMIX_DOUBLE\tValue: %f",
                    (NULL == prefix) ? " " : prefix, *src);
 
     if (0 > ret) {
@@ -558,7 +558,7 @@ int pmix_bfrops_base_print_time(char **output, char *prefix, time_t *src, pmix_d
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_TIME\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_TIME\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -571,7 +571,7 @@ int pmix_bfrops_base_print_time(char **output, char *prefix, time_t *src, pmix_d
     t = asctime(local);
     t[strlen(t) - 1] = '\0'; // remove trailing newline
 
-    ret = asprintf(output, "%sData type: PMIX_TIME\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_TIME\tValue: %s",
                    (NULL == prefix) ? " " : prefix, t);
 
     if (0 > ret) {
@@ -589,7 +589,7 @@ int pmix_bfrops_base_print_timeval(char **output, char *prefix, struct timeval *
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -598,7 +598,7 @@ int pmix_bfrops_base_print_timeval(char **output, char *prefix, struct timeval *
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: %lu.%lu",
+    ret = pmix_asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: %lu.%lu",
                    (NULL == prefix) ? " " : prefix,
                    (unsigned long)src->tv_sec,
                    (unsigned long)src->tv_usec);
@@ -619,7 +619,7 @@ int pmix_bfrops_base_print_status(char **output, char *prefix, pmix_status_t *sr
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_STATUS\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_STATUS\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -628,7 +628,7 @@ int pmix_bfrops_base_print_status(char **output, char *prefix, pmix_status_t *sr
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_STATUS\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_STATUS\tValue: %s",
                    (NULL == prefix) ? " " : prefix, PMIx_Error_string(*src));
 
     if (0 > ret) {
@@ -849,7 +849,7 @@ int pmix_bfrops_base_print_value(char **output, char *prefix, pmix_value_t *src,
 
     rc = print_val(&tp, src);
     if (PMIX_SUCCESS == rc) {
-        rc = asprintf(output, "%sPMIX_VALUE: %s",
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: %s",
                       (NULL == prefix) ? " " : prefix, tp);
         free(tp);
     }
@@ -870,7 +870,7 @@ int pmix_bfrops_base_print_info(char **output, char *prefix, pmix_info_t *src,
 
     pmix_bfrops_base_print_value(&tmp, prefix, &src->value, PMIX_VALUE);
     pmix_bfrops_base_print_info_directives(&tmp2, prefix, &src->flags, PMIX_INFO_DIRECTIVES);
-    ret = asprintf(output, "%sKEY: %s\n%s\t%s\n%s\t%s",
+    ret = pmix_asprintf(output, "%sKEY: %s\n%s\t%s\n%s\t%s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Get_attribute_name(src->key),
                    (NULL == prefix) ? " " : prefix, tmp2,
@@ -894,7 +894,7 @@ int pmix_bfrops_base_print_pdata(char **output, char *prefix, pmix_pdata_t *src,
 
     pmix_bfrops_base_print_proc(&tmp1, prefix, &src->proc, PMIX_PROC);
     pmix_bfrops_base_print_value(&tmp2, prefix, &src->value, PMIX_VALUE);
-    ret = asprintf(output, "%s  %s  KEY: %s %s",
+    ret = pmix_asprintf(output, "%s  %s  KEY: %s %s",
                    (NULL == prefix) ? " " : prefix, tmp1,
                    PMIx_Get_attribute_name(src->key),
                    (NULL == tmp2) ? "NULL" : tmp2);
@@ -939,19 +939,19 @@ int pmix_bfrops_base_print_proc(char **output, char *prefix, pmix_proc_t *src,
     } else {
         switch (src->rank) {
             case PMIX_RANK_UNDEF:
-                rc = asprintf(output, "%sPROC: %s:PMIX_RANK_UNDEF",
+                rc = pmix_asprintf(output, "%sPROC: %s:PMIX_RANK_UNDEF",
                               (NULL == prefix) ? " " : prefix, src->nspace);
                 break;
             case PMIX_RANK_WILDCARD:
-                rc = asprintf(output, "%sPROC: %s:PMIX_RANK_WILDCARD",
+                rc = pmix_asprintf(output, "%sPROC: %s:PMIX_RANK_WILDCARD",
                               (NULL == prefix) ? " " : prefix, src->nspace);
                 break;
             case PMIX_RANK_LOCAL_NODE:
-                rc = asprintf(output, "%sPROC: %s:PMIX_RANK_LOCAL_NODE",
+                rc = pmix_asprintf(output, "%sPROC: %s:PMIX_RANK_LOCAL_NODE",
                               (NULL == prefix) ? " " : prefix, src->nspace);
                 break;
             default:
-                rc = asprintf(output, "%sPROC: %s:%lu",
+                rc = pmix_asprintf(output, "%sPROC: %s:%lu",
                               (NULL == prefix) ? " " : prefix
                               , src->nspace, (unsigned long) (src->rank));
         }
@@ -977,14 +977,14 @@ int pmix_bfrops_base_print_persist(char **output, char *prefix, pmix_persistence
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_PERSIST\tValue: NULL pointer",
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_PERSIST\tValue: NULL pointer",
                          (NULL == prefix) ? " " : prefix)) {
             return PMIX_ERR_NOMEM;
         }
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_PERSIST\tValue: %ld",
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_PERSIST\tValue: %ld",
                      (NULL == prefix) ? " " : prefix, (long) *src)) {
         return PMIX_ERR_NOMEM;
     }
@@ -998,7 +998,7 @@ pmix_status_t pmix_bfrops_base_print_scope(char **output, char *prefix, pmix_sco
     PMIX_HIDE_UNUSED_PARAMS(type);
 
     if (0
-        > asprintf(output, "%sData type: PMIX_SCOPE\tValue: %s",
+        > pmix_asprintf(output, "%sData type: PMIX_SCOPE\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Scope_string(*src))) {
         return PMIX_ERR_NOMEM;
@@ -1012,7 +1012,7 @@ pmix_status_t pmix_bfrops_base_print_range(char **output, char *prefix, pmix_dat
 {
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    if (0 > asprintf(output, "%sData type: PMIX_DATA_RANGE\tValue: %s",
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_DATA_RANGE\tValue: %s",
                      (NULL == prefix) ? " " : prefix,
                      PMIx_Data_range_string(*src))) {
         return PMIX_ERR_NOMEM;
@@ -1025,7 +1025,7 @@ pmix_status_t pmix_bfrops_base_print_cmd(char **output, char *prefix, pmix_cmd_t
 {
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    if (0 > asprintf(output, "%sData type: PMIX_COMMAND\tValue: %s",
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_COMMAND\tValue: %s",
                      (NULL == prefix) ? " " : prefix,
                      pmix_command_string(*src))) {
         return PMIX_ERR_NOMEM;
@@ -1043,7 +1043,7 @@ pmix_status_t pmix_bfrops_base_print_info_directives(char **output, char *prefix
     PMIX_HIDE_UNUSED_PARAMS(type);
 
     tmp = PMIx_Info_directives_string(*src);
-    if (0 > asprintf(output, "%sPMIX_INFO_DIRECTIVES\tValue: %s",
+    if (0 > pmix_asprintf(output, "%sPMIX_INFO_DIRECTIVES\tValue: %s",
                      (NULL == prefix) ? " " : prefix, tmp)) {
         free(tmp);
         return PMIX_ERR_NOMEM;
@@ -1063,7 +1063,7 @@ pmix_status_t pmix_bfrops_base_print_datatype(char **output, char *prefix,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: PMIX_DATA_TYPE\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: PMIX_DATA_TYPE\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix);
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
@@ -1072,7 +1072,7 @@ pmix_status_t pmix_bfrops_base_print_datatype(char **output, char *prefix,
         }
     }
 
-    ret = asprintf(output, "%sData type: PMIX_DATA_TYPE\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_DATA_TYPE\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Data_type_string(*src));
 
@@ -1093,7 +1093,7 @@ int pmix_bfrops_base_print_bo(char **output, char *prefix,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        ret = asprintf(output, "%sData type: %s\tValue: NULL pointer",
+        ret = pmix_asprintf(output, "%sData type: %s\tValue: NULL pointer",
                        (NULL == prefix) ? " " : prefix,
                        (PMIX_COMPRESSED_BYTE_OBJECT == type) ? "PMIX_COMPRESSED_BYTE_OBJECT"
                                                              : "PMIX_BYTE_OBJECT");
@@ -1104,7 +1104,7 @@ int pmix_bfrops_base_print_bo(char **output, char *prefix,
         }
     }
 
-    ret = asprintf(output, "%sData type: %s\tSize: %ld",
+    ret = pmix_asprintf(output, "%sData type: %s\tSize: %ld",
                    (NULL == prefix) ? " " : prefix,
                    (PMIX_COMPRESSED_BYTE_OBJECT == type) ? "PMIX_COMPRESSED_BYTE_OBJECT"
                                                          : "PMIX_BYTE_OBJECT",
@@ -1124,7 +1124,7 @@ int pmix_bfrops_base_print_ptr(char **output, char *prefix, void *src,
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_POINTER\tAddress: %p",
+    ret = pmix_asprintf(output, "%sData type: PMIX_POINTER\tAddress: %p",
                    (NULL == prefix) ? " " : prefix, src);
 
     if (0 > ret) {
@@ -1142,7 +1142,7 @@ pmix_status_t pmix_bfrops_base_print_pstate(char **output, char *prefix,
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_PROC_STATE\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_PROC_STATE\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Proc_state_string(*src));
 
@@ -1162,7 +1162,7 @@ pmix_status_t pmix_bfrops_base_print_pinfo(char **output, char *prefix,
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    if (0 > asprintf(&p2, "%s\t", (NULL == prefix) ? " " : prefix)) {
+    if (0 > pmix_asprintf(&p2, "%s\t", (NULL == prefix) ? " " : prefix)) {
         rc = PMIX_ERR_NOMEM;
         goto done;
     }
@@ -1172,7 +1172,7 @@ pmix_status_t pmix_bfrops_base_print_pinfo(char **output, char *prefix,
         goto done;
     }
 
-    if (0 > asprintf(output,
+    if (0 > pmix_asprintf(output,
                      "%sData type: PMIX_PROC_INFO\tValue:\n%s\n%sHostname: %s\tExecutable: "
                      "%s\n%sPid: %lu\tExit code: %d\tState: %s",
                      (NULL == prefix) ? " " : prefix, tmp, p2,
@@ -1504,12 +1504,12 @@ pmix_status_t pmix_bfrops_base_print_query(char **output, char *prefix, pmix_que
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    if (0 > asprintf(&p2, "%s\t", (NULL == prefix) ? " " : prefix)) {
+    if (0 > pmix_asprintf(&p2, "%s\t", (NULL == prefix) ? " " : prefix)) {
         rc = PMIX_ERR_NOMEM;
         goto done;
     }
 
-    if (0 > asprintf(&tmp, "%sData type: PMIX_QUERY\tValue:",
+    if (0 > pmix_asprintf(&tmp, "%sData type: PMIX_QUERY\tValue:",
                      (NULL == prefix) ? " " : prefix)) {
         free(p2);
         rc = PMIX_ERR_NOMEM;
@@ -1519,7 +1519,7 @@ pmix_status_t pmix_bfrops_base_print_query(char **output, char *prefix, pmix_que
     /* print out the keys */
     if (NULL != src->keys) {
         for (n = 0; NULL != src->keys[n]; n++) {
-            if (0 > asprintf(&t2, "%s\n%sKey: %s", tmp, p2, src->keys[n])) {
+            if (0 > pmix_asprintf(&t2, "%s\n%sKey: %s", tmp, p2, src->keys[n])) {
                 free(p2);
                 free(tmp);
                 rc = PMIX_ERR_NOMEM;
@@ -1539,7 +1539,7 @@ pmix_status_t pmix_bfrops_base_print_query(char **output, char *prefix, pmix_que
                 free(tmp);
                 goto done;
             }
-            if (0 > asprintf(&t3, "%s\n%s", tmp, t2)) {
+            if (0 > pmix_asprintf(&t3, "%s\n%s", tmp, t2)) {
                 free(p2);
                 free(tmp);
                 free(t2);
@@ -1568,19 +1568,19 @@ pmix_status_t pmix_bfrops_base_print_rank(char **output, char *prefix, pmix_rank
 
     switch (*src) {
     case PMIX_RANK_UNDEF:
-        rc = asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_UNDEF",
+        rc = pmix_asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_UNDEF",
                       (NULL == prefix) ? " " : prefix);
         break;
     case PMIX_RANK_WILDCARD:
-        rc = asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_WILDCARD",
+        rc = pmix_asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_WILDCARD",
                       (NULL == prefix) ? " " : prefix);
         break;
     case PMIX_RANK_LOCAL_NODE:
-        rc = asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_LOCAL_NODE",
+        rc = pmix_asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_LOCAL_NODE",
                       (NULL == prefix) ? " " : prefix);
         break;
     default:
-        rc = asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: %lu",
+        rc = pmix_asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: %lu",
                       (NULL == prefix) ? " " : prefix,
                       (unsigned long) (*src));
     }
@@ -1598,7 +1598,7 @@ pmix_status_t pmix_bfrops_base_print_alloc_directive(char **output, char *prefix
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_ALLOC_DIRECTIVE\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_ALLOC_DIRECTIVE\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Alloc_directive_string(*src));
 
@@ -1617,7 +1617,7 @@ pmix_status_t pmix_bfrops_base_print_resblock_directive(char **output, char *pre
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_RESBLOCK_DIRECTIVE\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_RESBLOCK_DIRECTIVE\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Resource_block_directive_string(*src));
 
@@ -1636,7 +1636,7 @@ pmix_status_t pmix_bfrops_base_print_alloc_inheritance(char **output, char *pref
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_ALLOC_INHERIT\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_ALLOC_INHERIT\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Alloc_inheritance_string(*src));
 
@@ -1654,7 +1654,7 @@ pmix_status_t pmix_bfrops_base_print_iof_channel(char **output, char *prefix,
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_IOF_CHANNEL\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_IOF_CHANNEL\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_IOF_channel_string(*src));
 
@@ -1672,7 +1672,7 @@ pmix_status_t pmix_bfrops_base_print_envar(char **output, char *prefix, pmix_env
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_ENVAR\tName: %s\tValue: %s\tSeparator: %c",
+    ret = pmix_asprintf(output, "%sData type: PMIX_ENVAR\tName: %s\tValue: %s\tSeparator: %c",
                    (NULL == prefix) ? " " : prefix,
                    (NULL == src->envar) ? "NULL" : src->envar,
                    (NULL == src->value) ? "NULL" : src->value,
@@ -1702,7 +1702,7 @@ pmix_status_t pmix_bfrops_base_print_coord(char **output, char *prefix, pmix_coo
     } else {
         tp = "UNRECOGNIZED";
     }
-    ret = asprintf(output, "%sData type: PMIX_COORD\tView: %s\tDims: %lu",
+    ret = pmix_asprintf(output, "%sData type: PMIX_COORD\tView: %s\tDims: %lu",
                    (NULL == prefix) ? " " : prefix, tp,
                    (unsigned long) src->dims);
 
@@ -1720,7 +1720,7 @@ pmix_status_t pmix_bfrops_base_print_regattr(char **output, char *prefix, pmix_r
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_REGATTR\tName: %s\tString: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_REGATTR\tName: %s\tString: %s",
                    (NULL == prefix) ? " " : prefix,
                    (NULL == src->name) ? "NULL" : src->name,
                    (0 == strlen(src->string)) ? "NULL" : src->string);
@@ -1739,7 +1739,7 @@ pmix_status_t pmix_bfrops_base_print_regex(char **output, char *prefix, char *sr
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_REGEX\tName: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_REGEX\tName: %s",
                    (NULL == prefix) ? " " : prefix, src);
 
     if (0 > ret) {
@@ -1756,7 +1756,7 @@ pmix_status_t pmix_bfrops_base_print_jobstate(char **output, char *prefix, pmix_
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_JOB_STATE\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_JOB_STATE\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Job_state_string(*src));
 
@@ -1775,7 +1775,7 @@ pmix_status_t pmix_bfrops_base_print_linkstate(char **output, char *prefix, pmix
     PMIX_HIDE_UNUSED_PARAMS(type);
 
 
-    ret = asprintf(output, "%sData type: PMIX_LINK_STATE\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_LINK_STATE\tValue: %s",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Link_state_string(*src));
 
@@ -1799,7 +1799,7 @@ pmix_status_t pmix_bfrops_base_print_cpuset(char **output, char *prefix, pmix_cp
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
-    ret = asprintf(output, "%sData type: PMIX_CPUSET\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_CPUSET\tValue: %s",
                    (NULL == prefix) ? " " : prefix, string);
     free(string);
 
@@ -1819,7 +1819,7 @@ pmix_status_t pmix_bfrops_base_print_geometry(char **output, char *prefix, pmix_
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(&tmp,
+    ret = pmix_asprintf(&tmp,
                    "%sData type: PMIX_GEOMETRY\tValue: Fabric: %" PRIsize_t " UUID: %s OSName: %s",
                    (NULL == prefix) ? " " : prefix, src->fabric,
                    (NULL == src->uuid) ? "NULL" : src->uuid,
@@ -1855,7 +1855,7 @@ pmix_status_t pmix_bfrops_base_print_device(char **output, char *prefix,
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output,
+    ret = pmix_asprintf(output,
                    "%sData type: PMIX_DEVICE\tValue: UUID: %s OSName: %s Type: %s",
                    (NULL == prefix) ? " " : prefix,
                    (NULL == src->uuid) ? "NULL" : src->uuid, (NULL == src->osname) ? "NULL" : src->osname,
@@ -1875,7 +1875,7 @@ pmix_status_t pmix_bfrops_base_print_resunit(char **output, char *prefix,
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output,
+    ret = pmix_asprintf(output,
                    "%sData type: PMIX_RESOURCE_UNIT\tValue: Type: %s  Count: %" PRIsize_t "",
                    (NULL == prefix) ? " " : prefix,
                    PMIx_Device_type_string(src->type), src->count);
@@ -1894,7 +1894,7 @@ pmix_status_t pmix_bfrops_base_print_devdist(char **output, char *prefix,
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output,
+    ret = pmix_asprintf(output,
                    "%sData type: PMIX_DEVICE_DIST\tValue: UUID: %s OSName: %s Type: %s Min: %u Max: %u",
                    (NULL == prefix) ? " " : prefix,
                    (NULL == src->uuid) ? "NULL" : src->uuid, (NULL == src->osname) ? "NULL" : src->osname,
@@ -1914,7 +1914,7 @@ pmix_status_t pmix_bfrops_base_print_endpoint(char **output, char *prefix, pmix_
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_ENDPOINT\tValue: %s(%s) #bytes: %" PRIsize_t,
+    ret = pmix_asprintf(output, "%sData type: PMIX_ENDPOINT\tValue: %s(%s) #bytes: %" PRIsize_t,
                    (NULL == prefix) ? " " : prefix,
                    (NULL == src->uuid) ? "NULL" : src->uuid,
                    (NULL == src->osname) ? "NULL" : src->osname,
@@ -1940,7 +1940,7 @@ pmix_status_t pmix_bfrops_base_print_topology(char **output, char *prefix, pmix_
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
-    ret = asprintf(output, "%sData type: PMIX_TOPO\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_TOPO\tValue: %s",
                    (NULL == prefix) ? " " : prefix, string);
     free(string);
 
@@ -1958,7 +1958,7 @@ pmix_status_t pmix_bfrops_base_print_devtype(char **output, char *prefix, pmix_d
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_DEVICE_TYPE\tValue: 0x%" PRIx64,
+    ret = pmix_asprintf(output, "%sData type: PMIX_DEVICE_TYPE\tValue: 0x%" PRIx64,
                    (NULL == prefix) ? " " : prefix,
                    (uint64_t) src);
 
@@ -2010,7 +2010,7 @@ pmix_status_t pmix_bfrops_base_print_locality(char **output, char *prefix, pmix_
         PMIx_Argv_free(tmp);
     }
 
-    ret = asprintf(output, "%sData type: PMIX_LOCALITY\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_LOCALITY\tValue: %s",
                    (NULL == prefix) ? " " : prefix, str);
     free(str);
 
@@ -2028,7 +2028,7 @@ pmix_status_t pmix_bfrops_base_print_nspace(char **output, char *prefix, pmix_ns
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_PROC_NSPACE\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_PROC_NSPACE\tValue: %s",
                    (NULL == prefix) ? " " : prefix, *src);
 
     if (0 > ret) {
@@ -2090,7 +2090,7 @@ pmix_status_t pmix_bfrops_base_print_smed(char **output, char *prefix,
         PMIx_Argv_free(tmp);
     }
 
-    ret = asprintf(output, "%sData type: PMIX_STOR_MEDIUM\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_STOR_MEDIUM\tValue: %s",
                    (NULL == prefix) ? " " : prefix, str);
     free(str);
 
@@ -2131,7 +2131,7 @@ pmix_status_t pmix_bfrops_base_print_sacc(char **output, char *prefix,
     str = PMIx_Argv_join(tmp, ':');
     PMIx_Argv_free(tmp);
 
-    ret = asprintf(output, "%sData type: PMIX_STOR_ACCESS\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_STOR_ACCESS\tValue: %s",
                    (NULL == prefix) ? " " : prefix, str);
     free(str);
 
@@ -2176,7 +2176,7 @@ pmix_status_t pmix_bfrops_base_print_spers(char **output, char *prefix,
     str = PMIx_Argv_join(tmp, ':');
     PMIx_Argv_free(tmp);
 
-    ret = asprintf(output, "%sData type: PMIX_STOR_PERSIST\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_STOR_PERSIST\tValue: %s",
                    (NULL == prefix) ? " " : prefix, str);
     free(str);
 
@@ -2205,7 +2205,7 @@ pmix_status_t pmix_bfrops_base_print_satyp(char **output, char *prefix,
     str = PMIx_Argv_join(tmp, ':');
     PMIx_Argv_free(tmp);
 
-    ret = asprintf(output, "%sData type: PMIX_STOR_ACCESS_TYPE\tValue: %s",
+    ret = pmix_asprintf(output, "%sData type: PMIX_STOR_ACCESS_TYPE\tValue: %s",
                    (NULL == prefix) ? " " : prefix, str);
     free(str);
 
@@ -2223,7 +2223,7 @@ pmix_status_t pmix_bfrops_base_print_regex2(char **output, char *prefix,
     int ret;
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_REGEX2\tType: %s\tLen: %zu",
+    ret = pmix_asprintf(output, "%sData type: PMIX_REGEX2\tType: %s\tLen: %zu",
                    (NULL == prefix) ? " " : prefix,
                    (NULL == src->type) ? "NULL" : src->type,
                    src->len);
@@ -2237,7 +2237,7 @@ pmix_status_t pmix_bfrops_base_print_nodepid(char **output, char *prefix,
     int ret;
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    ret = asprintf(output, "%sData type: PMIX_NODE_PID\tValue: Host %s(%u) PID %d",
+    ret = pmix_asprintf(output, "%sData type: PMIX_NODE_PID\tValue: Host %s(%u) PID %d",
                    (NULL == prefix) ? " " : prefix,
                    (NULL == src->hostname) ? "NULL" : src->hostname,
                    src->nodeid, src->pid);

--- a/src/mca/bfrops/v12/pack.c
+++ b/src/mca/bfrops/v12/pack.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,6 +35,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
 
 pmix_status_t pmix12_bfrop_pack(pmix_buffer_t *buffer, const void *src, int32_t num_vals,
                                 pmix_data_type_t type)
@@ -385,7 +386,7 @@ pmix_status_t pmix12_bfrop_pack_float(pmix_pointer_array_t *regtypes, pmix_buffe
     PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     for (i = 0; i < num_vals; ++i) {
-        if (0 > asprintf(&convert, "%f", ssrc[i])) {
+        if (0 > pmix_asprintf(&convert, "%f", ssrc[i])) {
             return PMIX_ERR_NOMEM;
         }
         if (PMIX_SUCCESS
@@ -411,7 +412,7 @@ pmix_status_t pmix12_bfrop_pack_double(pmix_pointer_array_t *regtypes, pmix_buff
     PMIX_HIDE_UNUSED_PARAMS(regtypes, type);
 
     for (i = 0; i < num_vals; ++i) {
-        if (0 > asprintf(&convert, "%f", ssrc[i])) {
+        if (0 > pmix_asprintf(&convert, "%f", ssrc[i])) {
             return PMIX_ERR_NOMEM;
         }
         if (PMIX_SUCCESS

--- a/src/mca/bfrops/v12/print.c
+++ b/src/mca/bfrops/v12/print.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,6 +34,7 @@
 #include "bfrop_v12.h"
 #include "internal.h"
 #include "src/mca/bfrops/base/base.h"
+#include "src/util/pmix_printf.h"
 
 pmix_status_t pmix12_bfrop_print(char **output, char *prefix, void *src, pmix_data_type_t type)
 {
@@ -65,7 +66,7 @@ pmix_status_t pmix12_bfrop_print_bool(char **output, char *prefix, bool *src, pm
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -74,7 +75,7 @@ pmix_status_t pmix12_bfrop_print_bool(char **output, char *prefix, bool *src, pm
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_BOOL\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_BOOL\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -86,7 +87,7 @@ pmix_status_t pmix12_bfrop_print_bool(char **output, char *prefix, bool *src, pm
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_BOOL\tValue: %s", prefix,
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_BOOL\tValue: %s", prefix,
                      (*src) ? "TRUE" : "FALSE")) {
         if (prefx != prefix) {
             free(prefx);
@@ -109,7 +110,7 @@ pmix_status_t pmix12_bfrop_print_byte(char **output, char *prefix, uint8_t *src,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -118,7 +119,7 @@ pmix_status_t pmix12_bfrop_print_byte(char **output, char *prefix, uint8_t *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_BYTE\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_BYTE\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -130,7 +131,7 @@ pmix_status_t pmix12_bfrop_print_byte(char **output, char *prefix, uint8_t *src,
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_BYTE\tValue: %x", prefix, *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_BYTE\tValue: %x", prefix, *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -152,7 +153,7 @@ pmix_status_t pmix12_bfrop_print_string(char **output, char *prefix, char *src,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -161,7 +162,7 @@ pmix_status_t pmix12_bfrop_print_string(char **output, char *prefix, char *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_STRING\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_STRING\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -173,7 +174,7 @@ pmix_status_t pmix12_bfrop_print_string(char **output, char *prefix, char *src,
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_STRING\tValue: %s", prefx, src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_STRING\tValue: %s", prefx, src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -195,7 +196,7 @@ pmix_status_t pmix12_bfrop_print_size(char **output, char *prefix, size_t *src,
 
    /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -204,7 +205,7 @@ pmix_status_t pmix12_bfrop_print_size(char **output, char *prefix, size_t *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_SIZE\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_SIZE\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -216,7 +217,7 @@ pmix_status_t pmix12_bfrop_print_size(char **output, char *prefix, size_t *src,
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_SIZE\tValue: %lu", prefx, (unsigned long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_SIZE\tValue: %lu", prefx, (unsigned long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -237,7 +238,7 @@ pmix_status_t pmix12_bfrop_print_pid(char **output, char *prefix, pid_t *src, pm
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -246,7 +247,7 @@ pmix_status_t pmix12_bfrop_print_pid(char **output, char *prefix, pid_t *src, pm
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_PID\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_PID\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -258,7 +259,7 @@ pmix_status_t pmix12_bfrop_print_pid(char **output, char *prefix, pid_t *src, pm
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_PID\tValue: %lu", prefx, (unsigned long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_PID\tValue: %lu", prefx, (unsigned long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -278,7 +279,7 @@ pmix_status_t pmix12_bfrop_print_int(char **output, char *prefix, int *src, pmix
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -287,7 +288,7 @@ pmix_status_t pmix12_bfrop_print_int(char **output, char *prefix, int *src, pmix
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_INT\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_INT\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -299,7 +300,7 @@ pmix_status_t pmix12_bfrop_print_int(char **output, char *prefix, int *src, pmix
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INT\tValue: %ld", prefx, (long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INT\tValue: %ld", prefx, (long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -320,7 +321,7 @@ pmix_status_t pmix12_bfrop_print_uint(char **output, char *prefix, uint *src, pm
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -329,7 +330,7 @@ pmix_status_t pmix12_bfrop_print_uint(char **output, char *prefix, uint *src, pm
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_UINT\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -341,7 +342,7 @@ pmix_status_t pmix12_bfrop_print_uint(char **output, char *prefix, uint *src, pm
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_UINT\tValue: %lu", prefx, (unsigned long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT\tValue: %lu", prefx, (unsigned long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -363,7 +364,7 @@ pmix_status_t pmix12_bfrop_print_uint8(char **output, char *prefix, uint8_t *src
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -372,7 +373,7 @@ pmix_status_t pmix12_bfrop_print_uint8(char **output, char *prefix, uint8_t *src
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_UINT8\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT8\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -384,7 +385,7 @@ pmix_status_t pmix12_bfrop_print_uint8(char **output, char *prefix, uint8_t *src
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_UINT8\tValue: %u", prefx, (unsigned int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT8\tValue: %u", prefx, (unsigned int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -406,7 +407,7 @@ pmix_status_t pmix12_bfrop_print_uint16(char **output, char *prefix, uint16_t *s
 
    /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -415,7 +416,7 @@ pmix_status_t pmix12_bfrop_print_uint16(char **output, char *prefix, uint16_t *s
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_UINT16\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT16\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -427,7 +428,7 @@ pmix_status_t pmix12_bfrop_print_uint16(char **output, char *prefix, uint16_t *s
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_UINT16\tValue: %u", prefx, (unsigned int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT16\tValue: %u", prefx, (unsigned int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -449,7 +450,7 @@ pmix_status_t pmix12_bfrop_print_uint32(char **output, char *prefix, uint32_t *s
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -458,7 +459,7 @@ pmix_status_t pmix12_bfrop_print_uint32(char **output, char *prefix, uint32_t *s
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_UINT32\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT32\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -470,7 +471,7 @@ pmix_status_t pmix12_bfrop_print_uint32(char **output, char *prefix, uint32_t *s
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_UINT32\tValue: %u", prefx, (unsigned int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT32\tValue: %u", prefx, (unsigned int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -492,7 +493,7 @@ pmix_status_t pmix12_bfrop_print_int8(char **output, char *prefix, int8_t *src,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -501,7 +502,7 @@ pmix_status_t pmix12_bfrop_print_int8(char **output, char *prefix, int8_t *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_INT8\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_INT8\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -513,7 +514,7 @@ pmix_status_t pmix12_bfrop_print_int8(char **output, char *prefix, int8_t *src,
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INT8\tValue: %d", prefx, (int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INT8\tValue: %d", prefx, (int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -535,7 +536,7 @@ pmix_status_t pmix12_bfrop_print_int16(char **output, char *prefix, int16_t *src
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -544,7 +545,7 @@ pmix_status_t pmix12_bfrop_print_int16(char **output, char *prefix, int16_t *src
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_INT16\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_INT16\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -556,7 +557,7 @@ pmix_status_t pmix12_bfrop_print_int16(char **output, char *prefix, int16_t *src
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INT16\tValue: %d", prefx, (int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INT16\tValue: %d", prefx, (int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -578,7 +579,7 @@ pmix_status_t pmix12_bfrop_print_int32(char **output, char *prefix, int32_t *src
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -587,7 +588,7 @@ pmix_status_t pmix12_bfrop_print_int32(char **output, char *prefix, int32_t *src
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_INT32\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_INT32\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -599,7 +600,7 @@ pmix_status_t pmix12_bfrop_print_int32(char **output, char *prefix, int32_t *src
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INT32\tValue: %d", prefx, (int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INT32\tValue: %d", prefx, (int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -620,7 +621,7 @@ pmix_status_t pmix12_bfrop_print_uint64(char **output, char *prefix, uint64_t *s
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -629,7 +630,7 @@ pmix_status_t pmix12_bfrop_print_uint64(char **output, char *prefix, uint64_t *s
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_UINT64\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT64\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -641,7 +642,7 @@ pmix_status_t pmix12_bfrop_print_uint64(char **output, char *prefix, uint64_t *s
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_UINT64\tValue: %lu", prefx, (unsigned long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT64\tValue: %lu", prefx, (unsigned long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -663,7 +664,7 @@ pmix_status_t pmix12_bfrop_print_int64(char **output, char *prefix, int64_t *src
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -672,7 +673,7 @@ pmix_status_t pmix12_bfrop_print_int64(char **output, char *prefix, int64_t *src
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_INT64\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_INT64\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -684,7 +685,7 @@ pmix_status_t pmix12_bfrop_print_int64(char **output, char *prefix, int64_t *src
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INT64\tValue: %ld", prefx, (long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INT64\tValue: %ld", prefx, (long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -706,7 +707,7 @@ pmix_status_t pmix12_bfrop_print_float(char **output, char *prefix, float *src,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -715,7 +716,7 @@ pmix_status_t pmix12_bfrop_print_float(char **output, char *prefix, float *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_FLOAT\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_FLOAT\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -727,7 +728,7 @@ pmix_status_t pmix12_bfrop_print_float(char **output, char *prefix, float *src,
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_FLOAT\tValue: %f", prefx, *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_FLOAT\tValue: %f", prefx, *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -749,7 +750,7 @@ pmix_status_t pmix12_bfrop_print_double(char **output, char *prefix, double *src
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -758,7 +759,7 @@ pmix_status_t pmix12_bfrop_print_double(char **output, char *prefix, double *src
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_DOUBLE\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_DOUBLE\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -770,7 +771,7 @@ pmix_status_t pmix12_bfrop_print_double(char **output, char *prefix, double *src
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_DOUBLE\tValue: %f", prefx, *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_DOUBLE\tValue: %f", prefx, *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -793,7 +794,7 @@ pmix_status_t pmix12_bfrop_print_time(char **output, char *prefix, time_t *src,
 
    /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -802,7 +803,7 @@ pmix_status_t pmix12_bfrop_print_time(char **output, char *prefix, time_t *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_TIME\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_TIME\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -817,7 +818,7 @@ pmix_status_t pmix12_bfrop_print_time(char **output, char *prefix, time_t *src,
     t = ctime(src);
     t[strlen(t) - 1] = '\0'; // remove trailing newline
 
-    if (0 > asprintf(output, "%sData type: PMIX_TIME\tValue: %s", prefx, t)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_TIME\tValue: %s", prefx, t)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -839,7 +840,7 @@ pmix_status_t pmix12_bfrop_print_timeval(char **output, char *prefix, struct tim
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -848,7 +849,7 @@ pmix_status_t pmix12_bfrop_print_timeval(char **output, char *prefix, struct tim
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -860,7 +861,7 @@ pmix_status_t pmix12_bfrop_print_timeval(char **output, char *prefix, struct tim
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
                      (long) src->tv_sec, (long) src->tv_usec)) {
         if (prefx != prefix) {
             free(prefx);
@@ -889,7 +890,7 @@ pmix_status_t pmix12_bfrop_print_value(char **output, char *prefix, pmix_value_t
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -898,7 +899,7 @@ pmix_status_t pmix12_bfrop_print_value(char **output, char *prefix, pmix_value_t
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_VALUE\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_VALUE\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -912,76 +913,76 @@ pmix_status_t pmix12_bfrop_print_value(char **output, char *prefix, pmix_value_t
 
     switch (src->type) {
     case PMIX_BYTE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_BYTE\tValue: %x", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_BYTE\tValue: %x", prefx,
                       src->data.byte);
         break;
     case PMIX_STRING:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STRING\tValue: %s", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STRING\tValue: %s", prefx,
                       src->data.string);
         break;
     case PMIX_SIZE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SIZE\tValue: %lu", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SIZE\tValue: %lu", prefx,
                       (unsigned long) src->data.size);
         break;
     case PMIX_PID:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PID\tValue: %lu", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PID\tValue: %lu", prefx,
                       (unsigned long) src->data.pid);
         break;
     case PMIX_INT:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT\tValue: %d", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT\tValue: %d", prefx,
                       src->data.integer);
         break;
     case PMIX_INT8:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT8\tValue: %d", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT8\tValue: %d", prefx,
                       (int) src->data.int8);
         break;
     case PMIX_INT16:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT16\tValue: %d", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT16\tValue: %d", prefx,
                       (int) src->data.int16);
         break;
     case PMIX_INT32:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT32\tValue: %d", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT32\tValue: %d", prefx,
                       src->data.int32);
         break;
     case PMIX_INT64:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT64\tValue: %ld", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT64\tValue: %ld", prefx,
                       (long) src->data.int64);
         break;
     case PMIX_UINT:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT\tValue: %u", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT\tValue: %u", prefx,
                       src->data.uint);
         break;
     case PMIX_UINT8:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT8\tValue: %u", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT8\tValue: %u", prefx,
                       (unsigned int) src->data.uint8);
         break;
     case PMIX_UINT16:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT16\tValue: %u", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT16\tValue: %u", prefx,
                       (unsigned int) src->data.uint16);
         break;
     case PMIX_UINT32:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT32\tValue: %u", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT32\tValue: %u", prefx,
                       src->data.uint32);
         break;
     case PMIX_UINT64:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT64\tValue: %lu", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT64\tValue: %lu", prefx,
                       (unsigned long) src->data.uint64);
         break;
     case PMIX_FLOAT:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_FLOAT\tValue: %f", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_FLOAT\tValue: %f", prefx,
                       src->data.fval);
         break;
     case PMIX_DOUBLE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DOUBLE\tValue: %f", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DOUBLE\tValue: %f", prefx,
                       src->data.dval);
         break;
     case PMIX_TIMEVAL:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
                       (long) src->data.tv.tv_sec, (long) src->data.tv.tv_usec);
         break;
 
     default:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
         break;
     }
     if (prefx != prefix) {
@@ -1002,7 +1003,7 @@ pmix_status_t pmix12_bfrop_print_info(char **output, char *prefix, pmix_info_t *
     PMIX_HIDE_UNUSED_PARAMS(type);
 
     pmix12_bfrop_print_value(&tmp, NULL, &src->value, PMIX_VALUE);
-    rc = asprintf(output, "%sKEY: %s %s", prefix, src->key,
+    rc = pmix_asprintf(output, "%sKEY: %s %s", prefix, src->key,
                   (NULL == tmp) ? "PMIX_VALUE: NULL" : tmp);
     if (NULL != tmp) {
         free(tmp);
@@ -1023,7 +1024,7 @@ pmix_status_t pmix12_bfrop_print_pdata(char **output, char *prefix, pmix_pdata_t
 
     pmix12_bfrop_print_proc(&tmp1, NULL, &src->proc, PMIX_PROC);
     pmix12_bfrop_print_value(&tmp2, NULL, &src->value, PMIX_VALUE);
-    rc = asprintf(output, "%s  %s  KEY: %s %s", prefix, tmp1, src->key,
+    rc = pmix_asprintf(output, "%s  %s  KEY: %s %s", prefix, tmp1, src->key,
                   (NULL == tmp2) ? "NULL" : tmp2);
     if (NULL != tmp1) {
         free(tmp1);
@@ -1062,14 +1063,14 @@ pmix_status_t pmix12_bfrop_print_proc(char **output, char *prefix, pmix_proc_t *
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
         prefx = prefix;
     }
 
-    if (0 > asprintf(output, "%sPROC: %s:%d", prefx, src->nspace, src->rank)) {
+    if (0 > pmix_asprintf(output, "%sPROC: %s:%d", prefx, src->nspace, src->rank)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -1099,10 +1100,10 @@ pmix_status_t pmix12_bfrop_print_array(char **output, char *prefix, pmix_info_ar
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
+    if (0 > pmix_asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
         return PMIX_ERR_NOMEM;
     }
-    if (0 > asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix)) {
+    if (0 > pmix_asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix)) {
         free(tmp);
         return PMIX_ERR_NOMEM;
     }
@@ -1110,7 +1111,7 @@ pmix_status_t pmix12_bfrop_print_array(char **output, char *prefix, pmix_info_ar
 
     for (j = 0; j < src->size; j++) {
         pmix12_bfrop_print_info(&tmp2, pfx, &s1[j], PMIX_INFO);
-        if (0 > asprintf(&tmp3, "%s%s", tmp, tmp2)) {
+        if (0 > pmix_asprintf(&tmp3, "%s%s", tmp, tmp2)) {
             free(tmp);
             free(tmp2);
             free(pfx);
@@ -1142,7 +1143,7 @@ pmix_status_t pmix12_bfrop_print_persist(char **output, char *prefix, pmix_persi
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -1151,7 +1152,7 @@ pmix_status_t pmix12_bfrop_print_persist(char **output, char *prefix, pmix_persi
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_PERSIST\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_PERSIST\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -1163,7 +1164,7 @@ pmix_status_t pmix12_bfrop_print_persist(char **output, char *prefix, pmix_persi
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_PERSIST\tValue: %ld", prefx, (long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_PERSIST\tValue: %ld", prefx, (long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -1185,7 +1186,7 @@ pmix_status_t pmix12_bfrop_print_bo(char **output, char *prefix, pmix_byte_objec
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -1194,7 +1195,7 @@ pmix_status_t pmix12_bfrop_print_bo(char **output, char *prefix, pmix_byte_objec
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -1206,7 +1207,7 @@ pmix_status_t pmix12_bfrop_print_bo(char **output, char *prefix, pmix_byte_objec
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tSize: %ld", prefx, (long) src->size)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tSize: %ld", prefx, (long) src->size)) {
         if (prefx != prefix) {
             free(prefx);
         }

--- a/src/mca/bfrops/v20/pack.c
+++ b/src/mca/bfrops/v20/pack.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,6 +36,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
 
 pmix_status_t pmix20_bfrop_pack(pmix_buffer_t *buffer, const void *src, int32_t num_vals,
                                 pmix_data_type_t type)
@@ -381,7 +382,7 @@ pmix_status_t pmix20_bfrop_pack_float(pmix_pointer_array_t *regtypes, pmix_buffe
     PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
-        if (0 > asprintf(&convert, "%f", ssrc[i])) {
+        if (0 > pmix_asprintf(&convert, "%f", ssrc[i])) {
             return PMIX_ERR_NOMEM;
         }
         if (PMIX_SUCCESS
@@ -407,7 +408,7 @@ pmix_status_t pmix20_bfrop_pack_double(pmix_pointer_array_t *regtypes, pmix_buff
     PMIX_HIDE_UNUSED_PARAMS(type);
 
     for (i = 0; i < num_vals; ++i) {
-        if (0 > asprintf(&convert, "%f", ssrc[i])) {
+        if (0 > pmix_asprintf(&convert, "%f", ssrc[i])) {
             return PMIX_ERR_NOMEM;
         }
         if (PMIX_SUCCESS

--- a/src/mca/bfrops/v20/print.c
+++ b/src/mca/bfrops/v20/print.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,6 +36,7 @@
 #include "src/include/pmix_globals.h"
 #include "src/mca/bfrops/base/base.h"
 #include "src/util/pmix_error.h"
+#include "src/util/pmix_printf.h"
 
 pmix_status_t pmix20_bfrop_print(char **output, char *prefix, void *src, pmix_data_type_t type)
 {
@@ -68,7 +69,7 @@ pmix_status_t pmix20_bfrop_print_bool(char **output, char *prefix, bool *src, pm
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -77,7 +78,7 @@ pmix_status_t pmix20_bfrop_print_bool(char **output, char *prefix, bool *src, pm
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_BOOL\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_BOOL\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -89,7 +90,7 @@ pmix_status_t pmix20_bfrop_print_bool(char **output, char *prefix, bool *src, pm
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_BOOL\tValue: %s", prefix,
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_BOOL\tValue: %s", prefix,
                      (*src) ? "TRUE" : "FALSE")) {
         if (prefx != prefix) {
             free(prefx);
@@ -112,7 +113,7 @@ pmix_status_t pmix20_bfrop_print_byte(char **output, char *prefix, uint8_t *src,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -121,7 +122,7 @@ pmix_status_t pmix20_bfrop_print_byte(char **output, char *prefix, uint8_t *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_BYTE\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_BYTE\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -133,7 +134,7 @@ pmix_status_t pmix20_bfrop_print_byte(char **output, char *prefix, uint8_t *src,
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_BYTE\tValue: %x", prefx, *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_BYTE\tValue: %x", prefx, *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -155,7 +156,7 @@ pmix_status_t pmix20_bfrop_print_string(char **output, char *prefix, char *src,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -164,7 +165,7 @@ pmix_status_t pmix20_bfrop_print_string(char **output, char *prefix, char *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_STRING\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_STRING\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -176,7 +177,7 @@ pmix_status_t pmix20_bfrop_print_string(char **output, char *prefix, char *src,
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_STRING\tValue: %s", prefx, src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_STRING\tValue: %s", prefx, src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -198,7 +199,7 @@ pmix_status_t pmix20_bfrop_print_size(char **output, char *prefix, size_t *src,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -207,7 +208,7 @@ pmix_status_t pmix20_bfrop_print_size(char **output, char *prefix, size_t *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_SIZE\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_SIZE\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -219,7 +220,7 @@ pmix_status_t pmix20_bfrop_print_size(char **output, char *prefix, size_t *src,
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_SIZE\tValue: %lu", prefx, (unsigned long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_SIZE\tValue: %lu", prefx, (unsigned long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -240,7 +241,7 @@ pmix_status_t pmix20_bfrop_print_pid(char **output, char *prefix, pid_t *src, pm
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -249,7 +250,7 @@ pmix_status_t pmix20_bfrop_print_pid(char **output, char *prefix, pid_t *src, pm
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_PID\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_PID\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -261,7 +262,7 @@ pmix_status_t pmix20_bfrop_print_pid(char **output, char *prefix, pid_t *src, pm
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_PID\tValue: %lu", prefx, (unsigned long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_PID\tValue: %lu", prefx, (unsigned long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -281,7 +282,7 @@ pmix_status_t pmix20_bfrop_print_int(char **output, char *prefix, int *src, pmix
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -290,7 +291,7 @@ pmix_status_t pmix20_bfrop_print_int(char **output, char *prefix, int *src, pmix
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_INT\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_INT\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -302,7 +303,7 @@ pmix_status_t pmix20_bfrop_print_int(char **output, char *prefix, int *src, pmix
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INT\tValue: %ld", prefx, (long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INT\tValue: %ld", prefx, (long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -323,7 +324,7 @@ pmix_status_t pmix20_bfrop_print_uint(char **output, char *prefix, uint *src, pm
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -332,7 +333,7 @@ pmix_status_t pmix20_bfrop_print_uint(char **output, char *prefix, uint *src, pm
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_UINT\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -344,7 +345,7 @@ pmix_status_t pmix20_bfrop_print_uint(char **output, char *prefix, uint *src, pm
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_UINT\tValue: %lu", prefx, (unsigned long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT\tValue: %lu", prefx, (unsigned long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -366,7 +367,7 @@ pmix_status_t pmix20_bfrop_print_uint8(char **output, char *prefix, uint8_t *src
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -375,7 +376,7 @@ pmix_status_t pmix20_bfrop_print_uint8(char **output, char *prefix, uint8_t *src
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_UINT8\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT8\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -387,7 +388,7 @@ pmix_status_t pmix20_bfrop_print_uint8(char **output, char *prefix, uint8_t *src
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_UINT8\tValue: %u", prefx, (unsigned int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT8\tValue: %u", prefx, (unsigned int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -409,7 +410,7 @@ pmix_status_t pmix20_bfrop_print_uint16(char **output, char *prefix, uint16_t *s
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -418,7 +419,7 @@ pmix_status_t pmix20_bfrop_print_uint16(char **output, char *prefix, uint16_t *s
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_UINT16\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT16\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -430,7 +431,7 @@ pmix_status_t pmix20_bfrop_print_uint16(char **output, char *prefix, uint16_t *s
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_UINT16\tValue: %u", prefx, (unsigned int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT16\tValue: %u", prefx, (unsigned int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -452,7 +453,7 @@ pmix_status_t pmix20_bfrop_print_uint32(char **output, char *prefix, uint32_t *s
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -461,7 +462,7 @@ pmix_status_t pmix20_bfrop_print_uint32(char **output, char *prefix, uint32_t *s
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_UINT32\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT32\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -473,7 +474,7 @@ pmix_status_t pmix20_bfrop_print_uint32(char **output, char *prefix, uint32_t *s
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_UINT32\tValue: %u", prefx, (unsigned int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT32\tValue: %u", prefx, (unsigned int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -495,7 +496,7 @@ pmix_status_t pmix20_bfrop_print_int8(char **output, char *prefix, int8_t *src,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -504,7 +505,7 @@ pmix_status_t pmix20_bfrop_print_int8(char **output, char *prefix, int8_t *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_INT8\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_INT8\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -516,7 +517,7 @@ pmix_status_t pmix20_bfrop_print_int8(char **output, char *prefix, int8_t *src,
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INT8\tValue: %d", prefx, (int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INT8\tValue: %d", prefx, (int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -538,7 +539,7 @@ pmix_status_t pmix20_bfrop_print_int16(char **output, char *prefix, int16_t *src
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -547,7 +548,7 @@ pmix_status_t pmix20_bfrop_print_int16(char **output, char *prefix, int16_t *src
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_INT16\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_INT16\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -559,7 +560,7 @@ pmix_status_t pmix20_bfrop_print_int16(char **output, char *prefix, int16_t *src
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INT16\tValue: %d", prefx, (int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INT16\tValue: %d", prefx, (int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -581,7 +582,7 @@ pmix_status_t pmix20_bfrop_print_int32(char **output, char *prefix, int32_t *src
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -590,7 +591,7 @@ pmix_status_t pmix20_bfrop_print_int32(char **output, char *prefix, int32_t *src
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_INT32\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_INT32\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -602,7 +603,7 @@ pmix_status_t pmix20_bfrop_print_int32(char **output, char *prefix, int32_t *src
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INT32\tValue: %d", prefx, (int) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INT32\tValue: %d", prefx, (int) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -623,7 +624,7 @@ pmix_status_t pmix20_bfrop_print_uint64(char **output, char *prefix, uint64_t *s
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -632,7 +633,7 @@ pmix_status_t pmix20_bfrop_print_uint64(char **output, char *prefix, uint64_t *s
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_UINT64\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT64\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -644,7 +645,7 @@ pmix_status_t pmix20_bfrop_print_uint64(char **output, char *prefix, uint64_t *s
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_UINT64\tValue: %lu", prefx, (unsigned long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_UINT64\tValue: %lu", prefx, (unsigned long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -666,7 +667,7 @@ pmix_status_t pmix20_bfrop_print_int64(char **output, char *prefix, int64_t *src
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -675,7 +676,7 @@ pmix_status_t pmix20_bfrop_print_int64(char **output, char *prefix, int64_t *src
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_INT64\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_INT64\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -687,7 +688,7 @@ pmix_status_t pmix20_bfrop_print_int64(char **output, char *prefix, int64_t *src
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_INT64\tValue: %ld", prefx, (long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INT64\tValue: %ld", prefx, (long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -709,7 +710,7 @@ pmix_status_t pmix20_bfrop_print_float(char **output, char *prefix, float *src,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -718,7 +719,7 @@ pmix_status_t pmix20_bfrop_print_float(char **output, char *prefix, float *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_FLOAT\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_FLOAT\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -730,7 +731,7 @@ pmix_status_t pmix20_bfrop_print_float(char **output, char *prefix, float *src,
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_FLOAT\tValue: %f", prefx, *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_FLOAT\tValue: %f", prefx, *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -752,7 +753,7 @@ pmix_status_t pmix20_bfrop_print_double(char **output, char *prefix, double *src
 
    /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -761,7 +762,7 @@ pmix_status_t pmix20_bfrop_print_double(char **output, char *prefix, double *src
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_DOUBLE\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_DOUBLE\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -773,7 +774,7 @@ pmix_status_t pmix20_bfrop_print_double(char **output, char *prefix, double *src
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_DOUBLE\tValue: %f", prefx, *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_DOUBLE\tValue: %f", prefx, *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -796,7 +797,7 @@ pmix_status_t pmix20_bfrop_print_time(char **output, char *prefix, time_t *src,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -805,7 +806,7 @@ pmix_status_t pmix20_bfrop_print_time(char **output, char *prefix, time_t *src,
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_TIME\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_TIME\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -820,7 +821,7 @@ pmix_status_t pmix20_bfrop_print_time(char **output, char *prefix, time_t *src,
     t = ctime(src);
     t[strlen(t) - 1] = '\0'; // remove trailing newline
 
-    if (0 > asprintf(output, "%sData type: PMIX_TIME\tValue: %s", prefx, t)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_TIME\tValue: %s", prefx, t)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -842,7 +843,7 @@ pmix_status_t pmix20_bfrop_print_timeval(char **output, char *prefix, struct tim
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -851,7 +852,7 @@ pmix_status_t pmix20_bfrop_print_timeval(char **output, char *prefix, struct tim
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -863,7 +864,7 @@ pmix_status_t pmix20_bfrop_print_timeval(char **output, char *prefix, struct tim
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
                      (long) src->tv_sec, (long) src->tv_usec)) {
         if (prefx != prefix) {
             free(prefx);
@@ -886,7 +887,7 @@ pmix_status_t pmix20_bfrop_print_status(char **output, char *prefix, pmix_status
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -895,7 +896,7 @@ pmix_status_t pmix20_bfrop_print_status(char **output, char *prefix, pmix_status
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_STATUS\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_STATUS\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -908,7 +909,7 @@ pmix_status_t pmix20_bfrop_print_status(char **output, char *prefix, pmix_status
     }
 
     if (0
-        > asprintf(output, "%sData type: PMIX_STATUS\tValue: %s", prefx, PMIx_Error_string(*src))) {
+        > pmix_asprintf(output, "%sData type: PMIX_STATUS\tValue: %s", prefx, PMIx_Error_string(*src))) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -936,7 +937,7 @@ pmix_status_t pmix20_bfrop_print_value(char **output, char *prefix, pmix_value_t
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -945,7 +946,7 @@ pmix_status_t pmix20_bfrop_print_value(char **output, char *prefix, pmix_value_t
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_VALUE\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_VALUE\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -959,114 +960,114 @@ pmix_status_t pmix20_bfrop_print_value(char **output, char *prefix, pmix_value_t
 
     switch (src->type) {
     case PMIX_UNDEF:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UNDEF", prefx);
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UNDEF", prefx);
         break;
     case PMIX_BYTE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_BYTE\tValue: %x", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_BYTE\tValue: %x", prefx,
                       src->data.byte);
         break;
     case PMIX_STRING:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STRING\tValue: %s", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STRING\tValue: %s", prefx,
                       src->data.string);
         break;
     case PMIX_SIZE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SIZE\tValue: %lu", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SIZE\tValue: %lu", prefx,
                       (unsigned long) src->data.size);
         break;
     case PMIX_PID:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PID\tValue: %lu", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PID\tValue: %lu", prefx,
                       (unsigned long) src->data.pid);
         break;
     case PMIX_INT:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT\tValue: %d", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT\tValue: %d", prefx,
                       src->data.integer);
         break;
     case PMIX_INT8:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT8\tValue: %d", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT8\tValue: %d", prefx,
                       (int) src->data.int8);
         break;
     case PMIX_INT16:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT16\tValue: %d", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT16\tValue: %d", prefx,
                       (int) src->data.int16);
         break;
     case PMIX_INT32:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT32\tValue: %d", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT32\tValue: %d", prefx,
                       src->data.int32);
         break;
     case PMIX_INT64:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT64\tValue: %ld", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT64\tValue: %ld", prefx,
                       (long) src->data.int64);
         break;
     case PMIX_UINT:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT\tValue: %u", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT\tValue: %u", prefx,
                       src->data.uint);
         break;
     case PMIX_UINT8:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT8\tValue: %u", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT8\tValue: %u", prefx,
                       (unsigned int) src->data.uint8);
         break;
     case PMIX_UINT16:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT16\tValue: %u", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT16\tValue: %u", prefx,
                       (unsigned int) src->data.uint16);
         break;
     case PMIX_UINT32:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT32\tValue: %u", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT32\tValue: %u", prefx,
                       src->data.uint32);
         break;
     case PMIX_UINT64:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT64\tValue: %lu", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT64\tValue: %lu", prefx,
                       (unsigned long) src->data.uint64);
         break;
     case PMIX_FLOAT:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_FLOAT\tValue: %f", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_FLOAT\tValue: %f", prefx,
                       src->data.fval);
         break;
     case PMIX_DOUBLE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DOUBLE\tValue: %f", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DOUBLE\tValue: %f", prefx,
                       src->data.dval);
         break;
     case PMIX_TIMEVAL:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
                       (long) src->data.tv.tv_sec, (long) src->data.tv.tv_usec);
         break;
     case PMIX_TIME:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIME\tValue: %s", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIME\tValue: %s", prefx,
                       ctime(&src->data.time));
         break;
     case PMIX_STATUS:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STATUS\tValue: %s", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STATUS\tValue: %s", prefx,
                       PMIx_Error_string(src->data.status));
         break;
     case PMIX_PROC:
         if (NULL == src->data.proc) {
-            rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PROC\tNULL", prefx);
+            rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PROC\tNULL", prefx);
         } else {
-            rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PROC\t%s:%lu", prefx,
+            rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PROC\t%s:%lu", prefx,
                           src->data.proc->nspace, (unsigned long) src->data.proc->rank);
         }
         break;
     case PMIX_BYTE_OBJECT:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: BYTE_OBJECT\tSIZE: %ld", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: BYTE_OBJECT\tSIZE: %ld", prefx,
                       (long) src->data.bo.size);
         break;
     case PMIX_PERSIST:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PERSIST\tValue: %s", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PERSIST\tValue: %s", prefx,
                       PMIx_Persistence_string(src->data.persist));
         break;
     case PMIX_SCOPE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SCOPE\tValue: %s", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SCOPE\tValue: %s", prefx,
                       PMIx_Scope_string(src->data.scope));
         break;
     case PMIX_DATA_RANGE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DATA_RANGE\tValue: %s", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DATA_RANGE\tValue: %s", prefx,
                       PMIx_Data_range_string(src->data.range));
         break;
     case PMIX_PROC_STATE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STATE\tValue: %s", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STATE\tValue: %s", prefx,
                       PMIx_Proc_state_string(src->data.state));
         break;
     case PMIX_PROC_INFO:
-        rc = asprintf(output,
+        rc = pmix_asprintf(output,
                       "%sPMIX_VALUE: Data type: PMIX_PROC_INFO\tProc: %s:%lu\n%s\tHost: "
                       "%s\tExecutable: %s\tPid: %lu",
                       prefx, src->data.pinfo->proc.nspace,
@@ -1074,11 +1075,11 @@ pmix_status_t pmix20_bfrop_print_value(char **output, char *prefix, pmix_value_t
                       src->data.pinfo->executable_name, (unsigned long) src->data.pinfo->pid);
         break;
     case PMIX_DATA_ARRAY:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: DATA_ARRAY\tARRAY SIZE: %ld", prefx,
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: DATA_ARRAY\tARRAY SIZE: %ld", prefx,
                       (long) src->data.darray->size);
         break;
     default:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
+        rc = pmix_asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
         break;
     }
     if (prefx != prefix) {
@@ -1099,7 +1100,7 @@ pmix_status_t pmix20_bfrop_print_info(char **output, char *prefix, pmix_info_t *
     PMIX_HIDE_UNUSED_PARAMS(type);
 
     pmix20_bfrop_print_value(&tmp, NULL, &src->value, PMIX_VALUE);
-    rc = asprintf(output, "%sKEY: %s DIRECTIVES: %0x %s", prefix, src->key, src->flags,
+    rc = pmix_asprintf(output, "%sKEY: %s DIRECTIVES: %0x %s", prefix, src->key, src->flags,
                   (NULL == tmp) ? "PMIX_VALUE: NULL" : tmp);
     if (NULL != tmp) {
         free(tmp);
@@ -1120,7 +1121,7 @@ pmix_status_t pmix20_bfrop_print_pdata(char **output, char *prefix, pmix_pdata_t
 
     pmix20_bfrop_print_proc(&tmp1, NULL, &src->proc, PMIX_PROC);
     pmix20_bfrop_print_value(&tmp2, NULL, &src->value, PMIX_VALUE);
-    rc = asprintf(output, "%s  %s  KEY: %s %s", prefix, tmp1, src->key,
+    rc = pmix_asprintf(output, "%s  %s  KEY: %s %s", prefix, tmp1, src->key,
                   (NULL == tmp2) ? "NULL" : tmp2);
     if (NULL != tmp1) {
         free(tmp1);
@@ -1160,7 +1161,7 @@ pmix_status_t pmix20_bfrop_print_proc(char **output, char *prefix, pmix_proc_t *
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -1169,16 +1170,16 @@ pmix_status_t pmix20_bfrop_print_proc(char **output, char *prefix, pmix_proc_t *
 
     switch (src->rank) {
     case PMIX_RANK_UNDEF:
-        rc = asprintf(output, "%sPROC: %s:PMIX_RANK_UNDEF", prefx, src->nspace);
+        rc = pmix_asprintf(output, "%sPROC: %s:PMIX_RANK_UNDEF", prefx, src->nspace);
         break;
     case PMIX_RANK_WILDCARD:
-        rc = asprintf(output, "%sPROC: %s:PMIX_RANK_WILDCARD", prefx, src->nspace);
+        rc = pmix_asprintf(output, "%sPROC: %s:PMIX_RANK_WILDCARD", prefx, src->nspace);
         break;
     case PMIX_RANK_LOCAL_NODE:
-        rc = asprintf(output, "%sPROC: %s:PMIX_RANK_LOCAL_NODE", prefx, src->nspace);
+        rc = pmix_asprintf(output, "%sPROC: %s:PMIX_RANK_LOCAL_NODE", prefx, src->nspace);
         break;
     default:
-        rc = asprintf(output, "%sPROC: %s:%lu", prefx, src->nspace, (unsigned long) (src->rank));
+        rc = pmix_asprintf(output, "%sPROC: %s:%lu", prefx, src->nspace, (unsigned long) (src->rank));
     }
     if (prefx != prefix) {
         free(prefx);
@@ -1214,7 +1215,7 @@ pmix_status_t pmix20_bfrop_print_persist(char **output, char *prefix, pmix_persi
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -1223,7 +1224,7 @@ pmix_status_t pmix20_bfrop_print_persist(char **output, char *prefix, pmix_persi
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_PERSIST\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_PERSIST\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -1235,7 +1236,7 @@ pmix_status_t pmix20_bfrop_print_persist(char **output, char *prefix, pmix_persi
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_PERSIST\tValue: %ld", prefx, (long) *src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_PERSIST\tValue: %ld", prefx, (long) *src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -1257,7 +1258,7 @@ pmix_status_t pmix20_bfrop_print_scope(char **output, char *prefix, pmix_scope_t
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -1265,7 +1266,7 @@ pmix_status_t pmix20_bfrop_print_scope(char **output, char *prefix, pmix_scope_t
     }
 
     if (0
-        > asprintf(output, "%sData type: PMIX_SCOPE\tValue: %s", prefx, PMIx_Scope_string(*src))) {
+        > pmix_asprintf(output, "%sData type: PMIX_SCOPE\tValue: %s", prefx, PMIx_Scope_string(*src))) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -1287,14 +1288,14 @@ pmix_status_t pmix20_bfrop_print_range(char **output, char *prefix, pmix_data_ra
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
         prefx = prefix;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_DATA_RANGE\tValue: %s", prefx,
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_DATA_RANGE\tValue: %s", prefx,
                      PMIx_Data_range_string(*src))) {
         if (prefx != prefix) {
             free(prefx);
@@ -1317,7 +1318,7 @@ pmix_status_t pmix20_bfrop_print_cmd(char **output, char *prefix, pmix_cmd_t *sr
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -1325,7 +1326,7 @@ pmix_status_t pmix20_bfrop_print_cmd(char **output, char *prefix, pmix_cmd_t *sr
     }
 
     if (0
-        > asprintf(output, "%sData type: PMIX_CMD\tValue: %s", prefx, pmix_command_string(*src))) {
+        > pmix_asprintf(output, "%sData type: PMIX_CMD\tValue: %s", prefx, pmix_command_string(*src))) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -1347,7 +1348,7 @@ pmix_status_t pmix20_bfrop_print_infodirs(char **output, char *prefix, pmix_info
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -1355,7 +1356,7 @@ pmix_status_t pmix20_bfrop_print_infodirs(char **output, char *prefix, pmix_info
     }
 
     tmp = PMIx_Info_directives_string(*src);
-    if (0 > asprintf(output, "%sData type: PMIX_INFO_DIRECTIVES\tValue: %s", prefx, tmp)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_INFO_DIRECTIVES\tValue: %s", prefx, tmp)) {
         free(tmp);
         if (prefx != prefix) {
             free(prefx);
@@ -1379,7 +1380,7 @@ pmix_status_t pmix20_bfrop_print_bo(char **output, char *prefix, pmix_byte_objec
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -1388,7 +1389,7 @@ pmix_status_t pmix20_bfrop_print_bo(char **output, char *prefix, pmix_byte_objec
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        if (0 > asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tValue: NULL pointer", prefx)) {
+        if (0 > pmix_asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tValue: NULL pointer", prefx)) {
             if (prefx != prefix) {
                 free(prefx);
             }
@@ -1400,7 +1401,7 @@ pmix_status_t pmix20_bfrop_print_bo(char **output, char *prefix, pmix_byte_objec
         return PMIX_SUCCESS;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tSize: %ld", prefx, (long) src->size)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tSize: %ld", prefx, (long) src->size)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -1421,14 +1422,14 @@ pmix_status_t pmix20_bfrop_print_ptr(char **output, char *prefix, void *src, pmi
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
         prefx = prefix;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_POINTER\tAddress: %p", prefx, src)) {
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_POINTER\tAddress: %p", prefx, src)) {
         if (prefx != prefix) {
             free(prefx);
         }
@@ -1450,14 +1451,14 @@ pmix_status_t pmix20_bfrop_print_pstate(char **output, char *prefix, pmix_proc_s
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
         prefx = prefix;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_PROC_STATE\tValue: %s", prefx,
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_PROC_STATE\tValue: %s", prefx,
                      PMIx_Proc_state_string(*src))) {
         if (prefx != prefix) {
             free(prefx);
@@ -1482,14 +1483,14 @@ pmix_status_t pmix20_bfrop_print_pinfo(char **output, char *prefix, pmix_proc_in
 
    /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
         prefx = prefix;
     }
 
-    if (0 > asprintf(&p2, "%s\t", prefx)) {
+    if (0 > pmix_asprintf(&p2, "%s\t", prefx)) {
         rc = PMIX_ERR_NOMEM;
         goto done;
     }
@@ -1498,7 +1499,7 @@ pmix_status_t pmix20_bfrop_print_pinfo(char **output, char *prefix, pmix_proc_in
         goto done;
     }
 
-    if (0 > asprintf(output,
+    if (0 > pmix_asprintf(output,
                      "%sData type: PMIX_PROC_INFO\tValue:\n%s\n%sHostname: %s\tExecutable: "
                      "%s\n%sPid: %lu\tExit code: %d\tState: %s",
                      prefx, tmp, p2, src->hostname, src->executable_name, p2,
@@ -1526,14 +1527,14 @@ pmix_status_t pmix20_bfrop_print_darray(char **output, char *prefix, pmix_data_a
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
         prefx = prefix;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_DATA_ARRAY\tSize: %lu", prefx,
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_DATA_ARRAY\tSize: %lu", prefx,
                      (unsigned long) src->size)) {
         if (prefx != prefix) {
             free(prefx);
@@ -1559,19 +1560,19 @@ pmix_status_t pmix20_bfrop_print_query(char **output, char *prefix, pmix_query_t
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
         prefx = prefix;
     }
 
-    if (0 > asprintf(&p2, "%s\t", prefx)) {
+    if (0 > pmix_asprintf(&p2, "%s\t", prefx)) {
         rc = PMIX_ERR_NOMEM;
         goto done;
     }
 
-    if (0 > asprintf(&tmp, "%sData type: PMIX_QUERY\tValue:", prefx)) {
+    if (0 > pmix_asprintf(&tmp, "%sData type: PMIX_QUERY\tValue:", prefx)) {
         free(p2);
         rc = PMIX_ERR_NOMEM;
         goto done;
@@ -1580,7 +1581,7 @@ pmix_status_t pmix20_bfrop_print_query(char **output, char *prefix, pmix_query_t
     /* print out the keys */
     if (NULL != src->keys) {
         for (n = 0; NULL != src->keys[n]; n++) {
-            if (0 > asprintf(&t2, "%s\n%sKey: %s", tmp, p2, src->keys[n])) {
+            if (0 > pmix_asprintf(&t2, "%s\n%sKey: %s", tmp, p2, src->keys[n])) {
                 free(p2);
                 free(tmp);
                 rc = PMIX_ERR_NOMEM;
@@ -1600,7 +1601,7 @@ pmix_status_t pmix20_bfrop_print_query(char **output, char *prefix, pmix_query_t
                 free(tmp);
                 goto done;
             }
-            if (0 > asprintf(&t3, "%s\n%s", tmp, t2)) {
+            if (0 > pmix_asprintf(&t3, "%s\n%s", tmp, t2)) {
                 free(p2);
                 free(tmp);
                 free(t2);
@@ -1633,7 +1634,7 @@ pmix_status_t pmix20_bfrop_print_rank(char **output, char *prefix, pmix_rank_t *
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
@@ -1642,16 +1643,16 @@ pmix_status_t pmix20_bfrop_print_rank(char **output, char *prefix, pmix_rank_t *
 
     switch (*src) {
     case PMIX_RANK_UNDEF:
-        rc = asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_UNDEF", prefx);
+        rc = pmix_asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_UNDEF", prefx);
         break;
     case PMIX_RANK_WILDCARD:
-        rc = asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_WILDCARD", prefx);
+        rc = pmix_asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_WILDCARD", prefx);
         break;
     case PMIX_RANK_LOCAL_NODE:
-        rc = asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_LOCAL_NODE", prefx);
+        rc = pmix_asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_LOCAL_NODE", prefx);
         break;
     default:
-        rc = asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: %lu", prefx,
+        rc = pmix_asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: %lu", prefx,
                       (unsigned long) (*src));
     }
     if (prefx != prefix) {
@@ -1672,14 +1673,14 @@ pmix_status_t pmix20_bfrop_print_alloc_directive(char **output, char *prefix,
 
     /* deal with NULL prefix */
     if (NULL == prefix) {
-        if (0 > asprintf(&prefx, " ")) {
+        if (0 > pmix_asprintf(&prefx, " ")) {
             return PMIX_ERR_NOMEM;
         }
     } else {
         prefx = prefix;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_ALLOC_DIRECTIVE\tValue: %s", prefx,
+    if (0 > pmix_asprintf(output, "%sData type: PMIX_ALLOC_DIRECTIVE\tValue: %s", prefx,
                      PMIx_Alloc_directive_string(*src))) {
         if (prefx != prefix) {
             free(prefx);
@@ -1703,10 +1704,10 @@ pmix_status_t pmix20_bfrop_print_array(char **output, char *prefix, pmix_info_ar
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-   if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
+   if (0 > pmix_asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
         return PMIX_ERR_NOMEM;
     }
-    if (0 > asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix)) {
+    if (0 > pmix_asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix)) {
         free(tmp);
         return PMIX_ERR_NOMEM;
     }
@@ -1714,7 +1715,7 @@ pmix_status_t pmix20_bfrop_print_array(char **output, char *prefix, pmix_info_ar
 
     for (j = 0; j < src->size; j++) {
         pmix20_bfrop_print_info(&tmp2, pfx, &s1[j], PMIX_INFO);
-        if (0 > asprintf(&tmp3, "%s%s", tmp, tmp2)) {
+        if (0 > pmix_asprintf(&tmp3, "%s%s", tmp, tmp2)) {
             free(tmp);
             free(tmp2);
             free(pfx);

--- a/src/mca/bfrops/v21/bfrop_pmix21.c
+++ b/src/mca/bfrops/v21/bfrop_pmix21.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +29,7 @@
 
 #include "bfrop_pmix21.h"
 #include "src/mca/bfrops/base/base.h"
+#include "src/util/pmix_printf.h"
 
 static pmix_status_t init(void);
 static void finalize(void);
@@ -798,10 +799,10 @@ static pmix_status_t pmix21_bfrop_print_array(char **output, char *prefix, pmix_
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
+    if (0 > pmix_asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
         return PMIX_ERR_NOMEM;
     }
-    if (0 > asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix)) {
+    if (0 > pmix_asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix)) {
         free(tmp);
         return PMIX_ERR_NOMEM;
     }
@@ -809,7 +810,7 @@ static pmix_status_t pmix21_bfrop_print_array(char **output, char *prefix, pmix_
 
     for (j = 0; j < src->size; j++) {
         pmix_bfrops_base_print_info(&tmp2, pfx, &s1[j], PMIX_INFO);
-        if (0 > asprintf(&tmp3, "%s%s", tmp, tmp2)) {
+        if (0 > pmix_asprintf(&tmp3, "%s%s", tmp, tmp2)) {
             free(tmp);
             free(tmp2);
             free(pfx);

--- a/src/mca/bfrops/v3/bfrop_pmix3.c
+++ b/src/mca/bfrops/v3/bfrop_pmix3.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +29,7 @@
 
 #include "bfrop_pmix3.h"
 #include "src/mca/bfrops/base/base.h"
+#include "src/util/pmix_printf.h"
 
 static pmix_status_t init(void);
 static void finalize(void);
@@ -802,10 +803,10 @@ static pmix_status_t pmix3_bfrop_print_array(char **output, char *prefix, pmix_i
 
     PMIX_HIDE_UNUSED_PARAMS(type);
 
-    if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
+    if (0 > pmix_asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long) src->size)) {
         return PMIX_ERR_NOMEM;
     }
-    if (0 > asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix)) {
+    if (0 > pmix_asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix)) {
         free(tmp);
         return PMIX_ERR_NOMEM;
     }
@@ -813,7 +814,7 @@ static pmix_status_t pmix3_bfrop_print_array(char **output, char *prefix, pmix_i
 
     for (j = 0; j < src->size; j++) {
         pmix_bfrops_base_print_info(&tmp2, pfx, &s1[j], PMIX_INFO);
-        if (0 > asprintf(&tmp3, "%s%s", tmp, tmp2)) {
+        if (0 > pmix_asprintf(&tmp3, "%s%s", tmp, tmp2)) {
             free(tmp);
             free(tmp2);
             free(pfx);

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2022-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2024 Triad National Security, LLC. All rights reserved.
  * Copyright (c) 2026      Jeff Squyres  All rights reserved.
  * $COPYRIGHT$
@@ -22,6 +22,7 @@
 
 #include "src/include/pmix_dictionary.h"
 
+#include "src/util/pmix_printf.h"
 #include "src/util/pmix_string_copy.h"
 #include "src/util/pmix_vmem.h"
 
@@ -1541,7 +1542,7 @@ pack_shmem3_connection_info(
             break;
         }
         kv.value->type = PMIX_STRING;
-        int nw = asprintf(&kv.value->data.string, "%zd", (size_t)shmem3_id);
+        int nw = pmix_asprintf(&kv.value->data.string, "%zd", (size_t)shmem3_id);
         if (PMIX_UNLIKELY(nw == -1)) {
             rc = PMIX_ERR_NOMEM;
             PMIX_ERROR_LOG(rc);
@@ -1580,7 +1581,7 @@ pack_shmem3_connection_info(
             break;
         }
         kv.value->type = PMIX_STRING;
-        nw = asprintf(&kv.value->data.string, "%zx", shmem3->size);
+        nw = pmix_asprintf(&kv.value->data.string, "%zx", shmem3->size);
         if (PMIX_UNLIKELY(nw == -1)) {
             rc = PMIX_ERR_NOMEM;
             PMIX_ERROR_LOG(rc);
@@ -1602,7 +1603,7 @@ pack_shmem3_connection_info(
             break;
         }
         kv.value->type = PMIX_STRING;
-        nw = asprintf(
+        nw = pmix_asprintf(
             &kv.value->data.string, "%zx", (size_t)shmem3->hdr_address
         );
         if (PMIX_UNLIKELY(nw == -1)) {
@@ -1648,11 +1649,11 @@ pack_server_keyindex_description(
     for (int i = 0; NULL != description[i]; ++i) {
         int nw = -1;
         if (0 == i) {
-            nw = asprintf(&kv.value->data.string, "%s", description[i]);
+            nw = pmix_asprintf(&kv.value->data.string, "%s", description[i]);
         }
         else {
             char *curs = kv.value->data.string;
-            nw = asprintf(&kv.value->data.string, "%s\n%s", curs, description[i]);
+            nw = pmix_asprintf(&kv.value->data.string, "%s\n%s", curs, description[i]);
             free(curs);
         }
         if (PMIX_UNLIKELY(nw == -1)) {
@@ -1916,7 +1917,7 @@ unpack_shmem3_connection_info(
 
         // Every element of a seg blob is packed as a string; anything
         // else means the blob is not one of ours, and val would not be
-        // a pointer we can hand to asprintf()/strtost().
+        // a pointer we can hand to pmix_asprintf()/strtost().
         if (PMIX_UNLIKELY(NULL == kv.value ||
                           PMIX_STRING != kv.value->type ||
                           NULL == kv.value->data.string)) {
@@ -1926,7 +1927,7 @@ unpack_shmem3_connection_info(
         }
         const char *const val = kv.value->data.string;
         if (PMIX_CHECK_KEY(&kv, SHMEM3_SEG_NSID_KEY)) {
-            int nw = asprintf(&usb->nsid, "%s", val);
+            int nw = pmix_asprintf(&usb->nsid, "%s", val);
             if (PMIX_UNLIKELY(nw == -1)) {
                 rc = PMIX_ERR_NOMEM;
                 PMIX_ERROR_LOG(rc);
@@ -1943,7 +1944,7 @@ unpack_shmem3_connection_info(
             usb->smid = (pmix_gds_shmem3_job_shmem3_id_t)st_shmem3_id;
         }
         else if (PMIX_CHECK_KEY(&kv, SHMEM3_SEG_PATH_KEY)) {
-            int nw = asprintf(&usb->seg_path, "%s", val);
+            int nw = pmix_asprintf(&usb->seg_path, "%s", val);
             if (PMIX_UNLIKELY(nw == -1)) {
                 rc = PMIX_ERR_NOMEM;
                 PMIX_ERROR_LOG(rc);
@@ -2249,7 +2250,7 @@ unpack_srv_kindx_info(
         // Every element below is read out of the union according to the
         // key alone. A value whose type does not match the key it
         // arrived under would be read as a pointer and handed to
-        // asprintf() or PMIx_Argv_split().
+        // pmix_asprintf() or PMIx_Argv_split().
         if (PMIX_UNLIKELY(NULL == kv.value)) {
             rc = PMIX_ERR_TYPE_MISMATCH;
             PMIX_ERROR_LOG(rc);
@@ -2266,7 +2267,7 @@ unpack_srv_kindx_info(
         }
 
         if (PMIX_CHECK_KEY(&kv, SHMEM3_KIDX_NSID_KEY)) {
-            int nw = asprintf(&nspace_name, "%s", kv.value->data.string);
+            int nw = pmix_asprintf(&nspace_name, "%s", kv.value->data.string);
             if (PMIX_UNLIKELY(nw == -1)) {
                 rc = PMIX_ERR_NOMEM;
                 PMIX_ERROR_LOG(rc);
@@ -2312,7 +2313,7 @@ unpack_srv_kindx_info(
         }
         else if (PMIX_CHECK_KEY(&kv, SHMEM3_KIDX_NAME_KEY) &&
                  tmpsrvdict && tabindex < tabsize) {
-            const int nw = asprintf(
+            const int nw = pmix_asprintf(
                 &tmpsrvdict[tabindex].name, "%s", kv.value->data.string
             );
             if (PMIX_UNLIKELY(nw == -1)) {
@@ -2323,7 +2324,7 @@ unpack_srv_kindx_info(
         }
         else if (PMIX_CHECK_KEY(&kv, SHMEM3_KIDX_STRING_KEY) &&
                  tmpsrvdict && tabindex < tabsize) {
-            const int nw = asprintf(
+            const int nw = pmix_asprintf(
                 &tmpsrvdict[tabindex].string, "%s", kv.value->data.string
             );
             if (PMIX_UNLIKELY(nw == -1)) {

--- a/src/mca/pcompress/AGENTS.md
+++ b/src/mca/pcompress/AGENTS.md
@@ -123,11 +123,19 @@ calls it only when non-`NULL`).
 
 `get_decompressed_size` and `get_decompressed_strlen`, by contrast, **are**
 implemented by all three modules (the base default, `zlib`, and `zlibng`).
-They are called **unguarded** at their only call sites, in
+Their only call sites are in
 [`src/mca/bfrops/base/bfrop_base_fns.c`](../bfrops/base/bfrop_base_fns.c)
 (the `PMIX_COMPRESSED_STRING` / `PMIX_COMPRESSED_BYTE_OBJECT` cases of the
-`PMIx_Value_get_size` / data-array size computation), so it is essential
-that every module keep them non-`NULL`. Each reads the **4-byte length
+`PMIx_Value_get_size` / data-array size computation), and every module
+should keep them non-`NULL` — but those call sites no longer *assume* it.
+They used to call the slot directly, which turned a module that left it
+`NULL` into a jump to address zero. A component is a run-time-loadable
+plugin, so an installed component older than the `libpmix` that loads it
+is exactly what a partial upgrade produces, and one built before these
+two entry points existed is such a module. The two static helpers
+`decompressed_size()` / `decompressed_strlen()` in that file now answer
+0 in that case, which is what the base default already returns for a
+blob it cannot read. Each reads the **4-byte length
 prefix** the compressor folded into the blob and returns the inflated
 size without decompressing: `get_decompressed_size` returns the raw byte
 count, `get_decompressed_strlen` returns that count **+ 1** for the NUL
@@ -305,12 +313,15 @@ Golden rules that bite here:
 - **Respect the decline contract.** `compress*` returning `false` is
   normal and callers depend on it (they ship uncompressed). Never make it
   return `true` with a result that is not strictly smaller than the input.
-- **`init`/`finalize` are `NULL` today; `get_decompressed_*` are not.**
-  Guard any new call site that uses `init`/`finalize`. The two
-  `get_decompressed_*` pointers, by contrast, are relied on unguarded by
-  `bfrops` — if you add a new module (or a new base default), it **must**
-  implement them, or you reintroduce the NULL-deref they were added to
-  fix.
+- **Guard every module entry point you call.** `init`/`finalize` are
+  `NULL` in every module today, and `get_decompressed_size` /
+  `get_decompressed_strlen` were `NULL` in every module built before
+  July 2026 — which is a live configuration, because components are
+  run-time-loadable and an installed plugin can be older than the
+  `libpmix` that loads it. A new module should still implement both
+  `get_decompressed_*`, but no caller may treat that as guaranteed;
+  `bfrops` learned this the hard way (see the note under those two
+  fields above).
 - **Remember selection is a build-time fact.** Reproducing a "wrong
   compressor selected" report means checking what `configure` found, not
   an MCA parameter.

--- a/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
@@ -5,7 +5,7 @@
  *                         reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +26,7 @@
 #include "src/mca/pdl/pdl.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
+#include "src/util/pmix_printf.h"
 
 #include "pdl_pdlopen.h"
 
@@ -75,7 +76,7 @@ static int pdlopen_open(const char *fname, bool use_ext, bool private_namespace,
              ext = pmix_mca_pdl_pdlopen_component.filename_suffixes[++i]) {
             char *name;
 
-            rc = asprintf(&name, "%s%s", fname, ext);
+            rc = pmix_asprintf(&name, "%s%s", fname, ext);
             if (0 > rc) {
                 return PMIX_ERR_NOMEM;
             }
@@ -88,7 +89,7 @@ static int pdlopen_open(const char *fname, bool use_ext, bool private_namespace,
             /* coverity[TOCTOU] */
             if (stat(name, &buf) < 0) {
                 if (NULL != err_msg) {
-                    rc = asprintf(err_msg, "File %s not found", name);
+                    rc = pmix_asprintf(err_msg, "File %s not found", name);
                     if (0 > rc) {
                         free(name);
                         return PMIX_ERR_NOMEM;
@@ -186,7 +187,7 @@ static int pdlopen_foreachfile(const char *search_path,
 
             /* Make the absolute path name */
             char *abs_name = NULL;
-            ret = asprintf(&abs_name, "%s/%s", dirs[i], de->d_name);
+            ret = pmix_asprintf(&abs_name, "%s/%s", dirs[i], de->d_name);
             if (0 > ret) {
                 goto error;
             }

--- a/src/mca/pinstalldirs/base/pinstalldirs_base_expand.c
+++ b/src/mca/pinstalldirs/base/pinstalldirs_base_expand.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2007      Sun Microsystem, Inc.  All rights reserved.
  * Copyright (c) 2010      Sandia National Laboratories. All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,6 +21,7 @@
 #include "src/mca/pinstalldirs/base/base.h"
 #include "src/mca/pinstalldirs/pinstalldirs.h"
 #include "src/util/pmix_os_path.h"
+#include "src/util/pmix_printf.h"
 
 /* Support both ${name} and @{name} forms.  The latter allows us to
    pass values through AC_SUBST without being munged by m4 (e.g., if
@@ -34,7 +35,7 @@
             tmp = retval;                                                                          \
             *start_pos = '\0';                                                                     \
             end_pos = start_pos + strlen("${" #fieldname "}");                                     \
-            if (0 > asprintf(&retval, "%s%s%s", tmp, pmix_pinstall_dirs.ompiname + destdir_offset, \
+            if (0 > pmix_asprintf(&retval, "%s%s%s", tmp, pmix_pinstall_dirs.ompiname + destdir_offset, \
                              end_pos)) {                                                           \
                 pmix_output(0, "NOMEM");                                                           \
             }                                                                                      \
@@ -44,7 +45,7 @@
             tmp = retval;                                                                          \
             *start_pos = '\0';                                                                     \
             end_pos = start_pos + strlen("@{" #fieldname "}");                                     \
-            if (0 > asprintf(&retval, "%s%s%s", tmp, pmix_pinstall_dirs.ompiname + destdir_offset, \
+            if (0 > pmix_asprintf(&retval, "%s%s%s", tmp, pmix_pinstall_dirs.ompiname + destdir_offset, \
                              end_pos)) {                                                           \
                 pmix_output(0, "NOMEM");                                                           \
             }                                                                                      \

--- a/src/mca/plog/smtp/plog_smtp.c
+++ b/src/mca/plog/smtp/plog_smtp.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -296,7 +296,7 @@ static pmix_status_t send_email(char *msg, char *from, char *addrs,
 
 
     /* set the X-Mailer */
-    asprintf(&str, "PMIx SMTP Plog v%d.%d.%d", c->super.pmix_mca_component_major_version,
+    pmix_asprintf(&str, "PMIx SMTP Plog v%d.%d.%d", c->super.pmix_mca_component_major_version,
              c->super.pmix_mca_component_minor_version,
              c->super.pmix_mca_component_release_version);
     if (0 == smtp_set_header(message, "X-Mailer", str)) {

--- a/src/mca/pmdl/ompi/pmdl_ompi.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -989,14 +989,14 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
     PMIX_LOAD_PROCID(&undef, proc->nspace, PMIX_RANK_UNDEF);
 
     /* pass universe size */
-    if (0 > asprintf(&param, "%u", ns->univ_size)) {
+    if (0 > pmix_asprintf(&param, "%u", ns->univ_size)) {
         return PMIX_ERR_NOMEM;
     }
     PMIx_Setenv("OMPI_UNIVERSE_SIZE", param, true, env);
     free(param);
 
     /* pass the comm_world size in various formats */
-    if (0 > asprintf(&param, "%u", ns->job_size)) {
+    if (0 > pmix_asprintf(&param, "%u", ns->job_size)) {
         return PMIX_ERR_NOMEM;
     }
     PMIx_Setenv("OMPI_COMM_WORLD_SIZE", param, true, env);
@@ -1005,7 +1005,7 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
     free(param);
 
     /* pass the local size in various formats */
-    if (0 > asprintf(&param, "%u", ns->local_size)) {
+    if (0 > pmix_asprintf(&param, "%u", ns->local_size)) {
         return PMIX_ERR_NOMEM;
     }
     PMIx_Setenv("OMPI_COMM_WORLD_LOCAL_SIZE", param, true, env);
@@ -1013,7 +1013,7 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
     free(param);
 
     /* pass the number of apps in the job */
-    if (0 > asprintf(&param, "%u", ns->num_apps)) {
+    if (0 > pmix_asprintf(&param, "%u", ns->num_apps)) {
         return PMIX_ERR_NOMEM;
     }
     PMIx_Setenv("OMPI_NUM_APP_CTX", param, true, env);
@@ -1118,7 +1118,7 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
 #endif
 
     /* pass the rank */
-    if (0 > asprintf(&param, "%lu", (unsigned long) proc->rank)) {
+    if (0 > pmix_asprintf(&param, "%lu", (unsigned long) proc->rank)) {
         return PMIX_ERR_NOMEM;
     }
     PMIx_Setenv("OMPI_COMM_WORLD_RANK", param, true, env);
@@ -1145,7 +1145,7 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
     kv = (pmix_kval_t *) pmix_list_get_first(&cb.kvs);
     u16 = kv->value->data.uint16;
     PMIX_DESTRUCT(&cb);
-    if (0 > asprintf(&param, "%lu", (unsigned long) u16)) {
+    if (0 > pmix_asprintf(&param, "%lu", (unsigned long) u16)) {
         return PMIX_ERR_NOMEM;
     }
     PMIx_Setenv("OMPI_COMM_WORLD_LOCAL_RANK", param, true, env);
@@ -1172,7 +1172,7 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
     kv = (pmix_kval_t *) pmix_list_get_first(&cb.kvs);
     u16 = kv->value->data.uint16;
     PMIX_DESTRUCT(&cb);
-    if (0 > asprintf(&param, "%lu", (unsigned long) u16)) {
+    if (0 > pmix_asprintf(&param, "%lu", (unsigned long) u16)) {
         return PMIX_ERR_NOMEM;
     }
     PMIx_Setenv("OMPI_COMM_WORLD_NODE_RANK", param, true, env);

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -113,7 +113,7 @@ static char *transports_print(uint64_t *unique_key)
      * number if the system has a different sized long (8 would be for
      * sizeof(int) == 4)).
      */
-    if (0 > asprintf(&format, "%%0%dx", (int) (sizeof(unsigned int)) * 2)) {
+    if (0 > pmix_asprintf(&format, "%%0%dx", (int) (sizeof(unsigned int)) * 2)) {
         free(string_key);
         return NULL;
     }

--- a/src/mca/preg/compress/preg_compress.c
+++ b/src/mca/preg/compress/preg_compress.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,6 +38,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
 
 #include "preg_compress.h"
 #include "src/mca/pcompress/pcompress.h"
@@ -78,7 +79,7 @@ static pmix_status_t pack_blob(const uint8_t *tmp, size_t len, char **regexp)
     int idx;
 
     /* convert the length to a string */
-    if (0 > asprintf(&slen, "%lu", (unsigned long) len)) {
+    if (0 > pmix_asprintf(&slen, "%lu", (unsigned long) len)) {
         return PMIX_ERR_NOMEM;
     }
 

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -258,23 +258,23 @@ static pmix_status_t generate_node_regex(const char *input, char **regexp)
         }
         /* start the regex for this value with the prefix */
         if (NULL != vreg->prefix) {
-            if (0 > asprintf(&tmp, "%s[%d:", vreg->prefix, vreg->num_digits)) {
+            if (0 > pmix_asprintf(&tmp, "%s[%d:", vreg->prefix, vreg->num_digits)) {
                 return PMIX_ERR_NOMEM;
             }
         } else {
-            if (0 > asprintf(&tmp, "[%d:", vreg->num_digits)) {
+            if (0 > pmix_asprintf(&tmp, "[%d:", vreg->num_digits)) {
                 return PMIX_ERR_NOMEM;
             }
         }
         /* add the ranges */
         while (NULL != (range = (pmix_regex_range_t *) pmix_list_remove_first(&vreg->ranges))) {
             if (1 == range->cnt) {
-                if (0 > asprintf(&tmp2, "%s%d,", tmp, range->start)) {
+                if (0 > pmix_asprintf(&tmp2, "%s%d,", tmp, range->start)) {
                     free(tmp);
                     return PMIX_ERR_NOMEM;
                 }
             } else {
-                if (0 > asprintf(&tmp2, "%s%d-%d,", tmp, range->start,
+                if (0 > pmix_asprintf(&tmp2, "%s%d-%d,", tmp, range->start,
                                  range->start + range->cnt - 1)) {
                     free(tmp);
                     return PMIX_ERR_NOMEM;
@@ -288,7 +288,7 @@ static pmix_status_t generate_node_regex(const char *input, char **regexp)
         tmp[strlen(tmp) - 1] = ']';
         if (NULL != vreg->suffix) {
             /* add in the suffix, if provided */
-            if (0 > asprintf(&tmp2, "%s%s", tmp, vreg->suffix)) {
+            if (0 > pmix_asprintf(&tmp2, "%s%s", tmp, vreg->suffix)) {
                 return PMIX_ERR_NOMEM;
             }
             free(tmp);
@@ -302,7 +302,7 @@ static pmix_status_t generate_node_regex(const char *input, char **regexp)
     /* assemble final result */
     if (NULL != regexargs) {
         tmp = PMIx_Argv_join(regexargs, ',');
-        if (0 > asprintf(regexp, "pmix[%s]", tmp)) {
+        if (0 > pmix_asprintf(regexp, "pmix[%s]", tmp)) {
             return PMIX_ERR_NOMEM;
         }
         free(tmp);
@@ -408,12 +408,12 @@ static pmix_status_t generate_ppn(const char *input, char **regexp)
     PMIX_LIST_FOREACH (vreg, &nodes, pmix_regex_value_t) {
         while (NULL != (rng = (pmix_regex_range_t *) pmix_list_remove_first(&vreg->ranges))) {
             if (1 == rng->cnt) {
-                if (0 > asprintf(&tmp2, "%s%d,", tmp, rng->start)) {
+                if (0 > pmix_asprintf(&tmp2, "%s%d,", tmp, rng->start)) {
                     free(tmp);
                     return PMIX_ERR_NOMEM;
                 }
             } else {
-                if (0 > asprintf(&tmp2, "%s%d-%d,", tmp, rng->start, rng->start + rng->cnt - 1)) {
+                if (0 > pmix_asprintf(&tmp2, "%s%d-%d,", tmp, rng->start, rng->start + rng->cnt - 1)) {
                     free(tmp);
                     return PMIX_ERR_NOMEM;
                 }
@@ -900,7 +900,7 @@ static pmix_status_t pmix_regex_extract_ppn(char *regexp, char ***procs)
                 ++t;
                 end = strtol(t, NULL, 10);
                 for (k = start; k <= end; k++) {
-                    if (0 > asprintf(&t, "%d", k)) {
+                    if (0 > pmix_asprintf(&t, "%d", k)) {
                         PMIx_Argv_free(nds);
                         PMIx_Argv_free(rngs);
                         return PMIX_ERR_NOMEM;

--- a/src/mca/ptl/base/ptl_base_connect.c
+++ b/src/mca/ptl/base/ptl_base_connect.c
@@ -747,7 +747,7 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
         // cycle thru the requested order
         for (n=0; NULL != order[n]; n++) {
             if (0 == strcmp(order[n], PMIX_CONNECT_SYSTEM_FIRST)) {
-                if (0 > asprintf(&filename, "%s/pmix.sys.%s", pmix_ptl_base.system_tmpdir,
+                if (0 > pmix_asprintf(&filename, "%s/pmix.sys.%s", pmix_ptl_base.system_tmpdir,
                                  pmix_globals.hostname)) {
                     rc = PMIX_ERR_NOMEM;
                     goto cleanup;
@@ -763,7 +763,7 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
                 }
 
             } else if (0 == strcmp(order[n], PMIX_CONNECT_TO_SYSTEM)) {
-                if (0 > asprintf(&filename, "%s/pmix.sys.%s", pmix_ptl_base.system_tmpdir,
+                if (0 > pmix_asprintf(&filename, "%s/pmix.sys.%s", pmix_ptl_base.system_tmpdir,
                                  pmix_globals.hostname)) {
                     rc = PMIX_ERR_NOMEM;
                     goto cleanup;
@@ -782,7 +782,7 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
                 }
 
             } else if (0 == strcmp(order[n], PMIX_CONNECT_TO_SCHEDULER)) {
-                if (0 > asprintf(&filename, "%s/pmix.sched.%s",
+                if (0 > pmix_asprintf(&filename, "%s/pmix.sched.%s",
                                  pmix_ptl_base.system_tmpdir,
                                  pmix_globals.hostname)) {
                     rc = PMIX_ERR_NOMEM;
@@ -802,7 +802,7 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
                 }
 
             } else if (0 == strcmp(order[n], PMIX_CONNECT_TO_SYS_CONTROLLER)) {
-                if (0 > asprintf(&filename, "%s/pmix.sysctrlr.%s",
+                if (0 > pmix_asprintf(&filename, "%s/pmix.sysctrlr.%s",
                                  pmix_ptl_base.system_tmpdir,
                                  pmix_globals.hostname)) {
                     rc = PMIX_ERR_NOMEM;
@@ -826,7 +826,7 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
 
     /* if they gave us a pid, then look for it */
     if (0 != pid) {
-        if (0 > asprintf(&filename, "pmix.%s.tool.%d", pmix_globals.hostname, pid)) {
+        if (0 > pmix_asprintf(&filename, "pmix.%s.tool.%d", pmix_globals.hostname, pid)) {
             rc = PMIX_ERR_NOMEM;
             goto cleanup;
         }
@@ -845,7 +845,7 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
 
     /* if they gave us an nspace, then look for it */
     if (NULL != server_nspace) {
-        if (0 > asprintf(&filename, "pmix.%s.tool.%s", pmix_globals.hostname, server_nspace)) {
+        if (0 > pmix_asprintf(&filename, "pmix.%s.tool.%s", pmix_globals.hostname, server_nspace)) {
             rc = PMIX_ERR_NOMEM;
             goto cleanup;
         }
@@ -879,7 +879,7 @@ pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t *pr,
          * that succeeds - this is based on the likelihood that there is only
          * one session per user on a node */
 
-        if (0 > asprintf(&filename, "pmix.%s.tool", pmix_globals.hostname)) {
+        if (0 > pmix_asprintf(&filename, "pmix.%s.tool", pmix_globals.hostname)) {
             rc = PMIX_ERR_NOMEM;
             goto cleanup;
         }

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -838,7 +838,7 @@ complete:
         goto sockerror;
     }
 
-    rc = asprintf(&lt->uri, "%s.%u;%s%s:%d", pmix_globals.myid.nspace, pmix_globals.myid.rank,
+    rc = pmix_asprintf(&lt->uri, "%s.%u;%s%s:%d", pmix_globals.myid.nspace, pmix_globals.myid.rank,
                   prefix, myconnhost, myport);
     if (0 > rc || NULL == lt->uri) {
         goto sockerror;
@@ -928,7 +928,7 @@ nextstep:
     /* if we are the scheduler, then drop an appropriately named
      * contact file so the system's resource manager can find us */
     if (PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
-        if (0 > asprintf(&pmix_ptl_base.scheduler_filename, "%s/pmix.sched.%s",
+        if (0 > pmix_asprintf(&pmix_ptl_base.scheduler_filename, "%s/pmix.sched.%s",
                          pmix_ptl_base.system_tmpdir, pmix_globals.hostname)) {
             goto sockerror;
         }
@@ -943,7 +943,7 @@ nextstep:
     } else if (PMIX_PEER_IS_SYS_CTRLR(pmix_globals.mypeer)) {
         /* if we are the system controller, then drop an appropriately named
          * contact file so others can find us */
-            if (0 > asprintf(&pmix_ptl_base.sysctrlr_filename, "%s/pmix.sysctrlr.%s",
+            if (0 > pmix_asprintf(&pmix_ptl_base.sysctrlr_filename, "%s/pmix.sysctrlr.%s",
                          pmix_ptl_base.system_tmpdir, pmix_globals.hostname)) {
             goto sockerror;
         }
@@ -957,7 +957,7 @@ nextstep:
     } else if (pmix_ptl_base.tool_support) {
         /* if we are going to support tools, then drop contact file(s) */
         if (pmix_ptl_base.system_tool) {
-            if (0 > asprintf(&pmix_ptl_base.system_filename, "%s/pmix.sys.%s",
+            if (0 > pmix_asprintf(&pmix_ptl_base.system_filename, "%s/pmix.sys.%s",
                              pmix_ptl_base.system_tmpdir, pmix_globals.hostname)) {
                 goto sockerror;
             }
@@ -972,7 +972,7 @@ nextstep:
 
         if (pmix_ptl_base.session_tool) {
             /* first output to a std file */
-            if (0 > asprintf(&pmix_ptl_base.session_filename, "%s/pmix.%s.tool",
+            if (0 > pmix_asprintf(&pmix_ptl_base.session_filename, "%s/pmix.%s.tool",
                              pmix_ptl_base.session_tmpdir, pmix_globals.hostname)) {
                 goto sockerror;
             }
@@ -989,7 +989,7 @@ nextstep:
 
         /* now output to a file based on pid */
         mypid = getpid();
-        if (0 > asprintf(&pmix_ptl_base.pid_filename, "%s/pmix.%s.tool.%d",
+        if (0 > pmix_asprintf(&pmix_ptl_base.pid_filename, "%s/pmix.%s.tool.%d",
                          pmix_ptl_base.session_tmpdir, pmix_globals.hostname, mypid)) {
             goto sockerror;
         }
@@ -1004,7 +1004,7 @@ nextstep:
         }
 
         /* now output it into a file based on my nspace */
-        if (0 > asprintf(&pmix_ptl_base.nspace_filename, "%s/pmix.%s.tool.%s",
+        if (0 > pmix_asprintf(&pmix_ptl_base.nspace_filename, "%s/pmix.%s.tool.%s",
                          pmix_ptl_base.session_tmpdir, pmix_globals.hostname,
                          pmix_globals.myid.nspace)) {
             goto sockerror;

--- a/src/mca/ptl/client/ptl_client.c
+++ b/src/mca/ptl/client/ptl_client.c
@@ -57,6 +57,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_os_path.h"
+#include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
 
 #include "ptl_client.h"
@@ -160,7 +161,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *pr,
             pmix_globals.mypeer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(NULL);
             pmix_client_globals.myserver->nptr->compat.bfrops = pmix_bfrops_base_assign_module(NULL);
             /* setup the system rendezvous file name */
-            if (0 > asprintf(&rendfile, "%s/pmix.sys.%s", pmix_ptl_base.system_tmpdir,
+            if (0 > pmix_asprintf(&rendfile, "%s/pmix.sys.%s", pmix_ptl_base.system_tmpdir,
                              pmix_globals.hostname)) {
                 if (NULL != iptr) {
                     PMIX_INFO_FREE(iptr, niptr);

--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -72,6 +72,7 @@
 #include "src/util/pmix_name_fns.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
+#include "src/util/pmix_printf.h"
 
 #include "src/client/pmix_client_ops.h"
 #include "src/server/pmix_server_ops.h"
@@ -236,7 +237,7 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
                 continue;
             }
             /* prepend the nspace */
-            if (0 > asprintf(&prs, "%s:%s", ns->nspace, kv->value->data.string)) {
+            if (0 > pmix_asprintf(&prs, "%s:%s", ns->nspace, kv->value->data.string)) {
                 PMIX_LIST_DESTRUCT(&cb.kvs);
                 PMIX_CONSTRUCT(&cb.kvs, pmix_list_t);
                 continue;

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -18,7 +18,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -193,7 +193,7 @@ pmix_status_t pmix_unsetenv(const char *name, char ***env)
 
     /* Make something easy to compare to */
 
-    i = asprintf(&compare, "%s=", name);
+    i = pmix_asprintf(&compare, "%s=", name);
     if (NULL == compare || 0 > i) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }

--- a/src/util/pmix_output.c
+++ b/src/util/pmix_output.c
@@ -152,7 +152,7 @@ bool pmix_output_init(void)
     }
     gethostname(hostname, sizeof(hostname) - 1);
     hostname[sizeof(hostname) - 1] = '\0';
-    if (0 > asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid())) {
+    if (0 > pmix_asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid())) {
         return false;
     }
 
@@ -172,7 +172,7 @@ bool pmix_output_init(void)
 
     /* Set some defaults */
 
-    if (0 > asprintf(&output_prefix, "pmix-output-pid%d-", getpid())) {
+    if (0 > pmix_asprintf(&output_prefix, "pmix-output-pid%d-", getpid())) {
         return false;
     }
     output_dir = strdup(pmix_tmp_directory());
@@ -240,7 +240,7 @@ void pmix_output_reopen_all(void)
         free(verbose.lds_prefix);
         verbose.lds_prefix = NULL;
     }
-    if (0 > asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid())) {
+    if (0 > pmix_asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid())) {
         verbose.lds_prefix = NULL;
         return;
     }
@@ -727,7 +727,7 @@ static int make_string(char **out, char **no_newline_string, pmix_output_desc_t 
 
     /* Make the formatted string */
     *out = NULL;
-    if (0 > vasprintf(no_newline_string, format, arglist)) {
+    if (0 > pmix_vasprintf(no_newline_string, format, arglist)) {
         return PMIX_ERR_NOMEM;
     }
     total_len = len = strlen(*no_newline_string);

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -560,7 +560,7 @@ char *pmix_show_help_vstring(const char *filename,
 
     if (PMIX_SUCCESS == rc) {
         /* Apply the formatting to make the final output string */
-        if (0 > vasprintf(&output, single_string, arglist)) {
+        if (0 > pmix_vasprintf(&output, single_string, arglist)) {
             output = NULL;
         }
         free(single_string);

--- a/src/util/pmix_timings.c
+++ b/src/util/pmix_timings.c
@@ -40,6 +40,7 @@
 #include "src/include/pmix_globals.h"
 #include "src/util/pmix_basename.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
 
 #include "src/util/pmix_timings.h"
 
@@ -63,7 +64,7 @@ static bool pmix_timing_overhead = false;
 
 void pmix_init_id(char *nspace, int rank)
 {
-    asprintf(&jobid, "%s:%d", nspace, rank);
+    pmix_asprintf(&jobid, "%s:%d", nspace, rank);
 }
 
 /* Get current timestamp. Derived from MPI_Wtime */
@@ -359,16 +360,16 @@ int pmix_timing_report(pmix_timing_t *t, char *fname)
             // Service event, skip it.
             continue;
         case PMIX_TIMING_TRACE:
-            rc = asprintf(&line, "[%s:%d] %s \"%s\" [PMIX_TRACE] %s:%d %.10lf\n", nodename,
+            rc = pmix_asprintf(&line, "[%s:%d] %s \"%s\" [PMIX_TRACE] %s:%d %.10lf\n", nodename,
                           getpid(), jobid, ev->descr, file, ev->line, ev->ts + hnp_offs + overhead);
             break;
         case PMIX_TIMING_INTBEGIN:
-            rc = asprintf(&line, "[%s:%d] %s \"%s [start]\" [PMIX_TRACE] %s:%d %.10lf\n", nodename,
+            rc = pmix_asprintf(&line, "[%s:%d] %s \"%s [start]\" [PMIX_TRACE] %s:%d %.10lf\n", nodename,
                           getpid(), jobid, descr[ev->id].descr_ev->descr, file, ev->line,
                           ev->ts + hnp_offs + overhead);
             break;
         case PMIX_TIMING_INTEND:
-            rc = asprintf(&line, "[%s:%d] %s \"%s [stop]\" [PMIX_TRACE] %s:%d %.10lf\n", nodename,
+            rc = pmix_asprintf(&line, "[%s:%d] %s \"%s [stop]\" [PMIX_TRACE] %s:%d %.10lf\n", nodename,
                           getpid(), jobid, descr[ev->id].descr_ev->descr, file, ev->line,
                           ev->ts + hnp_offs + overhead);
             break;
@@ -547,7 +548,7 @@ int pmix_timing_deltas(pmix_timing_t *t, char *fname)
     for (i = 0; i < t->next_id_cntr; i++) {
         char *line = NULL;
         size_t line_size;
-        rc = asprintf(&line, "[%s:%d] %s \"%s\" [PMIX_OVHD] %le\n", nodename, getpid(), jobid,
+        rc = pmix_asprintf(&line, "[%s:%d] %s \"%s\" [PMIX_OVHD] %le\n", nodename, getpid(), jobid,
                       descr[i].descr_ev->descr, descr[i].interval - descr[i].overhead);
         if (rc < 0) {
             rc = PMIX_ERR_OUT_OF_RESOURCE;

--- a/test/unit/mca/mca_base_paramfile.c
+++ b/test/unit/mca/mca_base_paramfile.c
@@ -32,6 +32,7 @@
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/base/pmix_mca_base_vari.h"
 #include "src/runtime/pmix_init_util.h"
+#include "src/util/pmix_argv.h"
 
 static int npass = 0;
 static int nfail = 0;
@@ -343,6 +344,50 @@ static void test_file_list_precedence(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* build_env over a file-sourced variable                              */
+/* ------------------------------------------------------------------ */
+
+/* A FILE- or OVERRIDE-sourced variable is the only thing that makes
+ * pmix_mca_base_var_build_env() emit a "SOURCE_" entry, so it is the
+ * only thing that reaches the second asprintf() in that loop. This is
+ * the case mca_base_var's build_env test cannot construct: everything
+ * it sets comes from the environment, which takes the branch that
+ * emits nothing.
+ *
+ * Two things are asserted. The call must report PMIX_SUCCESS -- it used
+ * to return the *length* of the last string it formatted, so a caller
+ * testing PMIX_SUCCESS saw a failure whenever the walk ended on a
+ * file-sourced variable -- and the SOURCE_ entry must name the file the
+ * value came from. */
+static void test_build_env_file_source(void)
+{
+    char **env = NULL;
+    int num_env = 0;
+    bool saw_value = false, saw_source = false;
+    int i, rc;
+
+    rc = pmix_mca_base_var_build_env(&env, &num_env);
+    report("build_env succeeds with a file-sourced variable", PMIX_SUCCESS == rc);
+    if (PMIX_SUCCESS != rc || NULL == env) {
+        return;
+    }
+
+    for (i = 0; i < num_env; ++i) {
+        if (0 == strcmp(env[i], "PMIX_MCA_utest_file_an_int=77")) {
+            saw_value = true;
+        }
+        if (0 == strncmp(env[i], "PMIX_MCA_SOURCE_utest_file_an_int=FILE:", 39)
+            && NULL != strstr(env[i], "params.conf")) {
+            saw_source = true;
+        }
+    }
+    report("build_env forwards a file-sourced value", saw_value);
+    report("build_env forwards the file the value came from", saw_source);
+
+    PMIx_Argv_free(env);
+}
+
+/* ------------------------------------------------------------------ */
 
 static void write_file(const char *name, const char *contents)
 {
@@ -439,6 +484,7 @@ int main(int argc, char **argv)
     test_value_parsing();
     test_tilde_expansion();
     test_file_list_precedence();
+    test_build_env_file_source();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 


### PR DESCRIPTION
Four commits, each independently reviewable.

### Port of open-mpi/ompi#14267

That PR resolves a CodeQL double-free alert in `mca_base_var_build_env()`.
Its first commit (set `str` to NULL after `free()`) is already true here.
Its second — check the return of the `SOURCE_` `asprintf()` calls — was
not, and our version of the bug was worse: `pmix_mca_base_var_build_env()`
*assigned* the return to `ret` and never tested it, while the loop reset
`ret` at the top of every iteration. Two consequences:

* A failure was silently swallowed unless it happened on the very last
  variable of the walk, so a child could be launched with an incomplete
  environment and a success code.
* The value left in `ret` on the way out was whatever the last
  `asprintf()` returned — the *length* of the string it formatted, not a
  status. Any walk ending on a file-, override- or command-line-sourced
  variable therefore returned a positive number, which every caller reads
  as a failure. Only the environment-sourced case, which formats nothing,
  happened to leave `PMIX_SUCCESS` behind.

The new case in `test/unit/mca/mca_base_paramfile.c` covers it. It belongs
there rather than beside the other `build_env` cases in `mca_base_var`,
because reaching the `SOURCE_` branch requires a variable whose value came
from a parameter file, and `mca_base_var` deliberately runs with none.

### `pmix_asprintf` sweep

The libc `asprintf()` was called directly in 30 files. POSIX does not say
what happens to the output pointer when it fails, and modern glibc leaves
it indeterminate, so each of those sites had to reason about the failure
case before touching the pointer again — and several did not. That
non-locality is what the CodeQL alert was really about.
`pmix_asprintf()`/`pmix_vasprintf()` exist to close it: they guarantee the
output pointer is NULL on failure. Mechanical change; no behavior change
beyond the stronger guarantee.

### pcompress guard

`PMIx_Value_get_size()` and the data-array sizing helper beside it called
`pmix_compress.get_decompressed_strlen()` / `_size()` directly. Those slots
can be NULL: `pmix_compress` is a *copy* of whichever component the MCA
base selected, and a component is a run-time-loadable plugin — the
pcompress components built before those entry points were added in July
2026 leave them NULL, and the MCA base searches the install prefix ahead
of any path handed to it. A `$prefix` still holding an older installed
`pmix_mca_pcompress_zlib.so` therefore loads that plugin in preference to
the one just built, and sizing any compressed value becomes a jump to
address zero. An installed component older than the libpmix loading it is
what a partial upgrade produces. The four call sites now answer 0 when the
module cannot answer, which is what the base default already returns for a
blob whose length prefix it cannot read.

This one is unrelated to the rest of the branch and can be dropped or
split out if that reads better.

### Testing

Full `make check` passes (106 tests across `test/`, `test/unit`,
`test/unit/{class,mca,util}`) with zero compiler warnings, on macOS/clang
with `--enable-debug --enable-devel-check --disable-visibility`. The
`bfrops_null_object` failure that the pcompress guard fixes reproduces
without it and is gone with it.

Every swept file was compile-checked: the native build covers 28 of them,
`--enable-test-build` covers `plog/smtp`, and a Linux container build
covers `gds/shmem3`, which `configure.m4` excludes on Apple regardless of
`--enable-test-build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)