### PR TITLE
Stop pmix_info_init from freeing its caller's result object

### DIFF
--- a/src/runtime/pmix_info_support.c
+++ b/src/runtime/pmix_info_support.c
@@ -152,7 +152,8 @@ int pmix_info_init(int argc, char **argv, pmix_cli_result_t *pmix_info_cmd_line,
     if (PMIX_SUCCESS != pmix_mca_base_open(NULL)) {
         pmix_show_help("help-pmix_info.txt", "lib-call-fail", true, "mca_base_open", __FILE__,
                        __LINE__);
-        PMIX_RELEASE(pmix_info_cmd_line);
+        /* the result object belongs to the caller - it is typically a
+         * statically declared object, so we must not release it here */
         return PMIX_ERROR;
     }
 


### PR DESCRIPTION
Coverity CID 505078 (BAD_FREE).

On the failure path of `pmix_mca_base_open()`, `pmix_info_init()` called
`PMIX_RELEASE` on the `pmix_cli_result_t` it was handed. That object is
owned by the caller, and its only caller — `pmix_info` — passes the
address of a file-scope global that `main()` brings up with
`PMIX_CONSTRUCT` and tears down with `PMIX_DESTRUCT`. Releasing it drops
the reference count to zero, runs the destructors, and then calls
`free()` on the address of a static object.

The caller `exit()`s immediately on a failed return, so nothing needs
cleaning up there at all — just return the error and leave the object to
its owner.

Swept for the same shape elsewhere; this was the only instance. The
`PMIX_RELEASE(results)` calls in `src/common/pmix_{monitor,control,session}.c`
are on heap caddies, not CLI results.

Verified with a warning-free build under `--enable-devel-check`,
`pmix_info --version`, and `make check` (all C tests pass, including
`run_tools.pl`, which exercises `pmix_info`).