### PR TITLE
Restore the declarations update-my-copyright.pl needs to run

### DIFF
--- a/contrib/update-my-copyright.pl
+++ b/contrib/update-my-copyright.pl
@@ -65,9 +65,22 @@ my $QUIET = 0;
 # Set to true if we just want to see the help message
 my $HELP = 0;
 
+# Set by --manual-list to name a file listing the files to process
+# instead of asking git which ones changed.
+my $my_manual_list = "";
+
+# Files whose copyright block we must not touch: embedded copies of
+# external code, and this script itself (its own defaults are copyright
+# lines as far as the regexps below are concerned). Each entry is a
+# regexp matched against the repository-relative file name.
+my @protected = qw(
+    contrib\/update-my-copyright.pl
+    config\/oac\/
+);
+
 # Defaults
 my $my_search_name = "Nanook";
-my $my_formal_name = "Nanook Consulting.  All rights reserved.";
+my $my_formal_name = "Nanook Consulting  All rights reserved.";
 
 # Override the defaults if some values are set in the environment
 $my_search_name = $ENV{PMIX_COPYRIGHT_SEARCH_NAME}


### PR DESCRIPTION
`contrib/update-my-copyright.pl` has not parsed since it was ported from
Open MPI in e238a6ed (January 2026). `perl -c` fails, so the script cannot
run at all:

```
Global symbol "$my_manual_list" requires explicit package name at contrib/update-my-copyright.pl line 84.
Global symbol "@protected" requires explicit package name at contrib/update-my-copyright.pl line 142.
contrib/update-my-copyright.pl has too many errors.
```

The port kept both references but dropped the declarations that go with
them, and both are compile errors under `use strict`. The long cascade of
`String found where operator expected ... Do you need to predeclare
quiet_print?` that perl reports alongside them is fallout, not a second
bug — the parse gives up before it records the sub. Confirmed by history:
the parent commit is `syntax OK`, the file at e238a6ed already fails, and
today's file is byte-identical to that commit.

Restoring the two declarations is the whole fix. `@protected` gets
contents suited to this tree rather than Open MPI's `opal/mca/...` paths:
the `config/oac` submodule, and the script itself — its own default
copyright strings sit above a `$COPYRIGHT$` token, so without that entry
it rewrites its own defaults as though they were a copyright block.
`$my_manual_list` is still never read (it is dead upstream too), but
`--manual-list` is documented in the help text, so the option has to keep
parsing.

Also drops the period after "Nanook Consulting" in the default formal
name. The script does not merely append with that spelling — it rewrites
whatever line it matched — so with the period it churned the punctuation
of every file it touched. The tree overwhelmingly uses the form without
it (476 files to 338, including everything touched recently).

### Testing

Verified against a scratch git repository: a stale year is extended
(`2021-2024` → `2021-2026`), a missing line is inserted, a line already
naming the current year is left alone, both protected files are skipped,
the `PMIX_COPYRIGHT_SEARCH_NAME` / `PMIX_COPYRIGHT_FORMAL_NAME` overrides
work, and `--check-only` exits 111 when it finds work to do and 0 when it
does not. `perl -c` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)