### PR TITLE
Fix the Python bindings tests in a VPATH build

### DIFF
--- a/test/python/Makefile.am
+++ b/test/python/Makefile.am
@@ -37,4 +37,28 @@ TESTS = \
     run_server.sh \
     run_sched.sh
 
+# The extension is linked against libpmix but carries no rpath -- setup.py
+# is given --library-dirs, which is a *link* path, not a run-time one. So
+# importing it finds the module and then fails to load libpmix.so, and the
+# only test that reports that clearly is the one round-trip that dies on
+# it: test_bindings.py treats an unimportable module as "nothing to test"
+# and SKIPs, which looks like a pass. Point the loader at the library we
+# just built.
+#
+# DYLD_LIBRARY_PATH is set for macOS, with the caveat that System
+# Integrity Protection strips DYLD_* when it executes a protected binary,
+# so it only takes effect for a python3 outside /usr/bin.
+# PYTHONPATH likewise has to name the *build* tree. test_bindings.py
+# falls back to locating the extension itself, but it does so relative to
+# its own __file__ -- which is in the source tree, where a VPATH build
+# puts no extension. It then reports "No module named 'pmix'" and SKIPs,
+# so the whole bindings suite silently tested nothing out of tree.
+AM_TESTS_ENVIRONMENT = \
+    LD_LIBRARY_PATH=$(abs_top_builddir)/src/.libs$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH}; \
+    export LD_LIBRARY_PATH; \
+    DYLD_LIBRARY_PATH=$(abs_top_builddir)/src/.libs$${DYLD_LIBRARY_PATH:+:$$DYLD_LIBRARY_PATH}; \
+    export DYLD_LIBRARY_PATH; \
+    PYTHONPATH=`echo $(abs_top_builddir)/bindings/python/build/lib.*`$${PYTHONPATH:+:$$PYTHONPATH}; \
+    export PYTHONPATH;
+
 endif

--- a/test/python/run_sched.sh.in
+++ b/test/python/run_sched.sh.in
@@ -13,4 +13,6 @@ else
     export PYTHONPATH="$egg"
 fi
 
-./sched.py
+# See run_server.sh.in for why this reaches through the source tree
+# rather than cd'ing into it.
+exec @PMIX_TOP_SRCDIR@/test/python/sched.py

--- a/test/python/run_server.sh.in
+++ b/test/python/run_server.sh.in
@@ -25,4 +25,9 @@ else
     export PYTHONPATH="$egg"
 fi
 
-./server.py
+# Reach the script through the source tree: in a VPATH build the build
+# directory this runs from holds only the generated wrappers, not the
+# .py files.  Reach it rather than cd'ing into it -- a srcdir is not
+# necessarily writable (it is mounted read-only in the dockerswarm
+# builder), and automake runs a test from its build directory.
+exec @PMIX_TOP_SRCDIR@/test/python/server.py

--- a/test/python/sched.py
+++ b/test/python/sched.py
@@ -104,8 +104,10 @@ def main():
     rc = foo.setup_fork({'nspace':"testnspace", 'rank':0}, env)
     print("SetupFrk", foo.error_string(rc))
 
-    # setup the client argv
-    args = ["./client.py"]
+    # setup the client argv.  Locate the client beside this script
+    # rather than in cwd: under a VPATH build we are run from the build
+    # directory, which holds no .py files.
+    args = [os.path.join(os.path.dirname(os.path.abspath(__file__)), "client.py")]
     # open a subprocess with stdout and stderr
     # as distinct pipes so we can capture their
     # output as the process runs

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -448,8 +448,10 @@ def main():
     rc = foo.setup_fork({'nspace':"testnspace", 'rank':0}, env)
     print("SetupFrk", foo.error_string(rc))
 
-    # setup the client argv
-    args = ["./client.py"]
+    # setup the client argv.  Locate the client beside this script
+    # rather than in cwd: under a VPATH build we are run from the build
+    # directory, which holds no .py files.
+    args = [os.path.join(os.path.dirname(os.path.abspath(__file__)), "client.py")]
     # open a subprocess with stdout and stderr
     # as distinct pipes so we can capture their
     # output as the process runs


### PR DESCRIPTION
`make check` fails in any VPATH build with the Python bindings enabled,
and the bindings suite silently tests nothing there.  Found while
validating an unrelated change on Linux; unrelated to that change.

### Three layered problems, each hidden by the one before it

**1. The wrappers cannot find their scripts.**  `run_server.sh` and
`run_sched.sh` are generated into the build tree and run `./server.py`
/ `./sched.py`, which live in the source tree.  Same directory in an
in-tree build, so this has always worked for anyone building the usual
way; out of tree it is exit 127.  And because `test/python` is the last
subdirectory `test/` recurses into, the failure takes down the whole
`check-recursive` -- **the 21 tests in `test/` itself never run.**

**2. `server.py` and `sched.py` spawn the client the same way,** with a
bare `./client.py`, so fixing only the wrappers just moves the failure
one level down.

**3. The extension cannot load `libpmix.so`.**  `setup.py` is handed
`--library-dirs`, which is a *link* path, not a run-time one, and the
extension gets no rpath.  This one is not VPATH-specific -- but it was
invisible, because the only test that reports it clearly is a
round-trip that was already dying on problem 1.  `test_bindings.py`
treats an unimportable module as "nothing to test" and exits 77, which
automake reports as `SKIP` and a reader takes for a pass.

`test_bindings.py` additionally locates the extension relative to its
own `__file__` -- the source tree, where a VPATH build puts no
extension -- so out of tree it would find nothing even with the loader
path set.

### Fixes

Reach the scripts through `@PMIX_TOP_SRCDIR@` rather than `cd`'ing into
the source tree: a srcdir is not necessarily writable (the dockerswarm
builder mounts it read-only) and automake runs a test from its build
directory.  Locate `client.py` beside the script spawning it rather
than in the caller's cwd.

Set `LD_LIBRARY_PATH` and `PYTHONPATH` from `AM_TESTS_ENVIRONMENT`,
which is where the rest of the suite already gets its build-tree
environment -- `test/Makefile.am` and `test/unit/Makefile.am` both
source `pmix_test_env.sh` from it.  That reaches all four tests,
including the two plain `.py` files that have no generated wrapper to
carry it.  The scripts' own `PYTHONPATH` logic is left alone: it
computes the same path and still has to work for a developer running
one by hand.

`DYLD_LIBRARY_PATH` is set alongside for macOS, with the caveat -- noted
in the Makefile -- that SIP strips `DYLD_*` when executing a protected
binary, so it only takes effect for a `python3` outside `/usr/bin`.

### Result

In a VPATH build (Linux/gcc 14, Ubuntu 24.04, aarch64,
`--enable-devel-check`, `--enable-python-bindings`), `test/python` goes
from

```
SKIP: test_bindings.py     PASS: test_construct.py
FAIL: run_server.sh        FAIL: run_sched.sh
# TOTAL: 4  # PASS: 1  # SKIP: 1  # FAIL: 2
```

to 4 passed / 0 skipped / 0 failed, `test_bindings.py` actually runs,
and the full `make check` goes green end to end (110 tests) where it
previously exited 2 -- which also gets `test/`'s own 21 tests running
again.

### What is not covered

I could not exercise the **in-tree** build with bindings enabled: my
macOS configuration has them off, and the container's srcdir is
read-only so no in-tree build is possible there.  The changes are
path-equivalent in tree -- `abs_top_builddir` is `abs_top_srcdir`, the
absolute script paths resolve to the files `./server.py` and
`./client.py` already named, and the two environment variables were
previously unset so setting them is additive -- but that is reasoning,
not a test run, and CI building in tree is the real check.

macOS in-tree without bindings (where `TESTS` is empty, gated on
`WANT_PYTHON_BINDINGS`) is unaffected: 106 tests, all passing.
