### PR TITLE
Review src/runtime: bring-up correctness, per-cycle leaks, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,6 +286,7 @@ test/unit/tool_cycle
 test/unit/event_chain
 test/unit/hwloc_datatype
 test/unit/progress_threads
+test/unit/runtime_init
 test/unit/info_support
 test/unit/rndz_stale
 test/unit/singleton_register

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -28,6 +28,7 @@ two disagree, the README wins, and please fix this file.
 | `run-bfrops-tests.sh` | The `src/mca/bfrops` unit programs on Linux/optimized/`--enable-mca-dso`, **plus** `examples/datatypes` moving every data type between ranks on different nodes (README §15) |
 | `run-gds-tests.sh` | The `src/mca/gds` datastore: compiles `shmem3` (which macOS does not build at all), the gds unit programs in two configurations, and the collective/direct/fallback modex paths across separate servers (README §16) |
 | `run-ptl-tests.sh` | The `src/mca/ptl` transport over real sockets between real hosts: interface selection, node-local rendezvous discovery, a tool attaching across nodes, the inbound message-size ceiling, an exhausted port range (README §17) |
+| `run-runtime-tests.sh` | The `src/runtime` bring-up/tear-down suite in the optimized configuration and on Linux — where the progress thread's CPU-affinity path exists at all — plus that path driven through a real `PMIx_Init`, and node identity across real servers (README §18) |
 | `swarm-common.sh` | **Sourced, never executed.** `$PMIX_SWARM` naming and the one copy of `cleanup_swarm` |
 
 ## Things that will bite you

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -1078,3 +1078,108 @@ cases against a single local server. The ceiling cases lose nothing by
 being local: the parameter is read once, at framework registration, and
 the defect it guards against made every payload-bearing message fail.
 Everything else in the suite needs a second host by construction.
+
+## 18. The `src/runtime` suite (`run-runtime-tests.sh`)
+
+```sh
+./run-runtime-tests.sh linux     # the swarm
+./run-runtime-tests.sh macos     # single-host, both configurations
+```
+
+`src/runtime` is the layer every PMIx process passes through exactly once
+on the way in and once on the way out: `pmix_rte_init` /
+`pmix_rte_finalize`, the `pmix_globals` object they build and tear down,
+the MCA parameter registry, the progress-thread engine, and the
+`pmix_info` support library. Most of it is single-process, and
+`test/unit`'s `runtime_init`, `progress_threads`, `info_support`,
+`client_cycle` and `tool_cycle` cover it on the developer's own machine.
+Three things they do not.
+
+### Why the swarm buys something here
+
+* **Linux-only code that never compiles at home.** The progress thread's
+  CPU-affinity path — `start_progress_engine`'s `parse_cpu_range` and the
+  `pthread_setaffinity_np` call it feeds — is inside
+  `#ifdef HAVE_PTHREAD_SETAFFINITY_NP`. macOS has no such function, so on
+  the primary development host that code is not merely untested, it is
+  not compiled: `progress_threads` reports its whole `cpulist:` group as
+  `SKIP` there. It takes user input straight from the
+  `pmix_progress_thread_cpus` MCA parameter or the
+  `PMIX_BIND_PROGRESS_THREAD` attribute, and used to hand it to `strtoul`
+  and `CPU_SET` unchecked — `strtoul` reports 0 for a token with no
+  digits, so `cpu0` quietly became "bind to cpu 0", and a number past the
+  end of the mask is dropped by glibc but written past the end of it by
+  BSD.
+
+* **An optimized build.** Every tree in this workflow configures
+  `--enable-debug`. `start_progress_engine` opens with
+  `assert(!trk->ev_active)` and `pmix_info_close_components` with an
+  assert on its refcount; both vanish under `NDEBUG`, which is the build
+  users get.
+
+* **Re-entrancy under a real runtime.** This directory's standing
+  requirement is that a second `PMIx_Init` starts from a clean slate, and
+  nearly all of its recent history is about that. `client_cycle` and
+  `tool_cycle` cycle init/finalize 1200 times each; running them on Linux
+  *and* optimized is where a leak or a stale latch that macOS/debug hides
+  shows up.
+
+### The four stages
+
+1. **`--enable-debug`** — build from a copy of your tree in the
+   container and run all five programs.
+2. **`--disable-debug`** — the same, in the configuration users get.
+3. **CPU binding through `PMIx_Init`.** The unit test drives *named*
+   progress threads, because those are the ones it can create and destroy
+   at will. The list is also read for the **shared** thread, straight out
+   of `pmix_rte_init`, and that is the path a user actually takes — so
+   this stage drives it with the MCA parameter against a program that
+   stands up a real server. Both directions are asserted, and the second
+   matters more: with binding declared *required*, a list from which
+   nothing usable can be extracted must make init fail rather than leave
+   the thread silently bound to cpu 0. It also checks that the diagnostic
+   is the one about the list, since a missing `show_help` topic turns any
+   of these into "I couldn't find that help reference".
+4. **Node identity across real servers.** `pmix_rte_init` settles each
+   process's own node identity and `pmix_set_aliases` records the form of
+   the name the FQDN policy did not keep, so `pmix_check_local` matches
+   this node under either. That call used to be skipped whenever the host
+   supplied the name — which every resource manager does — leaving the
+   alias list empty. This stage runs `simple_resolve` across four nodes
+   and asserts every rank resolved its own node's peers and that all four
+   nodes appear in the node list.
+
+### What stage 4 is not
+
+It cannot exercise the FQDN half. The swarm's containers are named
+`node1`..`node10` with no domain part, so `pmix_set_aliases` has no second
+form to record and the interesting branch is never taken. Engineering
+dotted hostnames into `docker-compose.yml` would ripple through every
+other runner here for one branch that `test/unit/runtime_init` already
+pins down directly — it hands `PMIx_server_init` an FQDN and checks that
+both forms resolve. So the FQDN case is deliberately left to the unit
+test, and this stage guards the ordinary short-name path across nodes
+against the same change.
+
+### Two things about how it builds
+
+Unlike the older runners here, stages 1 and 2 build from a **copy** of
+the source rather than a VPATH tree against the read-only mount. Autoconf
+refuses a VPATH configure outright while the source directory holds a
+`config.status` ("source directory already configured; run make distclean
+there first"), and a developer's own tree is configured in place. An
+already-configured VPATH tree does not escape it either: touch any
+`Makefile.am` on the host and maintainer mode re-runs `config.status` in
+the container, which re-runs `configure`, which hits the same wall. The
+VPATH form therefore works right up until the moment you edit something,
+which is the moment you want to run it. Copying costs a full build per
+stage and is immune to whatever state the host tree is in.
+
+Stage 4 is the exception: it runs against the PMIx that `./build.sh`
+installed into the volume, because that is the library `prted` — the
+actual PMIx *server* in this picture — is linked against. Run
+`./build.sh` against your tree first or that stage reports on whatever
+was there before. Every runner here that drives `prterun` has the same
+contract. Note also that the nodes mount the build volume **read-only**,
+so anything that has to be compiled into it must be built from a
+`docker run`, not with `docker exec` on a node.

--- a/contrib/dockerswarm/run-runtime-tests.sh
+++ b/contrib/dockerswarm/run-runtime-tests.sh
@@ -1,0 +1,408 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Run the src/runtime suite -- library bring-up and tear-down, the
+# progress-thread engine, the MCA parameter registry, the pmix_info support
+# library -- against your live openpmix tree.
+#
+#   ./run-runtime-tests.sh linux    # in the swarm's containers
+#   ./run-runtime-tests.sh macos    # natively, optimized configuration
+#
+# WHY THIS EXISTS
+#
+# Most of src/runtime is single-process and `make check` on the developer's
+# own machine covers it.  Three things it does not:
+#
+#  1. LINUX-ONLY CODE THAT NEVER COMPILES AT HOME.  The progress thread's
+#     CPU-affinity path -- start_progress_engine's parse_cpu_range and the
+#     pthread_setaffinity_np call it feeds -- lives inside
+#     #ifdef HAVE_PTHREAD_SETAFFINITY_NP.  macOS has no such function, so on
+#     the primary development host that code is not merely untested, it is
+#     not compiled.  test/unit/progress_threads reports its whole cpulist:
+#     group as SKIP there.  Here it runs.
+#
+#     That path takes user input straight from an MCA parameter or the
+#     PMIX_BIND_PROGRESS_THREAD attribute, and used to hand it to strtoul and
+#     CPU_SET unchecked: strtoul reports 0 for a token with no digits in it,
+#     so "cpu0" quietly became "bind to cpu 0", and a number past the end of
+#     the mask is dropped by glibc but written past the end of it by BSD.
+#     Stage 3 below drives that through the real entry point -- the shared
+#     progress thread, from PMIx_server_init -- rather than the named threads
+#     the unit test can reach.
+#
+#  2. AN OPTIMIZED BUILD.  Every tree in this workflow configures
+#     --enable-debug.  start_progress_engine opens with assert(!trk->ev_active),
+#     and pmix_info_close_components with an assert on its refcount; both
+#     vanish under NDEBUG, which is the build users get.  A guard that only
+#     exists in a configuration nobody ships is not a guard.
+#
+#  3. RE-ENTRANCY UNDER A REAL RUNTIME.  This directory's standing
+#     requirement is that a second PMIx_Init starts from a clean slate, and
+#     nearly all of its recent history is about that.  client_cycle and
+#     tool_cycle cycle init/finalize a thousand times; running them on Linux
+#     and optimized is where a leak or a stale latch that macOS/debug hides
+#     shows up.
+#
+# WHAT THE MULTI-NODE STAGE IS, AND IS NOT
+#
+# Stage 4 is a guard, not a discovery test.  src/runtime is where every
+# process's own node identity is settled: pmix_rte_init resolves the hostname
+# (from PMIX_HOSTNAME, the environment, or the OS) and pmix_set_aliases
+# records the form of it that the FQDN policy did not keep, so that
+# pmix_check_local matches this node under either name.  That call used to be
+# skipped whenever the host supplied the name -- which every resource manager
+# does -- and the alias list came out empty.  Stage 4 runs a real job across
+# real servers and asserts that every rank resolves its own node's peers,
+# which is the cross-node consumer of that matching.
+#
+# It cannot exercise the FQDN half.  The swarm's containers are named node1..
+# node10 with no domain part, so pmix_set_aliases has no second form to
+# record and the interesting branch is never taken.  Engineering dotted
+# hostnames into docker-compose.yml would ripple through every other runner
+# here for one branch that test/unit/runtime_init already pins down directly
+# (it hands PMIx_server_init an FQDN and checks both forms resolve).  So the
+# FQDN case is deliberately left to the unit test; this stage guards the
+# ordinary short-name path across nodes against the same change.
+#
+# Prints PASS/FAIL per stage and exits non-zero if anything failed.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+. "$(dirname "$0")/swarm-common.sh"
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+# The programs in test/unit that belong to src/runtime.  Spelled out rather
+# than read from Makefile.am: that file's check_PROGRAMS is the whole unit
+# suite, and only these five are about this directory.
+RUNTIME_PROGS="runtime_init progress_threads info_support client_cycle tool_cycle"
+
+########################################################################
+# Stages 1 and 2: build and run the suite in the container, in both
+# configurations.
+########################################################################
+
+# This builds from a COPY of the source rather than a VPATH tree against the
+# read-only mount, which is what the older runners here do.  The reason is
+# worth stating, because the VPATH form looks cheaper and is not usable:
+# autoconf refuses a VPATH configure outright while the source directory
+# holds a config.status ("source directory already configured; run make
+# distclean there first"), and a developer's own tree is configured in place.
+# Worse, an already-configured VPATH tree does not escape it either -- touch
+# any Makefile.am on the host and maintainer mode re-runs config.status in
+# the container, which re-runs configure, which hits the same wall.  So the
+# runner would work until the moment you edited something, which is the
+# moment you want to run it.  Copying costs a full build per stage and is
+# immune to whatever state the host tree is in.
+#
+# $1 = label, $2 = configure args, $3 = staging subdir
+build_and_run() {
+    local label="$1" cfgargs="$2" stage="$3" rc
+
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e PROGS="$RUNTIME_PROGS" \
+        -e CFGARGS="$cfgargs" \
+        -e STAGE="$stage" \
+        "$IMAGE" bash -euo pipefail -c '
+            cp -a /pmix-src /work
+            cd /work
+            # The copy carries the host'"'"'s configure output and objects --
+            # macOS ones, most likely.  Clear them before configuring here.
+            make distclean >/dev/null 2>&1 || true
+            rm -f config.status config.log
+            ./autogen.pl > /tmp/autogen.log 2>&1 || { tail -20 /tmp/autogen.log; exit 1; }
+            ./configure $CFGARGS > /tmp/configure.log 2>&1 \
+                || { tail -30 /tmp/configure.log; exit 1; }
+            make -j"$(nproc)" > /tmp/make.log 2>&1 || { tail -30 /tmp/make.log; exit 1; }
+            # A fresh $TMPDIR: these programs stand up real PMIx servers, and
+            # a leftover session directory from an earlier run makes them fail
+            # for reasons that have nothing to do with the library.
+            TMPDIR="$(mktemp -d)"; export TMPDIR
+            for p in $PROGS; do
+                make -C test/unit "$p" >> /tmp/make.log 2>&1 \
+                    || { tail -30 /tmp/make.log; exit 1; }
+            done
+            ( cd test/unit && . ../pmix_test_env.sh
+              for p in $PROGS; do
+                  printf "    ---- %s ----\n" "$p"
+                  ./"$p" 2>&1 | tail -3 || exit 1
+              done )
+            mkdir -p "$STAGE" "$STAGE/lib"
+            for p in $PROGS; do
+                # Stage the real ELF binary, not the libtool wrapper: an
+                # uninstalled libtool target leaves a /bin/sh wrapper at
+                # test/unit/$p and puts the executable under .libs/.
+                cp "test/unit/.libs/$p" "$STAGE/" 2>/dev/null \
+                    || cp "test/unit/$p" "$STAGE/" 2>/dev/null || true
+            done
+            # and the library they were linked against, so a node can run
+            # them without depending on which PMIx the volume has installed
+            cp -a src/.libs/libpmix.so* "$STAGE/lib/" 2>/dev/null || true
+            cp -a src/mca/*/*/.libs/*.so "$STAGE/lib/" 2>/dev/null || true
+        '
+    rc=$?
+    [ "$rc" = 0 ] && ok "$label: suite green in the container" \
+                  || bad "$label: suite failed (rc=$rc)"
+    return $rc
+}
+
+########################################################################
+# Stage 3: the CPU-affinity path, through the real entry point.
+#
+# The unit test drives named progress threads, because those are the ones it
+# can create and destroy at will.  The list is also read for the *shared*
+# thread, straight out of pmix_rte_init, and that is the path a user actually
+# takes -- so drive it here with the MCA parameter, against a program that
+# stands up a real server.
+#
+# Both directions are asserted, and the second is the one that matters: with
+# binding declared required, a list from which nothing usable can be
+# extracted must make init fail rather than leave the thread silently bound
+# to cpu 0, which is what an unchecked strtoul produced for any typo.
+########################################################################
+
+test_cpu_binding() {
+    local stage="$1" out rc
+
+    if ! ON 1 "test -x $stage/client_cycle"; then
+        skp "cpu binding: binaries not staged"
+        return
+    fi
+
+    # Two cycles is all that is needed: the binding happens during PMIx_Init,
+    # and a second cycle proves the refusal did not wedge anything.
+    local base="export LD_LIBRARY_PATH=$stage/lib; \
+                export PMIX_MCA_mca_base_component_path=$stage/lib; \
+                export TMPDIR=\$(mktemp -d); cd $stage;"
+
+    # cpu 0 exists on every machine this can run on
+    out="$(ON 1 "$base PMIX_MCA_pmix_progress_thread_cpus=0 \
+                 PMIX_MCA_pmix_bind_progress_thread_reqd=1 ./client_cycle 2 2>&1")"
+    rc=$?
+    [ "$rc" = 0 ] && ok "cpu binding: a valid list is accepted" \
+                  || { bad "cpu binding: valid list rejected (rc=$rc)"; echo "$out" | tail -5; }
+
+    # a token with no digits in it must not be read as cpu 0
+    out="$(ON 1 "$base PMIX_MCA_pmix_progress_thread_cpus=cpu0 \
+                 PMIX_MCA_pmix_bind_progress_thread_reqd=1 ./client_cycle 2 2>&1")"
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        ok "cpu binding: a non-numeric list is refused when binding is required"
+    else
+        bad "cpu binding: 'cpu0' was accepted -- it is being read as cpu 0"
+        echo "$out" | tail -5
+    fi
+
+    # and the diagnostic has to be the one about the list, not a bare
+    # "failed to bind": a missing help topic used to turn every one of these
+    # into "I couldn't find that help reference"
+    case "$out" in
+        *"could not be used"*|*"comma-delimited series"*)
+            ok "cpu binding: the rejected entry is explained" ;;
+        *"couldn't find that help reference"*)
+            bad "cpu binding: help topic missing for the diagnostic" ;;
+        *)
+            skp "cpu binding: no diagnostic captured (init may have failed earlier)" ;;
+    esac
+
+    # an out-of-range cpu, likewise
+    out="$(ON 1 "$base PMIX_MCA_pmix_progress_thread_cpus=99999999 \
+                 PMIX_MCA_pmix_bind_progress_thread_reqd=1 ./client_cycle 2 2>&1")"
+    [ $? != 0 ] && ok "cpu binding: an out-of-range cpu is refused" \
+                || bad "cpu binding: cpu 99999999 was accepted"
+
+    # not required, so a bad list must be a warning and not a failure -- the
+    # thread runs unbound
+    out="$(ON 1 "$base PMIX_MCA_pmix_progress_thread_cpus=cpu0 ./client_cycle 2 2>&1")"
+    [ $? = 0 ] && ok "cpu binding: a bad list is survivable when not required" \
+               || { bad "cpu binding: bad list aborted init without being required"
+                    echo "$out" | tail -5; }
+}
+
+########################################################################
+
+test_linux() {
+    swarm_up_or_die
+
+    if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+        bad "build volume $VOLUME missing -- run ./build.sh first"
+        return
+    fi
+
+    echo "    suite: $RUNTIME_PROGS"
+
+    banner "stage 1: --enable-debug (asserts live; the affinity path compiles)"
+    build_and_run "debug build" \
+        "--prefix=/opt/prte/pmix-rt-dbg --enable-debug --enable-devel-check" \
+        /opt/prte/tests-runtime/debug
+
+    banner "stage 2: --disable-debug (the configuration users actually get)"
+    build_and_run "optimized build" \
+        "--prefix=/opt/prte/pmix-rt-opt --disable-debug --disable-devel-check" \
+        /opt/prte/tests-runtime/opt
+
+    banner "stage 3: progress-thread CPU binding through PMIx_Init"
+    test_cpu_binding /opt/prte/tests-runtime/debug
+
+    banner "stage 4: node identity across real servers"
+    # NOTE: unlike stages 1-3, this one runs against the PMIx that ./build.sh
+    # installed into the volume, because that is the library prted -- the
+    # actual PMIx *server* here -- is linked against. Run ./build.sh against
+    # your tree first or this stage reports on whatever was there before.
+    # Every runner in this directory that drives prterun has the same
+    # contract.
+    #
+    # simple_resolve asks the library to resolve the peers on its own node and
+    # then the nodes of its job.  Run it spread over four nodes: each rank
+    # must get an answer, which it only does if its server's idea of "this
+    # node" matches the name the job was described with.
+    local out rc
+    # Build it in a docker run, not on a node: the nodes mount the build
+    # volume READ-ONLY, so a compile there fails at the link step with
+    # "cannot open output file ... Read-only file system".
+    #
+    # -rpath, not just -L: prted does not give its children a login shell, so
+    # the LD_LIBRARY_PATH env.sh sets is not in scope for them and every rank
+    # dies with "libpmix.so.2: cannot open shared object file".
+    if ! docker run --rm \
+            -v "$root":/pmix-src:ro \
+            -v "$VOLUME":/opt/prte \
+            "$IMAGE" bash -euo pipefail -c '
+                mkdir -p /opt/prte/tests-runtime
+                gcc -O0 -g -o /opt/prte/tests-runtime/simple_resolve \
+                    /pmix-src/examples/simple_resolve.c \
+                    -I/opt/prte/pmix/include -I/pmix-src/examples \
+                    -L/opt/prte/pmix/lib -lpmix -Wl,-rpath,/opt/prte/pmix/lib
+            '; then
+        skp "resolve: could not build simple_resolve against the volume's PMIx"
+        return
+    fi
+
+    out="$(RUN 'prterun --host node1:2,node2:2,node3:2,node4:2 -np 8 --map-by node \
+                        --timeout 120 /opt/prte/tests-runtime/simple_resolve 2>&1')"
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        bad "resolve across four nodes: prterun failed (rc=$rc)"
+        printf '%s\n' "$out" | tail -20
+        return
+    fi
+
+    # One "ResPeers returned:" and one "ResNodes returned:" per rank - eight
+    # of each. A rank whose server could not match its own node name against
+    # the job description is the one that goes missing.
+    local npeers nnodes bad_lines
+    npeers="$(printf '%s\n' "$out" | grep -c 'ResPeers returned:')"
+    nnodes="$(printf '%s\n' "$out" | grep -c 'ResNodes returned:')"
+    [ "$npeers" = 8 ] && [ "$nnodes" = 8 ] \
+        && ok "resolve: all eight ranks reported" \
+        || bad "resolve: $npeers ResPeers / $nnodes ResNodes lines, expected 8 each"
+
+    # Note the string is PMIx_Error_string's, which is "PMIX_SUCCESS" - not
+    # "SUCCESS". Matching the short form silently passes on any output at all.
+    bad_lines="$(printf '%s\n' "$out" | grep -E 'Res(Peers|Nodes)( global)? returned:' \
+                 | grep -cv 'PMIX_SUCCESS')"
+    [ "$bad_lines" = 0 ] \
+        && ok "resolve: no rank failed to resolve its peers or nodes" \
+        || { bad "resolve: $bad_lines resolve calls failed"
+             printf '%s\n' "$out" | grep -E 'Res(Peers|Nodes)( global)? returned:' \
+                 | grep -v 'PMIX_SUCCESS' | head -5; }
+
+    # Every node named in the job has to come back in the node list. A node
+    # whose own name did not match what it was told would drop out here.
+    local nodelist missing="" n
+    nodelist="$(printf '%s\n' "$out" | grep -A1 'ResNodes returned: PMIX_SUCCESS' \
+                | grep -v 'ResNodes\|^--' | tr -d ' \t' | sort -u | head -1)"
+    for n in node1 node2 node3 node4; do
+        case ",$nodelist," in *",$n,"*) ;; *) missing="$missing $n" ;; esac
+    done
+    if [ -z "$missing" ]; then
+        ok "resolve: all four nodes appear in the node list ($nodelist)"
+    else
+        bad "resolve: missing from node list:$missing (got '$nodelist')"
+    fi
+}
+
+########################################################################
+# macOS: the optimized configuration natively.  The affinity path still
+# does not exist here -- that is stage 1/2's job in the container -- but
+# the rest of the suite gains the build users get.
+########################################################################
+
+test_macos() {
+    local rc jobs opt="$root/vpath-macos-pmix-opt" p
+
+    jobs="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+    echo "    suite: $RUNTIME_PROGS"
+    echo "    note: the progress-thread affinity path is absent on macOS;"
+    echo "          run '$0 linux' for it."
+
+    banner "in-tree build (whatever it is configured as)"
+    if [ ! -f "$root/config.status" ]; then
+        skp "no configured tree at $root -- run ./configure there first"
+    else
+        ( cd "$root" && make -j"$jobs" \
+          && for p in $RUNTIME_PROGS; do make -C test/unit "$p" || exit 1; done \
+          && cd test/unit && . ../pmix_test_env.sh \
+          && export TMPDIR="$(mktemp -d)" \
+          && for p in $RUNTIME_PROGS; do ./"$p" || exit 1; done ) \
+            >/tmp/runtime-intree.$$ 2>&1
+        rc=$?
+        [ "$rc" = 0 ] && ok "in-tree: suite green" \
+                      || { bad "in-tree: suite failed (rc=$rc)"; tail -30 /tmp/runtime-intree.$$; }
+        rm -f /tmp/runtime-intree.$$
+    fi
+
+    banner "--disable-debug VPATH build (the configuration nobody tests)"
+    # Autoconf refuses a VPATH build while the source directory itself holds
+    # a config.status ("source directory already configured").  A test script
+    # has no business running distclean on a working tree, so say what is in
+    # the way instead.
+    if [ -f "$root/config.status" ]; then
+        skp "srcdir is configured in place -- an out-of-tree build cannot coexist"
+        echo "     Either run './build.sh macos' (which distcleans first), or:" >&2
+        echo "         make -C $root distclean && $0 macos" >&2
+        echo "     The Linux half has no such restriction." >&2
+        return
+    fi
+
+    mkdir -p "$opt"
+    ( cd "$opt" \
+        && { [ -f config.status ] || "$root/configure" --prefix="$opt/install" \
+                 --disable-debug --disable-devel-check; } \
+        && make -j"$jobs" \
+        && for p in $RUNTIME_PROGS; do make -C test/unit "$p" || exit 1; done \
+        && cd test/unit && . ../pmix_test_env.sh \
+        && export TMPDIR="$(mktemp -d)" \
+        && for p in $RUNTIME_PROGS; do ./"$p" || exit 1; done ) >/tmp/runtime-opt.$$ 2>&1
+    rc=$?
+    [ "$rc" = 0 ] && ok "optimized: suite green" \
+                  || { bad "optimized: suite failed (rc=$rc)"; tail -30 /tmp/runtime-opt.$$; }
+    rm -f /tmp/runtime-opt.$$
+}
+
+########################################################################
+
+case "$mode" in
+    linux) test_linux ;;
+    macos) test_macos ;;
+    *) echo "usage: $0 [linux|macos]" >&2; exit 2 ;;
+esac
+
+printf '\n=== summary: %d passed, %d failed, %d skipped ===\n' "$pass" "$fail" "$skip"
+[ "$fail" -eq 0 ]

--- a/contrib/dockerswarm/run-runtime-tests.sh
+++ b/contrib/dockerswarm/run-runtime-tests.sh
@@ -325,9 +325,19 @@ test_linux() {
 
     # Every node named in the job has to come back in the node list. A node
     # whose own name did not match what it was told would drop out here.
+    #
+    # Pick the list out by its shape rather than by position. Eight ranks
+    # are writing to the same stderr, so "the line after ResNodes" is
+    # whatever happened to be flushed next -- which is how this read a
+    # fragment of another rank's banner.
     local nodelist missing="" n
-    nodelist="$(printf '%s\n' "$out" | grep -A1 'ResNodes returned: PMIX_SUCCESS' \
-                | grep -v 'ResNodes\|^--' | tr -d ' \t' | sort -u | head -1)"
+    nodelist="$(printf '%s\n' "$out" | tr -d ' \t' \
+                | grep -Ex 'node[0-9]+(,node[0-9]+)*' | sort -u | head -1)"
+    if [ -z "$nodelist" ]; then
+        bad "resolve: no node list found in the output"
+        printf '%s\n' "$out" | grep -A1 'ResNodes returned' | head -6
+        return
+    fi
     for n in node1 node2 node3 node4; do
         case ",$nodelist," in *",$n,"*) ;; *) missing="$missing $n" ;; esac
     done

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -38,3 +38,36 @@ Detailed changes since v6.1.0:
    terminal's stdin. The signal handler is registered with no callback
    data, and the handler it shares with the stdin restart path
    dereferenced that as a read event
+ - A process now records the alias forms of its own node name no matter
+   where that name came from. The library builds the alias list - which
+   is what lets it recognize its own node under both the FQDN and the
+   short form - only when it had to discover the hostname itself, so a
+   host environment that supplied PMIX_HOSTNAME, which every resource
+   manager does, left the list empty. Every other node's name was
+   already being passed through the same normalization, so ours was the
+   only one not getting it
+ - The list of CPUs to which the internal progress thread is to be bound
+   is now validated before it is used. An entry that is not a number, a
+   negative one, one beyond the end of the CPU mask, or a backwards
+   range is reported and skipped; if binding was requested as required
+   and nothing usable remains, initialization fails. Previously the list
+   went to strtoul unchecked, which reports zero for a token containing
+   no digits - so a typo such as "cpu0" silently became "bind to CPU 0"
+ - Added the missing help text for a malformed or unrecognized entry in
+   the pmix_var_dump_color MCA parameter. Both messages were being
+   requested by name and neither existed, so a user who mistyped that
+   parameter got "I couldn't find that help reference" in place of the
+   explanation
+ - Under PMIX_EXTERNAL_PROGRESS, finalize now releases the event base
+   and marks the library as no longer accepting work. Both were being
+   skipped along with the progress thread that mode does not start, so
+   the base outlived finalize while roughly a hundred API entry points
+   went on believing a torn-down library was open for business
+ - Several allocations are no longer leaked on each init/finalize cycle:
+   the output channels opened for the client verbosity parameters, the
+   two static IOF sinks in a server, the file and directory names given
+   by PMIX_IOF_OUTPUT_TO_FILE / _TO_DIRECTORY, and the environment-
+   variable harvest patterns held by the pnet, pgpu and pmdl components.
+   Also, directive state such as the node ID and the external-progress
+   and external-topology flags is now reset, so what one PMIx_Init was
+   told no longer becomes the default for the next one

--- a/src/mca/pgpu/amd/pgpu_amd_component.c
+++ b/src/mca/pgpu/amd/pgpu_amd_component.c
@@ -110,5 +110,19 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
 
 static pmix_status_t component_close(void)
 {
+    /* component_register split the envar patterns into these two argv
+     * arrays, and nothing else owns them. The MCA base calls us both when
+     * the framework closes and when our open fails, so this is the one
+     * place that runs either way - without it the arrays are rebuilt and
+     * abandoned on every PMIx init/finalize cycle. */
+    if (NULL != pmix_mca_pgpu_amd_component.include) {
+        PMIx_Argv_free(pmix_mca_pgpu_amd_component.include);
+        pmix_mca_pgpu_amd_component.include = NULL;
+    }
+    if (NULL != pmix_mca_pgpu_amd_component.exclude) {
+        PMIx_Argv_free(pmix_mca_pgpu_amd_component.exclude);
+        pmix_mca_pgpu_amd_component.exclude = NULL;
+    }
+
     return PMIX_SUCCESS;
 }

--- a/src/mca/pgpu/intel/pgpu_intel_component.c
+++ b/src/mca/pgpu/intel/pgpu_intel_component.c
@@ -109,5 +109,19 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
 
 static pmix_status_t component_close(void)
 {
+    /* component_register split the envar patterns into these two argv
+     * arrays, and nothing else owns them. The MCA base calls us both when
+     * the framework closes and when our open fails, so this is the one
+     * place that runs either way - without it the arrays are rebuilt and
+     * abandoned on every PMIx init/finalize cycle. */
+    if (NULL != pmix_mca_pgpu_intel_component.include) {
+        PMIx_Argv_free(pmix_mca_pgpu_intel_component.include);
+        pmix_mca_pgpu_intel_component.include = NULL;
+    }
+    if (NULL != pmix_mca_pgpu_intel_component.exclude) {
+        PMIx_Argv_free(pmix_mca_pgpu_intel_component.exclude);
+        pmix_mca_pgpu_intel_component.exclude = NULL;
+    }
+
     return PMIX_SUCCESS;
 }

--- a/src/mca/pgpu/nvd/pgpu_nvd_component.c
+++ b/src/mca/pgpu/nvd/pgpu_nvd_component.c
@@ -111,5 +111,19 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
 
 static pmix_status_t component_close(void)
 {
+    /* component_register split the envar patterns into these two argv
+     * arrays, and nothing else owns them. The MCA base calls us both when
+     * the framework closes and when our open fails, so this is the one
+     * place that runs either way - without it the arrays are rebuilt and
+     * abandoned on every PMIx init/finalize cycle. */
+    if (NULL != pmix_mca_pgpu_nvd_component.include) {
+        PMIx_Argv_free(pmix_mca_pgpu_nvd_component.include);
+        pmix_mca_pgpu_nvd_component.include = NULL;
+    }
+    if (NULL != pmix_mca_pgpu_nvd_component.exclude) {
+        PMIx_Argv_free(pmix_mca_pgpu_nvd_component.exclude);
+        pmix_mca_pgpu_nvd_component.exclude = NULL;
+    }
+
     return PMIX_SUCCESS;
 }

--- a/src/mca/pgpu/test/pgpu_test_component.c
+++ b/src/mca/pgpu/test/pgpu_test_component.c
@@ -130,5 +130,19 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
 
 static pmix_status_t component_close(void)
 {
+    /* component_register split the envar patterns into these two argv
+     * arrays, and nothing else owns them. The MCA base calls us both when
+     * the framework closes and when our open fails, so this is the one
+     * place that runs either way - without it the arrays are rebuilt and
+     * abandoned on every PMIx init/finalize cycle. */
+    if (NULL != pmix_mca_pgpu_test_component.include) {
+        PMIx_Argv_free(pmix_mca_pgpu_test_component.include);
+        pmix_mca_pgpu_test_component.include = NULL;
+    }
+    if (NULL != pmix_mca_pgpu_test_component.exclude) {
+        PMIx_Argv_free(pmix_mca_pgpu_test_component.exclude);
+        pmix_mca_pgpu_test_component.exclude = NULL;
+    }
+
     return PMIX_SUCCESS;
 }

--- a/src/mca/pmdl/ompi/pmdl_ompi_component.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi_component.c
@@ -30,6 +30,7 @@
 #include "src/util/pmix_argv.h"
 
 static pmix_status_t component_register(void);
+static pmix_status_t component_close(void);
 static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
 
 /*
@@ -49,6 +50,7 @@ pmix_pmdl_ompi_component_t pmix_mca_pmdl_ompi_component = {
 
         /* Component open and close functions */
         .pmix_mca_register_component_params = component_register,
+        .pmix_mca_close_component = component_close,
         .pmix_mca_query_component = component_query,
     },
     .include = NULL,
@@ -78,6 +80,24 @@ static pmix_status_t component_register(void)
          &pmix_mca_pmdl_ompi_component.excparms);
     if (NULL != pmix_mca_pmdl_ompi_component.excparms) {
         pmix_mca_pmdl_ompi_component.exclude = PMIx_Argv_split(pmix_mca_pmdl_ompi_component.excparms, ',');
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t component_close(void)
+{
+    /* component_register split the envar patterns into these two argv
+     * arrays, and nothing else owns them. This component had no close
+     * function at all, so they were rebuilt and abandoned on every PMIx
+     * init/finalize cycle. */
+    if (NULL != pmix_mca_pmdl_ompi_component.include) {
+        PMIx_Argv_free(pmix_mca_pmdl_ompi_component.include);
+        pmix_mca_pmdl_ompi_component.include = NULL;
+    }
+    if (NULL != pmix_mca_pmdl_ompi_component.exclude) {
+        PMIx_Argv_free(pmix_mca_pmdl_ompi_component.exclude);
+        pmix_mca_pmdl_ompi_component.exclude = NULL;
     }
 
     return PMIX_SUCCESS;

--- a/src/mca/pnet/nvd/pnet_nvd_component.c
+++ b/src/mca/pnet/nvd/pnet_nvd_component.c
@@ -116,5 +116,19 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
 
 static pmix_status_t component_close(void)
 {
+    /* component_register split the envar patterns into these two argv
+     * arrays, and nothing else owns them. The MCA base calls us both when
+     * the framework closes and when our open fails, so this is the one
+     * place that runs either way - without it the arrays are rebuilt and
+     * abandoned on every PMIx init/finalize cycle. */
+    if (NULL != pmix_mca_pnet_nvd_component.include) {
+        PMIx_Argv_free(pmix_mca_pnet_nvd_component.include);
+        pmix_mca_pnet_nvd_component.include = NULL;
+    }
+    if (NULL != pmix_mca_pnet_nvd_component.exclude) {
+        PMIx_Argv_free(pmix_mca_pnet_nvd_component.exclude);
+        pmix_mca_pnet_nvd_component.exclude = NULL;
+    }
+
     return PMIX_SUCCESS;
 }

--- a/src/mca/pnet/opa/pnet_opa_component.c
+++ b/src/mca/pnet/opa/pnet_opa_component.c
@@ -111,5 +111,19 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
 
 static pmix_status_t component_close(void)
 {
+    /* component_register split the envar patterns into these two argv
+     * arrays, and nothing else owns them. The MCA base calls us both when
+     * the framework closes and when our open fails, so this is the one
+     * place that runs either way - without it the arrays are rebuilt and
+     * abandoned on every PMIx init/finalize cycle. */
+    if (NULL != pmix_mca_pnet_opa_component.include) {
+        PMIx_Argv_free(pmix_mca_pnet_opa_component.include);
+        pmix_mca_pnet_opa_component.include = NULL;
+    }
+    if (NULL != pmix_mca_pnet_opa_component.exclude) {
+        PMIx_Argv_free(pmix_mca_pnet_opa_component.exclude);
+        pmix_mca_pnet_opa_component.exclude = NULL;
+    }
+
     return PMIX_SUCCESS;
 }

--- a/src/mca/pnet/tcp/pnet_tcp_component.c
+++ b/src/mca/pnet/tcp/pnet_tcp_component.c
@@ -114,6 +114,19 @@ static pmix_status_t component_query(pmix_mca_base_module_t **module, int *prior
 
 static pmix_status_t component_close(void)
 {
+    /* component_register split the envar patterns into these two argv
+     * arrays, and nothing else owns them. The MCA base calls us both when
+     * the framework closes and when our open fails, so this is the one
+     * place that runs either way - without it the arrays are rebuilt and
+     * abandoned on every PMIx init/finalize cycle. */
+    if (NULL != pmix_mca_pnet_tcp_component.include) {
+        PMIx_Argv_free(pmix_mca_pnet_tcp_component.include);
+        pmix_mca_pnet_tcp_component.include = NULL;
+    }
+    if (NULL != pmix_mca_pnet_tcp_component.exclude) {
+        PMIx_Argv_free(pmix_mca_pnet_tcp_component.exclude);
+        pmix_mca_pnet_tcp_component.exclude = NULL;
+    }
 
     return PMIX_SUCCESS;
 }

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -87,7 +87,13 @@ compatible order. The spine is:
 5. **Globals construction** — ids, `mypeer` (a `pmix_peer_t` stamped
    with our version), the events/notifications/nspaces/keyindex
    structures, client-globals lists, verbosity output channels, uid/gid,
-   `PMIX_DEBUG` channel, hostname/aliases.
+   `PMIX_DEBUG` channel, hostname/aliases. The hostname is resolved from
+   the first of: the `PMIX_HOSTNAME` directive, the `PMIX_HOSTNAME`
+   environment variable, `gethostname()` — but `pmix_set_aliases` then
+   runs **regardless of which** supplied it. Every *other* node's name
+   goes through `pmix_set_aliases` too (see `gds/hash`), so skipping it
+   for our own leaves `pmix_check_local()` unable to match the form of
+   our name we did not keep.
 6. **Framework open+select, in dependency order**: bfrops → pcompress →
    ptl → psec → gds → preg (preg **must** follow pcompress) → plog.
    `pmix_init_registered_attrs()` then builds the attribute registry.
@@ -166,13 +172,24 @@ follow:
   matching `pmix_output_open` block in `pmix_init.c`.
 - `pmix_deregister_params` intentionally does **not** free the
   registered vars (the `mca_base_var` system frees them in
-  `pmix_mca_base_var_finalize`); it only resets the latch so a second
-  init re-registers cleanly. The one thing that *is* hand-freed is
-  `pmix_var_dump_color[]`, released in `pmix_rte_finalize`.
+  `pmix_mca_base_var_finalize` — `var_destructor` frees each string var
+  through its *storage* pointer and NULLs it, which is also why the
+  `free()`+`strdup()` the directive scan does to
+  `pmix_progress_thread_cpus` is safe). It resets the latch so a second
+  init re-registers cleanly, and frees the one thing that really is ours:
+  the `pmix_var_dump_color[]` escapes built by `parse_color_string`.
 - The `var_dump_color` machinery (`parse_color_string`) turns a
   `key=ansi_code` list into ready-to-emit `\033[..m` escape strings used
-  by `pmix_info`. It reports malformed tokens via `help-pmix-runtime.txt`
-  and, on any allocation failure, frees the whole partial result.
+  by `pmix_info`. A malformed or unrecognized entry is reported via
+  `help-pmix-runtime.txt` and skipped — the rest of the list still
+  applies — and on any allocation failure the whole partial result is
+  freed. Every slot always ends up holding a free-able string (`""` when
+  no entry named it), so callers can emit it unconditionally.
+- Assigning a string literal to a `char *` C global right before
+  registering it is the established idiom here (`pmix_net_private_ipv4`,
+  `pmix_var_dump_color_string`) and is safe: `register_variable`
+  immediately replaces the storage with `strdup` of it. Do not "fix" it
+  by heap-allocating the default.
 
 Help text for this directory lives in
 [`help-pmix-runtime.txt`](help-pmix-runtime.txt). Per the top-level
@@ -211,7 +228,30 @@ Key facts:
 - `stop_progress_engine` sets/clears `pmix_globals.progress_thread_stopped`
   for the *shared* thread only. That flag gates whether PMIx APIs may
   still thread-shift work in — code that posts to the progress thread
-  checks it to avoid enqueuing onto a dead loop.
+  checks it to avoid enqueuing onto a dead loop. Roughly a hundred call
+  sites across `src/client`, `src/server`, `src/common` and `src/event`
+  read it, so anything that leaves it stale is felt library-wide.
+- **`external_progress` suppresses the *engine*, never the bookkeeping.**
+  When the host drives our base itself there is no thread to spin, join,
+  or pause — but `start`/`pause`/`resume` must still move
+  `progress_thread_stopped`, and `stop` must still drop the refcount and
+  free the base. An early-out that skips those leaves the shared tracker
+  and its base alive past `pmix_rte_finalize`, with the flag still
+  reading "running", so every API guard above believes a torn-down
+  library is open for work.
+- `PMIX_NEW` does **not** zero the object it allocates (see
+  `pmix_obj_new_tma`), so the tracker's embedded `block` event is garbage
+  until `pmix_event_assign` runs. `block_assigned` records that, and the
+  destructor consults it — a tracker released on an allocation-failure
+  path would otherwise hand libevent uninitialized memory.
+- The CPU list behind `pmix_progress_thread_cpus` /
+  `PMIX_BIND_PROGRESS_THREAD` is user input and is validated
+  (`parse_cpu_range`) before any of it reaches `CPU_SET`. `strtoul` alone
+  cannot do this: it reports 0 for a token with no digits, so a typo used
+  to become "bind to cpu 0" silently, and it returns values past
+  `CPU_SETSIZE`, which `CPU_SET` drops on glibc/musl but writes out of
+  bounds for on BSD. Rejected entries are reported through
+  `help-pmix-runtime.txt` and skipped.
 - The public **`PMIx_Progress_thread_stop`** (2-arg, in `pmix.h`) is
   *not* the same as internal `pmix_progress_thread_stop` (1-arg name).
   The public one parses `PMIX_PROGRESS_THREAD_NAME` /
@@ -249,11 +289,14 @@ Notable pieces:
 
 ## Threading notes specific to this directory
 
-- `pmix_init_util` guards itself with an **atomic** bool
-  (`pmix_atomic_check_bool`/`set_bool`) because tools can race into it;
-  the rest of init assumes single-threaded bring-up (the progress
-  thread does not exist yet for most of it, and is paused first thing in
-  finalize).
+- `pmix_init_util` latches on an **atomic** bool
+  (`pmix_atomic_check_bool`/`set_bool`). Note what that does and does
+  not buy you: those macros are a plain `atomic_load`/`atomic_store`, so
+  the latch makes the *repeat* call cheap and race-free to read, but it
+  is a check-then-set, not a compare-and-swap — two threads arriving
+  together would both run the body. Bring-up is expected to be
+  single-threaded; the progress thread does not exist yet for most of
+  init, and is paused first thing in finalize.
 - Everything after `pmix_progress_thread_start` and before
   `pmix_progress_thread_pause` is the normal PMIx world where the
   progress-thread / caddy rules from the top-level guide apply. Init and
@@ -262,14 +305,33 @@ Notable pieces:
 ## Building and testing
 
 Plain top-level `make` picks up edits here (no `configure` needed unless
-you add/remove a file). There is **no dedicated unit test** for
-`src/runtime` — every `make check` test and every `./simptest` run
-exercises init/finalize implicitly, and the re-entrancy fixes were
-validated with init→finalize→init cycles. If you change the
-init/finalize contract, an explicit double-cycle smoke test is the
-right thing to add under `test/unit`. Do not diagnose functional
-failures against an `--enable-test-build` tree (see the top-level
-guide).
+you add/remove a file). Do not diagnose functional failures against an
+`--enable-test-build` tree (see the top-level guide).
+
+Beyond the implicit coverage every `make check` test and every
+`./simptest` run gives init/finalize, four `test/unit` programs target
+this directory directly:
+
+| Test | Covers |
+|------|--------|
+| [`runtime_init`](../../test/unit/runtime_init.c) | hostname/alias resolution from a host-supplied `PMIX_HOSTNAME`, `pmix_set_aliases` under both FQDN policies, `var_dump_color` parsing, and that every `show_help` topic `src/runtime` names actually exists |
+| [`progress_threads`](../../test/unit/progress_threads.c) | the whole name-addressed engine — refcounting, distinct bases, start/pause/resume/stop, CPU-list validation, and the blocking-call-from-the-progress-thread guard |
+| [`info_support`](../../test/unit/info_support.c) | `pmix_info_make_version_str` and the parsable `pmix_info_out` formatter |
+| [`client_cycle`](../../test/unit/client_cycle.c) / [`tool_cycle`](../../test/unit/tool_cycle.c) | the re-entrancy contract — many init→finalize→init cycles in one process |
+
+Two notes for anyone adding to these:
+
+- **Cover a new `show_help` topic in `runtime_init`.** A missing topic is
+  invisible until the rare path that emits it fires, and then the user
+  gets "I couldn't find that help reference" instead of the diagnostic.
+  `pmix_show_help_string` returns `NULL` for a topic that is not in the
+  file, so one line asserting non-`NULL` — with the same arguments the
+  real call site passes — keeps code and help text in step.
+- **The affinity path is Linux/BSD-only.** Everything inside
+  `#ifdef HAVE_PTHREAD_SETAFFINITY_NP` compiles out on macOS, so the
+  `cpulist:` cases in `progress_threads` report `SKIP` there and must be
+  exercised on Linux (a container is enough — this needs no multi-node
+  setup) before you trust a change to `parse_cpu_range`.
 
 ## Known rough spots
 
@@ -283,6 +345,19 @@ Structural quirks worth knowing before you touch the relevant code:
   `PMIx_Init` aborts the process. Do not mistake this for a leak to
   "fix" on the error path; if you add a new failure point, follow the
   same pattern (set `error` to a short label and `goto return_error`).
+  Note that `return_error` reads `ret`, so any new `goto` must set it.
+- **Directive values come from the host and are not pre-validated.**
+  `pmix_rte_init`'s scan is the first thing in the library to touch what
+  an RM passed to `PMIx_server_init`. A key given the wrong type, or a
+  `PMIX_STRING` carrying a `NULL`, is a host bug — but it must produce
+  `PMIX_ERR_BAD_PARAM`, not a `strdup(NULL)`. Check the type before
+  dereferencing when you add a directive.
+- **`pmix_globals` fields that are MCA-var storage.** Several
+  (`max_events`, `output_limit`, `tag_output`, …) are handed to
+  `pmix_mca_base_var_register` as backing store, so their values arrive
+  from the environment. `pmix_rte_finalize` walks the notification hotel
+  with `pmix_globals.max_events`, which is why that walk has to stay
+  consistent with the value the hotel was sized with.
 
 ## When modifying code here
 

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -390,8 +390,18 @@ Two notes for anyone adding to these:
 - **The affinity path is Linux/BSD-only.** Everything inside
   `#ifdef HAVE_PTHREAD_SETAFFINITY_NP` compiles out on macOS, so the
   `cpulist:` cases in `progress_threads` report `SKIP` there and must be
-  exercised on Linux (a container is enough — this needs no multi-node
-  setup) before you trust a change to `parse_cpu_range`.
+  exercised on Linux before you trust a change to `parse_cpu_range`.
+
+That last point is what
+[`contrib/dockerswarm/run-runtime-tests.sh`](../../contrib/dockerswarm/run-runtime-tests.sh)
+exists for (README §18). It runs all five programs on Linux in **both**
+`--enable-debug` and `--disable-debug` — the asserts in
+`start_progress_engine` and `pmix_info_close_components` only exist in the
+first, and users only ever get the second — then drives the CPU list
+through a real `PMIx_Init` (the unit test can only reach *named* progress
+threads; the shared one is configured from `pmix_rte_init`), and finally
+resolves peers across four nodes to guard the alias change end to end.
+Run it after touching the progress thread or the init/finalize contract.
 
 ## Known rough spots
 

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -159,6 +159,22 @@ library. Rules:
   init if it needs it, and destruct/free/NULL it in finalize. A field
   constructed but not destructed leaks on every finalize; one destructed
   but not re-constructed crashes on second init.
+- **The scalars need resetting too, not just the containers.** The
+  containers and pointers are obvious; the `bool`s and `uint32_t`s are
+  the ones that get missed, because forgetting them costs nothing until
+  a *second* init. Nothing re-initializes them on the way in —
+  `pmix_rte_init` writes them only when the matching directive is
+  present — so whatever cycle N was told becomes cycle N+1's default.
+  `pmix_rte_finalize` therefore restores them to their static-init
+  values at the very end. Two are worth knowing by name:
+  `external_progress` left set makes the next
+  `pmix_progress_thread_start` decline to spin the engine, so if that
+  cycle's host is not driving the loop the first blocking call hangs;
+  and `external_topology` left set makes `pmix_hwloc_finalize` decline
+  to destroy the next cycle's self-discovered topology. `nodeid` and
+  `sessionid` reset to `UINT32_MAX`, which is the "not told" sentinel.
+  The reset must come **after** the progress-thread teardown, which
+  reads `external_progress`.
 - The finalize path deliberately drains the notification hotel
   room-by-room and the `iof_requests` pointer array item-by-item before
   destructing the containers — mirror that discipline for any new

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -155,6 +155,32 @@ library. Rules:
   destructing the containers — mirror that discipline for any new
   container-of-refcounted-objects you add.
 
+### Two things in `pmix_globals` this directory does *not* finish
+
+Both look like violations of the rule above. Neither is. Read this
+before "fixing" either one — each has cost a debugging session.
+
+- **`mypeer` carries two references, and this file only drops one.**
+  `pmix_rte_init` creates it (refcount 1) and the role then retains it
+  when it points `pmix_client_globals.myserver` at the same object
+  (`pmix_server.c`, `pmix_client.c`, `pmix_tool.c`). `pmix_rte_finalize`
+  drops the first; the role drops the second immediately after
+  `pmix_rte_finalize()` returns, and *that* is what frees it. So
+  **`PMIX_RELEASE` here does not free, and the pointer must not be
+  NULLed** — every role guards its release with
+  `if (NULL != pmix_globals.mypeer)`, so clearing it cancels the release
+  that does the freeing and leaks the peer and its namespace (~3KB) on
+  every cycle. Note also that `PMIX_RELEASE` never clears the pointer it
+  is handed; only the magic id.
+- **The `iof_stdout` / `iof_stderr` sinks are constructed here and
+  destructed by each role.** That split is not tidy, but it is forced:
+  `iof_sink_destruct` reads `pmix_globals.mypeer` (released above) and,
+  in a server, walks `pmix_server_globals.iof_residuals` (destructed in
+  `PMIx_server_finalize`). Moving the destruct into `pmix_rte_finalize`
+  segfaults the client tests. If you add a role, destruct them in its
+  finalize; if you add state with the same shape, expect the same
+  constraint.
+
 ## MCA parameters (`pmix_params.c`)
 
 `pmix_register_params` is latched by the file-scope `pmix_register_done`
@@ -169,7 +195,16 @@ follow:
 - Verbosity params write directly into `pmix_client_globals.*_verbose` /
   `pmix_server_globals.*_verbose`; `pmix_rte_init` later opens an output
   channel for each nonzero one. If you add a verbosity var, add the
-  matching `pmix_output_open` block in `pmix_init.c`.
+  matching `pmix_output_open` block in `pmix_init.c` **and the matching
+  `close_output` in `pmix_finalize.c`.** The close is not optional: an
+  output descriptor owns a `strdup`ed prefix that only
+  `pmix_output_close` frees, the next `pmix_output_init` marks every slot
+  unused without clearing what it pointed at, and the id lives in a
+  file-scope struct that outlives the library — so an unclosed channel
+  both leaks on every init/finalize cycle and leaves an id naming a slot
+  the next cycle may hand to someone else. It also has to happen *before*
+  `pmix_output_finalize`, because `pmix_output_close` is a no-op once the
+  output system is down.
 - `pmix_deregister_params` intentionally does **not** free the
   registered vars (the `mca_base_var` system frees them in
   `pmix_mca_base_var_finalize` — `var_destructor` frees each string var

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -80,7 +80,16 @@ compatible order. The spine is:
    `PMIX_NODE_INFO_ARRAY`, `PMIX_EXTERNAL_PROGRESS`,
    `PMIX_EXTERNAL_AUX_EVENT_BASE`, `PMIX_HOSTNAME_KEEP_FQDN`,
    `PMIX_BIND_PROGRESS_THREAD`, `PMIX_BIND_REQUIRED`); everything else
-   is handed to `pmix_iof_check_flags`.
+   is handed to `pmix_iof_check_flags`. Two things follow from that.
+   First, these values come straight from the host and nothing has
+   validated them yet, so check `value.type` before following a union
+   member — `PMIX_CHECK_KEY` says what the key is, never what is in the
+   value. Second, `pmix_iof_check_flags` **allocates**: it `strdup`s
+   `PMIX_IOF_OUTPUT_TO_FILE` / `_TO_DIRECTORY` into the local flag block,
+   which is then copied wholesale into `pmix_globals.iof_flags`. That
+   copy is a bare struct member with no destructor behind it (only the
+   per-namespace `pmix_iof_flags_t` gets one), so `pmix_rte_finalize`
+   owns those two strings.
 4. **Progress thread + event base** (`pmix_progress_thread_init(NULL)`)
    — creates `pmix_globals.evbase`. If no external aux event base was
    supplied, `evauxbase` is aliased to `evbase`.

--- a/src/runtime/help-pmix-runtime.txt
+++ b/src/runtime/help-pmix-runtime.txt
@@ -102,6 +102,50 @@ only be provided once and cannot be overwritten.
 
 Please correct your program and try again.
 #
+[progress-thread:bad-cpu-list]
+An entry in the list of CPUs to which the PMIx progress thread is to be
+bound could not be used, and has been ignored:
+
+  Entry:  %s
+  List:   %s
+
+The list is a comma-delimited series of entries, where each entry is
+either a single CPU number or an inclusive range written "start-end" -
+for example "0,2,8-11". Each number must be between 0 and %d inclusive,
+and a range must not run backwards.
+
+The list is set either by the "pmix_progress_thread_cpus" MCA parameter
+or by the PMIX_BIND_PROGRESS_THREAD attribute passed to initialization.
+If no entry in it is usable, and binding was requested as required
+(PMIX_BIND_REQUIRED / "pmix_bind_progress_thread_reqd"), initialization
+will fail; otherwise the thread is left unbound.
+#
+[var_dump_color:format-error]
+A malformed entry was found in the "pmix_var_dump_color" MCA parameter
+and has been ignored:
+
+  Entry: %s
+
+Each entry in the parameter must have the form "key=code", where "code"
+is an ANSI X3.64 CSI SGR sequence (for example, 34 for blue), and the
+entries are separated by commas - e.g.
+
+  name=34,value=32,valid_values=36
+
+Keys not given a color are left uncolored.
+#
+[var_dump_color:unknown-key]
+An entry in the "pmix_var_dump_color" MCA parameter names a key this
+version of PMIx does not recognize. The entry has been ignored:
+
+  Key:    %s
+  Entry:  %s
+
+Recognized keys are: %s
+
+Note that a key added by a later release of PMIx will be reported here
+by an earlier one - the parameter is otherwise being read normally.
+#
 [blocking-call-from-progress-thread]
 A blocking call to %s was made from the PMIx progress thread.
 

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -200,6 +200,20 @@ void pmix_rte_finalize(void)
         PMIx_Argv_free(pmix_globals.aliases);
         pmix_globals.aliases = NULL;
     }
+    /* pmix_rte_init took ownership of these two when it copied the
+     * directive-scan flags into pmix_globals; pmix_iof_check_flags
+     * strdup'ed them out of PMIX_IOF_OUTPUT_TO_FILE /
+     * PMIX_IOF_OUTPUT_TO_DIRECTORY. Only the namespace-level copies of
+     * pmix_iof_flags_t are freed by a destructor - this one is a bare
+     * struct member, so it is ours to release. */
+    if (NULL != pmix_globals.iof_flags.file) {
+        free(pmix_globals.iof_flags.file);
+        pmix_globals.iof_flags.file = NULL;
+    }
+    if (NULL != pmix_globals.iof_flags.directory) {
+        free(pmix_globals.iof_flags.directory);
+        pmix_globals.iof_flags.directory = NULL;
+    }
     PMIX_LIST_DESTRUCT(&pmix_globals.nspaces);
     PMIX_LIST_DESTRUCT(&pmix_client_globals.groups);
     PMIX_DESTRUCT(&pmix_globals.keyindex);

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -59,6 +59,28 @@
 extern int pmix_initialized;
 extern bool pmix_init_called;
 
+/* Release an output channel opened by pmix_rte_init and restore the -1
+ * sentinel it started life with.
+ *
+ * This has to happen, and has to happen before pmix_output_finalize:
+ * pmix_output_close is a no-op once the output system is down, and the
+ * descriptor owns a strdup'ed prefix that nothing else frees. The next
+ * pmix_output_init marks every slot unused again without clearing what
+ * the slot pointed at, so an unclosed channel loses its prefix on every
+ * init/finalize cycle. Restoring -1 matters just as much: the id is
+ * cached in a file-scope struct that outlives the library, and after a
+ * finalize it names a slot the next cycle may hand to someone else.
+ *
+ * This mirrors what framework_close_output does for the per-framework
+ * channels in src/mca/base/pmix_mca_base_framework.c. */
+static void close_output(int *id)
+{
+    if (0 <= *id) {
+        pmix_output_close(*id);
+        *id = -1;
+    }
+}
+
 void pmix_rte_finalize(void)
 {
     int i;
@@ -115,6 +137,20 @@ void pmix_rte_finalize(void)
     /* finalize the show_help system */
     pmix_show_help_finalize();
 
+    /* release the verbosity channels pmix_rte_init opened - see
+     * close_output above for why this cannot wait until after
+     * pmix_output_finalize. Roles that open channels of their own
+     * (pmix_client.c, pmix_server.c) release those themselves. */
+    close_output(&pmix_client_globals.get_output);
+    close_output(&pmix_client_globals.connect_output);
+    close_output(&pmix_client_globals.fence_output);
+    close_output(&pmix_client_globals.pub_output);
+    close_output(&pmix_client_globals.spawn_output);
+    close_output(&pmix_client_globals.event_output);
+    close_output(&pmix_client_globals.iof_output);
+    close_output(&pmix_client_globals.group_output);
+    close_output(&pmix_globals.debug_output);
+
     /* finalize the output system.  This has to come *after* the
        malloc code, as the malloc code needs to call into this, but
        the malloc code turning off doesn't affect pmix_output that
@@ -122,6 +158,21 @@ void pmix_rte_finalize(void)
     pmix_output_finalize();
 
     /* clean out the globals */
+
+    /* mypeer carries TWO references by the time we get here: the one
+     * pmix_rte_init created it with, and one the role took when it
+     * pointed pmix_client_globals.myserver at the same object
+     * (pmix_server.c, pmix_client.c, pmix_tool.c). This drops the first;
+     * the role drops the second immediately after we return, which is
+     * what actually frees it.
+     *
+     * So do NOT NULL the pointer here, however much the re-entrancy
+     * rules for this file otherwise want it. Every role guards its
+     * release with "if (NULL != pmix_globals.mypeer)", so clearing it
+     * silently cancels the release that does the freeing and leaks the
+     * peer - and its namespace - on every init/finalize cycle. The
+     * pointer is not dangling at this point; the object is still alive
+     * on the role's reference, and the role NULLs it once it is gone. */
     PMIX_RELEASE(pmix_globals.mypeer);
     PMIX_DESTRUCT(&pmix_globals.events);
     PMIX_LIST_DESTRUCT(&pmix_globals.cached_events);

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -153,14 +153,11 @@ void pmix_rte_finalize(void)
     PMIX_LIST_DESTRUCT(&pmix_client_globals.groups);
     PMIX_DESTRUCT(&pmix_globals.keyindex);
     free(pmix_globals.myidval.data.proc);
+    pmix_globals.myidval.data.proc = NULL;
 
     // release the topology
     pmix_hwloc_finalize();
 
-    for (i = 0; i < PMIX_VAR_DUMP_COLOR_KEY_COUNT; i++) {
-        free(pmix_var_dump_color[i]);
-        pmix_var_dump_color[i] = NULL;
-    }
     pmix_tsd_keys_destruct();
     /* clear the print-buffer TSD latch now that its key has been deleted,
      * so a subsequent PMIx_Init recreates it */

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -31,6 +31,7 @@
 #include "src/class/pmix_object.h"
 #include "src/client/pmix_client_ops.h"
 #include "src/common/pmix_attributes.h"
+#include "src/common/pmix_iof.h"
 #include "src/hwloc/pmix_hwloc.h"
 #include "src/mca/base/pmix_base.h"
 #include "src/mca/base/pmix_mca_base_var.h"
@@ -238,4 +239,39 @@ void pmix_rte_finalize(void)
      * we only drop our reference, we do not free it here */
     pmix_globals.evbase = NULL;
     pmix_globals.evauxbase = NULL;
+
+    /* Put the scalar bootstrap state back to the values pmix_globals was
+     * statically initialized with. These are all set from directives the
+     * host passes to init, or discovered during it, and none of them is
+     * re-initialized on the way in - pmix_rte_init only writes them when
+     * the corresponding directive is present. So whatever cycle N was
+     * told silently becomes cycle N+1's default, which is wrong in ways
+     * that are hard to trace back here:
+     *
+     *   external_progress - the worst of them. Left set, the next
+     *     pmix_progress_thread_start returns without spinning the engine
+     *     because it believes the host is driving the loop. If that
+     *     cycle's host is not, nothing progresses and the first blocking
+     *     call hangs.
+     *   external_topology - pmix_hwloc_finalize (just above) declines to
+     *     destroy a topology it does not own. Left set, the next cycle's
+     *     self-discovered topology is never destroyed either.
+     *   nodeid / sessionid - UINT32_MAX is the "not told" sentinel, so a
+     *     stale value is indistinguishable from a real one.
+     *
+     * This must come after the progress-thread teardown above, which
+     * reads external_progress. */
+    pmix_globals.nodeid = UINT32_MAX;
+    pmix_globals.sessionid = UINT32_MAX;
+    pmix_globals.appnum = 0;
+    pmix_globals.pindex = 0;
+    pmix_globals.external_progress = false;
+    pmix_globals.external_topology = false;
+    pmix_globals.pushstdin = false;
+    pmix_globals.commits_pending = false;
+    /* the file/directory strings were freed above; this clears the
+     * formatting decisions that came with them */
+    pmix_iof_init_flags(&pmix_globals.iof_flags);
+    pmix_iof_init_flags(&pmix_globals.spawn_iof_flags);
+    PMIX_LOAD_PROCID(&pmix_globals.myid, NULL, PMIX_RANK_INVALID);
 }

--- a/src/runtime/pmix_info_support.c
+++ b/src/runtime/pmix_info_support.c
@@ -450,7 +450,12 @@ void pmix_info_show_path(const char *type, const char *value)
     char *pretty, *path;
 
     pretty = strdup(type);
-    pretty[0] = toupper(pretty[0]);
+    if (NULL == pretty) {
+        return;
+    }
+    /* toupper is undefined for a negative char, so widen through
+     * unsigned char before handing it over */
+    pretty[0] = (char) toupper((unsigned char) pretty[0]);
 
     pmix_asprintf(&path, "path:%s", type);
     pmix_info_out(pretty, path, value);

--- a/src/runtime/pmix_info_support.c
+++ b/src/runtime/pmix_info_support.c
@@ -310,12 +310,16 @@ int pmix_info_register_framework_params(pmix_pointer_array_t *component_map)
     if (PMIX_SUCCESS != pmix_mca_base_open(NULL)) {
         pmix_show_help("help-pmix_info.txt", "lib-call-fail", true, "pmix_mca_base_open",
                        __FILE__, __LINE__);
+        /* give the count back: we registered nothing, and leaving it up
+         * makes the matching close a no-op that never closes anything */
+        --pmix_info_registered;
         return PMIX_ERROR;
     }
 
     /* Register the PMIX layer's MCA parameters */
     if (PMIX_SUCCESS != (rc = pmix_register_params())) {
         fprintf(stderr, "pmix_info_register: pmix_register_params failed\n");
+        --pmix_info_registered;
         return rc;
     }
 
@@ -485,8 +489,14 @@ void pmix_info_do_path(bool wall, pmix_cli_result_t *cmd_line,
     pmix_cli_item_t *opt;
     bool want_all = wall;
 
-    /* Check bozo case */
+    /* Check bozo case. Note the values check: pmix_info declares --path
+     * with a required argument so it always has one, but this is exported
+     * and another tool need not - and the loops below walk the array
+     * unconditionally (compare pmix_info_do_params/do_type). */
     opt = pmix_cmd_line_get_param(cmd_line, PMIX_CLI_INFO_PATH);
+    if (NULL != opt && NULL == opt->values) {
+        opt = NULL;
+    }
     if (NULL != opt) {
         for (i = 0; NULL != opt->values[i]; ++i) {
             if (0 == strcmp("all", opt->values[i])) {
@@ -982,6 +992,12 @@ void pmix_info_out(const char *pretty_message, const char *plain_message, const 
             }
 #endif
         }
+        /* size_t arithmetic: on a terminal narrower than the label
+         * itself this wraps to a huge value, which reads as "do not
+         * wrap" and is the right answer - there is no width to wrap
+         * into. It cannot index out of bounds either, because the
+         * splitting below is only reached when strlen(v) is at least
+         * max_value_chars. */
         max_line_width = screen_width - strlen(spaces) - strlen(pretty_message) - 2;
         if (0 < strlen(pretty_message)) {
             pmix_asprintf(&filler, "%s%s: ", spaces, pretty_message);

--- a/src/runtime/pmix_info_support.c
+++ b/src/runtime/pmix_info_support.c
@@ -238,6 +238,9 @@ static int info_register_framework(const char *project_name,
 
     if (NULL != component_map) {
         map = PMIX_NEW(pmix_info_component_map_t);
+        if (NULL == map) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
         map->project = strdup(project_name);
         map->type = strdup(framework->framework_name);
         map->components = &framework->framework_components;
@@ -323,8 +326,14 @@ void pmix_info_close_components(void)
 {
     int i;
 
-    assert(pmix_info_registered);
-    if (--pmix_info_registered) {
+    /* an unbalanced close would take the counter negative, and a
+     * negative counter is truthy - every later close would then return
+     * early and the frameworks would never be closed at all. Refuse the
+     * unbalanced call instead of quietly disabling the real one. An
+     * assert alone does not do this: it disappears under NDEBUG, which
+     * is exactly when the silent version bites. */
+    assert(0 < pmix_info_registered);
+    if (0 >= pmix_info_registered || 0 != --pmix_info_registered) {
         return;
     }
 
@@ -669,7 +678,7 @@ void pmix_info_do_type(pmix_cli_result_t *pmix_info_cmd_line)
     int i, j, k, len, ret;
     const pmix_mca_base_var_t *var;
     char **strings, *message;
-    const pmix_mca_base_var_group_t *group;
+    const pmix_mca_base_var_group_t *group = NULL;
 
     opt = pmix_cmd_line_get_param(pmix_info_cmd_line, PMIX_CLI_INFO_TYPES);
     if (NULL == opt) {
@@ -700,7 +709,18 @@ void pmix_info_do_type(pmix_cli_result_t *pmix_info_cmd_line)
                 if (PMIX_SUCCESS != ret) {
                     continue;
                 }
-                (void) pmix_mca_base_var_group_get(var->mbv_group_index, &group);
+                /* the group is only read for the pretty-mode heading, but
+                 * it is read unchecked below - and group_get leaves the
+                 * pointer untouched for a negative index and NULLs it for
+                 * a group that has been invalidated */
+                if (PMIX_SUCCESS != pmix_mca_base_var_group_get(var->mbv_group_index, &group) ||
+                    NULL == group) {
+                    for (j = 0; strings[j]; ++j) {
+                        free(strings[j]);
+                    }
+                    free(strings);
+                    continue;
+                }
                 for (j = 0; strings[j]; ++j) {
                     if (0 == j && pmix_info_pretty) {
                         pmix_asprintf(&message, "MCA %s", group->group_framework);
@@ -814,12 +834,17 @@ static void pmix_info_show_mca_group_params(const pmix_mca_base_var_group_t *gro
     groups = PMIX_VALUE_ARRAY_GET_BASE(&group->group_subgroups, const int);
     count = pmix_value_array_get_size((pmix_value_array_t *) &group->group_subgroups);
 
+    /* recurse into a *separate* variable: 'group' is still the group
+     * whose subgroup list 'groups' points into, and overwriting it here
+     * leaves a reader unable to tell that the loop is still valid */
     for (i = 0; i < count; ++i) {
-        ret = pmix_mca_base_var_group_get(groups[i], &group);
-        if (PMIX_SUCCESS != ret) {
+        const pmix_mca_base_var_group_t *subgroup = NULL;
+
+        ret = pmix_mca_base_var_group_get(groups[i], &subgroup);
+        if (PMIX_SUCCESS != ret || NULL == subgroup) {
             continue;
         }
-        pmix_info_show_mca_group_params(group, want_internal);
+        pmix_info_show_mca_group_params(subgroup, want_internal);
     }
     free(component_msg);
 }
@@ -827,27 +852,23 @@ static void pmix_info_show_mca_group_params(const pmix_mca_base_var_group_t *gro
 void pmix_info_show_mca_params(const char *type, const char *component,
                                bool want_internal)
 {
-    const pmix_mca_base_var_group_t *group;
+    const pmix_mca_base_var_group_t *group = NULL;
     int ret;
 
-    if (0 == strcmp(component, "all")) {
-        ret = pmix_mca_base_var_group_find("*", type, NULL);
-        if (0 > ret) {
-            return;
-        }
-
-        (void) pmix_mca_base_var_group_get(ret, &group);
-
-        pmix_info_show_mca_group_params(group, want_internal);
-    } else {
-        ret = pmix_mca_base_var_group_find("*", type, component);
-        if (0 > ret) {
-            return;
-        }
-
-        (void) pmix_mca_base_var_group_get(ret, &group);
-        pmix_info_show_mca_group_params(group, want_internal);
+    ret = pmix_mca_base_var_group_find("*", type,
+                                       (0 == strcmp(component, "all")) ? NULL : component);
+    if (0 > ret) {
+        return;
     }
+
+    /* a group can be found by index and still come back NULL here - it
+     * has been invalidated in between - and the display walk below
+     * dereferences it immediately */
+    if (PMIX_SUCCESS != pmix_mca_base_var_group_get(ret, &group) || NULL == group) {
+        return;
+    }
+
+    pmix_info_show_mca_group_params(group, want_internal);
 }
 
 void pmix_info_do_arch(void)

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -261,6 +261,14 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     if (NULL != info) {
         for (n = 0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME)) {
+                /* the value comes from the host environment - a key given
+                 * the wrong type, or a NULL string, must not reach strdup */
+                if (PMIX_STRING != info[n].value.type ||
+                    NULL == info[n].value.data.string) {
+                    ret = PMIX_ERR_BAD_PARAM;
+                    error = "hostname";
+                    goto return_error;
+                }
                 if (NULL != pmix_globals.hostname) {
                     free(pmix_globals.hostname);
                 }
@@ -281,6 +289,12 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
                 minfo = info[n].value.data.darray->size;
                 for (m = 0; m < minfo; m++) {
                     if (PMIX_CHECK_KEY(&iptr[m], PMIX_HOSTNAME)) {
+                        if (PMIX_STRING != iptr[m].value.type ||
+                            NULL == iptr[m].value.data.string) {
+                            ret = PMIX_ERR_BAD_PARAM;
+                            error = "hostname";
+                            goto return_error;
+                        }
                         if (NULL != pmix_globals.hostname) {
                             free(pmix_globals.hostname);
                         }
@@ -300,6 +314,12 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME_KEEP_FQDN)) {
                 pmix_keep_fqdn_hostnames = PMIX_INFO_TRUE(&info[n]);
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_BIND_PROGRESS_THREAD)) {
+                if (PMIX_STRING != info[n].value.type ||
+                    NULL == info[n].value.data.string) {
+                    ret = PMIX_ERR_BAD_PARAM;
+                    error = "bind progress thread";
+                    goto return_error;
+                }
                 if (NULL != pmix_progress_thread_cpus) {
                     free(pmix_progress_thread_cpus);
                 }
@@ -462,8 +482,13 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
             gethostname(hostname, PMIX_MAXHOSTNAMELEN - 1);
             pmix_globals.hostname = strdup(hostname);
         }
-        pmix_set_aliases(&pmix_globals.aliases, pmix_globals.hostname);
     }
+    /* build the alias list regardless of where the name came from. Every
+     * *other* node's name is passed through pmix_set_aliases (see
+     * gds/hash), so if our own is not, pmix_check_local cannot match the
+     * form of our name we did not keep - which is exactly the case a host
+     * that hands us PMIX_HOSTNAME used to land in */
+    pmix_set_aliases(&pmix_globals.aliases, pmix_globals.hostname);
 
     /* open the bfrops and select the active plugins */
     ret = pmix_mca_base_framework_open(&pmix_bfrops_base_framework,

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -280,8 +280,11 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
                     goto return_error;
                 }
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODE_INFO_ARRAY)) {
-                /* contains info about our node */
-                if (NULL == info[n].value.data.darray ||
+                /* contains info about our node. Check the type before
+                 * reading darray - the union member we would otherwise
+                 * follow is whatever the real type left there */
+                if (PMIX_DATA_ARRAY != info[n].value.type ||
+                    NULL == info[n].value.data.darray ||
                     NULL == info[n].value.data.darray->array) {
                     continue;
                 }
@@ -310,6 +313,14 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_EXTERNAL_PROGRESS)) {
                 pmix_globals.external_progress = PMIX_INFO_TRUE(&info[n]);
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_EXTERNAL_AUX_EVENT_BASE)) {
+                /* the attribute is declared (void*); taking the pointer
+                 * out of a value that holds something else hands libevent
+                 * a fabricated base */
+                if (PMIX_POINTER != info[n].value.type) {
+                    ret = PMIX_ERR_BAD_PARAM;
+                    error = "external aux event base";
+                    goto return_error;
+                }
                 pmix_globals.evauxbase = (pmix_event_base_t*)info[n].value.data.ptr;
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME_KEEP_FQDN)) {
                 pmix_keep_fqdn_hostnames = PMIX_INFO_TRUE(&info[n]);
@@ -599,11 +610,17 @@ return_error:
         pmix_show_help("help-pmix-runtime.txt", "pmix_init:startup:internal-failure", true, error,
                        ret);
     }
+    /* these are the transient copies built by the directive scan. If we
+     * got far enough to hand them to pmix_globals they are the same two
+     * pointers, so clear the globals as well - a failed init aborts the
+     * process, but nothing here should leave a freed pointer reachable */
     if (NULL != flags.file) {
         free(flags.file);
+        pmix_globals.iof_flags.file = NULL;
     }
     if (NULL != flags.directory) {
         free(flags.directory);
+        pmix_globals.iof_flags.directory = NULL;
     }
     return ret;
 }

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -389,6 +389,17 @@ pmix_status_t pmix_register_params(void)
 
 pmix_status_t pmix_deregister_params(void)
 {
+    int k;
+
+    /* the registered vars themselves are freed by the mca_base_var
+     * system in pmix_mca_base_var_finalize; the color escape strings are
+     * ours, built by parse_color_string above, so they are released here
+     * where they pair with the code that allocated them */
+    for (k = 0; k < PMIX_VAR_DUMP_COLOR_KEY_COUNT; k++) {
+        free(pmix_var_dump_color[k]);
+        pmix_var_dump_color[k] = NULL;
+    }
+
     pmix_register_done = false;
 
     return PMIX_SUCCESS;

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -119,7 +119,7 @@ pmix_status_t pmix_register_params(void)
         PMIX_MCA_BASE_VAR_TYPE_STRING,
         &pmix_net_private_ipv4);
     if (0 > ret) {
-        return ret;
+        goto failed;
     }
 
     pmix_event_caching_window = 1;
@@ -351,7 +351,8 @@ pmix_status_t pmix_register_params(void)
 
     string = pmix_argv_join_range(pmix_var_dump_color_keys, 0, PMIX_VAR_DUMP_COLOR_KEY_COUNT, ',');
     if (NULL == string) {
-        return PMIX_ERR_OUT_OF_RESOURCE;
+        ret = PMIX_ERR_OUT_OF_RESOURCE;
+        goto failed;
     }
 
     ret = pmix_asprintf(&tmp, "The colors to use when dumping MCA vars with color "
@@ -361,7 +362,8 @@ pmix_status_t pmix_register_params(void)
     free(string);
     string = tmp;
     if (0 > ret) {
-        return PMIX_ERR_OUT_OF_RESOURCE;
+        ret = PMIX_ERR_OUT_OF_RESOURCE;
+        goto failed;
     }
 
     /* Basic color options: 30=black, 31=red, 32=green,
@@ -373,18 +375,24 @@ pmix_status_t pmix_register_params(void)
                                      &pmix_var_dump_color_string);
     free(string);
     if (0 > ret) {
-        return ret;
+        goto failed;
     }
 
     ret = parse_color_string(pmix_var_dump_color_string, pmix_var_dump_color_keys,
                              PMIX_VAR_DUMP_COLOR_KEY_COUNT, pmix_var_dump_color);
     if (PMIX_SUCCESS != ret) {
-        return ret;
+        goto failed;
     }
 
 
     pmix_hwloc_register();
     return PMIX_SUCCESS;
+
+failed:
+    /* clear the latch so a caller that retries actually re-registers
+     * rather than being told everything is already in place */
+    pmix_register_done = false;
+    return ret;
 }
 
 pmix_status_t pmix_deregister_params(void)

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -23,6 +23,8 @@
 #ifdef HAVE_PTHREAD_NP_H
 #    include <pthread_np.h>
 #endif
+#include <errno.h>
+#include <stdlib.h>
 #include <string.h>
 #include <event.h>
 
@@ -52,6 +54,7 @@ typedef struct {
     /* This event will always be set on the ev_base (so that the
        ev_base is not empty!) */
     pmix_event_t block;
+    bool block_assigned;
     bool engine_constructed;
     pmix_thread_t engine;
 } pmix_progress_tracker_t;
@@ -62,12 +65,19 @@ static void tracker_constructor(pmix_progress_tracker_t *p)
     p->name = NULL;
     p->ev_base = NULL;
     p->ev_active = false;
+    p->block_assigned = false;
     p->engine_constructed = false;
 }
 
 static void tracker_destructor(pmix_progress_tracker_t *p)
 {
-    pmix_event_del(&p->block);
+    /* PMIX_NEW does not zero the object, so 'block' holds garbage until
+     * pmix_event_assign has run. A tracker released before that point -
+     * an allocation failure in pmix_progress_thread_init - must not hand
+     * that garbage to libevent */
+    if (p->block_assigned) {
+        pmix_event_del(&p->block);
+    }
 
     if (NULL != p->name) {
         free(p->name);
@@ -233,7 +243,12 @@ void PMIx_Progress_thread_stop(const pmix_info_t *info, size_t ninfo)
         if (PMIx_Check_key(key, PMIX_PROGRESS_THREAD_FLUSH)) {
             flush = PMIX_INFO_TRUE(&info[n]);
         } else if (PMIx_Check_key(key, PMIX_PROGRESS_THREAD_NAME)) {
-            name = info[n].value.data.string;
+            /* a caller that gives us the key with the wrong type, or with
+             * a NULL string, must not send strcmp a NULL below */
+            if (PMIX_STRING == info[n].value.type &&
+                NULL != info[n].value.data.string) {
+                name = info[n].value.data.string;
+            }
         }
     }
 
@@ -242,7 +257,7 @@ void PMIx_Progress_thread_stop(const pmix_info_t *info, size_t ninfo)
     }
 
     PMIX_LIST_FOREACH (trk, &tracking, pmix_progress_tracker_t) {
-        if (NULL == name || 0 == strcmp(name, trk->name)) {
+        if (0 == strcmp(name, trk->name)) {
             /* If the progress thread is active, stop it */
             if (trk->ev_active) {
                 if (flush) {
@@ -261,12 +276,68 @@ void PMIx_Progress_thread_stop(const pmix_info_t *info, size_t ninfo)
 
 }
 
+#ifdef HAVE_PTHREAD_SETAFFINITY_NP
+/*
+ * Parse one entry of the progress_thread_cpus list.
+ *
+ * An entry is either a single cpu number or an inclusive "start-end"
+ * range. Returns true, and fills in start/end, only if the whole entry
+ * parsed and every cpu it names is representable in a cpu_set_t.
+ *
+ * strtoul on its own cannot answer that question: it reports 0 for a
+ * token containing no digits at all, so a typo silently becomes "bind to
+ * cpu 0", and it happily returns values beyond CPU_SETSIZE, which CPU_SET
+ * either drops on the floor (glibc, musl) or writes past the end of the
+ * mask for (BSD). Reject the entry here instead and tell the user.
+ */
+static bool parse_cpu_range(const char *entry, long *start, long *end)
+{
+    char *endp;
+    const char *rest;
+    long lo, hi;
+
+    if (NULL == entry || '\0' == entry[0]) {
+        return false;
+    }
+
+    errno = 0;
+    lo = strtol(entry, &endp, 10);
+    if (endp == entry || 0 != errno) {
+        return false;
+    }
+
+    if ('\0' == *endp) {
+        /* a bare entry is a single cpu */
+        hi = lo;
+    } else if ('-' == *endp) {
+        rest = endp + 1;
+        errno = 0;
+        hi = strtol(rest, &endp, 10);
+        if (endp == rest || '\0' != *endp || 0 != errno) {
+            return false;
+        }
+    } else {
+        /* trailing garbage */
+        return false;
+    }
+
+    if (0 > lo || hi < lo || CPU_SETSIZE <= hi) {
+        return false;
+    }
+
+    *start = lo;
+    *end = hi;
+    return true;
+}
+#endif
+
 static int start_progress_engine(pmix_progress_tracker_t *trk)
 {
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
     cpu_set_t cpuset;
-    char **ranges, *dash;
-    int k, n, start, end;
+    char **ranges;
+    int k, n, ncpus;
+    long start, end;
 #endif
 
     assert(!trk->ev_active);
@@ -290,30 +361,36 @@ static int start_progress_engine(pmix_progress_tracker_t *trk)
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
     if (NULL != pmix_progress_thread_cpus) {
         CPU_ZERO(&cpuset);
+        ncpus = 0;
         // comma-delimited list of cpu ranges
         ranges = PMIx_Argv_split(pmix_progress_thread_cpus, ',');
         for (n=0; NULL != ranges && NULL != ranges[n]; n++) {
-            // a range is "start-end"; a bare entry is a single cpu. Note
-            // that strtoul sets 'dash' to the character where parsing
-            // stopped - which is never NULL - so we must test what it
-            // points at, not whether the pointer itself is NULL.
-            start = strtoul(ranges[n], &dash, 10);
-            if ('-' != *dash) {
-                // single cpu
-                CPU_SET(start, &cpuset);
-            } else {
-                ++dash;  // skip over the '-'
-                end = strtoul(dash, NULL, 10);
-                // the range is inclusive of both endpoints
-                for (k=start; k <= end; k++) {
-                    CPU_SET(k, &cpuset);
-                }
+            if (!parse_cpu_range(ranges[n], &start, &end)) {
+                pmix_show_help("help-pmix-runtime.txt", "progress-thread:bad-cpu-list",
+                               true, ranges[n], pmix_progress_thread_cpus,
+                               (int) CPU_SETSIZE - 1);
+                continue;
+            }
+            // the range is inclusive of both endpoints
+            for (k = (int) start; k <= (int) end; k++) {
+                CPU_SET(k, &cpuset);
+                ++ncpus;
             }
         }
-        rc = pthread_setaffinity_np(trk->engine.t_handle, sizeof(cpu_set_t), &cpuset);
-        if (0 != rc && pmix_bind_progress_thread_reqd) {
+        PMIx_Argv_free(ranges);
+
+        if (0 == ncpus) {
+            /* every entry was rejected. Calling setaffinity with an empty
+             * mask just fails with EINVAL, which would be reported as a
+             * binding failure and send the user looking in the wrong
+             * place - we have already said what is actually wrong */
+            rc = PMIX_ERR_BAD_PARAM;
+        } else {
+            rc = (0 == pthread_setaffinity_np(trk->engine.t_handle, sizeof(cpu_set_t), &cpuset))
+                 ? PMIX_SUCCESS : PMIX_ERR_NOT_SUPPORTED;
+        }
+        if (PMIX_SUCCESS != rc && pmix_bind_progress_thread_reqd) {
             pmix_output(0, "Failed to bind progress thread %s", trk->name);
-            rc = PMIX_ERR_NOT_SUPPORTED;
             /* the engine thread is already running - stop it before we
              * report failure so the caller can safely tear down the
              * tracker without freeing a live event base */
@@ -321,7 +398,6 @@ static int start_progress_engine(pmix_progress_tracker_t *trk)
         } else {
             rc = PMIX_SUCCESS;
         }
-        PMIx_Argv_free(ranges);
     }
 #endif
     return rc;
@@ -372,6 +448,7 @@ pmix_event_base_t *pmix_progress_thread_init(const char *name)
     /* add an event to the new event base (if there are no events,
        pmix_event_loop() will return immediately) */
     pmix_event_assign(&trk->block, trk->ev_base, -1, PMIX_EV_PERSIST, dummy_timeout_cb, trk);
+    trk->block_assigned = true;
     pmix_event_add(&trk->block, &long_timeout);
 
     /* construct the thread object */
@@ -397,10 +474,14 @@ pmix_status_t pmix_progress_thread_start(const char *name)
     }
 
     if (NULL == name) {
+        name = shared_thread_name;
         if (pmix_globals.external_progress) {
+            /* the host drives our event base itself, so there is no
+             * engine to spin - but the library is now open for business,
+             * and the public APIs gate on this flag */
+            pmix_atomic_unset_bool(&pmix_globals.progress_thread_stopped);
             return PMIX_SUCCESS;
         }
-        name = shared_thread_name;
     }
 
     /* find the specified engine */
@@ -439,10 +520,14 @@ pmix_status_t pmix_progress_thread_stop(const char *name)
     }
 
     if (NULL == name) {
-        if (pmix_globals.external_progress) {
-            return PMIX_SUCCESS;
-        }
         name = shared_thread_name;
+        /* NOTE: deliberately no external_progress early-out here. In that
+         * mode there is no engine to join, but the refcount still has to
+         * be dropped and the base still has to be freed - otherwise the
+         * shared tracker outlives finalize, PMIx_Progress can still be
+         * pointed at a base whose components have all been closed, and
+         * the base is never returned to the system. The stop below is
+         * already gated on ev_active, which is false in that mode. */
     }
 
     /* find the specified engine */
@@ -466,6 +551,11 @@ pmix_status_t pmix_progress_thread_stop(const char *name)
              * not dereference freed memory */
             if (trk == shared_thread_tracker) {
                 shared_thread_tracker = NULL;
+                /* nothing may be posted to a base we are about to free.
+                 * stop_progress_engine sets this too, but only when there
+                 * was a running engine to stop - which is not the case
+                 * under external progress */
+                pmix_atomic_set_bool(&pmix_globals.progress_thread_stopped);
             }
             PMIX_RELEASE(trk);
             return PMIX_SUCCESS;
@@ -488,10 +578,14 @@ pmix_status_t pmix_progress_thread_pause(const char *name)
     }
 
     if (NULL == name) {
+        name = shared_thread_name;
         if (pmix_globals.external_progress) {
+            /* there is no engine to stop, but the shared loop is no
+             * longer to be fed - say so, or the APIs go on accepting
+             * work for a loop nobody is going to drive again */
+            pmix_atomic_set_bool(&pmix_globals.progress_thread_stopped);
             return PMIX_SUCCESS;
         }
-        name = shared_thread_name;
     }
 
     /* find the specified engine */
@@ -518,10 +612,13 @@ pmix_status_t pmix_progress_thread_resume(const char *name)
     }
 
     if (NULL == name) {
+        name = shared_thread_name;
         if (pmix_globals.external_progress) {
+            /* mirror of pause: no engine to re-spin, but the shared loop
+             * is being fed again */
+            pmix_atomic_unset_bool(&pmix_globals.progress_thread_stopped);
             return PMIX_SUCCESS;
         }
-        name = shared_thread_name;
     }
 
     /* find the specified engine */

--- a/src/runtime/pmix_progress_threads.h
+++ b/src/runtime/pmix_progress_threads.h
@@ -24,9 +24,9 @@
  * already associated with that name, start a progress thread.
  *
  * If you have general events that need to run in *a* progress thread
- * (but not necessarily a your own, dedicated progress thread), pass
- * NULL the "name" argument to the pmix_progress_thead_init() function
- * to glom on to the general PMIX-wide progress thread.
+ * (but not necessarily your own, dedicated progress thread), pass NULL
+ * as the "name" argument to pmix_progress_thread_init() to glom on to
+ * the general PMIX-wide progress thread.
  *
  * If a name is passed that was already used in a prior call to
  * pmix_progress_thread_init(), the event base associated with that

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1102,6 +1102,17 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stdout);
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stderr);
 
+    /* pmix_rte_init constructs these two sinks for every role, so every
+     * role has to tear them down - the client and tool finalize paths
+     * already do, and a server leaked both (each holds a write event
+     * carrying a sizable buffer) on every init/finalize cycle. It has to
+     * happen here rather than in pmix_rte_finalize: iof_sink_destruct
+     * reads pmix_globals.mypeer, which pmix_rte_finalize has released by
+     * the time it destructs anything, and for a server it also walks
+     * pmix_server_globals.iof_residuals, destructed just below. */
+    PMIX_DESTRUCT(&pmix_client_globals.iof_stdout);
+    PMIX_DESTRUCT(&pmix_client_globals.iof_stderr);
+
     pmix_ptl_base_stop_listening();
 
     for (i = 0; i < pmix_server_globals.clients.size; i++) {

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -71,7 +71,7 @@ These run anywhere and are the bulk of the suite: `compress`, `preg`,
 `bfrops_malformed`, `bfrops_get_number`, `bfrops_null_object`,
 `bfrops_helpers`, `info_support`, `iof_pattern`,
 `hwloc_datatype`, `tracker_match`, `trk_complete`, `collective_status`,
-`collect_job_info`, `progress_threads`, `pmix_log`.
+`collect_job_info`, `progress_threads`, `runtime_init`, `pmix_log`.
 
 **Singleton client tests** — call the real public API in a process that
 comes up with no server. `client_cycle` (init/finalize cycling),
@@ -283,6 +283,34 @@ under either, so it cannot fail on them. That half is
 [`examples/datatypes.c`](../../examples/datatypes.c), driven across
 separate nodes by
 [`contrib/dockerswarm/run-bfrops-tests.sh`](../../contrib/dockerswarm/AGENTS.md).
+
+### `runtime_init` — the `src/runtime` bring-up regression test
+
+[`runtime_init.c`](runtime_init.c) covers what `pmix_rte_init` makes of
+the directives a host passes it, and what `pmix_rte_finalize` gives back.
+It comes up as a server because that is the role that actually passes
+host directives through `pmix_rte_init`, and it runs **two full
+init/finalize cycles**, re-checking everything on the second: this layer's
+standing requirement is that a second `PMIx_Init` starts from a clean
+slate, and per-cycle state rebuilt wrongly — or not rebuilt at all — shows
+up nowhere else in the suite.
+
+Its cases come from the August 2026 review of that directory (see
+[`src/runtime/AGENTS.md`](../../src/runtime/AGENTS.md)): the alias list
+that was never built for a host-supplied `PMIX_HOSTNAME`, the verbosity
+channel and the IOF file/directory strings that were never released, and
+the scalar directive state (`external_progress`, `external_topology`,
+`nodeid`) that leaked from one cycle into the next.
+
+One case is a different kind of thing and is worth keeping in mind for
+any directory: `test_help_topics()` asks `pmix_show_help_string()` for
+**every `show_help` topic `src/runtime` names**, with the same arguments
+the real call site passes. That function returns `NULL` for a topic that
+is not in the file, so one line per topic keeps code and help text in
+step — two topics in `pmix_params.c` had never existed, and a user who
+mistyped the color parameter got "I couldn't find that help reference"
+instead of the diagnostic. The test also asks for a deliberately absent
+topic, so the assertion is known to have teeth.
 
 ### `common_api` — the `src/common` regression test
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace runtime_init
 
-TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace runtime_init
 
 client_api_SOURCES = \
         client_api.c
@@ -210,6 +210,12 @@ hwloc_datatype_SOURCES = \
 hwloc_datatype_CPPFLAGS = -DPMIX_TEST_TOPO_DIR=\"$(abs_top_srcdir)/test/topologies\"
 hwloc_datatype_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 hwloc_datatype_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+runtime_init_SOURCES = \
+        runtime_init.c
+runtime_init_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+runtime_init_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 progress_threads_SOURCES = \

--- a/test/unit/progress_threads.c
+++ b/test/unit/progress_threads.c
@@ -26,10 +26,15 @@
  *     which start/stop of that name report PMIX_ERR_NOT_FOUND;
  *   - operations on an unknown name report PMIX_ERR_NOT_FOUND.
  *
- * Not covered: CPU-affinity binding (start_progress_engine's
- * pthread_setaffinity_np path) is not observable through any public
- * interface - the bound thread handle is internal - so it cannot be
- * asserted from a unit test.
+ *   - the progress_thread_cpus list is validated before it is turned
+ *     into a CPU mask, so a typo is reported instead of silently
+ *     becoming "bind to cpu 0" (Linux/BSD only - the whole affinity
+ *     path is compiled out where pthread_setaffinity_np is absent).
+ *
+ * Not covered: which CPUs the thread actually ends up on. The bound
+ * thread handle is internal, so a successful binding is not observable
+ * through any interface a test can reach; only the accept/reject
+ * decision about the list is.
  */
 
 #include "src/include/pmix_config.h"
@@ -42,6 +47,7 @@
 #include "src/include/pmix_globals.h"
 #include "src/include/pmix_types.h"
 #include "src/runtime/pmix_progress_threads.h"
+#include "src/runtime/pmix_rte.h"
 #include "src/threads/pmix_threads.h"
 
 static int npass = 0;
@@ -204,6 +210,107 @@ static void test_unknown_name(void)
     report("unknown:pause", PMIX_ERR_NOT_FOUND == pmix_progress_thread_pause(nm));
     report("unknown:resume", PMIX_ERR_NOT_FOUND == pmix_progress_thread_resume(nm));
 }
+
+/* ------------------------------------------------------------------
+ * Validation of the progress_thread_cpus list
+ *
+ * The list is user input - an MCA parameter, or the
+ * PMIX_BIND_PROGRESS_THREAD attribute - and it used to be handed
+ * straight to strtoul + CPU_SET. strtoul reports 0 for a token with no
+ * digits in it, so "cpu0" or a stray space quietly became "bind to cpu
+ * 0"; a number past the end of the mask was dropped on the floor by
+ * glibc and written past the end of it by BSD; and an inverted or
+ * enormous range span turned into a very long loop.
+ *
+ * The accept/reject decision is observable: with binding declared
+ * *required*, a list from which nothing usable could be extracted makes
+ * the start fail rather than leaving the thread silently mis-bound.
+ *
+ * The whole affinity block is inside #ifdef HAVE_PTHREAD_SETAFFINITY_NP,
+ * so on platforms without it (macOS) there is nothing here to test and
+ * the list is ignored entirely.
+ * ------------------------------------------------------------------ */
+
+#ifdef HAVE_PTHREAD_SETAFFINITY_NP
+
+/* run one start with the given cpu list, binding required, and report
+ * whether it was accepted */
+static bool try_cpu_list(const char *nm, const char *list)
+{
+    char *saved_cpus = pmix_progress_thread_cpus;
+    bool saved_reqd = pmix_bind_progress_thread_reqd;
+    pmix_status_t rc;
+
+    pmix_progress_thread_cpus = (NULL == list) ? NULL : strdup(list);
+    pmix_bind_progress_thread_reqd = true;
+
+    if (NULL == pmix_progress_thread_init(nm)) {
+        rc = PMIX_ERROR;
+    } else {
+        rc = pmix_progress_thread_start(nm);
+        /* a failed start has already dropped the tracker; a successful
+         * one is ours to tear down */
+        if (PMIX_SUCCESS == rc) {
+            (void) pmix_progress_thread_stop(nm);
+        }
+    }
+
+    if (NULL != pmix_progress_thread_cpus) {
+        free(pmix_progress_thread_cpus);
+    }
+    pmix_progress_thread_cpus = saved_cpus;
+    pmix_bind_progress_thread_reqd = saved_reqd;
+
+    return (PMIX_SUCCESS == rc);
+}
+
+static void test_cpu_list_validation(void)
+{
+    /* cpu 0 exists everywhere this test can run */
+    report("cpulist:a single valid cpu is accepted",
+           try_cpu_list("UT-cpu-ok", "0"));
+
+    /* a token with no digits must not be read as cpu 0 */
+    report("cpulist:a non-numeric entry is rejected",
+           !try_cpu_list("UT-cpu-alpha", "cpu0"));
+
+    /* trailing garbage after a good number is still garbage */
+    report("cpulist:trailing garbage is rejected",
+           !try_cpu_list("UT-cpu-trail", "0x"));
+
+    /* beyond the end of the mask */
+    report("cpulist:an out-of-range cpu is rejected",
+           !try_cpu_list("UT-cpu-huge", "99999999"));
+
+    /* a range that runs backwards names no cpus */
+    report("cpulist:an inverted range is rejected",
+           !try_cpu_list("UT-cpu-inverted", "8-2"));
+
+    /* a negative cpu is not a cpu */
+    report("cpulist:a negative cpu is rejected",
+           !try_cpu_list("UT-cpu-negative", "-1"));
+
+    /* an empty entry between two commas */
+    report("cpulist:an empty entry alone is rejected",
+           !try_cpu_list("UT-cpu-empty", ","));
+
+    /* one bad entry does not discard the good ones: cpu 0 still binds */
+    report("cpulist:a good entry survives a bad neighbor",
+           try_cpu_list("UT-cpu-mixed", "nope,0"));
+
+    /* an unset list means "do not bind", not "bind to nothing" */
+    report("cpulist:no list at all is fine",
+           try_cpu_list("UT-cpu-none", NULL));
+}
+
+#else
+
+static void test_cpu_list_validation(void)
+{
+    fprintf(stdout, "  SKIP: cpulist (no pthread_setaffinity_np on this platform)\n");
+}
+
+#endif /* HAVE_PTHREAD_SETAFFINITY_NP */
 
 /* ------------------------------------------------------------------
  * Blocking calls made FROM the progress thread
@@ -381,6 +488,7 @@ int main(int argc, char **argv)
     test_start_progresses();
     test_pause_resume();
     test_unknown_name();
+    test_cpu_list_validation();
     test_blocking_call_from_progress_thread();
     /* must come last - it stops the shared progress thread */
     test_void_deregisters_report_a_dropped_request();

--- a/test/unit/runtime_init.c
+++ b/test/unit/runtime_init.c
@@ -34,6 +34,9 @@
  *   output        a verbosity channel opened by pmix_rte_init is given
  *                 back by pmix_rte_finalize, id and all.
  *
+ *   iof flags     the IOF output-file/directory strings the directive
+ *                 scan hands to pmix_globals are released with it.
+ *
  * Everything except the help topics is then re-checked over a second
  * init/finalize cycle: this layer's standing requirement is that a
  * second PMIx_Init starts from a clean slate, and per-cycle state that
@@ -66,6 +69,10 @@
  * entry naming a key that does not exist, one entry with no '=' at all,
  * and one more good entry after the damage */
 #define UT_COLORS "name=34,bogus_key=1,value,valid_values=36"
+
+/* an IOF output-file directive: never actually written to (no client
+ * ever produces output here), it just has to be captured and released */
+#define UT_IOF_FILE "ut-runtime-init-output"
 
 static int npass = 0;
 static int nfail = 0;
@@ -307,24 +314,54 @@ static void test_output_channels_released(const char *when)
     report(label, -1 == pmix_globals.debug_output);
 }
 
+/* ------------------------------------------------------------------ */
+/* IOF flag strings                                                    */
+/* ------------------------------------------------------------------ */
+
+/* Anything in the incoming info array that is not one of the handful of
+ * bootstrap directives goes to pmix_iof_check_flags, which strdups
+ * PMIX_IOF_OUTPUT_TO_FILE / _TO_DIRECTORY into the flag block that
+ * pmix_rte_init then copies into pmix_globals. That copy is a bare
+ * struct member with no destructor behind it, so pmix_rte_finalize owns
+ * the strings - and a host that asks for file output is not exotic. */
+static void test_iof_flags_captured(void)
+{
+    report("iof:file directive captured",
+           NULL != pmix_globals.iof_flags.file &&
+           0 == strcmp(pmix_globals.iof_flags.file, UT_IOF_FILE));
+}
+
+static void test_iof_flags_released(const char *when)
+{
+    char label[128];
+
+    snprintf(label, sizeof(label), "iof:file string released (%s)", when);
+    report(label, NULL == pmix_globals.iof_flags.file);
+
+    snprintf(label, sizeof(label), "iof:directory string released (%s)", when);
+    report(label, NULL == pmix_globals.iof_flags.directory);
+}
+
 int main(int argc, char **argv)
 {
     static pmix_server_module_t mymodule = {0};
-    pmix_info_t info[1];
+    pmix_info_t info[2];
     pmix_status_t rc;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* all of this has to be in place before the library comes up: the
-     * parameters are read by pmix_register_params, and the hostname
-     * directive is consumed by pmix_rte_init's directive scan */
+     * parameters are read by pmix_register_params, and the directives
+     * are consumed by pmix_rte_init's directive scan */
     setenv("PMIX_MCA_pmix_var_dump_color", UT_COLORS, 1);
     setenv("PMIX_MCA_pmix_client_get_verbose", "1", 1);
     PMIX_INFO_LOAD(&info[0], PMIX_HOSTNAME, UT_FQDN, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_IOF_OUTPUT_TO_FILE, UT_IOF_FILE, PMIX_STRING);
 
-    rc = PMIx_server_init(&mymodule, info, 1);
+    rc = PMIx_server_init(&mymodule, info, 2);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
         PMIX_INFO_DESTRUCT(&info[0]);
+        PMIX_INFO_DESTRUCT(&info[1]);
         return 1;
     }
 
@@ -335,16 +372,19 @@ int main(int argc, char **argv)
     test_set_aliases();
     test_var_dump_color();
     test_output_channel_open();
+    test_iof_flags_captured();
 
     PMIx_server_finalize();
     test_output_channels_released("first cycle");
+    test_iof_flags_released("first cycle");
 
     /* and the whole thing again, because everything above is state that
      * has to be rebuilt from scratch. A second cycle that comes up with
      * the same answers is the evidence that finalize left nothing
      * behind - and nothing missing either */
-    rc = PMIx_server_init(&mymodule, info, 1);
+    rc = PMIx_server_init(&mymodule, info, 2);
     PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "second PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
         return 1;
@@ -354,9 +394,11 @@ int main(int argc, char **argv)
     test_supplied_hostname();
     test_var_dump_color();
     test_output_channel_open();
+    test_iof_flags_captured();
 
     PMIx_server_finalize();
     test_output_channels_released("second cycle");
+    test_iof_flags_released("second cycle");
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 

--- a/test/unit/runtime_init.c
+++ b/test/unit/runtime_init.c
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the bring-up decisions made in src/runtime -
+ * specifically the parts of pmix_rte_init/pmix_params that turn what the
+ * host hands the library into process-wide state.
+ *
+ * What is covered:
+ *
+ *   help topics   Every show_help topic src/runtime references must
+ *                 actually exist in help-pmix-runtime.txt. A missing one
+ *                 is invisible until the rare path that emits it fires,
+ *                 and then the user gets "I couldn't find that help
+ *                 reference" instead of the diagnostic. Asking for the
+ *                 topic is the cheap way to keep the two in step.
+ *
+ *   hostname      pmix_set_aliases applies the FQDN policy and records
+ *                 the form it did not keep as an alias, so that
+ *                 pmix_check_local matches our node under either name.
+ *                 This must happen no matter where the name came from:
+ *                 a host that supplies PMIX_HOSTNAME (every RM does)
+ *                 gets the same treatment as a name read from the OS.
+ *
+ *   var_dump_color  the pmix_var_dump_color MCA parameter is turned into
+ *                 ready-to-emit ANSI escapes, and a malformed or
+ *                 unrecognized entry is reported and skipped rather than
+ *                 taking the good entries down with it.
+ *
+ * The process comes up as a PMIx server because that is the role that
+ * passes host-supplied directives - notably PMIX_HOSTNAME - through
+ * pmix_rte_init.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+#include "src/runtime/pmix_rte.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_show_help.h"
+
+/* the hostname we hand the library at init, and the two forms of it that
+ * must both resolve to "this node" afterwards */
+#define UT_FQDN  "utnode.unit-test.example.org"
+#define UT_SHORT "utnode"
+
+/* what we set the color parameter to before init: one good entry, one
+ * entry naming a key that does not exist, one entry with no '=' at all,
+ * and one more good entry after the damage */
+#define UT_COLORS "name=34,bogus_key=1,value,valid_values=36"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* show_help topics referenced from src/runtime                        */
+/* ------------------------------------------------------------------ */
+
+/* pmix_show_help_string returns NULL - and prints a "couldn't find that
+ * help reference" complaint - when the topic is not in the file, so a
+ * non-NULL return is exactly the assertion we want. It takes the same
+ * arguments the real call site does, so a topic whose format string
+ * stops matching its caller shows up here too. */
+static void check_topic(const char *topic, char *rendered)
+{
+    char label[256];
+
+    snprintf(label, sizeof(label), "help:%s", topic);
+    report(label, NULL != rendered);
+    if (NULL != rendered) {
+        free(rendered);
+    }
+}
+
+static void test_help_topics(void)
+{
+    char *s;
+
+    check_topic("pmix_init:startup:internal-failure",
+                pmix_show_help_string("help-pmix-runtime.txt",
+                                      "pmix_init:startup:internal-failure", false,
+                                      "some stage", PMIX_ERR_BAD_PARAM));
+
+    check_topic("blocking-call-from-progress-thread",
+                pmix_show_help_string("help-pmix-runtime.txt",
+                                      "blocking-call-from-progress-thread", false,
+                                      "PMIx_Get"));
+
+    check_topic("var_dump_color:format-error",
+                pmix_show_help_string("help-pmix-runtime.txt",
+                                      "var_dump_color:format-error", false,
+                                      "value"));
+
+    check_topic("var_dump_color:unknown-key",
+                pmix_show_help_string("help-pmix-runtime.txt",
+                                      "var_dump_color:unknown-key", false,
+                                      "bogus_key", "bogus_key=1",
+                                      "name,value,valid_values"));
+
+    check_topic("progress-thread:bad-cpu-list",
+                pmix_show_help_string("help-pmix-runtime.txt",
+                                      "progress-thread:bad-cpu-list", false,
+                                      "3-x", "0,3-x", 1023));
+
+    /* and prove the check above has teeth: a topic that really is
+     * missing must come back NULL */
+    s = pmix_show_help_string("help-pmix-runtime.txt",
+                              "ut-no-such-topic-should-not-exist", false);
+    report("help:missing topic reports missing", NULL == s);
+    if (NULL != s) {
+        free(s);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* hostname / alias resolution                                         */
+/* ------------------------------------------------------------------ */
+
+static bool has_alias(char **aliases, const char *want)
+{
+    int n;
+
+    if (NULL == aliases) {
+        return false;
+    }
+    for (n = 0; NULL != aliases[n]; n++) {
+        if (0 == strcmp(aliases[n], want)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* The library was initialized with PMIX_HOSTNAME set to an FQDN and the
+ * default FQDN policy (do not keep it). Both forms of the name must now
+ * resolve to this node - which they only do if the aliases were built,
+ * and they were not built for a host-supplied name before. */
+static void test_supplied_hostname(void)
+{
+    report("hostname:short name kept",
+           NULL != pmix_globals.hostname &&
+           0 == strcmp(pmix_globals.hostname, UT_SHORT));
+
+    report("hostname:fqdn retained as an alias",
+           has_alias(pmix_globals.aliases, UT_FQDN));
+
+    report("hostname:check_local matches the short name",
+           pmix_check_local(UT_SHORT));
+
+    report("hostname:check_local matches the fqdn",
+           pmix_check_local(UT_FQDN));
+
+    report("hostname:check_local rejects another node",
+           !pmix_check_local("some-other-node.unit-test.example.org"));
+
+    report("hostname:check_local tolerates NULL", !pmix_check_local(NULL));
+}
+
+/* pmix_set_aliases itself, driven directly over the cases that decide
+ * which form of a name is kept and which becomes the alias. It rewrites
+ * the name in place, so each case gets its own buffer. */
+static void test_set_aliases(void)
+{
+    bool saved = pmix_keep_fqdn_hostnames;
+    char **aliases;
+    char *name;
+
+    /* policy "drop the FQDN": the name is truncated to the short form
+     * and the FQDN is kept as the alias */
+    pmix_keep_fqdn_hostnames = false;
+    aliases = NULL;
+    name = strdup("node01.example.com");
+    pmix_set_aliases(&aliases, name);
+    report("aliases:drop-fqdn shortens the name", 0 == strcmp(name, "node01"));
+    report("aliases:drop-fqdn keeps the fqdn as alias",
+           has_alias(aliases, "node01.example.com"));
+    PMIx_Argv_free(aliases);
+    free(name);
+
+    /* policy "keep the FQDN": the name is left alone and the short form
+     * becomes the alias */
+    pmix_keep_fqdn_hostnames = true;
+    aliases = NULL;
+    name = strdup("node01.example.com");
+    pmix_set_aliases(&aliases, name);
+    report("aliases:keep-fqdn leaves the name alone",
+           0 == strcmp(name, "node01.example.com"));
+    report("aliases:keep-fqdn keeps the short name as alias",
+           has_alias(aliases, "node01"));
+    PMIx_Argv_free(aliases);
+    free(name);
+
+    /* a name with no domain part has no second form - nothing to record */
+    pmix_keep_fqdn_hostnames = false;
+    aliases = NULL;
+    name = strdup("node01");
+    pmix_set_aliases(&aliases, name);
+    report("aliases:no-domain leaves the name alone", 0 == strcmp(name, "node01"));
+    report("aliases:no-domain adds no alias", NULL == aliases);
+    free(name);
+
+    /* an IP literal is full of dots but is not an FQDN - truncating it
+     * would produce a different address, so it must be left intact */
+    aliases = NULL;
+    name = strdup("10.11.12.13");
+    pmix_set_aliases(&aliases, name);
+    report("aliases:ipv4 literal is left intact", 0 == strcmp(name, "10.11.12.13"));
+    report("aliases:ipv4 literal adds no alias", NULL == aliases);
+    free(name);
+
+    pmix_keep_fqdn_hostnames = saved;
+}
+
+/* ------------------------------------------------------------------ */
+/* var_dump_color parsing                                              */
+/* ------------------------------------------------------------------ */
+
+/* UT_COLORS was placed in the environment before init, so the values
+ * below are what pmix_register_params made of it. Every slot must hold a
+ * free-able string: the ones named by a good entry hold the assembled
+ * escape, and the rest hold "" so pmix_info can emit them unconditionally. */
+static void test_var_dump_color(void)
+{
+    int k;
+    bool all_set = true;
+
+    for (k = 0; k < PMIX_VAR_DUMP_COLOR_KEY_COUNT; k++) {
+        if (NULL == pmix_var_dump_color[k]) {
+            all_set = false;
+        }
+    }
+    report("color:every key has a string", all_set);
+
+    report("color:good entry becomes an escape",
+           NULL != pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VAR_NAME] &&
+           0 == strcmp(pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VAR_NAME], "\033[34m"));
+
+    /* "value" had no '=' - it is reported and skipped, and the key it
+     * names is left uncolored rather than taking a garbage code */
+    report("color:malformed entry leaves its key uncolored",
+           NULL != pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VAR_VALUE] &&
+           0 == strlen(pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VAR_VALUE]));
+
+    /* a good entry after the two bad ones still lands - one bad entry
+     * must not abandon the rest of the list */
+    report("color:entry after a bad one still applies",
+           NULL != pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES] &&
+           0 == strcmp(pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES], "\033[36m"));
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_info_t info[1];
+    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* both of these have to be in place before the library comes up:
+     * the parameter is read by pmix_register_params, and the hostname
+     * directive is consumed by pmix_rte_init's directive scan */
+    setenv("PMIX_MCA_pmix_var_dump_color", UT_COLORS, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_HOSTNAME, UT_FQDN, PMIX_STRING);
+
+    rc = PMIx_server_init(&mymodule, info, 1);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== runtime bring-up unit tests ===\n\n");
+
+    test_help_topics();
+    test_supplied_hostname();
+    test_set_aliases();
+    test_var_dump_color();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/runtime_init.c
+++ b/test/unit/runtime_init.c
@@ -74,6 +74,9 @@
  * ever produces output here), it just has to be captured and released */
 #define UT_IOF_FILE "ut-runtime-init-output"
 
+/* a nodeid the library would never invent for itself */
+#define UT_NODEID 4242
+
 static int npass = 0;
 static int nfail = 0;
 
@@ -342,11 +345,50 @@ static void test_iof_flags_released(const char *when)
     report(label, NULL == pmix_globals.iof_flags.directory);
 }
 
+/* ------------------------------------------------------------------ */
+/* scalar bootstrap state across the finalize gap                      */
+/* ------------------------------------------------------------------ */
+
+/* None of these is re-initialized on the way in - pmix_rte_init only
+ * writes them when the matching directive is present - so anything
+ * finalize leaves behind silently becomes the next cycle's default.
+ * The first cycle here supplies PMIX_NODEID, so a stale value is
+ * distinguishable from the "not told" sentinel. */
+static void test_scalars_reset(const char *when)
+{
+    char label[128];
+
+    snprintf(label, sizeof(label), "scalars:nodeid back to sentinel (%s)", when);
+    report(label, UINT32_MAX == pmix_globals.nodeid);
+
+    snprintf(label, sizeof(label), "scalars:sessionid back to sentinel (%s)", when);
+    report(label, UINT32_MAX == pmix_globals.sessionid);
+
+    /* left set, the next pmix_progress_thread_start declines to spin the
+     * engine because it believes the host is driving the loop */
+    snprintf(label, sizeof(label), "scalars:external_progress cleared (%s)", when);
+    report(label, !pmix_globals.external_progress);
+
+    /* left set, pmix_hwloc_finalize declines to destroy the next
+     * cycle's self-discovered topology too */
+    snprintf(label, sizeof(label), "scalars:external_topology cleared (%s)", when);
+    report(label, !pmix_globals.external_topology);
+
+    snprintf(label, sizeof(label), "scalars:iof formatting cleared (%s)", when);
+    report(label, !pmix_globals.iof_flags.set && !pmix_globals.iof_flags.local_output);
+}
+
+static void test_nodeid_captured(void)
+{
+    report("scalars:nodeid directive captured", UT_NODEID == pmix_globals.nodeid);
+}
+
 int main(int argc, char **argv)
 {
     static pmix_server_module_t mymodule = {0};
-    pmix_info_t info[2];
+    pmix_info_t info[3];
     pmix_status_t rc;
+    uint32_t n;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     /* all of this has to be in place before the library comes up: the
@@ -356,12 +398,15 @@ int main(int argc, char **argv)
     setenv("PMIX_MCA_pmix_client_get_verbose", "1", 1);
     PMIX_INFO_LOAD(&info[0], PMIX_HOSTNAME, UT_FQDN, PMIX_STRING);
     PMIX_INFO_LOAD(&info[1], PMIX_IOF_OUTPUT_TO_FILE, UT_IOF_FILE, PMIX_STRING);
+    n = UT_NODEID;
+    PMIX_INFO_LOAD(&info[2], PMIX_NODEID, &n, PMIX_UINT32);
 
-    rc = PMIx_server_init(&mymodule, info, 2);
+    rc = PMIx_server_init(&mymodule, info, 3);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
         PMIX_INFO_DESTRUCT(&info[0]);
         PMIX_INFO_DESTRUCT(&info[1]);
+        PMIX_INFO_DESTRUCT(&info[2]);
         return 1;
     }
 
@@ -373,18 +418,21 @@ int main(int argc, char **argv)
     test_var_dump_color();
     test_output_channel_open();
     test_iof_flags_captured();
+    test_nodeid_captured();
 
     PMIx_server_finalize();
     test_output_channels_released("first cycle");
     test_iof_flags_released("first cycle");
+    test_scalars_reset("first cycle");
 
     /* and the whole thing again, because everything above is state that
      * has to be rebuilt from scratch. A second cycle that comes up with
      * the same answers is the evidence that finalize left nothing
      * behind - and nothing missing either */
-    rc = PMIx_server_init(&mymodule, info, 2);
+    rc = PMIx_server_init(&mymodule, info, 3);
     PMIX_INFO_DESTRUCT(&info[0]);
     PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_INFO_DESTRUCT(&info[2]);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "second PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
         return 1;
@@ -395,10 +443,12 @@ int main(int argc, char **argv)
     test_var_dump_color();
     test_output_channel_open();
     test_iof_flags_captured();
+    test_nodeid_captured();
 
     PMIx_server_finalize();
     test_output_channels_released("second cycle");
     test_iof_flags_released("second cycle");
+    test_scalars_reset("second cycle");
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 

--- a/test/unit/runtime_init.c
+++ b/test/unit/runtime_init.c
@@ -31,6 +31,14 @@
  *                 unrecognized entry is reported and skipped rather than
  *                 taking the good entries down with it.
  *
+ *   output        a verbosity channel opened by pmix_rte_init is given
+ *                 back by pmix_rte_finalize, id and all.
+ *
+ * Everything except the help topics is then re-checked over a second
+ * init/finalize cycle: this layer's standing requirement is that a
+ * second PMIx_Init starts from a clean slate, and per-cycle state that
+ * is rebuilt wrongly - or not rebuilt at all - shows up nowhere else.
+ *
  * The process comes up as a PMIx server because that is the role that
  * passes host-supplied directives - notably PMIX_HOSTNAME - through
  * pmix_rte_init.
@@ -43,6 +51,7 @@
 #include <string.h>
 
 #include "include/pmix_server.h"
+#include "src/client/pmix_client_ops.h"
 #include "src/include/pmix_globals.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/util/pmix_argv.h"
@@ -268,6 +277,36 @@ static void test_var_dump_color(void)
            0 == strcmp(pmix_var_dump_color[PMIX_VAR_DUMP_COLOR_VALID_VALUES], "\033[36m"));
 }
 
+/* ------------------------------------------------------------------ */
+/* verbosity output channels                                           */
+/* ------------------------------------------------------------------ */
+
+/* pmix_rte_init opens an output channel for every client verbosity var
+ * that is set, and pmix_rte_finalize has to give it back. An output
+ * descriptor owns a strdup'ed prefix that only pmix_output_close frees,
+ * and the id is cached in a file-scope struct that outlives the library
+ * - so an unclosed channel both leaks its prefix on every cycle and
+ * leaves behind an id naming a slot the next cycle may reissue.
+ *
+ * pmix_client_get_verbose was set in the environment before init, so
+ * this channel is genuinely open. */
+static void test_output_channel_open(void)
+{
+    report("output:a set verbosity opens a channel",
+           0 <= pmix_client_globals.get_output);
+}
+
+static void test_output_channels_released(const char *when)
+{
+    char label[128];
+
+    snprintf(label, sizeof(label), "output:channel released (%s)", when);
+    report(label, -1 == pmix_client_globals.get_output);
+
+    snprintf(label, sizeof(label), "output:debug channel released (%s)", when);
+    report(label, -1 == pmix_globals.debug_output);
+}
+
 int main(int argc, char **argv)
 {
     static pmix_server_module_t mymodule = {0};
@@ -275,16 +314,17 @@ int main(int argc, char **argv)
     pmix_status_t rc;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
-    /* both of these have to be in place before the library comes up:
-     * the parameter is read by pmix_register_params, and the hostname
+    /* all of this has to be in place before the library comes up: the
+     * parameters are read by pmix_register_params, and the hostname
      * directive is consumed by pmix_rte_init's directive scan */
     setenv("PMIX_MCA_pmix_var_dump_color", UT_COLORS, 1);
+    setenv("PMIX_MCA_pmix_client_get_verbose", "1", 1);
     PMIX_INFO_LOAD(&info[0], PMIX_HOSTNAME, UT_FQDN, PMIX_STRING);
 
     rc = PMIx_server_init(&mymodule, info, 1);
-    PMIX_INFO_DESTRUCT(&info[0]);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        PMIX_INFO_DESTRUCT(&info[0]);
         return 1;
     }
 
@@ -294,10 +334,31 @@ int main(int argc, char **argv)
     test_supplied_hostname();
     test_set_aliases();
     test_var_dump_color();
-
-    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    test_output_channel_open();
 
     PMIx_server_finalize();
+    test_output_channels_released("first cycle");
+
+    /* and the whole thing again, because everything above is state that
+     * has to be rebuilt from scratch. A second cycle that comes up with
+     * the same answers is the evidence that finalize left nothing
+     * behind - and nothing missing either */
+    rc = PMIx_server_init(&mymodule, info, 1);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "second PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n--- second init/finalize cycle ---\n\n");
+    test_supplied_hostname();
+    test_var_dump_color();
+    test_output_channel_open();
+
+    PMIx_server_finalize();
+    test_output_channels_released("second cycle");
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 
     return (nfail > 0) ? 1 : 0;
 }


### PR DESCRIPTION
A deep review of `src/runtime` — the layer every PMIx process passes
through once on the way in and once on the way out — plus the fixes it
turned up. Nine commits, each independent and reviewable on its own.

### Correctness

- **Alias forms of our own node name were never recorded when the host
  supplied it.** `pmix_set_aliases` ran only when the library had to
  discover the hostname itself, so a host passing `PMIX_HOSTNAME` — which
  every resource manager does — left the alias list empty and
  `pmix_check_local()` could not match this node under its other name
  form. Every *remote* node's name already goes through the same
  normalization in `gds/hash`; ours was the only one that did not.
- **The progress-thread CPU list went to `strtoul`/`CPU_SET`
  unvalidated.** `strtoul` reports 0 for a token with no digits, so a typo
  such as `cpu0` silently became "bind to CPU 0"; a value past
  `CPU_SETSIZE` is dropped by glibc and musl but written past the end of
  the mask on BSD.
- **Three `show_help` topics were referenced but had never been written** —
  a mistyped `pmix_var_dump_color` produced "I couldn't find that help
  reference" instead of the diagnostic.
- **`external_progress` suppressed bookkeeping, not just the engine.**
  `stop` also has to drop the refcount and free the base, and
  `start`/`pause`/`resume` still have to move `progress_thread_stopped`.
  The shared tracker outlived `pmix_rte_finalize` with the flag still
  reading "running", so the ~100 API guards that consult it believed a
  torn-down library was open for work.
- **`tracker_destructor` handed libevent an unassigned event** on the two
  allocation-failure paths — `PMIX_NEW` does not zero what it allocates.
- **Two `pmix_info` callers dereferenced the result of
  `pmix_mca_base_var_group_get` unchecked.** It leaves the pointer
  untouched for a negative index and NULLs it for an invalidated group.

### Leaks

Measured with a 12-cycle `PMIx_server_init`/`PMIx_server_finalize` probe
under valgrind: **18,480 bytes in 44 blocks → 0**.

- Verbosity output channels opened by `pmix_rte_init` were never closed —
  in fact nothing in the library called `pmix_output_close` except the MCA
  framework layer, which does exactly this for its own channel.
- The two static IOF sinks were destructed by the client and tool finalize
  paths but not by the server.
- The IOF file/directory strings copied into `pmix_globals.iof_flags` were
  never freed.
- The env-var harvest patterns split by `component_register()` were never
  freed in **eight** components (`pnet/{opa,tcp,nvd}`,
  `pgpu/{intel,nvd,amd,test}`, `pmdl/ompi`). Seven had an empty
  `component_close`; `pmdl/ompi` had none at all. `pdl/pdlopen` was the
  model. *(Separate commit — it is a different subsystem, found from here.)*
- Scalar directive state (`external_progress`, `external_topology`,
  `nodeid`, `sessionid`, the IOF formatting flags) was never reset, so
  what one `PMIx_Init` was told became the next one's default.
  `external_progress` left set means the next init never spins the
  progress thread and the first blocking call hangs.

### Two traps now written into `src/runtime/AGENTS.md`

Both look like bugs and are not; each cost a debugging cycle here.

1. `pmix_globals.mypeer` carries **two** references — `pmix_rte_init`
   creates it and the role retains it for `pmix_client_globals.myserver`.
   The `PMIX_RELEASE` in `pmix_rte_finalize` does not free it, and the
   pointer **must not be NULLed** there: every role guards its own release
   with `if (NULL != pmix_globals.mypeer)`, so clearing it cancels the
   release that does the freeing.
2. The IOF sinks cannot be destructed in `pmix_rte_finalize`:
   `iof_sink_destruct` reads `mypeer` (already released) and, in a server,
   walks `pmix_server_globals.iof_residuals` (already destructed).
   Per-role teardown is forced, not sloppy.

### Tests

- **`test/unit/runtime_init`** (new, 58 checks) — hostname/alias
  resolution, `var_dump_color` parsing, output-channel and IOF-string
  release, scalar reset, and a check that **every `show_help` topic
  `src/runtime` names actually exists**. Everything is re-verified over a
  second init/finalize cycle.
- **`test/unit/progress_threads`** — nine CPU-list validation cases.
- **`contrib/dockerswarm/run-runtime-tests.sh`** (new, README §18) — the
  suite on Linux in both `--enable-debug` and `--disable-debug`, the CPU
  list driven through a real `PMIx_Init`, and peer resolution across four
  nodes. The affinity path is inside `#ifdef HAVE_PTHREAD_SETAFFINITY_NP`,
  so on macOS it is not merely untested but *not compiled*.

### Verification

- `make check`: 117 tests, 0 failures (macOS/clang and Linux/gcc).
- `--enable-test-build` on Linux: all eight touched components compiled,
  warning-free. Six of them do not build on macOS at all, so a green build
  there says nothing about them.
- Dockerswarm suite: 10 passed, 0 failed, verified twice.
- Docs rebuild clean; news entries added under `docs/news/news-v7.x.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
