### PR TITLE
Fix TOCTOU races and symlink following in pmix_os_dirpath

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1055,9 +1055,11 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
         /* construct the directory where the output files will go */
         pmix_asprintf(&outdir, "%s/%s/rank.%0*u", nptr->iof_flags.directory,
                       nptr->nspace, numdigs, rank);
-        /* ensure the directory exists */
+        /* ensure the directory exists. An existing directory is fine:
+         * the job may legitimately be writing into one that is already
+         * there (a rerun, or another rank that got here first) */
         rc = pmix_os_dirpath_create(outdir, S_IRWXU | S_IRGRP | S_IXGRP);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
             PMIX_ERROR_LOG(rc);
             free(outdir);
             return NULL;

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -285,6 +285,10 @@ static bool _check_file(const char *root, const char *path)
     if (0 == strncmp(path, "output-", strlen("output-"))) {
         memset(&st, 0, sizeof(struct stat));
         fullpath = pmix_os_path(false, root, path, NULL);
+        if (NULL == fullpath) {
+            /* cannot assemble the name: allow removal */
+            return true;
+        }
         rc = stat(fullpath, &st);
         if (0 != rc) {
             free(fullpath);

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -243,31 +243,40 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
 }
 
 /**
- * This function attempts to remove a directory along with all the
- * files in it.  If the recursive variable is non-zero, then it will
- * try to recursively remove all directories.  If provided, the
- * callback function is executed prior to the directory or file being
- * removed.  If the callback returns non-zero, then no removal is
- * done.
+ * Empty out the directory that fd refers to, and remove any
+ * subdirectories under it.  Takes ownership of fd - it is closed by
+ * the closedir() below before we return.
+ *
+ * Every entry is inspected and removed *relative to the open
+ * descriptor* (fstatat/openat/unlinkat) rather than by rebuilding and
+ * re-resolving its path, so no entry can be swapped between the point
+ * where it is classified and the point where it is acted on: the
+ * thing we looked at is always the thing we remove.
+ *
+ * AT_SYMLINK_NOFOLLOW and O_NOFOLLOW keep symlinks as entries to be
+ * unlinked rather than paths to be followed. unlinkat() removes the
+ * link itself, never its target, and an entry swapped for a symlink
+ * just before we descend into it is refused by O_NOFOLLOW instead of
+ * sending the recursion outside the tree we were asked to destroy.
+ *
+ * path is the printable path of this directory. It is used only for
+ * the caller's callback, for building child display paths, and for
+ * error messages.
  */
-int pmix_os_dirpath_destroy(const char *path, bool recursive,
-                            pmix_os_dirpath_destroy_callback_fn_t cbfunc)
+static int dirpath_destroy_at(int fd, const char *path, bool recursive,
+                              pmix_os_dirpath_destroy_callback_fn_t cbfunc)
 {
-    int rc, exit_status = PMIX_SUCCESS;
+    int rc, childfd, exit_status = PMIX_SUCCESS;
     DIR *dp;
     struct dirent *ep;
-    char *filenm = NULL;
+    struct stat buf;
+    char *filenm;
 
-    if (NULL == path) { /* protect against error */
-        return PMIX_ERROR;
-    }
-
-    /* Open up the directory */
-    dp = opendir(path);
+    /* fdopendir() takes ownership of fd; closedir() will close it */
+    dp = fdopendir(fd);
     if (NULL == dp) {
-        /* per the documented contract, a directory that does not exist is
-         * reported as NOT_FOUND; any other open failure is a generic error */
-        return (ENOENT == errno) ? PMIX_ERR_NOT_FOUND : PMIX_ERROR;
+        close(fd);
+        return PMIX_ERROR;
     }
 
     while (NULL != (ep = readdir(dp))) {
@@ -289,62 +298,113 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
             }
         }
 
-        /* Create a pathname.  This is not always needed, but it makes
-         * for cleaner code just to create it here.  Note that we are
-         * allocating memory here, so we need to free it later on.
-         */
-        filenm = pmix_os_path(false, path, ep->d_name, NULL);
+        if (0 != fstatat(dirfd(dp), ep->d_name, &buf, AT_SYMLINK_NOFOLLOW)) {
+            /* it went away underneath us - that typically happens when
+             * one task is removing the job session dir while another is
+             * still removing its own proc session dir */
+            continue;
+        }
 
-        // attempt to unlink it
-        rc = unlink(filenm);
-        if (0 > rc) {
-            // we failed to unlink it - save the error
-            rc = errno;
-            if (EPERM == rc || EISDIR == rc) {
-                // it's a directory - attempt to remove it
-                rc = rmdir(filenm);
-                if (0 == rc) {
-                    // success
-                    free(filenm);
+        if (!S_ISDIR(buf.st_mode)) {
+            /* a plain file, or a symlink: unlinkat() removes the link
+             * itself and leaves whatever it pointed at alone */
+            if (0 != unlinkat(dirfd(dp), ep->d_name, 0)) {
+                rc = errno;
+                if (ENOENT == rc) {
+                    /* someone else got there first */
                     continue;
                 }
-                /* if it wasn't empty and we are recursively removing
-                 * paths, then proceed downwards */
-                if (ENOTEMPTY == errno && recursive) {
-                    rc = pmix_os_dirpath_destroy(filenm, recursive, cbfunc);
-                    free(filenm);
-                    if (PMIX_SUCCESS != rc) {
-                        exit_status = rc;
-                        closedir(dp);
-                        goto cleanup;
-                    }
-                } else {
-                    free(filenm);
+                if (EBUSY == rc) {
+                    /* file system mount point or another process
+                     * is using it */
+                    exit_status = PMIX_ERROR;
+                    continue;
                 }
-            } else if (EBUSY == rc) {
-                /* file system mount point or another process
-                 * is using it */
-                exit_status = PMIX_ERROR;
-                free(filenm);
-                continue;
-            } else {
                 // uncorrectable error
+                filenm = pmix_os_path(false, path, ep->d_name, NULL);
                 pmix_show_help("help-pmix-util.txt", "unlink-error", true,
-                               filenm,  strerror(rc));
+                               (NULL == filenm) ? ep->d_name : filenm, strerror(rc));
                 free(filenm);
-                filenm = NULL;
                 exit_status = PMIX_ERROR;
                 break;
             }
-        } else {
-            free(filenm);
+            continue;
         }
+
+        /* it's a directory - if it is empty we can drop it right here,
+         * whether or not we were asked to recurse */
+        if (0 == unlinkat(dirfd(dp), ep->d_name, AT_REMOVEDIR)) {
+            continue;
+        }
+        if (ENOENT == errno) {
+            continue;
+        }
+        if (!recursive) {
+            /* it isn't empty and we were not told to descend into it,
+             * so we cannot honor the request */
+            exit_status = PMIX_ERROR;
+            continue;
+        }
+
+        /* proceed downwards through the descriptor we already hold */
+        childfd = openat(dirfd(dp), ep->d_name, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+        if (0 > childfd) {
+            if (ENOENT != errno) {
+                /* the entry is no longer an ordinary directory -
+                 * leave it alone rather than chase it */
+                exit_status = PMIX_ERROR;
+            }
+            continue;
+        }
+        filenm = pmix_os_path(false, path, ep->d_name, NULL);
+        rc = dirpath_destroy_at(childfd, (NULL == filenm) ? ep->d_name : filenm,
+                                recursive, cbfunc);
+        free(filenm);
+        if (PMIX_SUCCESS != rc) {
+            exit_status = rc;
+            break;
+        }
+        /* remove the now-empty subdirectory. This fails harmlessly if
+         * the callback chose to preserve something inside it */
+        unlinkat(dirfd(dp), ep->d_name, AT_REMOVEDIR);
     }
 
     /* Done with this directory */
     closedir(dp);
 
-cleanup:
+    return exit_status;
+}
+
+/**
+ * This function attempts to remove a directory along with all the
+ * files in it.  If the recursive variable is non-zero, then it will
+ * try to recursively remove all directories.  If provided, the
+ * callback function is executed prior to the directory or file being
+ * removed.  If the callback returns non-zero, then no removal is
+ * done.
+ */
+int pmix_os_dirpath_destroy(const char *path, bool recursive,
+                            pmix_os_dirpath_destroy_callback_fn_t cbfunc)
+{
+    int fd, exit_status;
+
+    if (NULL == path) { /* protect against error */
+        return PMIX_ERROR;
+    }
+
+    /* Open up the directory. O_NOFOLLOW: never destroy through a
+     * symlinked base path - the session directories sit under a
+     * world-writable root with predictable names, so a link planted
+     * there would otherwise redirect this whole recursive removal at
+     * a tree of the attacker's choosing */
+    fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if (0 > fd) {
+        /* per the documented contract, a directory that does not exist is
+         * reported as NOT_FOUND; any other open failure is a generic error */
+        return (ENOENT == errno) ? PMIX_ERR_NOT_FOUND : PMIX_ERROR;
+    }
+
+    exit_status = dirpath_destroy_at(fd, path, recursive, cbfunc);
 
     /*
      * If the directory is empty, then remove it - but

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -23,6 +23,7 @@
 #include "pmix_config.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <string.h>
 #ifdef HAVE_UNISTD_H
 #    include <unistd.h>
@@ -51,6 +52,76 @@
 
 static const char path_sep[] = PMIX_PATH_SEP;
 
+/**
+ * The named path already exists: make sure it really is a directory,
+ * and give it (at least) the requested mode bits.
+ *
+ * The inspection and the mode change are both done through a
+ * descriptor, so the object that gets inspected is the object that
+ * gets modified. A path-based stat()/chmod() pair is the classic
+ * TOCTOU race: the path can be swapped between the two calls,
+ * redirecting the chmod onto an object that was never inspected. The
+ * paths that reach this code are the rendezvous and session
+ * directories, whose names are fully predictable and whose default
+ * root (/tmp) is world-writable, so the race is not theoretical.
+ *
+ * O_DIRECTORY: a plain file sitting at the requested name is an error
+ * rather than something we chmod and report as usable.
+ *
+ * O_NOFOLLOW: refuse a symlink planted at the final component.
+ * Following one would point every subsequent operation at the link's
+ * *target* -- which an attacker gets to choose, which we would chmod,
+ * and which pmix_os_dirpath_destroy() would later recurse into.
+ *
+ * Note that we deliberately do not ask whether the directory is
+ * writable. Whether the caller can put files here is settled by the
+ * caller actually creating one; testing for permission first and
+ * acting on the answer afterwards is itself a time-of-check /
+ * time-of-use race, and one that access()/faccessat() cannot avoid
+ * no matter which uid they resolve against.
+ *
+ * @retval PMIX_SUCCESS       It is a directory; mode is now adequate.
+ * @retval PMIX_ERR_NOT_FOUND It vanished under us. No error has been
+ *                            displayed; the caller is expected to
+ *                            retry or report.
+ * @retval PMIX_ERR_SILENT    Refused; an error has been displayed.
+ */
+static int dirpath_ensure_mode(const char *path, const mode_t mode)
+{
+    struct stat buf;
+    int fd, ret;
+
+    fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if (0 > fd) {
+        if (ENOENT == errno) {
+            return PMIX_ERR_NOT_FOUND;
+        }
+        /* ELOOP (symlink) and ENOTDIR (plain file) land here:
+         * something that is not a directory is occupying the name we
+         * were asked to create */
+        pmix_show_help("help-pmix-util.txt", "mkdir-failed", true,
+                       path, strerror(errno));
+        return PMIX_ERR_SILENT;
+    }
+
+    if (0 == fstat(fd, &buf) && mode != (mode & buf.st_mode)) {
+        // try to add the requested bits.
+        // Silently fail the chmod if it hits an error - we'll
+        // let us fail later when we try to actually create a
+        // file if we aren't allowed to do so. However, we have
+        // to capture the return to silence static code
+        // analyzer complaints
+        ret = fchmod(fd, buf.st_mode | mode);
+        if (0 != ret) {
+            pmix_output_verbose(2, pmix_globals.debug_output,
+                                "PATH %s ALREADY EXISTS AND CHMOD FAILED: %s",
+                                path, strerror(errno));
+        }
+    }
+    close(fd);
+    return PMIX_SUCCESS;
+}
+
 int pmix_os_dirpath_create(const char *path, const mode_t mode)
 {
     char **parts, *tmp;
@@ -69,19 +140,18 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
 
     /* check the error */
     if (EEXIST == ret) {
-        // already exists - try to set the mode.
-        // Silently fail the chmod if it hits an error - we'll
-        // let us fail later when we try to actually create a
-        // file if we aren't allowed to do so. However, we have
-        // to capture the return to silence static code
-        // analyzer complaints
-        ret = chmod(path, mode);
-        if (0 != ret) {
-            pmix_output_verbose(2, pmix_globals.debug_output,
-                                "PATH %s ALREADY EXISTS AND CHMOD FAILED: %s",
-                                path, strerror(errno));
+        // already exists - make sure it really is a directory, and
+        // that it carries the requested mode
+        ret = dirpath_ensure_mode(path, mode);
+        if (PMIX_SUCCESS == ret) {
+            return PMIX_ERR_EXISTS;
         }
-        return PMIX_ERR_EXISTS;
+        if (PMIX_ERR_NOT_FOUND != ret) {
+            return ret;
+        }
+        /* it vanished between the mkdir and the open - fall through
+         * and build the tree, which will report any real error */
+        ret = ENOENT;
     }
     if (ENOENT != ret) {
         // cannot create it
@@ -133,13 +203,35 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
 
         /* Now that we have the name, try to create it */
         ret = mkdir(tmp, mode);
-        if (0 != ret && EEXIST != errno) {
+        if (0 == ret) {
+            continue;
+        }
+        if (EEXIST != errno) {
             // true error
             pmix_show_help("help-pmix-util.txt", "mkdir-failed", true,
                            tmp, strerror(errno));
             PMIx_Argv_free(parts);
             free(tmp);
             return PMIX_ERR_SILENT;
+        }
+        /* This component already exists. Intermediate components need
+         * only exist - we just have to be able to traverse them, and
+         * a traverse-only (e.g. 0711) directory is legitimate. The
+         * final component is the one the caller is going to use, so
+         * it has to really be a directory and carry the mode we were
+         * asked for */
+        if (i == (len - 1)) {
+            ret = dirpath_ensure_mode(tmp, mode);
+            if (PMIX_SUCCESS != ret) {
+                if (PMIX_ERR_NOT_FOUND == ret) {
+                    pmix_show_help("help-pmix-util.txt", "mkdir-failed", true,
+                                   tmp, strerror(ENOENT));
+                    ret = PMIX_ERR_SILENT;
+                }
+                PMIx_Argv_free(parts);
+                free(tmp);
+                return ret;
+            }
         }
     }
 

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -427,9 +427,19 @@ bool pmix_os_dirpath_is_empty(const char *path)
 {
     DIR *dp;
     struct dirent *ep;
+    int fd;
 
     if (NULL != path) { /* protect against error */
-        dp = opendir(path);
+        /* O_DIRECTORY | O_NOFOLLOW to match pmix_os_dirpath_destroy():
+         * the answer to this question is normally used to decide
+         * whether to remove the directory, so a symlink must not be
+         * able to answer on behalf of whatever it points at */
+        fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+        if (0 > fd) {
+            return false;
+        }
+        /* fdopendir() takes ownership of fd; closedir() will close it */
+        dp = fdopendir(fd);
         if (NULL != dp) {
             while ((ep = readdir(dp))) {
                 if ((0 != strcmp(ep->d_name, ".")) && (0 != strcmp(ep->d_name, ".."))) {
@@ -440,6 +450,7 @@ bool pmix_os_dirpath_is_empty(const char *path)
             closedir(dp);
             return true;
         }
+        close(fd);
         return false;
     }
 

--- a/test/unit/util/util_os_dirpath.c
+++ b/test/unit/util/util_os_dirpath.c
@@ -214,6 +214,215 @@ static void test_destroy_recursive(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Symlink / non-directory hardening                                   */
+/*                                                                     */
+/* pmix_os_dirpath_create() must not adopt (or chmod) something that   */
+/* is not a directory, and pmix_os_dirpath_destroy() must never follow */
+/* a symlink -- either as its base path or as an entry it finds while  */
+/* walking the tree.  The session and rendezvous directories have      */
+/* fully predictable names under a world-writable root, so a link      */
+/* planted at one of those names would otherwise redirect a chmod, or  */
+/* an entire recursive removal, at a tree of the planter's choosing.   */
+/* ------------------------------------------------------------------ */
+
+static int file_exists(const char *path)
+{
+    struct stat st;
+    return (0 == stat(path, &st) && S_ISREG(st.st_mode));
+}
+
+static int is_symlink(const char *path)
+{
+    struct stat st;
+    return (0 == lstat(path, &st) && S_ISLNK(st.st_mode));
+}
+
+static void make_file(const char *path)
+{
+    FILE *f = fopen(path, "w");
+    if (NULL != f) {
+        fclose(f);
+    }
+}
+
+static void test_create_on_file(void)
+{
+    char path[512];
+    int rc;
+
+    snprintf(path, sizeof(path), "%s/plainfile", tmpbase);
+    make_file(path);
+
+    rc = pmix_os_dirpath_create(path, S_IRWXU);
+    report("create_on_file: refused with ERR_SILENT", PMIX_ERR_SILENT == rc);
+    report("create_on_file: file left in place", file_exists(path));
+
+    unlink(path);
+}
+
+static void test_create_on_symlink(void)
+{
+    char target[512];
+    char link[512];
+    struct stat st;
+    int rc;
+
+    snprintf(target, sizeof(target), "%s/link_target", tmpbase);
+    snprintf(link, sizeof(link), "%s/dirlink", tmpbase);
+    mkdir(target, S_IRWXU);
+    if (0 != symlink(target, link)) {
+        report("create_on_symlink: SKIPPED (symlink unavailable)", 1);
+        rmdir(target);
+        return;
+    }
+
+    /* ask for group bits the target does not have: if the link were
+     * followed, the target would come back chmod'ed */
+    rc = pmix_os_dirpath_create(link, S_IRWXU | S_IRWXG);
+    report("create_on_symlink: refused with ERR_SILENT", PMIX_ERR_SILENT == rc);
+    report("create_on_symlink: link not replaced", is_symlink(link));
+    report("create_on_symlink: target mode untouched",
+           0 == stat(target, &st) && 0 == (st.st_mode & S_IRWXG));
+
+    unlink(link);
+    rmdir(target);
+}
+
+static void test_destroy_does_not_follow_symlink(void)
+{
+    char victim[512];
+    char victimfile[512];
+    char base[512];
+    char link[512];
+    int rc;
+
+    snprintf(victim, sizeof(victim), "%s/victim", tmpbase);
+    snprintf(victimfile, sizeof(victimfile), "%s/victim/precious", tmpbase);
+    snprintf(base, sizeof(base), "%s/walkme", tmpbase);
+    snprintf(link, sizeof(link), "%s/walkme/escape", tmpbase);
+    mkdir(victim, S_IRWXU);
+    make_file(victimfile);
+    mkdir(base, S_IRWXU);
+    if (0 != symlink(victim, link)) {
+        report("destroy_does_not_follow_symlink: SKIPPED (symlink unavailable)", 1);
+        unlink(victimfile);
+        rmdir(victim);
+        rmdir(base);
+        return;
+    }
+
+    rc = pmix_os_dirpath_destroy(base, true, NULL);
+    report("destroy_does_not_follow_symlink: returns SUCCESS", PMIX_SUCCESS == rc);
+    report("destroy_does_not_follow_symlink: tree removed", !dir_exists(base));
+    report("destroy_does_not_follow_symlink: target survives", dir_exists(victim));
+    report("destroy_does_not_follow_symlink: target contents survive",
+           file_exists(victimfile));
+
+    unlink(victimfile);
+    rmdir(victim);
+}
+
+static void test_destroy_symlink_base(void)
+{
+    char victim[512];
+    char victimfile[512];
+    char link[512];
+    int rc;
+
+    snprintf(victim, sizeof(victim), "%s/basevictim", tmpbase);
+    snprintf(victimfile, sizeof(victimfile), "%s/basevictim/precious", tmpbase);
+    snprintf(link, sizeof(link), "%s/baselink", tmpbase);
+    mkdir(victim, S_IRWXU);
+    make_file(victimfile);
+    if (0 != symlink(victim, link)) {
+        report("destroy_symlink_base: SKIPPED (symlink unavailable)", 1);
+        unlink(victimfile);
+        rmdir(victim);
+        return;
+    }
+
+    rc = pmix_os_dirpath_destroy(link, true, NULL);
+    report("destroy_symlink_base: refused", PMIX_SUCCESS != rc);
+    report("destroy_symlink_base: target survives", dir_exists(victim));
+    report("destroy_symlink_base: target contents survive", file_exists(victimfile));
+
+    unlink(link);
+    unlink(victimfile);
+    rmdir(victim);
+}
+
+static void test_destroy_nonrecursive_with_subdir(void)
+{
+    char base[512];
+    char sub[512];
+    char subfile[512];
+    char topfile[512];
+    int rc;
+
+    snprintf(base, sizeof(base), "%s/nonrec", tmpbase);
+    snprintf(sub, sizeof(sub), "%s/nonrec/sub", tmpbase);
+    snprintf(subfile, sizeof(subfile), "%s/nonrec/sub/f", tmpbase);
+    snprintf(topfile, sizeof(topfile), "%s/nonrec/topf", tmpbase);
+    mkdir(base, S_IRWXU);
+    mkdir(sub, S_IRWXU);
+    make_file(subfile);
+    make_file(topfile);
+
+    rc = pmix_os_dirpath_destroy(base, false, NULL);
+    report("destroy_nonrecursive_with_subdir: returns PMIX_ERROR", PMIX_ERROR == rc);
+    report("destroy_nonrecursive_with_subdir: top-level file removed",
+           !file_exists(topfile));
+    report("destroy_nonrecursive_with_subdir: subdirectory preserved", dir_exists(sub));
+    report("destroy_nonrecursive_with_subdir: subdirectory contents preserved",
+           file_exists(subfile));
+
+    unlink(subfile);
+    rmdir(sub);
+    rmdir(base);
+}
+
+static bool veto_keepme(const char *root, const char *path)
+{
+    (void) root;
+    /* refuse to remove the file named "keepme" wherever it is found */
+    return (0 != strcmp(path, "keepme"));
+}
+
+static void test_destroy_callback_veto_in_subdir(void)
+{
+    char base[512];
+    char sub[512];
+    char keep[512];
+    char drop[512];
+    char topfile[512];
+    int rc;
+
+    snprintf(base, sizeof(base), "%s/veto", tmpbase);
+    snprintf(sub, sizeof(sub), "%s/veto/sub", tmpbase);
+    snprintf(keep, sizeof(keep), "%s/veto/sub/keepme", tmpbase);
+    snprintf(drop, sizeof(drop), "%s/veto/sub/dropme", tmpbase);
+    snprintf(topfile, sizeof(topfile), "%s/veto/topf", tmpbase);
+    mkdir(base, S_IRWXU);
+    mkdir(sub, S_IRWXU);
+    make_file(keep);
+    make_file(drop);
+    make_file(topfile);
+
+    rc = pmix_os_dirpath_destroy(base, true, veto_keepme);
+    report("destroy_callback_veto_in_subdir: returns SUCCESS", PMIX_SUCCESS == rc);
+    report("destroy_callback_veto_in_subdir: vetoed file preserved", file_exists(keep));
+    report("destroy_callback_veto_in_subdir: parent of vetoed file preserved",
+           dir_exists(sub));
+    report("destroy_callback_veto_in_subdir: sibling removed", !file_exists(drop));
+    report("destroy_callback_veto_in_subdir: top-level file removed",
+           !file_exists(topfile));
+
+    unlink(keep);
+    rmdir(sub);
+    rmdir(base);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -242,6 +451,13 @@ int main(int argc, char **argv)
     test_destroy_empty();
     test_destroy_with_files();
     test_destroy_recursive();
+
+    test_create_on_file();
+    test_create_on_symlink();
+    test_destroy_does_not_follow_symlink();
+    test_destroy_symlink_base();
+    test_destroy_nonrecursive_with_subdir();
+    test_destroy_callback_veto_in_subdir();
 
     /* Remove the test root; all subdirectories were cleaned up above. */
     rmdir(tmpbase);

--- a/test/unit/util/util_os_dirpath.c
+++ b/test/unit/util/util_os_dirpath.c
@@ -351,6 +351,29 @@ static void test_destroy_symlink_base(void)
     rmdir(victim);
 }
 
+static void test_is_empty_symlink(void)
+{
+    char target[512];
+    char link[512];
+
+    snprintf(target, sizeof(target), "%s/empty_target", tmpbase);
+    snprintf(link, sizeof(link), "%s/emptylink", tmpbase);
+    mkdir(target, S_IRWXU);
+    if (0 != symlink(target, link)) {
+        report("is_empty_symlink: SKIPPED (symlink unavailable)", 1);
+        rmdir(target);
+        return;
+    }
+
+    /* the target is empty, but a symlink must not answer on its
+     * behalf: callers use this to decide whether to remove the path */
+    report("is_empty_symlink: symlink reported not empty",
+           !pmix_os_dirpath_is_empty(link));
+
+    unlink(link);
+    rmdir(target);
+}
+
 static void test_destroy_nonrecursive_with_subdir(void)
 {
     char base[512];
@@ -456,6 +479,7 @@ int main(int argc, char **argv)
     test_create_on_symlink();
     test_destroy_does_not_follow_symlink();
     test_destroy_symlink_base();
+    test_is_empty_symlink();
     test_destroy_nonrecursive_with_subdir();
     test_destroy_callback_veto_in_subdir();
 


### PR DESCRIPTION
Backport of the `opal_os_dirpath` hardening in
[open-mpi/ompi#14257](https://github.com/open-mpi/ompi/pull/14257), which
notes that "the same TOCTOU patterns exist upstream in OpenPMIx's
`pmix_os_dirpath.c`, which PRRTE also uses -- and that is what creates
session dirs under `mpirun`."  They do.  This is not a cherry-pick: our
copy has already diverged (we mkdir-first in `create()` and unlink-first
in `destroy()`), so these are reimplementations of the same two fixes
against our code.

The paths that reach this code are the rendezvous and session
directories.  Their names are fully predictable and their default root
(`/tmp`) is world-writable, so the exposure is reachable rather than
theoretical.

### The defects

**`pmix_os_dirpath_create()`** chmod'ed by name on `EEXIST` without ever
inspecting what was there -- no `stat`, no descriptor.  A symlink planted
at the name was followed and its target chmod'ed (0755 rather than 0700
when `allow_foreign_tools` is set).  A plain file at the name was
chmod'ed and reported as `PMIX_ERR_EXISTS`, which `write_rndz_file()`
accepts as usable.

**`pmix_os_dirpath_destroy()`** was path-based end to end.  `opendir()`
on the base follows a symlink, so a link planted at a session directory
name redirected the whole recursive removal at a tree of the planter's
choosing.  Descending into a subdirectory re-resolved its name
(`unlink` → `EISDIR`/`EPERM`, `rmdir` → `ENOTEMPTY`, then a recursive
call that opened the rebuilt path afresh), so an entry swapped inside
that window was followed.

**`pmix_os_dirpath_is_empty()`** used `opendir()` and so answered on
behalf of whatever a link pointed at, while callers use the answer to
decide whether to remove the path.

### The fixes

All inspection and modification now happens through a descriptor.  A
descriptor is bound to its inode at `open()` time and cannot be
redirected afterwards, so the object that is checked is necessarily the
object that is acted on.  `create()` opens once with
`O_DIRECTORY | O_NOFOLLOW` and uses `fstat`/`fchmod`; `destroy()` opens
the base the same way and then walks with
`fstatat(AT_SYMLINK_NOFOLLOW)` / `openat(O_NOFOLLOW)` / `unlinkat()`
against the descriptor it holds.  All of those are POSIX.1-2008.

Deliberately **not** added is any test of whether a directory is
writable, or of who owns it.  Whether the caller can put files here is
settled by the caller creating one, and by the kernel, which re-runs
that check at `open()` time regardless -- asking first with `access()`
or `faccessat()` and acting on the answer afterwards is itself a
time-of-check/time-of-use race, so it would trade the bug being fixed
here for a fresh instance of the same bug.  Ownership is not the right
question either: a directory legitimately shared with the caller (a
group-writable `--output dir:` the user named) is perfectly usable, and
PMIx has callers that rely on that.  This is the one place this series
deliberately diverges from the Open MPI PR, which does refuse
foreign-owned directories.

### Behavior changes

* a pre-existing regular file at the requested name is an error rather
  than something we chmod and report as usable
* a symlink at the final component is refused rather than followed
* a symlinked base path to `destroy()` is refused outright
* `is_empty()` reports a symlink as "not empty" -- the safe direction,
  and already how it reports any path it cannot open
* a non-empty subdirectory found in non-recursive `destroy()` now sets
  `PMIX_ERROR`.  The header has always documented that return; the old
  code left `exit_status` at `PMIX_SUCCESS` and reported the request
  honored when it was not.

Two incidental fixes ride along as their own commits: `_check_file()`
handed `pmix_os_path()`'s result straight to `stat()` without a NULL
check, and the IOF *directory* sink treated `PMIX_ERR_EXISTS` as fatal
while both sibling file sinks allow it -- reachable whenever stdout and
stderr are set up for the same rank, since they share a directory.

### Testing

`test/unit/util/util_os_dirpath.c` grows seven cases (39 assertions).
**Six assertions fail against the unfixed library**, including
`destroy_symlink_base: target contents survive` -- the old code deleted
a file outside the tree through a planted symlink.

The in-tree-symlink case passes either way, because PMIx already
unlinked entries before classifying them and so never followed one found
during the walk.  It is kept as a guard on the new `fstatat`/`unlinkat`
traversal.

Verified on **macOS/clang (arm64)** and **Linux/gcc 14 (Ubuntu 24.04,
aarch64, VPATH, `--enable-devel-check`)**: warning-free on both, and
`make check` green on both (106 tests) apart from two pre-existing
`test/python` failures that are a VPATH bug in the test drivers and
unrelated to this change -- `run_server.sh`/`run_sched.sh` invoke
`./server.py`/`./sched.py`, which live in the srcdir, from the build
dir.  I will send that separately.

Linux mattered here specifically: `unlink()` on a directory returns
`EISDIR` there and `EPERM` on macOS, and the old code branched on both.
The rewrite depends on neither, which the non-recursive subdirectory
case now demonstrates on both platforms.

Also run through the ten-node dockerswarm suite (12/12, including the
participant-death and voluntary-leave fault paths), after which `/tmp`
was empty on every node -- the reworked `destroy()` cleaning up real
session directories across real servers.

Not exercised: x86_64.  Nothing here is endianness- or word-size
sensitive, but CI will cover it.
