### PR TITLE
Fix a Coverity-reported leak in the key index

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -3941,9 +3941,12 @@ void pmix_bfrops_base_tma_data_array_construct(pmix_data_array_t *p,
             /* one pointer per element, not one byte: this array used to
              * be sized as int8_t while copy_darray (correctly) reads
              * sizeof(char*) per element, so copying one over-read the
-             * block by a factor of sizeof(void*) */
-            p->array = pmix_tma_malloc(tma, num * sizeof(void *));
-            memset(p->array, 0, num * sizeof(void *));
+             * block by a factor of sizeof(void*). Size it through a
+             * typed pointer so the element width is stated in the code
+             * rather than inferred from the untyped p->array. */
+            void **ptrs = (void **)pmix_tma_malloc(tma, num * sizeof(void *));
+            memset(ptrs, 0, num * sizeof(void *));
+            p->array = ptrs;
 
         } else if (PMIX_STRING == type) {
             p->array = pmix_tma_malloc(tma, num * sizeof(char*));

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -901,6 +901,11 @@ static pmix_regattr_input_t* lookup_key(uint32_t inid,
         ptr->type = PMIX_UNDEF; // we don't know what type the user will set
         ptr->description = (char**)pmix_tma_malloc(tma, 2 * sizeof(char*));
         if (PMIX_UNLIKELY(NULL == ptr->description)) {
+            /* the entry was never handed to the keyindex, so nothing
+             * else will ever free it - release what we took here */
+            pmix_tma_free(tma, ptr->name);
+            pmix_tma_free(tma, ptr->string);
+            pmix_tma_free(tma, ptr);
             return NULL;
         }
         ptr->description[0] = pmix_tma_strdup(tma, "USER DEFINED");


### PR DESCRIPTION
Two Coverity reports from the latest scan, plus a note on two more that
are false positives.

**CID 505072 — real leak.** `lookup_key()` mints a `pmix_regattr_input_t`
for an unknown key and strdup's the key into both of its name fields
before allocating the two-slot description array. If that last
allocation failed it returned NULL without freeing any of it — the entry
is not handed to the keyindex until the bottom of the block, so the
struct and both strings were unreachable. It now releases all three on
the way out, mirroring `keyindex_destruct()`.

**CIDs 505061 / 505062 — false positives, defused.** `data_array_construct()`
sizes a `PMIX_POINTER` array as one `void*` per element, which is correct
and deliberate: `copy_darray()` strides it that way, and the old
one-byte-per-element sizing was a fixed over-read. Coverity flags it only
because the result lands in the untyped `p->array`, so its heuristic
compares `sizeof(void *)` against the allocator's `void *` return. The
allocation and memset now go through a `void **` local, which states the
element width rather than leaving it inferred. No behavior change — same
bytes allocated and zeroed. Happy to drop this commit if you would rather
carry the CIDs as triaged.

**CIDs 505034 / 505035 — false positives, no change here.** These are the
`pmix_group_t` con/destructor touching `p->nmbrs` without `grouplock`. A
constructor runs before the object is reachable and a destructor after the
last reference is dropped. In practice it is stricter still: both
`PMIX_NEW(pmix_group_t)` sites and both `PMIX_RELEASE` sites already hold
`pmix_client_globals.grouplock`, and the release happens only after the
group is off the list. Suggest marking them Intentional in the triage
queue — taking the lock in the con/destructor would deadlock against the
callers that already hold it.

Built warning-free under `--enable-devel-check` and `make check` passes
(21 + 10 + 7 + 50 tests) on Linux.