### PR TITLE
Decide per rank and per key what the maps have to fill in

### DIFF
--- a/docs/how-things-work/sets_groups/group_implementation.rst
+++ b/docs/how-things-work/sets_groups/group_implementation.rst
@@ -92,7 +92,7 @@ non-blocking form:
 
 #. **Packs the message** (``construct_msg()``): the command, group ID,
    participant array, and info array, folding in the caller's own endpoint
-   data (fetched at ``PMIX_REMOTE`` scope and packed as ``PMIX_PROC_DATA``)
+   data (fetched at ``PMIX_REMOTE`` scope and packed as ``PMIX_PROC_INFO_ARRAY``)
    and prepending the caller's proc ID to any ``PMIX_GROUP_INFO`` array.
 
 #. **Dispatches** with ``PMIX_PTL_SEND_RECV(..., construct_cbfunc, cb)`` and
@@ -245,7 +245,7 @@ For the collective (fully-specified) method:
 * When the predicate holds and the block has not already been forwarded,
   ``aggregate_info()`` merges every tracker's procs/info into the block
   (deduplicating and special-casing ``PMIX_GROUP_ADD_MEMBERS``,
-  ``PMIX_GROUP_BOOTSTRAP``, ``PMIX_PROC_DATA``, and ``PMIX_GROUP_INFO``), the
+  ``PMIX_GROUP_BOOTSTRAP``, ``PMIX_PROC_INFO_ARRAY``, and ``PMIX_GROUP_INFO``), the
   fault decision below is applied, the local-phase timer is deleted,
   ``host_called`` is set, and the operation is forwarded to
   ``pmix_host_server.group()``.

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -71,3 +71,19 @@ Detailed changes since v6.1.0:
    Also, directive state such as the node ID and the external-progress
    and external-topology flags is now reset, so what one PMIx_Init was
    told no longer becomes the default for the next one
+ - The datastore now fills in the per-proc location keys - hostname,
+   nodeid, local rank and node rank - for every rank a host did not
+   describe itself, and for every one of those keys a host left out. It
+   works these out from the node and proc maps, and it rightly declines
+   to overwrite anything the host stated in a PMIX_PROC_INFO_ARRAY,
+   since what it computes is only an assumption. But that decision was
+   being made once for the whole job: a single proc-info array anywhere
+   in the registration suppressed the derivation of nodeid, local rank
+   and node rank for every rank in it. So a host that described one
+   process lost those three keys for all the others, and a host that
+   described every process but named only some of the keys lost the
+   rest for all of them - PMIx_Get answering PMIX_ERR_NOT_FOUND with
+   nothing to fall back on. The choice is now made per rank and per
+   key. Hostname, which was being derived outside the same test, now
+   follows the rule in both directions: it is supplied when the host
+   gave none, and left alone when the host gave one

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -282,7 +282,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
                 return rc;
             }
             // insert into a pmix_info_t for packing
-            PMIX_INFO_LOAD(&xfer, PMIX_PROC_DATA, &darray, PMIX_DATA_ARRAY);
+            PMIX_INFO_LOAD(&xfer, PMIX_PROC_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
             PMIX_DATA_ARRAY_DESTRUCT(&darray);
             // append it if this peer can carry it
             rc = append_optional(msg, &xfer);

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -240,7 +240,7 @@ static pmix_status_t get_endpts(pmix_info_t *xfer,
                 return rc;
             }
             // insert into a pmix_info_t for packing
-            PMIX_INFO_LOAD(xfer, PMIX_PROC_DATA, &darray, PMIX_DATA_ARRAY);
+            PMIX_INFO_LOAD(xfer, PMIX_PROC_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
             PMIX_DATA_ARRAY_DESTRUCT(&darray);
             *endpts = true;
         }

--- a/src/common/pmix_pfexec.c
+++ b/src/common/pmix_pfexec.c
@@ -977,7 +977,7 @@ static pmix_status_t register_nspace(char *nspace, pmix_setup_caddy_t *fcd)
             /* release the list */
             PMIX_INFO_LIST_RELEASE(pinfo);
             /* add it to the job info array */
-            PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_PROC_DATA, &darray, PMIX_DATA_ARRAY);
+            PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_PROC_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
             /* release the memory - the array was copied */
             PMIX_DATA_ARRAY_DESTRUCT(&darray);
         }

--- a/src/mca/gds/AGENTS.md
+++ b/src/mca/gds/AGENTS.md
@@ -417,8 +417,11 @@ golden rule does not usually bite here.
   `PMIX_GDS_MODULE` directives), the base modex envelope walker and its
   callback contract, node/proc map decoding in all accepted forms at both
   the top level and nested in a `PMIX_JOB_INFO_ARRAY`, malformed
-  job-level input, and store/fetch scope routing including
-  `PMIX_ERR_EXISTS_OUTSIDE_SCOPE`.
+  job-level input, store/fetch scope routing including
+  `PMIX_ERR_EXISTS_OUTSIDE_SCOPE`, and the rule that a per-proc value
+  the datastore derives from the maps is only a default: the host's own
+  `PMIX_PROC_INFO_ARRAY` wins, but per rank and per key, so a host that
+  described some procs or some keys still gets the rest filled in.
 - **`test/unit/gds_fallback`** — `pmix_gds_base_get_fallback_module()` and
   `PMIX_GDS_PEER_MODULE()`.
 - **`test/unit/proc_array_id`** — `pmix_gds_base_proc_array_id()`.

--- a/src/mca/gds/hash/AGENTS.md
+++ b/src/mca/gds/hash/AGENTS.md
@@ -87,7 +87,7 @@ job-defining keys have already been seen while caching, so duplicates
   session/app/node/job info arrays go through the `process_*_array`
   helpers; `PMIX_NODE_MAP` / `PMIX_PROC_MAP` are decoded via `pmix_preg`
   (handling `PMIX_REGEX`, `PMIX_REGEX2`, and plain `PMIX_STRING` forms) and
-  turned into per-rank hostname data by `store_map`; `PMIX_PROC_DATA`
+  turned into per-rank hostname data by `store_map`; `PMIX_PROC_INFO_ARRAY`
   arrays are expanded to per-rank keys; model/personality keys are handed to
   `pmix_pmdl`. Everything lands on `trk->internal` under
   `PMIX_RANK_WILDCARD` or the specific rank.

--- a/src/mca/gds/hash/AGENTS.md
+++ b/src/mca/gds/hash/AGENTS.md
@@ -76,9 +76,14 @@ The three hash tables encode PMIx **scope**: `store` routes an
 `INTERNAL`-scope kval to `internal`, `REMOTE` to `remote`, `LOCAL` to
 `local`, and `GLOBAL` to *both* `remote` and `local`; `fetch` then honors
 the requested scope when reading them back. The `PMIX_HASH_*` bitmask flags
-(`PROC_DATA`, `JOB_SIZE`, `NODE_MAP`, `PROC_MAP`, …) track which
+(`JOB_SIZE`, `MAX_PROCS`, `NUM_NODES`, `NODE_MAP`, `PROC_MAP`) track which
 job-defining keys have already been seen while caching, so duplicates
-(e.g. two node maps) are caught as `PMIX_ERR_BAD_PARAM`.
+(e.g. two node maps) are caught as `PMIX_ERR_BAD_PARAM` and so `store_map`
+knows which job-level values it still has to compute for itself. **Every
+one of them is a job-wide statement**, which is what they are for; do not
+add a flag to record something that is true of one rank or one key. There
+used to be a sixth, `PROC_DATA`, that did exactly that — see the gotcha
+below.
 
 ## What the module functions do
 
@@ -87,7 +92,7 @@ job-defining keys have already been seen while caching, so duplicates
   session/app/node/job info arrays go through the `process_*_array`
   helpers; `PMIX_NODE_MAP` / `PMIX_PROC_MAP` are decoded via `pmix_preg`
   (handling `PMIX_REGEX`, `PMIX_REGEX2`, and plain `PMIX_STRING` forms) and
-  turned into per-rank hostname data by `store_map`; `PMIX_PROC_INFO_ARRAY`
+  turned into per-rank location data by `store_map`; `PMIX_PROC_INFO_ARRAY`
   arrays are expanded to per-rank keys; model/personality keys are handed to
   `pmix_pmdl`. Everything lands on `trk->internal` under
   `PMIX_RANK_WILDCARD` or the specific rank.
@@ -131,6 +136,29 @@ job-defining keys have already been seen while caching, so duplicates
   `PMIX_RANK_WILDCARD` in `trk->internal`, alongside a proc's own copy of
   its data. Fetches for `rank=WILDCARD` read job-level data; do not assume
   `internal` holds only per-rank entries.
+- **What `store_map` derives is a default, and the host always outranks
+  it — per rank and per key.** `store_map` works out `PMIX_HOSTNAME`,
+  `PMIX_NODEID`, `PMIX_LOCAL_RANK` and `PMIX_NODE_RANK` for every rank out
+  of the node and proc maps, and those are assumptions: the nodeid is the
+  node's index in the map and the node rank is computed as though this
+  were the only job on the node. So a value the host stated itself in a
+  `PMIX_PROC_INFO_ARRAY` has to win. Because `cache_job_info` expands
+  those arrays onto `trk->internal` during its scan and calls `store_map`
+  only after the scan finishes, the check is simply "is this key already
+  there for this rank?" — `store_derived()` in `gds_utils.c` asks
+  `pmix_hash_fetch` and skips if so. **Do not replace that with a flag.**
+  It used to be one: a single `PMIX_PROC_INFO_ARRAY` anywhere in the array
+  set `PMIX_HASH_PROC_DATA`, and `store_map` then skipped the nodeid,
+  local rank and node rank derivation for the *entire job*. A host that
+  described one proc lost those three keys for every other proc, and a
+  host that described every proc but named only some of the keys lost the
+  rest for all of them — `PMIx_Get` answering `PMIX_ERR_NOT_FOUND` with no
+  recovery, since the node-info fallback in `fetch` applies only to
+  wildcard ranks. `PMIX_HOSTNAME` sat outside the same gate, so it was
+  simultaneously the one key that survived and the one key a host could
+  not state without having it overwritten (`pmix_hash_store` replaces a
+  differing value). PRRTE supplies the full set for every proc, which is
+  why this stayed invisible.
 - **Regex decode depends on `preg`, and goes through one decoder.**
   A `PMIX_NODE_MAP` / `PMIX_PROC_MAP` value may arrive as a `PMIX_REGEX`
   byte object, a `PMIX_REGEX2` (which needs `pmix_preg.parse_regex` first),
@@ -158,6 +186,10 @@ job-defining keys have already been seen while caching, so duplicates
 `test/unit/gds_datastore` drives this component (it is the assigned module
 on macOS and wherever `shmem3` is unavailable) through the `PMIX_GDS_*`
 macros and `PMIx_server_register_nspace`: map decoding in every accepted
-form, malformed job-level input, and store/fetch scope routing. The
+form, malformed job-level input, store/fetch scope routing, and the
+per-rank/per-key derivation rule above — `test_derived_proc_info()`
+registers a job whose proc-info arrays cover only some ranks and name
+only some of the keys, and asserts both halves of the rule: what the host
+said survives, and everything it did not say is still filled in. The
 component's own symbols are not exported, so nothing can call
 `pmix_gds_hash_*` directly.

--- a/src/mca/gds/hash/gds_fetch.c
+++ b/src/mca/gds/hash/gds_fetch.c
@@ -601,7 +601,7 @@ pmix_status_t pmix_gds_hash_fetch(struct pmix_peer_t *pr,
             }
             ninfo = pmix_list_get_size(&rkvs);
             /* setup to return the result */
-            PMIX_KVAL_NEW(kv, PMIX_PROC_DATA);
+            PMIX_KVAL_NEW(kv, PMIX_PROC_INFO_ARRAY);
             if (NULL == kv) {
                 PMIX_LIST_DESTRUCT(&rkvs);
                 return PMIX_ERR_NOMEM;

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -266,7 +266,7 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
             }
             /* mark that we got the map */
             flags |= PMIX_HASH_PROC_MAP;
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_PROC_DATA)) {
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_PROC_INFO_ARRAY)) {
             flags |= PMIX_HASH_PROC_DATA;
             found = false;
             /* an array of data pertaining to a specific proc */
@@ -1184,7 +1184,7 @@ static pmix_status_t hash_store_job_info(const char *nspace, pmix_buffer_t *buf)
                 PMIX_VALUE_XFER(rc, kp3->value, kptr.value);
                 pmix_list_append(&nd->info, &kp3->super);
             }
-        } else if (PMIX_CHECK_KEY(&kptr, PMIX_PROC_DATA)) {
+        } else if (PMIX_CHECK_KEY(&kptr, PMIX_PROC_INFO_ARRAY)) {
             /* the caching path checks this; so must the path that takes
              * the same key from a server's reply */
             if (PMIX_DATA_ARRAY != kptr.value->type ||
@@ -1327,7 +1327,7 @@ pmix_status_t pmix_gds_hash_store(const pmix_proc_t *proc,
     if (PMIX_INTERNAL == scope) {
         /* if this is proc data, then we have to expand it and
          * store the values on that rank */
-        if (PMIX_CHECK_KEY(kv, PMIX_PROC_DATA)) {
+        if (PMIX_CHECK_KEY(kv, PMIX_PROC_INFO_ARRAY)) {
             /* an array of data pertaining to a specific proc */
             if (PMIX_DATA_ARRAY != kv->value->type ||
                 NULL == kv->value->data.darray ||

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -267,7 +267,6 @@ static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
             /* mark that we got the map */
             flags |= PMIX_HASH_PROC_MAP;
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_PROC_INFO_ARRAY)) {
-            flags |= PMIX_HASH_PROC_DATA;
             found = false;
             /* an array of data pertaining to a specific proc */
             if (PMIX_DATA_ARRAY != info[n].value.type ||

--- a/src/mca/gds/hash/gds_hash.h
+++ b/src/mca/gds/hash/gds_hash.h
@@ -38,7 +38,6 @@ extern pmix_gds_base_module_t pmix_hash_module;
 
 /* Define a bitmask to track what information may not have
  * been provided but is computable from other info */
-#define PMIX_HASH_PROC_DATA 0x00000001
 #define PMIX_HASH_JOB_SIZE  0x00000002
 #define PMIX_HASH_MAX_PROCS 0x00000004
 #define PMIX_HASH_NUM_NODES 0x00000008

--- a/src/mca/gds/hash/gds_utils.c
+++ b/src/mca/gds/hash/gds_utils.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2018-2020 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -354,6 +354,55 @@ pmix_nodeinfo_t* pmix_gds_hash_check_nodename(pmix_list_t *nodes, char *hostname
     return NULL;
 }
 
+/* Store a per-proc value we worked out from the node and proc maps -
+ * but only if the host has not already told us that key for that rank.
+ *
+ * The PMIX_PROC_INFO_ARRAY entries a host provides are expanded onto
+ * the table before store_map is called, so anything already present is
+ * the host's own word about that proc, while what we compute here is at
+ * best an assumption - the node rank, in particular, is derived as
+ * though this were the only job on the node.
+ *
+ * The check is made per rank and per key on purpose. A host may
+ * describe one proc and not another, or give a proc some of these keys
+ * and not the rest; every proc and key it did not speak to still has to
+ * be filled in. */
+static pmix_status_t store_derived(pmix_job_t *trk, pmix_rank_t rank, const char *key,
+                                   const void *data, pmix_data_type_t type)
+{
+    pmix_hash_table_t *ht = &trk->internal;
+    pmix_status_t rc;
+    pmix_list_t kvs;
+    pmix_value_t val;
+    pmix_kval_t kv;
+
+    PMIX_CONSTRUCT(&kvs, pmix_list_t);
+    rc = pmix_hash_fetch(ht, rank, key, NULL, 0, &kvs, NULL);
+    PMIX_LIST_DESTRUCT(&kvs);
+    if (PMIX_SUCCESS == rc) {
+        /* the host described this one itself - leave it alone */
+        pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                            "[%s:%d] gds:hash:store_map for [%s:%u]: key %s given by host",
+                            pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank, key);
+        return PMIX_SUCCESS;
+    }
+
+    PMIX_VALUE_LOAD(&val, data, type);
+    /* kv borrows both fields - it was never constructed, so it must
+     * not be destructed either. Only val is ours to release. */
+    kv.key = (char *) key;
+    kv.value = &val;
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
+                        pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank, key);
+    rc = pmix_hash_store(ht, rank, &kv, NULL, 0, NULL);
+    PMIX_VALUE_DESTRUCT(&val);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+    }
+    return rc;
+}
+
 pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn, uint32_t flags)
 {
     pmix_status_t rc;
@@ -362,6 +411,8 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
     pmix_kval_t *kp1, *kp2;
     char **procs;
     uint32_t totalprocs = 0;
+    uint32_t nodeid;
+    uint16_t urank;
     pmix_hash_table_t *ht = &trk->internal;
     pmix_nodeinfo_t *nd;
 
@@ -495,97 +546,31 @@ pmix_status_t pmix_gds_hash_store_map(pmix_job_t *trk, char **nodes, char **ppn,
          * didn't give it to us */
         totalprocs += PMIx_Argv_count(procs);
         for (m = 0; NULL != procs[m]; m++) {
-            /* store the hostname for each proc */
-            kp2 = PMIX_NEW(pmix_kval_t);
-            kp2->key = strdup(PMIX_HOSTNAME);
-            kp2->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-            if (NULL == kp2->value) {
-                PMIX_RELEASE(kp2);
-                PMIx_Argv_free(procs);
-                return PMIX_ERR_NOMEM;
-            }
-            kp2->value->type = PMIX_STRING;
-            kp2->value->data.string = strdup(nd->hostname);
             rank = strtol(procs[m], NULL, 10);
-            pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                                "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
-                                pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
-                                kp2->key);
-            if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0, NULL))) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(kp2);
+            /* each of these is only a default: store it for this rank
+             * unless the host already described that rank itself */
+            rc = store_derived(trk, rank, PMIX_HOSTNAME, nd->hostname, PMIX_STRING);
+            if (PMIX_SUCCESS != rc) {
                 PMIx_Argv_free(procs);
                 return rc;
             }
-            PMIX_RELEASE(kp2); // maintain acctg
-            if (!(PMIX_HASH_PROC_DATA & flags)) {
-                /* add an entry for the nodeid */
-                kp2 = PMIX_NEW(pmix_kval_t);
-                kp2->key = strdup(PMIX_NODEID);
-                kp2->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-                if (NULL == kp2->value) {
-                    PMIX_RELEASE(kp2);
-                    PMIx_Argv_free(procs);
-                    return PMIX_ERR_NOMEM;
-                }
-                kp2->value->type = PMIX_UINT32;
-                pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                                    "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
-                                    pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
-                                    kp2->key);
-                kp2->value->data.uint32 = n;
-                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0, NULL))) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(kp2);
-                    PMIx_Argv_free(procs);
-                    return rc;
-                }
-                PMIX_RELEASE(kp2); // maintain acctg
-                /* add an entry for the local rank */
-                kp2 = PMIX_NEW(pmix_kval_t);
-                kp2->key = strdup(PMIX_LOCAL_RANK);
-                kp2->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-                if (NULL == kp2->value) {
-                    PMIX_RELEASE(kp2);
-                    PMIx_Argv_free(procs);
-                    return PMIX_ERR_NOMEM;
-                }
-                kp2->value->type = PMIX_UINT16;
-                kp2->value->data.uint16 = m;
-                pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                                    "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
-                                    pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
-                                    kp2->key);
-                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0, NULL))) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(kp2);
-                    PMIx_Argv_free(procs);
-                    return rc;
-                }
-                PMIX_RELEASE(kp2); // maintain acctg
-                /* add an entry for the node rank - for now, we assume
-                 * only the one job is running */
-                kp2 = PMIX_NEW(pmix_kval_t);
-                kp2->key = strdup(PMIX_NODE_RANK);
-                kp2->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
-                if (NULL == kp2->value) {
-                    PMIX_RELEASE(kp2);
-                    PMIx_Argv_free(procs);
-                    return PMIX_ERR_NOMEM;
-                }
-                kp2->value->type = PMIX_UINT16;
-                kp2->value->data.uint16 = m;
-                pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                                    "[%s:%d] gds:hash:store_map for [%s:%u]: key %s",
-                                    pmix_globals.myid.nspace, pmix_globals.myid.rank, trk->ns, rank,
-                                    kp2->key);
-                if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2, NULL, 0, NULL))) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(kp2);
-                    PMIx_Argv_free(procs);
-                    return rc;
-                }
-                PMIX_RELEASE(kp2); // maintain acctg
+            nodeid = n;
+            rc = store_derived(trk, rank, PMIX_NODEID, &nodeid, PMIX_UINT32);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Argv_free(procs);
+                return rc;
+            }
+            urank = m;
+            rc = store_derived(trk, rank, PMIX_LOCAL_RANK, &urank, PMIX_UINT16);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Argv_free(procs);
+                return rc;
+            }
+            /* the node rank assumes only the one job is running */
+            rc = store_derived(trk, rank, PMIX_NODE_RANK, &urank, PMIX_UINT16);
+            if (PMIX_SUCCESS != rc) {
+                PMIx_Argv_free(procs);
+                return rc;
             }
         }
         PMIx_Argv_free(procs);

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -1903,8 +1903,8 @@ get_local_job_data_info(
             NULL != kvi->value->data.darray &&
             NULL != kvi->value->data.darray->array &&
             0 != kvi->value->data.darray->size) {
-            // PMIX_PROC_DATA is stored in the hash table.
-            if (PMIX_CHECK_KEY(kvi, PMIX_PROC_DATA)) {
+            // PMIX_PROC_INFO_ARRAY is stored in the hash table.
+            if (PMIX_CHECK_KEY(kvi, PMIX_PROC_INFO_ARRAY)) {
                 nhtentries += kvi->value->data.darray->size;
             }
             // See if this is the job's session ID. If so, capture it.

--- a/src/mca/gds/shmem3/gds_shmem3_fetch.c
+++ b/src/mca/gds/shmem3/gds_shmem3_fetch.c
@@ -661,7 +661,7 @@ shmem3_fetch_from_job(
             // Setup to return the result.
             // TODO(skg) Maybe place to help with zero-copy?
             pmix_kval_t *kv;
-            PMIX_KVAL_NEW(kv, PMIX_PROC_DATA);
+            PMIX_KVAL_NEW(kv, PMIX_PROC_INFO_ARRAY);
             kv->value->type = PMIX_DATA_ARRAY;
             const size_t niptr = ninfo + 1; // Need space for the rank.
             PMIX_DATA_ARRAY_CREATE(kv->value->data.darray, niptr, PMIX_INFO);

--- a/src/mca/gds/shmem3/gds_shmem3_store.c
+++ b/src/mca/gds/shmem3/gds_shmem3_store.c
@@ -401,7 +401,7 @@ store_proc_data(
     pmix_status_t rc = PMIX_SUCCESS;
 
     // First, make sure this is proc data.
-    if (PMIX_UNLIKELY(!PMIX_CHECK_KEY(kval, PMIX_PROC_DATA))) {
+    if (PMIX_UNLIKELY(!PMIX_CHECK_KEY(kval, PMIX_PROC_INFO_ARRAY))) {
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return PMIX_ERR_BAD_PARAM;
     }

--- a/src/mca/pnet/AGENTS.md
+++ b/src/mca/pnet/AGENTS.md
@@ -334,7 +334,7 @@ that keeps `nvd` out of the library today).
   flow.
 - **`simptest` shows the per-proc vs. per-node split.** Fabric endpoints
   (`PMIX_FABRIC_ENDPT`) are per-process data, fetched by rank, so they go
-  in a `PMIX_PROC_DATA` array; fabric coordinates
+  in a `PMIX_PROC_INFO_ARRAY` array; fabric coordinates
   (`PMIX_FABRIC_COORDINATES`) are per-node, fetched at the node level
   (rank `PMIX_RANK_UNDEF`), so they must be delivered in a
   `PMIX_NODE_INFO_ARRAY` rather than proc data or the client's `PMIx_Get`

--- a/src/mca/pnet/simptest/AGENTS.md
+++ b/src/mca/pnet/simptest/AGENTS.md
@@ -91,7 +91,7 @@ is a recognizable placeholder.
 - **`allocate`** (scheduler only) parses `PMIX_PROC_MAP` and
   `PMIX_NODE_MAP` via `pmix_preg.parse_procs` / `parse_nodes`, then for
   each node emits **two** kinds of data into the blob:
-  - a `PMIX_ALLOC_FABRIC_ENDPTS` kval whose value is a `PMIX_PROC_DATA`
+  - a `PMIX_ALLOC_FABRIC_ENDPTS` kval whose value is a `PMIX_PROC_INFO_ARRAY`
     array — one entry per local rank holding the rank and its
     `PMIX_FABRIC_ENDPT` (a data array of byte objects). The endpoint is
     **per-process** data, fetched by rank.

--- a/src/mca/pnet/simptest/pnet_simptest.c
+++ b/src/mca/pnet/simptest/pnet_simptest.c
@@ -301,8 +301,8 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
             /* each proc is assigned a fabric endpoint corresponding to
              * the node upon which it is executing. The endpoint is
              * per-process data (PMIX_FABRIC_ENDPT is fetched by rank),
-             * so it lives in this proc's PMIX_PROC_DATA array */
-            PMIX_LOAD_KEY(iptr[m].key, PMIX_PROC_DATA);
+             * so it lives in this proc's PMIX_PROC_INFO_ARRAY array */
+            PMIX_LOAD_KEY(iptr[m].key, PMIX_PROC_INFO_ARRAY);
             PMIX_DATA_ARRAY_CREATE(d2, 2, PMIX_INFO);
             iptr[m].value.type = PMIX_DATA_ARRAY;
             iptr[m].value.data.darray = d2;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1237,7 +1237,7 @@ static void _register_nspace(int sd, short args, void *cbdata)
         gds = pmix_globals.mypeer->nptr->compat.gds;
         if (NULL != gds && NULL != gds->store) {
             for (i=0; i < cd->ninfo; i++) {
-                if (PMIX_CHECK_KEY(&cd->info[i], PMIX_PROC_DATA)) {
+                if (PMIX_CHECK_KEY(&cd->info[i], PMIX_PROC_INFO_ARRAY)) {
                     iptr = (pmix_info_t*)cd->info[i].value.data.darray->array;
                     ninfo = cd->info[i].value.data.darray->size;
                     /* the first position is the rank */

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -949,7 +949,7 @@ static pmix_status_t aggregate_info(grp_block_t *blk)
                             PMIX_LIST_DESTRUCT(&ilist);
                             return PMIX_ERR_BAD_PARAM;
                         }
-                    } else if (PMIX_CHECK_KEY(&blk->info[m], PMIX_PROC_DATA) ||
+                    } else if (PMIX_CHECK_KEY(&blk->info[m], PMIX_PROC_INFO_ARRAY) ||
                                PMIX_CHECK_KEY(&blk->info[m], PMIX_GROUP_INFO)) {
                         // keep the duplicates
                         icd = PMIX_NEW(pmix_info_caddy_t);

--- a/test/simple/gwtest.c
+++ b/test/simple/gwtest.c
@@ -570,7 +570,7 @@ static void set_namespace(int nprocs, char *ranks, char *nspace, pmix_op_cbfunc_
     x->info[6].value.data.uint32 = nprocs;
 
     for (n = 0; n < nprocs; n++) {
-        pmix_strncpy(x->info[7 + n].key, PMIX_PROC_DATA, PMIX_MAX_KEYLEN);
+        pmix_strncpy(x->info[7 + n].key, PMIX_PROC_INFO_ARRAY, PMIX_MAX_KEYLEN);
         x->info[7 + n].value.type = PMIX_DATA_ARRAY;
         darray = (pmix_data_array_t *) malloc(sizeof(pmix_data_array_t));
         darray->size = 2;

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -716,7 +716,7 @@ static void set_namespace(int nprocs, char *nspace, pmix_op_cbfunc_t cbfunc, myx
 
     /* add the proc-specific data */
     for (m = 0; m < nprocs; m++) {
-        pmix_strncpy(x->info[n].key, PMIX_PROC_DATA, PMIX_MAX_KEYLEN);
+        pmix_strncpy(x->info[n].key, PMIX_PROC_INFO_ARRAY, PMIX_MAX_KEYLEN);
         x->info[n].value.type = PMIX_DATA_ARRAY;
         PMIX_DATA_ARRAY_CREATE(array, 6, PMIX_INFO);
         x->info[n].value.data.darray = array;

--- a/test/simple/stability.c
+++ b/test/simple/stability.c
@@ -633,7 +633,7 @@ static void set_namespace(int nprocs, char *ranks, char *nspace, pmix_op_cbfunc_
 
     /* add the proc-specific data */
     for (m = 0; m < nprocs; m++) {
-        pmix_strncpy(x->info[n].key, PMIX_PROC_DATA, PMIX_MAX_KEYLEN);
+        pmix_strncpy(x->info[n].key, PMIX_PROC_INFO_ARRAY, PMIX_MAX_KEYLEN);
         x->info[n].value.type = PMIX_DATA_ARRAY;
         PMIX_DATA_ARRAY_CREATE(array, 5, PMIX_INFO);
         x->info[n].value.data.darray = array;

--- a/test/unit/collect_job_info.c
+++ b/test/unit/collect_job_info.c
@@ -43,7 +43,7 @@ static void report(const char *name, int passed)
 
 /* Register a namespace with a minimal-but-valid job description: a
  * PMIX_JOB_INFO_ARRAY carrying the node/proc maps and job sizes, one
- * PMIX_NODE_INFO_ARRAY, and one PMIX_PROC_DATA entry per rank. This mirrors the
+ * PMIX_NODE_INFO_ARRAY, and one PMIX_PROC_INFO_ARRAY entry per rank. This mirrors the
  * shape a real host builds in PMIx_server_register_nspace. */
 static pmix_status_t register_job(const char *nspace, int nprocs)
 {
@@ -101,7 +101,7 @@ static pmix_status_t register_job(const char *nspace, int nprocs)
 
     /* per-proc data */
     for (m = 0; m < nprocs; m++) {
-        pmix_strncpy(info[n].key, PMIX_PROC_DATA, PMIX_MAX_KEYLEN);
+        pmix_strncpy(info[n].key, PMIX_PROC_INFO_ARRAY, PMIX_MAX_KEYLEN);
         info[n].value.type = PMIX_DATA_ARRAY;
         PMIX_DATA_ARRAY_CREATE(array, 3, PMIX_INFO);
         info[n].value.data.darray = array;

--- a/test/unit/gds_datastore.c
+++ b/test/unit/gds_datastore.c
@@ -31,6 +31,13 @@
  *   - a PMIX_QUALIFIED_VALUE carrying an empty data array (the primary
  *     value was read out of bounds and SIZE_MAX qualifiers requested).
  *
+ * A different class of case covers what the datastore *computes* rather
+ * than what it is given: the per-proc hostname, nodeid, local rank and
+ * node rank derived from the node and proc maps are assumptions, so the
+ * host's own PMIX_PROC_INFO_ARRAY has to win - but per rank and per key.
+ * That decision used to be made once for the whole job, which lost those
+ * keys for every proc a host did not fully describe.
+ *
  * The base modex walker case pins the contract every component's
  * store_modex callback has to honor: it is called once per proc blob and
  * then once per involved nspace with a NULL buffer, and a callback that
@@ -589,6 +596,179 @@ static void test_map_forms(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* derivation of per-proc info the host did not supply                  */
+/* ------------------------------------------------------------------ */
+
+/* Register a job whose node/proc maps describe every rank, but whose
+ * PMIX_PROC_INFO_ARRAY entries cover only the first "ndescribed" ranks -
+ * and, for those, name only PMIX_LOCAL_RANK, carrying a sentinel value
+ * no derivation would ever produce. Everything else the maps imply has
+ * to be filled in by the datastore. */
+static pmix_status_t register_with_proc_info(const char *nspace, int nprocs,
+                                             int ndescribed, uint16_t sentinel)
+{
+    char *noderegex = NULL, *ppnregex = NULL;
+    char *ppnstr = NULL, **agg = NULL;
+    char rankstr[64];
+    pmix_info_t *info, *pdata;
+    pmix_data_array_t *array;
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    size_t ninfo, n;
+    uint16_t lrank;
+    int m;
+
+    for (m = 0; m < nprocs; m++) {
+        snprintf(rankstr, sizeof(rankstr), "%d", m);
+        PMIx_Argv_append_nosize(&agg, rankstr);
+    }
+    ppnstr = PMIx_Argv_join(agg, ',');
+    PMIx_Argv_free(agg);
+
+    PMIx_generate_regex(pmix_globals.hostname, &noderegex);
+    PMIx_generate_ppn(ppnstr, &ppnregex);
+    free(ppnstr);
+
+    ninfo = 3 + (size_t) ndescribed;
+    PMIX_INFO_CREATE(info, ninfo);
+    PMIX_INFO_LOAD(&info[0], PMIX_NODE_MAP, noderegex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&info[1], PMIX_PROC_MAP, ppnregex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&info[2], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    free(noderegex);
+    free(ppnregex);
+
+    n = 3;
+    for (m = 0; m < ndescribed; m++) {
+        PMIX_LOAD_KEY(info[n].key, PMIX_PROC_INFO_ARRAY);
+        info[n].value.type = PMIX_DATA_ARRAY;
+        PMIX_DATA_ARRAY_CREATE(array, 2, PMIX_INFO);
+        info[n].value.data.darray = array;
+        pdata = (pmix_info_t *) array->array;
+        PMIX_LOAD_KEY(pdata[0].key, PMIX_RANK);
+        pdata[0].value.type = PMIX_PROC_RANK;
+        pdata[0].value.data.rank = (pmix_rank_t) m;
+        lrank = sentinel + (uint16_t) m;
+        PMIX_INFO_LOAD(&pdata[1], PMIX_LOCAL_RANK, &lrank, PMIX_UINT16);
+        ++n;
+    }
+
+    PMIX_LOAD_NSPACE(ns, nspace);
+    rc = PMIx_server_register_nspace(ns, nprocs, info, ninfo, NULL, NULL);
+    PMIX_INFO_FREE(info, ninfo);
+    return rc;
+}
+
+/* Fetch one key for one rank as a number. Returns false if the key is
+ * absent, which is the failure mode these cases are about. */
+static bool fetch_number(const char *nspace, pmix_rank_t rank,
+                         const char *key, uint32_t *out)
+{
+    pmix_list_t kvs;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+    bool found = false;
+
+    PMIX_CONSTRUCT(&kvs, pmix_list_t);
+    rc = fetch_key(nspace, rank, key, &kvs);
+    kv = (pmix_kval_t *) pmix_list_get_first(&kvs);
+    if (PMIX_SUCCESS == rc && NULL != kv && NULL != kv->value) {
+        found = (PMIX_SUCCESS == PMIx_Value_get_number(kv->value, out, PMIX_UINT32));
+    }
+    PMIX_LIST_DESTRUCT(&kvs);
+    return found;
+}
+
+static void check_number(const char *what, const char *nspace, pmix_rank_t rank,
+                         const char *key, uint32_t expect)
+{
+    uint32_t got = UINT32_MAX;
+    char label[200];
+    bool found;
+
+    found = fetch_number(nspace, rank, key, &got);
+    snprintf(label, sizeof(label), "%s", what);
+    report(label, found && got == expect);
+    if (!found) {
+        fprintf(stdout, "        (%s for rank %u: not found)\n", key, rank);
+    } else if (got != expect) {
+        fprintf(stdout, "        (%s for rank %u: got %u, expected %u)\n",
+                key, rank, got, expect);
+    }
+}
+
+/* The datastore derives PMIX_HOSTNAME, PMIX_NODEID, PMIX_LOCAL_RANK and
+ * PMIX_NODE_RANK for each rank from the node and proc maps. Those values
+ * are assumptions, so anything the host stated itself in a
+ * PMIX_PROC_INFO_ARRAY must win - but the decision has to be made per
+ * rank and per key.
+ *
+ * It used to be made once for the whole job: a single proc-info array
+ * anywhere in the array set a flag that suppressed the derivation of
+ * nodeid, local rank and node rank for *every* rank. A host that
+ * described one proc lost those three keys for all the others, and a
+ * host that described every proc but named only some of the keys lost
+ * the rest for all of them - PMIx_Get returning PMIX_ERR_NOT_FOUND, with
+ * no fallback, since the node-info fallback in fetch applies only to
+ * wildcard ranks. PMIX_HOSTNAME was stored outside the same gate, so it
+ * was the one key that survived - and, conversely, the one key a host
+ * could not state for itself without having it overwritten. */
+static void test_derived_proc_info(void)
+{
+    pmix_list_t kvs;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+    const uint16_t sentinel = 100;
+
+    fprintf(stdout, "\n-- per-proc info derived from the maps --\n");
+
+    /* two ranks, only rank 0 described */
+    rc = register_with_proc_info("gds-derive-partial", 2, 1, sentinel);
+    report("job with proc info for some ranks is accepted", registered(rc));
+    if (registered(rc)) {
+        /* the described rank keeps what the host said... */
+        check_number("host-supplied local rank survives derivation",
+                     "gds-derive-partial", 0, PMIX_LOCAL_RANK, sentinel);
+        /* ...and still gets the keys the host did not name */
+        check_number("described rank still gets a derived node rank",
+                     "gds-derive-partial", 0, PMIX_NODE_RANK, 0);
+        check_number("described rank still gets a derived nodeid",
+                     "gds-derive-partial", 0, PMIX_NODEID, 0);
+
+        /* the rank the host never mentioned gets the whole set */
+        check_number("undescribed rank gets a derived local rank",
+                     "gds-derive-partial", 1, PMIX_LOCAL_RANK, 1);
+        check_number("undescribed rank gets a derived node rank",
+                     "gds-derive-partial", 1, PMIX_NODE_RANK, 1);
+        check_number("undescribed rank gets a derived nodeid",
+                     "gds-derive-partial", 1, PMIX_NODEID, 0);
+
+        PMIX_CONSTRUCT(&kvs, pmix_list_t);
+        rc = fetch_key("gds-derive-partial", 1, PMIX_HOSTNAME, &kvs);
+        kv = (pmix_kval_t *) pmix_list_get_first(&kvs);
+        report("undescribed rank gets a derived hostname",
+               PMIX_SUCCESS == rc && NULL != kv && NULL != kv->value &&
+                   PMIX_STRING == kv->value->type &&
+                   NULL != kv->value->data.string &&
+                   0 == strcmp(kv->value->data.string, pmix_globals.hostname));
+        PMIX_LIST_DESTRUCT(&kvs);
+    }
+
+    /* every rank described, but none of them named a node rank */
+    rc = register_with_proc_info("gds-derive-full", 2, 2, sentinel);
+    report("job with proc info for every rank is accepted", registered(rc));
+    if (registered(rc)) {
+        check_number("rank 0 keeps its host-supplied local rank",
+                     "gds-derive-full", 0, PMIX_LOCAL_RANK, sentinel);
+        check_number("rank 1 keeps its host-supplied local rank",
+                     "gds-derive-full", 1, PMIX_LOCAL_RANK, sentinel + 1);
+        check_number("rank 0 gets the node rank the host omitted",
+                     "gds-derive-full", 0, PMIX_NODE_RANK, 0);
+        check_number("rank 1 gets the node rank the host omitted",
+                     "gds-derive-full", 1, PMIX_NODE_RANK, 1);
+    }
+}
+
+/* ------------------------------------------------------------------ */
 /* malformed job-level input                                            */
 /* ------------------------------------------------------------------ */
 
@@ -935,6 +1115,7 @@ int main(int argc, char **argv)
     test_store_modex();
     test_store_modex_nspace_filter();
     test_map_forms();
+    test_derived_proc_info();
     test_malformed_job_info();
     test_scope_routing();
     test_realm_classifiers();

--- a/test/unit/proc_array_id.c
+++ b/test/unit/proc_array_id.c
@@ -177,7 +177,7 @@ static pmix_status_t register_job(const char *nspace, int nprocs)
     /* per-proc data, identified by a procid that is deliberately not
      * the first element */
     for (m = 0; m < nprocs; m++) {
-        pmix_strncpy(info[n].key, PMIX_PROC_DATA, PMIX_MAX_KEYLEN);
+        pmix_strncpy(info[n].key, PMIX_PROC_INFO_ARRAY, PMIX_MAX_KEYLEN);
         info[n].value.type = PMIX_DATA_ARRAY;
         PMIX_DATA_ARRAY_CREATE(array, 3, PMIX_INFO);
         info[n].value.data.darray = array;


### PR DESCRIPTION
`PMIX_PROC_INFO_ARRAY` and the deprecated `PMIX_PROC_DATA` are the same string, `"pmix.pdata"`. A single occurrence of it anywhere in a namespace registration used to switch off the datastore's derivation of `PMIX_NODEID`, `PMIX_LOCAL_RANK` and `PMIX_NODE_RANK` for *every* rank in the job.

### The mechanism

`hash_cache_job_info()` makes one scan over the job-level info array (`gds_hash.c:206`). Inside that scan, a `PMIX_PROC_INFO_ARRAY` set `flags |= PMIX_HASH_PROC_DATA`. Only *after* the scan finishes does it call `pmix_gds_hash_store_map()` (`gds_hash.c:493`), which gated its whole per-rank derivation block on `!(PMIX_HASH_PROC_DATA & flags)` (`gds_utils.c:521`).

So the flag accumulated across the entire array before `store_map` ever ran. The intent is right — what `store_map` computes is only an assumption (the nodeid is the node's index in the map; the node rank is derived as though this were the only job on the node), so anything the host stated itself must win. But the instrument was job-wide, and the consequences were not:

- A host that describes **one** process loses those three keys for **all** the others.
- A host that describes **every** process but names only **some** of the keys loses the rest for all of them.

For a specific rank there is nothing to recover them from — the node-info fallback in `fetch` applies only to wildcard ranks (`gds_fetch.c:665`), so `PMIx_Get` simply answers `PMIX_ERR_NOT_FOUND`.

`PMIX_HOSTNAME` was stored *outside* the same gate, and `pmix_hash_store()` replaces a value that differs. That made it simultaneously the one key that survived and the one key a host could not state without having it silently overwritten.

PRRTE supplies the full set for every process, which is why none of this was visible in ordinary use.

### The fix

Because the proc-info arrays are expanded onto `trk->internal` during the scan and `store_map` runs afterwards, the precise question is already answerable directly: *is this key present for this rank?* `store_derived()` asks `pmix_hash_fetch` and skips the derivation if so.

That is per rank and per key, it puts hostname under the same rule as the other three, and it retires `PMIX_HASH_PROC_DATA` entirely — `store_map` now derives exactly what the host left unsaid. It also collapses four near-identical malloc/error-path blocks into four calls.

### Commits

1. **Use the current name for the proc-info array attribute** — 20 files switched from the deprecated `PMIX_PROC_DATA` spelling to `PMIX_PROC_INFO_ARRAY`. The definition in `pmix_deprecated.h` stays, as does the news entry that names the old spelling on purpose. No behavior change; the string is unchanged.
2. **Decide per rank and per key what the maps have to fill in** — the fix above, plus `test_derived_proc_info()` in `test/unit/gds_datastore`, an `AGENTS.md` gotcha explaining why this must not go back to being a flag, and a news entry.

### Verification

The new test registers a 2-rank job whose proc-info arrays cover only some ranks and name only `PMIX_LOCAL_RANK`, using a sentinel value no derivation would produce, then asserts both halves of the rule: what the host said survives, and everything it did not say is still filled in.

All 13 cases pass against the fix. Against the pre-fix sources, 7 fail — and exactly the predicted ones:

```
FAIL: described rank still gets a derived node rank   (pmix.nrank rank 0: not found)
FAIL: described rank still gets a derived nodeid      (pmix.nodeid rank 0: not found)
FAIL: undescribed rank gets a derived local rank      (pmix.lrank rank 1: not found)
FAIL: undescribed rank gets a derived node rank
FAIL: undescribed rank gets a derived nodeid
FAIL: rank 0 gets the node rank the host omitted
FAIL: rank 1 gets the node rank the host omitted
PASS: undescribed rank gets a derived hostname        <- the ungated key
PASS: host-supplied local rank survives derivation
```

Full `make check` passes 117/117 across all six subdirectories, the build is warning-free under `--enable-devel-check`, and the docs rebuild clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)