### PR TITLE
Fix the leaks the sanitizer found, and check for them in CI

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -152,31 +152,39 @@ jobs:
             submodules: recursive
     - name: Build and run the unit suite under AddressSanitizer
       env:
-        # allocator_may_return_null: several cases deliberately request
-        #   an impossible allocation to exercise the failure path. ASan
-        #   aborts on that by default; these tests want the NULL that
-        #   the real allocator would return.
-        # detect_leaks: OFF, deliberately, and not because leaks do not
-        #   matter. A handful of cases allocate through a STATIC_INIT
-        #   object, whose destructor by design does not free what the
-        #   object acquired, so they leak by construction. Turning leak
-        #   detection on means cleaning those up first; that is worth
-        #   doing and is not what this job is for. Memory *errors* -
-        #   overflows, use-after-free, uninitialized reads - are caught
-        #   either way, and those are what have been biting.
-        ASAN_OPTIONS: allocator_may_return_null=1:detect_leaks=0
+        # Several cases deliberately request an impossible allocation to
+        # exercise the failure path. ASan aborts on that by default;
+        # those tests want the NULL a real allocator would return.
+        ASAN_OPTS: allocator_may_return_null=1
       run: |
         ./autogen.pl
         ./configure --prefix=${PWD}/install --enable-devel-check \
             CFLAGS="-fsanitize=address -g -O1" \
             LDFLAGS="-fsanitize=address"
         make -j
-        # test/unit only. The server-driven run_*.pl cases under test/
-        # bring up a real PMIx server in the scheduler role, which is a
-        # node-wide singleton and does not belong in a job whose point
-        # is memory checking; test/unit is where the library is driven
-        # directly and where the value is.
-        make -C test/unit check
+
+        # Leak checking is on for the three subdirectories that are
+        # clean under it. They are self-contained - no server, no
+        # launcher - which is what makes them able to stay clean.
+        export ASAN_OPTIONS="$ASAN_OPTS:detect_leaks=1"
+        make -C test/unit/class check
+        make -C test/unit/util check
+        make -C test/unit/mca check
+
+        # The programs in test/unit itself run errors-only. Several are
+        # run_*.pl drivers that bring up a real PMIx server and tools,
+        # and that lifecycle still leaks - a few hundred records, all in
+        # server/tool teardown rather than in anything the library does
+        # per operation. Cleaning that up is its own piece of work; until
+        # it happens, turning leak detection on here would mean a job
+        # nobody can keep green. Memory *errors* are caught regardless,
+        # and those are what have been biting.
+        #
+        # check-am, not check: check would recurse back into the three
+        # subdirectories above and run them a second time, and util
+        # alone takes over two minutes under ASan.
+        export ASAN_OPTIONS="$ASAN_OPTS:detect_leaks=0"
+        make -C test/unit check-am
 
   distcheck:
     runs-on: ubuntu-latest

--- a/src/mca/base/pmix_mca_base_components_open.c
+++ b/src/mca/base/pmix_mca_base_components_open.c
@@ -282,8 +282,12 @@ bool pmix_mca_base_show_load_errors(const char *framework_name,
 
 int pmix_mca_base_show_load_errors_finalize(void)
 {
-    PMIX_DESTRUCT(&show_load_errors_include);
-    PMIX_DESTRUCT(&show_load_errors_exclude);
+    /* PMIX_LIST_DESTRUCT, not PMIX_DESTRUCT: a pmix_list_t does not own
+     * what is on it, so destructing the list alone orphans every
+     * fc_pair_t this parsed - and each of those owns two strdup'd
+     * strings. See the ownership rules in src/class/AGENTS.md. */
+    PMIX_LIST_DESTRUCT(&show_load_errors_include);
+    PMIX_LIST_DESTRUCT(&show_load_errors_exclude);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/base/pmix_mca_base_var_enum.c
+++ b/src/mca/base/pmix_mca_base_var_enum.c
@@ -752,6 +752,15 @@ static void pmix_mca_base_var_enum_flag_constructor(pmix_mca_base_var_enum_flag_
 
 static void pmix_mca_base_var_enum_flag_destructor(pmix_mca_base_var_enum_flag_t *enumerator)
 {
+    /* This class derives from pmix_object_t, NOT from
+     * pmix_mca_base_var_enum_t, so pmix_mca_base_var_enum_destructor()
+     * is not in its chain and will not free the name that
+     * create_flag() strdup'd into super. Anything owned by the embedded
+     * super has to be released here. */
+    if (enumerator->super.enum_name) {
+        free(enumerator->super.enum_name);
+        enumerator->super.enum_name = NULL;
+    }
     /* release the copy of the values */
     if (enumerator->enum_flags) {
         for (int i = 0; i < enumerator->super.enum_value_count; ++i) {

--- a/test/unit/class/class_bitmap.c
+++ b/test/unit/class/class_bitmap.c
@@ -568,6 +568,15 @@ static void test_static_init_matches_constructor(void)
     report("static init: find_and_set finds bit 0",
            PMIX_SUCCESS == pmix_bitmap_find_and_set_first_unset_bit(&stat, &pos) && 0 == pos);
 
+    /* A STATIC_INIT object carries the BASE class, so PMIX_DESTRUCT on
+     * it runs pmix_object_t's (empty) chain and never the derived
+     * destructor - which means everything the calls above made it
+     * allocate would leak. That is the whole point of the invariant in
+     * src/class/AGENTS.md: STATIC_INIT gives a defined state, and a
+     * PMIX_CONSTRUCT is what makes an object a live instance of its own
+     * class. Here the object has been used without one, deliberately, so
+     * name its class before tearing it down. */
+    stat.super.obj_class = PMIX_CLASS(pmix_bitmap_t);
     PMIX_DESTRUCT(&stat);
     PMIX_DESTRUCT(&ctor);
 }

--- a/test/unit/class/class_pointer_array.c
+++ b/test/unit/class/class_pointer_array.c
@@ -405,6 +405,15 @@ static void test_static_init_matches_constructor(void)
     report("static init: the pointer reads back",
            (void *) 0x55 == pmix_pointer_array_get_item(&stat, idx));
 
+    /* A STATIC_INIT object carries the BASE class, so PMIX_DESTRUCT on
+     * it runs pmix_object_t's (empty) chain and never the derived
+     * destructor - which means the storage add() just grew would leak.
+     * That is the whole point of the invariant in src/class/AGENTS.md:
+     * STATIC_INIT gives a defined state, and a PMIX_CONSTRUCT is what
+     * makes an object a live instance of its own class. Here the object
+     * has been used without one, deliberately, so name its class before
+     * tearing it down. */
+    stat.super.obj_class = PMIX_CLASS(pmix_pointer_array_t);
     PMIX_DESTRUCT(&stat);
     PMIX_DESTRUCT(&ctor);
 }

--- a/test/unit/class/class_ring_buffer.c
+++ b/test/unit/class/class_ring_buffer.c
@@ -335,6 +335,15 @@ static void test_static_init_matches_constructor(void)
     report("static init: push works", NULL == pmix_ring_buffer_push(&stat, (void *) 0xc1));
     report("static init: pop returns it", (void *) 0xc1 == pmix_ring_buffer_pop(&stat));
 
+    /* A STATIC_INIT object carries the BASE class, so PMIX_DESTRUCT on
+     * it runs pmix_object_t's (empty) chain and never the derived
+     * destructor - which means everything the calls above made it
+     * allocate would leak. That is the whole point of the invariant in
+     * src/class/AGENTS.md: STATIC_INIT gives a defined state, and a
+     * PMIX_CONSTRUCT is what makes an object a live instance of its own
+     * class. Here the object has been used without one, deliberately, so
+     * name its class before tearing it down. */
+    stat.super.obj_class = PMIX_CLASS(pmix_ring_buffer_t);
     PMIX_DESTRUCT(&stat);
     PMIX_DESTRUCT(&ctor);
 }


### PR DESCRIPTION
Follow-on to #4090, which added a sanitizer job but ran it with
`detect_leaks=0` — honest at the time, since the suite leaked, but it
left the job saying nothing at all about leaks. This does the cleanup
that comment promised and turns detection on where it now holds.

## Two library leaks

Both found by running the suite under `-fsanitize=address` with leak
detection enabled.

**`pmix_mca_base_show_load_errors_finalize()` orphaned its list items.**
It destructed the include/exclude lists with `PMIX_DESTRUCT`. A
`pmix_list_t` does not own what is on it — the ownership rule in
`src/class/AGENTS.md` — so that frees the list and leaves every
`fc_pair_t` the parser built, each owning two `strdup`'d strings.
`PMIX_LIST_DESTRUCT` is what was meant. One direct plus several indirect
leaks per init/finalize cycle.

**A flag enumerator never freed its name.**
`pmix_mca_base_var_enum_flag_t` derives from `pmix_object_t`, not from
`pmix_mca_base_var_enum_t` — so `pmix_mca_base_var_enum_destructor()` is
not in its chain, even though the flag type embeds that struct as
`super` and fills it in. `create_flag()` `strdup`s the caller's name into
`super.enum_name` and nothing released it, so every flag enumerator
leaked its name for the life of the process. Freed in the flag
destructor; re-parenting the class would be tidier but moves a type
other code embeds, which is not worth it for one string.

## Three test-side leaks, and why they were invisible

`class_bitmap`, `class_ring_buffer` and `class_pointer_array` each build
an object with `PMIX_*_STATIC_INIT`, use it *without* a
`PMIX_CONSTRUCT` — deliberately, since the point is that such an object
is usable — and then call `PMIX_DESTRUCT`.

That destruct does nothing. A `STATIC_INIT` object carries the **base**
class, so the chain that runs is `pmix_object_t`'s empty one and the
derived destructor never sees it. The tests already intended to clean
up; the cleanup was a no-op by construction, and the bitmap's word
array, the ring's slots and the pointer array's storage all leaked.

Naming the class before teardown is what a `PMIX_CONSTRUCT` would have
done had these cases been allowed to use one. It is the invariant in
`src/class/AGENTS.md` seen from the other side, and the comments say so
at each site — a reader who does not know it will read the old two-line
teardown as correct.

## The job

`test/unit/class`, `test/unit/util` and `test/unit/mca` now run with
`detect_leaks=1`. They are the self-contained part of the suite — no
server, no launcher — which is both why they could be cleaned up and why
they can be expected to stay clean.

The programs in `test/unit` itself stay errors-only, and that boundary
is deliberate rather than incidental. Several are `run_*.pl` drivers
that bring up a real PMIx server and tools, and that lifecycle still
leaks — a few hundred records, concentrated in server and tool teardown
rather than in anything the library does per operation. Cleaning it up
is its own piece of work; turning detection on for it now would produce
a job nobody can keep green, which is worse than a job with a documented
boundary.

One mechanical note: that stage uses `make -C test/unit check-am`, not
`check`. `check` recurses back into the three subdirectories and runs
them a second time, and `util` alone takes over two minutes under ASan.

## Testing

Verified with the job's exact command sequence on Linux: **88 tests, 0
failures, ~5 minutes**, with leak detection live for the 38 tests in the
three subdirectories.

| | with `detect_leaks=1` |
|---|---|
| `test/unit/class` | 10/10, no leak records |
| `test/unit/util` | 21/21, no leak records |
| `test/unit/mca` | 7/7, no leak records |

## Still open

The server/tool teardown leaks above. They are why `test/unit` itself is
not leak-checked yet, and they are the obvious next piece if someone
wants the whole suite under detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
