### PR TITLE
Review src/server: caddy ownership, request lifetimes, and the tests a single node cannot run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,6 +287,7 @@ test/unit/event_chain
 test/unit/hwloc_datatype
 test/unit/progress_threads
 test/unit/runtime_init
+test/unit/server_get
 test/unit/info_support
 test/unit/rndz_stale
 test/unit/singleton_register

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -29,6 +29,7 @@ two disagree, the README wins, and please fix this file.
 | `run-gds-tests.sh` | The `src/mca/gds` datastore: compiles `shmem3` (which macOS does not build at all), the gds unit programs in two configurations, and the collective/direct/fallback modex paths across separate servers (README §16) |
 | `run-ptl-tests.sh` | The `src/mca/ptl` transport over real sockets between real hosts: interface selection, node-local rendezvous discovery, a tool attaching across nodes, the inbound message-size ceiling, an exhausted port range (README §17) |
 | `run-runtime-tests.sh` | The `src/runtime` bring-up/tear-down suite in the optimized configuration and on Linux — where the progress thread's CPU-affinity path exists at all — plus that path driven through a real `PMIx_Init`, and node identity across real servers (README §18) |
+| `run-server-tests.sh` | `src/server` — the server-role half of libpmix — across separate servers: direct modex, cross-namespace get, group blocks spanning nodes, IOF pull/dereg against a persistent DVM, and a valgrind pass on the daemon (README §19) |
 | `swarm-common.sh` | **Sourced, never executed.** `$PMIX_SWARM` naming and the one copy of `cleanup_swarm` |
 
 ## Things that will bite you
@@ -116,6 +117,41 @@ two disagree, the README wins, and please fix this file.
   about the path. `run-ptl-tests.sh` writes its URI to `/tmp` for this
   reason — and deliberately not to a name matching `pmix*`, which is the
   glob `cleanup_swarm` sweeps out of `/tmp` between cases.
+
+- **`--host` IS the allocation, so an example that spawns needs slots
+  nobody is using.** Three of the `run-server-tests.sh` examples
+  (`dynamic`, `multi_nspace_group`, `resolve`) call `PMIx_Spawn`. Size the
+  parent job to half the listed nodes or the spawn has nowhere to land and
+  the job blocks until the launch timeout — which is indistinguishable
+  from a library hang in the log, and it is not one. Leaving room is also
+  what makes the child job land on *other* servers, which is the whole
+  point of the cross-namespace cases.
+
+- **`examples/resolve.c` spawns its child as the relative path
+  `./resolve`.** Launch it from the staging directory or the spawned job
+  dies with "could not access an executable" and the surviving parent rank
+  hangs at its fence. Nothing in the message mentions the working
+  directory.
+
+- **Do not count completion markers per rank without checking who
+  prints them.** `examples/dmodex.c` announces its finalize from rank 0
+  only, so "one per rank" is the wrong expectation and a correct run looks
+  like a partial one. Check the example before writing the assertion.
+
+- **`ON` does not set the run-as-root variables; `RUN` does.** A stage
+  that reaches for `ON <n>` to launch `prterun` gets the run-as-root
+  advisory and a non-zero exit that looks like whatever the stage was
+  actually testing. `run-server-tests.sh`'s valgrind stage uses `RUN` for
+  the launch and `ON 1` only to read the log back.
+
+- **valgrind prints bare basenames unless you pass `--fullpath-after=`.**
+  That matters here because PRRTE has its own `pmix_server.c`,
+  `pmix_server_fence.c` and `pmix_server_gen.c`: a basename match
+  attributes PRRTE's leaks to PMIx, and a path match finds nothing at all.
+  With the full path, PMIx frames read `/pmix-src/src/server/...` and
+  PRRTE's read `/src/prrte/src/prted/pmix/...`, which separates them
+  cleanly. The image carries no valgrind, so the stage installs it into
+  the one node it needs at run time and skips if there is no network.
 
 - **The build volume outlives your branch.** `pmix-build` persists
   across runs and across checkouts, so a tree in it can be older than

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -1183,3 +1183,79 @@ was there before. Every runner here that drives `prterun` has the same
 contract. Note also that the nodes mount the build volume **read-only**,
 so anything that has to be compiled into it must be built from a
 `docker run`, not with `docker exec` on a node.
+
+## 19. The `src/server` suite (`run-server-tests.sh`)
+
+```sh
+./run-server-tests.sh linux     # the swarm
+./run-server-tests.sh macos     # single-host subset
+```
+
+`src/server` is the server-role half of `libpmix` — the code a launcher
+daemon (here `prted`) runs. Its central decision, taken in
+`pmix_server_get()`, is whether a request can be answered out of what
+this server already holds or has to be deferred and fetched from whoever
+hosts the target process. **On one node that decision has one arm.**
+Every rank is local, every key is already in the local datastore, and the
+entire remote half of the file — the direct-modex engine: `local_reqs`,
+`remote_pnd`, `dmdx_cbfunc` → `_process_dmdx_reply` →
+`pmix_pending_resolve` — never executes. That half is not a corner case;
+it is where the deferred-request lifetime bugs live, and it is why this
+runner exists.
+
+**Every stage puts one rank per node.** That is not load spreading. With
+two ranks on a node, a rank asking for its neighbour's data is answered
+out of local storage and the request never leaves the server, so a run
+can be green with the whole remote path broken. If you change the
+geometry of a stage here, keep one rank per node.
+
+What each stage reaches:
+
+| Stage | What it drives |
+|-------|----------------|
+| `dmodex`, `modex_twice`, `group_dmodex` | A rank fetches a peer's data from a server that is not its own — the only thing that exercises the local-vs-remote classification, the deferral onto `local_reqs`, the host `direct_modex` up-call and the reply ingest. `modex_twice` repeats the fetch so the second request joins an existing tracker instead of creating one. |
+| `dynamic` | Spawn plus connect, so a rank gets a key from a process in a *different* namespace: the `diffnspace` arm of `_satisfy_request()`, which packs job-level data ahead of the per-rank data. |
+| `multi_nspace_group` | A group spanning namespaces and nodes, driving the two-level block/tracker engine through a real host rather than through `simptest`. |
+| `resolve`, `simple_resolve` | `pmix_server_resolve_peers()` / `pmix_server_resolve_node()`. |
+| `pub` | Publish/lookup/unpublish — the setup-caddy family, whose whole job is to survive a host up-call and answer exactly once. |
+| `iof-dvm` | Two jobs in a row against one **persistent** DVM. `prterun` attaches as a *tool* and calls `PMIx_IOF_pull`, which is the only thing that drives `pmix_server_iofreg()`/`iofdereg()` on the daemon; a transient DVM never gets there because it is torn down with the job. The second registration happening after the first deregistered is the sequence that fails if a registration caddy is released while the host still owns it. |
+| `valgrind-server` | The daemon itself under valgrind. |
+
+### What this deliberately does not cover
+
+`resolve` and `simple_resolve` take the **host** arm: `prte` implements
+the query interface, so the server's own local-datastore fallback
+(`pmix_server_locally_resolve_peers`/`_node`) is never reached. That
+fallback is what runs under a host *without* query support, and it has no
+coverage here. Saying so is more useful than implying otherwise.
+
+The valgrind stage runs the DVM on a single node, so it is about the
+request handlers, the caddy accounting and the collective trackers — not
+about direct modex. Do not let it stand in for the multi-node stages.
+
+### The valgrind stage
+
+This is the only leak check anywhere in the harness that runs against the
+**server** library. Every other suite valgrinds a client, and a client
+never executes `src/server` at all.
+
+Two mechanics are load-bearing:
+
+- The stage passes `--fullpath-after=` (empty argument) so valgrind
+  prints full source paths rather than basenames. PRRTE has its own
+  `pmix_server.c`, `pmix_server_fence.c` and `pmix_server_gen.c`, so a
+  basename match would attribute PRRTE's leaks to PMIx and a path match
+  would find nothing. With full paths, ours read
+  `/pmix-src/src/server/...` and PRRTE's read
+  `/src/prrte/src/prted/pmix/...`.
+- Only *definitely lost* blocks whose allocation stack passes through
+  `src/server` are failed on. `prte` leaks at exit in ways that are not
+  this suite's business — a current run shows one definite leak of ~8 KB
+  in `prte_iof_base_write_output`, which is PRRTE's — and holding the
+  stage to a whole-process clean bill would make it permanently red and
+  therefore ignored.
+
+The image carries no valgrind (it is a build image, and it is shared with
+the other swarm, so rebuilding it to add a package moves it under that
+swarm's feet). The stage installs valgrind into the one node it needs at
+run time and skips cleanly if there is no network to do that with.

--- a/contrib/dockerswarm/run-server-tests.sh
+++ b/contrib/dockerswarm/run-server-tests.sh
@@ -1,0 +1,439 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Exercise src/server -- the server-role half of libpmix -- across real,
+# *separate* PMIx servers.
+#
+#   ./run-server-tests.sh linux    # in the 10-container swarm
+#                                  #   (requires: ./build.sh && docker compose up -d)
+#   ./run-server-tests.sh macos    # single-host subset natively
+#                                  #   (requires: ./build.sh macos)
+#
+# WHY THIS IS A MULTI-NODE TEST
+#
+# The PMIx server library is what a launcher daemon (here prted) runs.  Its
+# central decision -- taken in pmix_server_get() -- is whether a request can
+# be answered out of what this server already holds, or has to be deferred
+# and fetched from whichever server hosts the target process.  On one node
+# that decision has one arm: every rank is local, every key is already in
+# the local datastore, and the entire remote half of the file never runs.
+# That half is not a corner: it is the direct-modex engine (local_reqs,
+# remote_pnd, dmdx_cbfunc -> _process_dmdx_reply -> pmix_pending_resolve),
+# and it is where the deferred-request lifetime bugs live.
+#
+# So every stage here puts ONE rank per node.  That is not a load-spreading
+# preference -- with two ranks on a node, a rank asking for its neighbour's
+# data is answered out of local storage and the request never leaves the
+# server.  A run with two ranks per node can be green with the whole remote
+# path broken.  Keep the geometry.
+#
+# What the stages reach that `make check` cannot:
+#
+#   * dmodex / modex_twice / group_dmodex -- a rank fetches a peer's data
+#     from a server that is not its own.  This is the only way
+#     pmix_server_get()'s local-vs-remote classification, the deferral onto
+#     pmix_server_globals.local_reqs, the host direct_modex up-call, and the
+#     reply ingest are exercised at all.  modex_twice repeats the fetch so
+#     the second request finds an existing tracker rather than creating one.
+#   * dynamic -- spawn plus connect, so a rank gets a key from a process in
+#     a DIFFERENT namespace.  That is the diffnspace arm of
+#     _satisfy_request(), which packs job-level data before the per-rank
+#     data and is the arm whose not-found path used to strand the packed
+#     buffer.
+#   * multi_nspace_group -- a group whose members span namespaces and
+#     nodes, which drives the two-level group block/tracker engine through
+#     a real host rather than through simptest.
+#   * resolve / simple_resolve -- pmix_server_resolve_peers() and
+#     pmix_server_resolve_node() against a host (prte) that answers the
+#     query itself.  NOTE what this does and does not cover: because prte
+#     implements the query interface, these take the host arm and the
+#     server's own local-datastore fallback
+#     (pmix_server_locally_resolve_peers/_node) is NOT reached.  The
+#     fallback is what runs under a host without query support; it has no
+#     coverage here and saying so is more useful than implying otherwise.
+#   * pub -- publish/lookup/unpublish, the setup-caddy family whose whole
+#     job is to survive a host up-call and answer exactly once.
+#   * IOF pull against a persistent DVM -- prterun attaches to the DVM as a
+#     TOOL and calls PMIx_IOF_pull, which is the only thing that drives
+#     pmix_server_iofreg()/pmix_server_iofdereg() on the daemon.  A
+#     transient DVM does not: it is torn down with the job.  Running two
+#     jobs in a row against one DVM means the second registers after the
+#     first has deregistered, which is the sequence that fails if the
+#     registration caddy is released while the host still owns it.
+#   * a valgrind stage on the daemon itself.  Every other suite valgrinds a
+#     client; the server library only ever runs inside prted, so leaks in
+#     it are invisible to all of them.
+#
+# Prints PASS/FAIL per case and a summary; exits non-zero if anything failed.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+# RUN/ON, cleanup_swarm, swarm_up_or_die and the swarm naming (PMIX_SWARM,
+# NODE, IMAGE, VOLUME) all live in swarm-common.sh.
+. "$(dirname "$0")/swarm-common.sh"
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+# The examples this runner drives.  Each one puts the server library on a
+# path a single-node run cannot take; see the header.
+SERVER_EXAMPLES="${SERVER_EXAMPLES:-dmodex modex_twice group_dmodex dynamic multi_nspace_group resolve simple_resolve pub}"
+
+# See run-client-tests.sh: these are COMPILED in a throwaway builder
+# container and RUN in the long-lived node containers, so they must link the
+# PMIx that build.sh installed into the shared volume -- the only tree that
+# is the same in both.
+PMIX_PREFIX=/opt/prte/pmix
+
+OUT=""
+WANT=""
+RC=0
+HOSTS=""
+NP=0
+
+# Launch geometry.  ONE rank per node, always -- see the header.  The
+# default spread is four nodes; a couple of the examples want more ranks to
+# make their point.
+sv_geom() {
+    HOSTS="node1:1,node2:1,node3:1,node4:1"; NP=4
+    WANT='PMIx_Finalize successfully completed'
+    case "$1" in
+        dynamic|multi_nspace_group|resolve)
+            # These three call PMIx_Spawn. --host IS the allocation, so a
+            # parent job that fills every listed slot leaves the spawn with
+            # nowhere to land and the job blocks until the launch timeout --
+            # which looks exactly like a library hang and is not one. Give
+            # the DVM twice the nodes the parent uses, so the child job gets
+            # servers of its own: that is also what makes the subsequent
+            # cross-namespace get cross a server boundary rather than being
+            # answered out of the parent's own datastore.
+            HOSTS="node1:1,node2:1,node3:1,node4:1"; NP=2 ;;
+    esac
+    case "$1" in
+        # Not every example announces itself the same way. Match what each
+        # one actually prints on the way out, or the case passes/fails on
+        # the marker rather than on the behavior.
+        modex_twice)    WANT='second fence: new values visible, old values kept' ;;
+        group_dmodex)   WANT='COMPLETE' ;;
+        resolve)        WANT='Bye\.' ;;
+        pub|simple_resolve) WANT='' ;;
+    esac
+}
+
+# Launch from the staging directory, not from wherever the shell landed.
+# examples/resolve.c spawns its child as the RELATIVE path "./resolve", so a
+# launch from anywhere else fails on the spawned job with "could not access
+# an executable" and then hangs the surviving parent rank at its fence --
+# which reads as a library hang and is not one.
+launch() {
+    local prog="$1"; shift
+    sv_geom "$prog"
+    OUT="$(RUN "cd /opt/prte/tests-server && prterun --host $HOSTS -np $NP --map-by node --timeout 90 ./$prog $* 2>&1")"
+    RC=$?
+}
+
+# Judge one launch.  A hang is always a failure.  Otherwise require the
+# completion marker (when the example prints one) and the absence of a
+# crash.  Deliberately NOT "any line mentioning PMIX_ERR_*": several of
+# these examples probe for things the swarm has no provider for and print
+# the error they get.  A crash, a lost connection, or a client that never
+# reaches PMIx_Finalize is what must never happen.
+judge() {
+    local name="$1" what="$2"
+    if echo "$OUT" | grep -qiE 'time limit for job|timed out|DVM timeout'; then
+        bad "$name: HUNG (hit the launch timeout)"
+        return
+    fi
+    if [ -n "$WANT" ] && ! echo "$OUT" | grep -qiE "$WANT"; then
+        bad "$name: no completion (output: $(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+        return
+    fi
+    if [ "$RC" != 0 ]; then
+        bad "$name: exit $RC (output: $(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+        return
+    fi
+    if echo "$OUT" | grep -qiE 'Segmentation|core dumped|connection refused|: ERROR!'; then
+        bad "$name: $(echo "$OUT" | grep -iE 'Segmentation|core dumped|connection refused|: ERROR!' | head -1)"
+        return
+    fi
+    ok "$name: $what"
+}
+
+########################################################################
+# Linux: the 10-node swarm.
+########################################################################
+
+test_linux() {
+    local ex rc
+
+    swarm_up_or_die
+
+    banner "preflight: install present in shared volume"
+    if RUN 'command -v prterun prte pterm >/dev/null'; then
+        ok "prterun/prte/pterm on PATH"
+    else
+        bad "tools missing -- did ./build.sh run?"; return
+    fi
+
+    if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+        bad "build volume $VOLUME missing -- run ./build.sh first"
+        return
+    fi
+
+    # The nodes are long-lived containers while the install they read is
+    # replaced under them, so a node predating the current image runs a
+    # different PMIx than the builder container compiles against.
+    banner "preflight: containers are running the current image"
+    local imgid cimg imgn stalenodes=""
+    imgid=$(docker images --no-trunc --format '{{.ID}}' "$IMAGE" 2>/dev/null | head -1)
+    for imgn in $(seq 1 10); do
+        cimg=$(docker inspect "$NODE$imgn" --format '{{.Image}}' 2>/dev/null)
+        [ "$cimg" = "$imgid" ] || stalenodes="$stalenodes node$imgn"
+    done
+    if [ -z "$stalenodes" ]; then
+        ok "all 10 containers are on the current $IMAGE"
+    else
+        bad "containers predate $IMAGE:$stalenodes"
+        echo "     Recreate them: ${SWARM_ENV}docker compose up -d --force-recreate" >&2
+        return
+    fi
+
+    banner "preflight: PMIx installed in the shared volume"
+    if ON 1 "test -f $PMIX_PREFIX/include/pmix_common.h"; then
+        ok "PMIx headers/libs under $PMIX_PREFIX"
+    else
+        bad "no $PMIX_PREFIX in the volume -- run ./build.sh first"
+        return
+    fi
+
+    banner "build the server-path examples"
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e EXAMPLES="$SERVER_EXAMPLES" \
+        -e PFX="$PMIX_PREFIX" \
+        "$IMAGE" bash -euo pipefail -c '
+            mkdir -p /opt/prte/tests-server
+            for ex in $EXAMPLES; do
+                gcc -O0 -g -o "/opt/prte/tests-server/$ex" "/pmix-src/examples/$ex.c" \
+                    -I"$PFX/include" -I/pmix-src/examples \
+                    -L"$PFX/lib" -lpmix -Wl,-rpath,"$PFX/lib"
+            done
+        '
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        bad "could not build the server-path examples (rc=$rc)"
+        return
+    fi
+    ok "built: $SERVER_EXAMPLES"
+
+    banner "server-side request handling across separate PMIx servers"
+    for ex in $SERVER_EXAMPLES; do
+        cleanup_swarm
+        if ! RUN "test -x /opt/prte/tests-server/$ex"; then
+            skp "$ex (not built)"; continue
+        fi
+        launch "$ex"
+        case "$ex" in
+            dmodex)      judge "$ex" "direct modex: a key fetched from another server" ;;
+            modex_twice) judge "$ex" "repeated modex: second request joins an existing tracker" ;;
+            group_dmodex) judge "$ex" "modex within a group spanning servers" ;;
+            dynamic)     judge "$ex" "spawn + connect: a get across namespaces and servers" ;;
+            multi_nspace_group)
+                         judge "$ex" "group block/tracker engine across namespaces and nodes" ;;
+            resolve)     judge "$ex" "resolve_peers/resolve_node answered by the host" ;;
+            simple_resolve)
+                         judge "$ex" "resolve against a host that owns the answer" ;;
+            pub)         judge "$ex" "publish/lookup/unpublish round-tripped through the host" ;;
+            *)           judge "$ex" "completed" ;;
+        esac
+        [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ] \
+            || bad "$ex: stray prted left behind"
+    done
+
+    # ------------------------------------------------------------------
+    # IOF registration/deregistration on the daemon.
+    #
+    # prterun attaches to a PERSISTENT DVM as a tool and calls
+    # PMIx_IOF_pull; that is what reaches pmix_server_iofreg() in the
+    # daemon, and the tool's departure is what reaches
+    # pmix_server_iofdereg().  A transient DVM never gets there, because it
+    # is created and torn down with the job.
+    #
+    # Two jobs in a row against ONE DVM is the sequence that matters: the
+    # second registration happens after the first has deregistered, so a
+    # registration caddy that was freed while the host still owned it shows
+    # up as a crashed or silent daemon on the second job rather than the
+    # first.
+    # ------------------------------------------------------------------
+    banner "IOF pull/dereg against a persistent DVM"
+    cleanup_swarm
+    if ! RUN 'test -x /opt/prte/tests-server/dmodex'; then
+        skp "iof-dvm (dmodex not built)"
+    else
+        OUT="$(RUN 'prte --daemonize --host node1:1,node2:1,node3:1,node4:1 >/tmp/svr-dvm.log 2>&1; sleep 5;
+                    echo "--- job 1 ---";
+                    prterun --host node1:1,node2:1 -np 2 --map-by node --timeout 60 /opt/prte/tests-server/dmodex 2>&1;
+                    echo "--- job 2 ---";
+                    prterun --host node3:1,node4:1 -np 2 --map-by node --timeout 60 /opt/prte/tests-server/dmodex 2>&1;
+                    echo "--- done ---";
+                    pterm >/dev/null 2>&1' )"
+        RC=$?
+        if ! echo "$OUT" | grep -q -- '--- done ---'; then
+            bad "iof-dvm: the DVM sequence did not complete ($(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+        elif echo "$OUT" | grep -qiE 'time limit for job|timed out'; then
+            bad "iof-dvm: HUNG"
+        elif echo "$OUT" | grep -qiE 'Segmentation|core dumped|: ERROR!'; then
+            bad "iof-dvm: $(echo "$OUT" | grep -iE 'Segmentation|core dumped|: ERROR!' | head -1)"
+        elif [ "$(echo "$OUT" | grep -c 'PMIx_Finalize successfully completed')" -lt 2 ]; then
+            # dmodex announces its finalize from RANK 0 ONLY, so the count to
+            # expect is one per job, not one per rank
+            bad "iof-dvm: both jobs did not finish ($(echo "$OUT" | grep -c 'PMIx_Finalize successfully completed') of 2)"
+        elif [ "$(echo "$OUT" | grep 'PMIx_Finalize successfully completed' | awk '{print $3}' | sort -u | wc -l)" -lt 2 ]; then
+            # ... and they must be two DIFFERENT namespaces, or we have one
+            # job's output forwarded twice rather than two jobs each forwarded
+            bad "iof-dvm: both completions came from one job -- the second tool attachment forwarded nothing"
+        else
+            ok "iof-dvm: two tool attachments in a row, output forwarded for both"
+        fi
+        cleanup_swarm
+    fi
+
+    # ------------------------------------------------------------------
+    # The daemon under valgrind.
+    #
+    # This is the only stage in the whole harness that leak-checks the
+    # SERVER library.  Every other suite valgrinds a client, and a client
+    # never runs src/server at all.
+    #
+    # The DVM's own daemons are started by prte, so the way to get valgrind
+    # underneath one is to run the whole DVM under it on a single node and
+    # then drive real work through it.  One node is a real limitation --
+    # the remote-fetch half of pmix_server_get is not entered -- so this
+    # stage is about the request handlers, the caddy accounting, and the
+    # collective trackers, not about direct modex.  Do not let it stand in
+    # for the multi-node stages above.
+    #
+    # Only "definitely lost" blocks whose stack names a src/server frame are
+    # failed on.  prte itself leaks at exit in ways that are not this
+    # suite's business, and holding this stage to a whole-process clean bill
+    # would make it permanently red and therefore ignored.
+    # ------------------------------------------------------------------
+    banner "server library under valgrind"
+    cleanup_swarm
+    # The image does not carry valgrind (it is a build image, not a debug
+    # one, and it is shared with the other swarm so rebuilding it to add a
+    # package moves it under that swarm's feet). Install it into the one
+    # node we need it on, at run time, and skip cleanly if there is no
+    # network to do that with.
+    if ! ON 1 'command -v valgrind >/dev/null 2>&1'; then
+        ON 1 'apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq valgrind >/dev/null 2>&1' || true
+    fi
+    if ! ON 1 'command -v valgrind >/dev/null 2>&1'; then
+        skp "valgrind-server (valgrind unavailable and could not be installed)"
+    elif ! RUN 'test -x /opt/prte/tests-server/dmodex'; then
+        skp "valgrind-server (dmodex not built)"
+    else
+        ON 1 'rm -f /tmp/svr-vg.log'
+        # RUN, not ON: prterun refuses to run as root unless
+        # PRTE_ALLOW_RUN_AS_ROOT[_CONFIRM] are in the environment, and RUN is
+        # the helper that sets them. ON leaves them out and the launch dies
+        # with the run-as-root advisory rather than with anything to do with
+        # valgrind.
+        # --fullpath-after= (empty argument) makes valgrind print the FULL
+        # source path in each frame instead of the bare basename. Without it
+        # a PMIx server frame reads "pmix_server_get.c:123", which is both
+        # unmatchable by a path pattern and ambiguous: PRRTE has its own
+        # pmix_server.c, pmix_server_fence.c and pmix_server_gen.c, so a
+        # basename match would attribute PRRTE's leaks to us and a path
+        # match would find nothing at all. The full path separates them.
+        OUT="$(RUN 'valgrind --leak-check=full --show-leak-kinds=definite \
+                        --track-origins=yes --error-exitcode=0 \
+                        --fullpath-after= \
+                        --log-file=/tmp/svr-vg.log \
+                        prterun -np 2 --timeout 90 /opt/prte/tests-server/dmodex 2>&1' )"
+        RC=$?
+        if [ "$RC" != 0 ]; then
+            bad "valgrind-server: the run itself failed (exit $RC): $(echo "$OUT" | tr '\n' ' ' | tail -c 200)"
+        else
+            # a definite leak whose allocation stack passes through
+            # src/server is ours; anything else is not this stage's subject
+            # --show-leak-kinds=definite means the log holds definite-leak
+            # records and the summary, nothing else, so a src/server frame
+            # anywhere in it is a frame in a definite leak's allocation stack
+            local srvleaks
+            srvleaks="$(ON 1 "grep -c 'src/server/pmix_server' /tmp/svr-vg.log" 2>/dev/null | tr -dc '0-9')"
+            srvleaks="${srvleaks:-0}"
+            if [ "$srvleaks" = 0 ]; then
+                ok "valgrind-server: no definite leak attributed to a src/server frame"
+            else
+                bad "valgrind-server: $srvleaks definite-leak frames in src/server"
+                ON 1 'grep -B2 -A12 "definitely lost" /tmp/svr-vg.log | head -60' >&2
+            fi
+        fi
+        cleanup_swarm
+    fi
+}
+
+########################################################################
+# macOS: natively on this host.  One PMIx server, so the remote half of
+# pmix_server_get is not reached at all -- but the request handlers, the
+# collective trackers and the caddy accounting are still driven by a real
+# host, which test/unit cannot do either.
+########################################################################
+
+test_macos() {
+    local ex prefix="$root/../build/master"
+
+    [ -d "$prefix" ] || prefix="/opt/prte/pmix"
+
+    banner "native single-host server pass"
+    echo "  NOTE: one node means one server -- the direct-modex half of"
+    echo "        src/server is NOT covered here. Use the linux mode for that."
+    if [ ! -x "$prefix/bin/prterun" ] && ! command -v prterun >/dev/null; then
+        skp "no prterun available -- run ./build.sh macos first"
+        return
+    fi
+
+    mac_isolate "$prefix" 2>/dev/null || true
+
+    for ex in $SERVER_EXAMPLES; do
+        local bin="/tmp/pmix-server-$ex.$$"
+        if ! cc -O0 -g -o "$bin" "$root/examples/$ex.c" \
+                -I"$root/include" -I"$root" \
+                -L"$root/src/.libs" -lpmix -Wl,-rpath,"$root/src/.libs" \
+                >/dev/null 2>&1; then
+            skp "$ex (would not compile against the in-tree library)"
+            continue
+        fi
+        sv_geom "$ex"
+        OUT="$(prterun -np "$NP" --timeout 90 "$bin" 2>&1)"; RC=$?
+        judge "$ex" "completed against a single local server"
+        rm -f "$bin"
+    done
+}
+
+########################################################################
+
+case "$mode" in
+    linux) test_linux ;;
+    macos) test_macos ;;
+    *) echo "usage: $0 [linux|macos]" >&2; exit 2 ;;
+esac
+
+banner "summary"
+printf '  passed %d, failed %d, skipped %d\n' "$pass" "$fail" "$skip"
+[ "$fail" -eq 0 ]

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -87,3 +87,50 @@ Detailed changes since v6.1.0:
    key. Hostname, which was being derived outside the same test, now
    follows the rule in both directions: it is supplied when the host
    gave none, and left alone when the host gave one
+ - A batch of server-side request-handling fixes from a review of
+   src/server. Two of them are use-after-free or double-free rather
+   than leaks: the IOF pull and deregister handlers released the
+   caddy the host had just accepted ownership of, so the host's
+   completion callback ran on freed memory; and the fabric-register
+   handler released its query caddy twice on a malformed request.
+   Related, the internal response path for a fabric request the
+   pnet layer answered itself handed the completion function a
+   server caddy where it expected a query caddy, and the fabric
+   update path left that function unset entirely
+ - A server no longer answers a PMIx_Get for a rank that is not one
+   of its own by reading a peer id out of a list sentinel. The value
+   is arbitrary, and when it happened to name a live client slot the
+   request was treated as local and parked to wait for a commit that
+   was never coming
+ - A deferred direct-modex request that the server could not launch -
+   no host support, or a host that rejected the up-call - is now
+   fully discarded. Only the tracker's own reference was being
+   dropped, and since every parked requester holds one of its own,
+   the tracker survived unreachable: off the pending list where no
+   later resolve could find it, and still holding a pointer to the
+   caddy that was about to be freed
+ - A registration for a default event handler (one made with no event
+   codes) now checks the notification cache, so an event that arrived
+   before the handler registered is still delivered to it
+ - PMIX_TIMEOUT is now read into a variable of the width the accessor
+   is told to write. The fence, connect and get handlers were passing
+   the address of a time_t while asking for a 32-bit conversion, which
+   fills the wrong half of the field on a big-endian host
+ - Assorted leaks on server error paths: the group id and participant
+   array of a malformed group request, the scratch lists of a job
+   control request that was rejected part-way through the directive
+   scan, the retained caddy behind a failed fabric request, the reply
+   buffer of a collective or get whose status could not be packed, and
+   the payload already assembled for a cross-namespace get that then
+   found nothing. The fence and connect timeout handlers also no longer
+   release a tracker that is still linked into the collectives list
+ - The fence and connect handlers no longer drive their completion
+   callback on the internal error path that has no tracker to give it -
+   in connect's case it was being handed a caddy instead, and in both
+   cases the caller was then answered and released a second time by
+   the switchyard
+ - A server asked to resolve the peers of every known namespace now
+   reports that it found none, rather than reporting success with an
+   empty list, and gives each namespace its own first-choice lookup
+   rather than letting one namespace's fallback rank change the search
+   for all the ones after it

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -134,3 +134,10 @@ Detailed changes since v6.1.0:
    empty list, and gives each namespace its own first-choice lookup
    rather than letting one namespace's fallback rank change the search
    for all the ones after it
+ - The fence collective's duplicate-contributor check now works. The
+   list it consults was never appended to, so it was always empty: a
+   clone sharing a rank with its parent had its remote data packed into
+   the modex bucket twice, and one tracking object was leaked per
+   contributor per fence. The per-rank blob that same loop assembles is
+   also released now, rather than being leaked once the pack has copied
+   it

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -141,3 +141,28 @@ Detailed changes since v6.1.0:
    contributor per fence. The per-rank blob that same loop assembles is
    also released now, rather than being leaked once the pack has copied
    it
+ - A server no longer answers a notification addressed to several
+   processes by rebuilding its target list out of copies of the one
+   process being removed from it. The purge that runs when a peer departs
+   indexed the surviving array by the wrong loop variable
+ - When a process others are waiting on departs, the direct-modex
+   requests parked against it are now failed rather than dropped. The
+   tracker was being released while each waiting request still held a
+   reference on it, so it survived unreachable and the waiting clients
+   were left expecting a reply nobody would send
+ - A namespace update that carries a group context id now stores it
+   against the namespace rather than against whatever process identity
+   happened to be left on the stack, and reports a failure of that store
+   instead of the result of the preceding value copy
+ - PMIx_server_finalize now releases the system temporary directory it
+   recorded at init. Besides the leak, a second PMIx_server_init found it
+   still set and silently kept the previous cycle's value
+ - A server told to make an optional connection to another server, and
+   unable to make it, no longer composes a PMIX_SERVER_URI out of the
+   connection that did not happen
+ - Assorted server leaks on paths that "can do nothing": five host
+   callbacks that returned without honoring the release function the host
+   gave them, the scratch lists of PMIx_server_register_resources, the
+   directive array a launcher-spawned server uses to attach to its parent,
+   and the result caddies of PMIx_server_setup_application and
+   PMIx_server_collect_inventory when the caller supplies no callback

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -144,6 +144,14 @@ interchangeable across files: `modex_cbfunc` parks the host's data in
 correct expression differs between `_mdxcbfunc` and `_grpcbfunc`. Check
 which one the *producing* callback set before copying a line.
 
+**Honor the release contract on the paths that "can do nothing".** Every
+host callback that receives a `(relfn, relcbdata)` pair owes the host that
+call, including on the arm where it has just failed to allocate its own
+thread-shift caddy and returns early. Five of them - alloc, query,
+session-control, job-control and monitor - returned without it, stranding
+the host's data for the life of the host process. `modex_cbfunc` and the
+fabric/dist family show the shape to copy.
+
 **An internal completion path must hand the callback the object that
 callback casts.** `_fabric_response` exists to answer a fabric request the
 `pnet` layer satisfied locally, and it called the switchyard's
@@ -297,6 +305,16 @@ the switchyard answer it, so calling the callback would answer that
 caller twice. If you ever discard an lcd that could have *other*
 requesters, they do need their callbacks — follow
 `pmix_pending_nspace_requests`, which drains with callbacks.
+
+**A tracker on `local_reqs` whose target has departed must fail its
+waiters, not just disappear.** `pmix_server_purge_events` runs when a peer
+finalizes or a namespace is deregistered, and any direct-modex tracker
+naming that peer is never going to be answered. Use
+`pmix_server_fail_local_reqs`, which calls each parked requester's
+callback with a status before discarding the tracker: those requesters are
+*other* local procs, and nobody else is going to answer them. This is the
+same reference-counting trap as the one below - the difference is only
+whether the waiters deserve to be told.
 
 **Do not read a `PMIX_LIST_FOREACH` variable after the loop.** A loop
 that runs to completion leaves it pointing at the list's sentinel, which
@@ -491,3 +509,46 @@ misbehave by design).
   ownership discipline line for line.
 - **Preserve wire compatibility:** V1/version gating, append-only layouts,
   tolerate-short-buffer unpacks.
+- **Screen the shape of anything the host hands you before indexing it.**
+  A `pmix_info_t` carrying a `PMIX_DATA_ARRAY` is a host-supplied
+  structure, and several sites here read `array[0]` and `array[1]`
+  positionally on the strength of a comment. Check the array is non-NULL
+  and long enough first: `_register_nspace` and `_register_resources` both
+  did not, and neither is reachable only from trusted code - a host is
+  free to get this wrong.
+- **`pmix_server_globals.system_tmpdir` is read by the directory-removal
+  guard, so finalize must not free it early.** Only the string is freed
+  here; the directory is removed by `pmix_ptl_close()` (inside
+  `pmix_rte_finalize()`) and only if that code created it. But the second
+  guard, in `pmix_os_dirpath_destroy()`, decides by comparing its path
+  against this string, and treats NULL as "the caller has no system
+  tmpdir of its own" - the ordinary case for a client or tool, which
+  takes the *unconditional* `rmdir` arm. Free it above any
+  session-directory cleanup and that guard becomes an `rmdir` of a
+  system-defined directory. It sits below `pmix_rte_finalize()` for that
+  reason and there is a comment at the site saying so.
+- **A public API's non-blocking form still has to clean up when the
+  caller passes no callback.** `PMIx_server_setup_application` and
+  `PMIx_server_collect_inventory` take a callback and have no blocking
+  variant, so a NULL one is legal and simply means "do it and tell me
+  nothing". Both assembled a result caddy and then leaked it, because the
+  only thing that would have released it was the release function handed
+  to a callback that was never called.
+
+## A note on `PMIx_Notify_event` from inside the library
+
+The top-level rule is that back-end code must not call a public `PMIx_*`
+API that thread-shifts. Several sites here do call `PMIx_Notify_event`
+from the progress thread - `pdiedfn`, `psetdef`, `psetdel` - and they are
+correct, which is worth knowing before "fixing" them. That entry point
+blocks **only when its callback argument is NULL**; with a callback it
+thread-shifts and returns, and queuing an event onto the thread you are
+already running on is fine. All three pass a callback.
+
+`pmix_server_group.c` deliberately uses the internal
+`pmix_server_notify_client_of_event` instead, and its comment says the
+public one "cannot be called from the progress thread". Read that as
+shorthand for the blocking form. What all of these *do* owe is the return
+value: a refused notification never reaches the release function, so the
+payload has to be handed back by hand - `pdiedfn` always did this, and the
+two pset handlers now do.

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -123,6 +123,36 @@ Host up-calls use a tri-state return convention throughout:
 invoke the completion yourself"; any error = "rejected." Handle all
 three on every up-call site.
 
+**`PMIX_SUCCESS` from an up-call transfers ownership of the caddy to the
+host.** This is the arm most easily lost, because it is usually the one
+that needs no code: the handler returns and the host's callback does the
+rest. A handler whose error cleanup sits under a bare `exit:` label
+therefore has to *return* on the success arm, not fall into it. Both
+`pmix_server_iofreg` and `pmix_server_iofdereg` fell through and released
+the caddy the host was still holding, so the host's completion ran on
+freed memory — and each carried a comment describing the very discipline
+the code did not implement. When you add a handler, read the success arm
+and the label as one thing.
+
+**A release function belongs to whoever gave it to you, and so does its
+argument.** The host hands down a `(relfn, relcbdata)` pair; `relfn` must
+be called with *that* `relcbdata` and nothing else. The temptation is to
+reach for whichever pointer is in scope — the tracker, the block, our own
+caddy — and several sites had. Note the two spellings are not
+interchangeable across files: `modex_cbfunc` parks the host's data in
+`scd->relcbdata`, while `grpcbfunc` parks it in `scd->cbdata`, so the
+correct expression differs between `_mdxcbfunc` and `_grpcbfunc`. Check
+which one the *producing* callback set before copying a line.
+
+**An internal completion path must hand the callback the object that
+callback casts.** `_fabric_response` exists to answer a fabric request the
+`pnet` layer satisfied locally, and it called the switchyard's
+`fabric_cbfunc` with `qcd->cbdata` — a `pmix_server_caddy_t` — where that
+function casts to `pmix_query_caddy_t` and dereferences the result. The
+sibling `pmix_server_fabric_update` never set `qcd->cbfunc` at all. Both
+are latent only because no in-tree `pnet` component answers a fabric
+request; a component that did would crash immediately.
+
 ## The caddy zoo
 
 | Type | Defined | Role |
@@ -213,7 +243,19 @@ guarded by `!trk->event_active`, and the fence family does **not** add a
 retain when arming (the collectives-list reference is the sole
 reference; completion cancels the timer before releasing). Follow the
 fence pattern precisely — arming a timer with an unbalanced `PMIX_RETAIN`
-or without the `event_active` guard leaks the tracker.
+or without the `event_active` guard leaks the tracker. A timeout handler
+that has to tear the tracker down itself (no completion function was ever
+attached) is bound by the same rule as everything else here: **unlink
+from `collectives` first, then release.**
+
+**Read `PMIX_TIMEOUT` into a variable of the width you ask for.**
+`PMIx_Value_get_number(value, dest, type)` writes exactly `sizeof(type)`
+bytes through `dest`. Handing it `&tv.tv_sec` while asking for
+`PMIX_UINT32` therefore fills four bytes of a `time_t` — the low half on
+a little-endian host, which happens to work, and the high half on a
+big-endian one, which multiplies every timeout by 2^32. Convert through a
+`uint32_t` of its own and assign. The fence, connect and get handlers all
+do this now; `pmix_server_group` always did.
 
 ### Data collection
 
@@ -241,6 +283,32 @@ requests are parked on two list types:
 - `pmix_dmdx_request_t` — one per interested local requester, on the
   lcd's `loc_reqs`; holds a **PMIX_RETAIN on its lcd** and caches the
   requester's `cbfunc`/`cbdata` (the `cd`).
+
+**That retain is why an lcd cannot be discarded by releasing it.** Each
+parked request holds a reference, so `pmix_list_remove_item` +
+`PMIX_RELEASE` on the lcd drops only the creation reference and leaves
+the object alive and now unreachable — off `local_reqs`, so no later
+`pmix_pending_resolve` can ever drain or free it, and with every request
+still holding the `pmix_server_caddy_t` the switchyard is about to free.
+Use `discard_local_tracker`, which drains `loc_reqs` first. It does not
+invoke the requests' callbacks, and that is deliberate: the only
+requester on a freshly created lcd is the caller whose error return makes
+the switchyard answer it, so calling the callback would answer that
+caller twice. If you ever discard an lcd that could have *other*
+requesters, they do need their callbacks — follow
+`pmix_pending_nspace_requests`, which drains with callbacks.
+
+**Do not read a `PMIX_LIST_FOREACH` variable after the loop.** A loop
+that runs to completion leaves it pointing at the list's sentinel, which
+is a bare `pmix_list_item_t`; reading any later field of the element type
+out of it is undefined and returns whatever the enclosing object happens
+to hold there. `pmix_server_get` did this with `iptr->peerid` on the
+"target rank is not one of my local ranks" path — the common case for
+every remote get — and used the garbage as an index into the `clients`
+array. Note what this class of bug does *not* do: the read stays inside
+the enclosing `pmix_namespace_t`, so no sanitizer flags it, and the value
+is usually out of range and accidentally produces the right answer. Track
+a `found` flag and gate on it.
 
 When data arrives the host calls `dmdx_cbfunc` (off-thread) →
 thread-shift → `_process_dmdx_reply` stores the returned data into GDS
@@ -356,6 +424,31 @@ file. `help-pmix-server.txt` is a `show_help` file — if you add, remove,
 or edit any message in it, follow the top-level rule and rebuild the
 generated `show_help` content (`rm src/util/pmix_show_help_content.* &&
 make`).
+
+## Testing what a single node cannot reach
+
+Most of this directory is only half-exercised by `make check`. The
+local-vs-remote decision in `pmix_server_get` has one arm on one node:
+every rank is local, every key is already in the local datastore, and the
+whole direct-modex engine — `local_reqs`, `remote_pnd`, `dmdx_cbfunc` →
+`_process_dmdx_reply` → `pmix_pending_resolve` — never runs. That is
+where the deferred-request lifetime bugs live.
+
+Two suites cover the halves:
+
+- [`test/unit/server_get.c`](../../test/unit/server_get.c) drives
+  `pmix_server_get` directly against a registered nspace whose job size
+  exceeds its local size, and asserts the classification and that nothing
+  is left parked on `local_reqs`. Read its header for what it pins down
+  and what it deliberately cannot reproduce.
+- [`contrib/dockerswarm/run-server-tests.sh`](../../contrib/dockerswarm/run-server-tests.sh)
+  is the multi-node half: direct modex, spawn-plus-connect across
+  namespaces, group blocks spanning nodes, IOF pull/dereg against a
+  persistent DVM, and a valgrind pass on the daemon — the only leak check
+  anywhere that runs against the *server* library, since every other
+  suite valgrinds a client. **Its stages put one rank per node
+  deliberately**; with two ranks on a node a peer's data is answered out
+  of local storage and the run can be green with the remote path broken.
 
 After building, smoke-test per the top-level guide: `make check` in
 `test/`, then `./simptest` in `test/simple/`. The server paths are

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -4191,9 +4191,12 @@ static void _mdxcbfunc(int sd, short args, void *cbdata)
 
     if (NULL == tracker) {
         /* give them a release if they want it - this should
-         * never happen, but protect against the possibility */
+         * never happen, but protect against the possibility.
+         * modex_cbfunc parks the host's release data in relcbdata; cbdata
+         * is not set on this caddy at all, so handing that to the host's
+         * release function passes it something that is not its own. */
         if (NULL != scd->cbfunc.relfn) {
-            scd->cbfunc.relfn(scd->cbdata);
+            scd->cbfunc.relfn(scd->relcbdata);
         }
         PMIX_RELEASE(scd);
         return;
@@ -4293,6 +4296,7 @@ finish_collective:
         PMIX_BFROPS_PACK(ret, cd->peer, reply, &rc, 1, PMIX_STATUS);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
+            PMIX_RELEASE(reply);
             goto cleanup;
         }
         /* let the gds have a chance to add any data it needs
@@ -4353,9 +4357,10 @@ static void modex_cbfunc(pmix_status_t status, const char *data, size_t ndata, v
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        /* nothing we can do */
+        /* nothing we can do beyond honoring the release contract - with
+         * the host's own release data, not the tracker we were handed */
         if (NULL != relfn) {
-            relfn(cbdata);
+            relfn(relcbd);
         }
         return;
     }
@@ -4397,6 +4402,7 @@ static void _getcbfunc(int sd, short args, void *cbdata)
     PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(reply);
         goto cleanup;
     }
     /* if there are data, pack the blob being returned */
@@ -4453,9 +4459,10 @@ static void get_cbfunc(pmix_status_t status, const char *data, size_t ndata, voi
     /* need to thread-shift this callback as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        /* nothing we can do beyond honoring the release contract - with
+         * the host's own release data, not the caddy we were handed */
         if (NULL != relfn) {
-            relfn(cbdata);
+            relfn(relcbd);
         }
         return;
     }
@@ -4492,7 +4499,8 @@ static void _cnct(int sd, short args, void *cbdata)
     }
 
     if (NULL == tracker) {
-        /* nothing to do */
+        /* nothing to do - but the shifter is still ours to free */
+        PMIX_RELEASE(scd);
         return;
     }
 
@@ -4698,7 +4706,8 @@ static void _discnct(int sd, short args, void *cbdata)
     }
 
     if (NULL == tracker) {
-        /* nothing to do */
+        /* nothing to do - but the shifter is still ours to free */
+        PMIX_RELEASE(scd);
         return;
     }
 
@@ -6301,7 +6310,7 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
 
     if (PMIX_FENCENB_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        if (PMIX_SUCCESS != (rc = pmix_server_fence(cd, buf, modex_cbfunc, op_cbfunc))) {
+        if (PMIX_SUCCESS != (rc = pmix_server_fence(cd, buf, modex_cbfunc))) {
             PMIX_RELEASE(cd);
         }
         return rc;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2229,8 +2229,15 @@ void pmix_server_execute_collective(int sd, short args, void *cbdata)
                 if (found) {
                     continue;
                 } else {
+                    /* record it, or the list stays empty forever: the
+                     * duplicate check above then never matches, a clone
+                     * sharing a rank with its parent has its remote data
+                     * packed into the bucket twice, and every one of these
+                     * objects is leaked because the list destructor below
+                     * has nothing to free */
                     pn = PMIX_NEW(pmix_namelist_t);
                     pn->pname = &cd->peer->info->pname;
+                    pmix_list_append(&pnames, &pn->super);
                 }
                 if (trk->hybrid || first) {
                     /* setup the nspace */
@@ -2255,6 +2262,8 @@ void pmix_server_execute_collective(int sd, short args, void *cbdata)
                         PMIX_DESTRUCT(&cb);
                         PMIX_DESTRUCT(&pbkt);
                         PMIX_DESTRUCT(&bucket);
+                        PMIX_LIST_DESTRUCT(&pnames);
+                        PMIX_RELEASE(tcd);
                         return;
                     }
                     PMIX_LIST_FOREACH (kv, &cb.kvs, pmix_kval_t) {
@@ -2264,22 +2273,27 @@ void pmix_server_execute_collective(int sd, short args, void *cbdata)
                             PMIX_DESTRUCT(&cb);
                             PMIX_DESTRUCT(&pbkt);
                             PMIX_DESTRUCT(&bucket);
+                            PMIX_LIST_DESTRUCT(&pnames);
+                            PMIX_RELEASE(tcd);
                             return;
                         }
                     }
                     /* extract the resulting byte object */
                     PMIX_UNLOAD_BUFFER(&pbkt, bo.bytes, bo.size);
                     PMIX_DESTRUCT(&pbkt);
-                    /* now pack that into the bucket for return */
+                    /* now pack that into the bucket for return - the pack
+                     * copies, so the unloaded bytes are ours to free */
                     PMIX_BFROPS_PACK(rc, peer, &bucket, &bo, 1, PMIX_BYTE_OBJECT);
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DESTRUCT(&cb);
                         PMIX_BYTE_OBJECT_DESTRUCT(&bo);
                         PMIX_DESTRUCT(&bucket);
+                        PMIX_LIST_DESTRUCT(&pnames);
                         PMIX_RELEASE(tcd);
                         return;
                     }
+                    PMIX_BYTE_OBJECT_DESTRUCT(&bo);
                 }
                 PMIX_DESTRUCT(&cb);
             }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -504,7 +504,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     bool nspace_given = false, rank_given = false;
     bool share_topo = false;
     pmix_info_t ginfo, *iptr, evinfo[3];
-    char *evar, *nspace = NULL, *suri;
+    char *evar, *nspace = NULL, *suri = NULL;
     pmix_rank_t rank = PMIX_RANK_INVALID;
     pmix_rank_info_t *rinfo;
     pmix_proc_type_t ptype = PMIX_PROC_TYPE_STATIC_INIT;
@@ -523,14 +523,18 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
 
     // check if an init has been called
     if (pmix_atomic_test_and_set(&pmix_globals.init_called)) {
-        // track the ref count
-        pmix_atomic_fetch_add(&server_init_cntr, 1);
         // did the prior call get far enough? We might be in a tight
         // race between multiple calls to PMIx_server_init - bad programming
-        // technique, but all we can do is try to protect against it
+        // technique, but all we can do is try to protect against it.
+        // Test BEFORE counting the call: a caller that is handed an error
+        // has no reason to call finalize, so a reference counted here
+        // would never be given back and the real finalize would decline
+        // to tear anything down.
         if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
             return PMIX_ERR_INIT;
         }
+        // track the ref count
+        pmix_atomic_fetch_add(&server_init_cntr, 1);
         /* setup the function pointers if they weren't previously defined */
         if (NULL != module && !pmix_server_globals.module_set) {
             pmix_host_server = *module;
@@ -949,6 +953,10 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         cbptr = PMIX_NEW(pmix_cb_t);
         cbptr->info = iptr;
         cbptr->ninfo = 3;
+        /* the caddy's destructor releases its info array only when
+         * infocopy says the array is its own - say so, or the three
+         * directives (two of them carrying strdup'd strings) are leaked */
+        cbptr->infocopy = true;
         PMIX_THREADSHIFT(cbptr, pmix_tool_retry_attach);
 
         PMIX_WAIT_THREAD(&cbptr->lock);
@@ -985,6 +993,10 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, bfr, job_data, (void *) &cb);
         if (PMIX_SUCCESS != rc) {
+            /* the transport refused the message without taking it, so the
+             * recv callback will never fire - unwind both here */
+            PMIX_RELEASE(bfr);
+            PMIX_DESTRUCT(&cb);
             return rc;
         }
         /* wait for the data to return */
@@ -1048,21 +1060,33 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         /* connect to another server, if the info's direct us to */
         rc = pmix_ptl.connect_to_peer((struct pmix_peer_t *) pmix_client_globals.myserver,
                                       info, ninfo, &suri);
-        if (PMIX_SUCCESS != rc && !connect_optional) {
-            return rc;
-        }
-        /* store the URI for subsequent lookups */
-        PMIX_KVAL_NEW(kptr, PMIX_SERVER_URI);
-        kptr->value->type = PMIX_STRING;
-        pmix_asprintf(&kptr->value->data.string, "%s.%u;%s",
-                      pmix_client_globals.myserver->info->pname.nspace,
-                      pmix_client_globals.myserver->info->pname.rank, suri);
-        free(suri);
-        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
-        PMIX_RELEASE(kptr); // maintain accounting
         if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            return rc;
+            if (!connect_optional) {
+                return rc;
+            }
+            /* the connection was optional and did not happen, so there is
+             * no URI to record. Falling through used to compose one anyway
+             * out of a suri the failed call left NULL - undefined behavior
+             * in the "%s" conversion, and on the platforms that survive it
+             * a stored PMIX_SERVER_URI of "<nspace>.<rank>;(null)" that
+             * every later lookup would hand back */
+            free(suri);
+            suri = NULL;
+        } else {
+            /* store the URI for subsequent lookups */
+            PMIX_KVAL_NEW(kptr, PMIX_SERVER_URI);
+            kptr->value->type = PMIX_STRING;
+            pmix_asprintf(&kptr->value->data.string, "%s.%u;%s",
+                          pmix_client_globals.myserver->info->pname.nspace,
+                          pmix_client_globals.myserver->info->pname.rank, suri);
+            free(suri);
+            suri = NULL;
+            PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
+            PMIX_RELEASE(kptr); // maintain accounting
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
         }
     }
 
@@ -1173,6 +1197,25 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
         free(pmix_server_globals.tmpdir);
         pmix_server_globals.tmpdir = NULL;
     }
+    /* The system tmpdir is strdup'd alongside it in init and was being
+     * kept: not just a leak per cycle, but stale state - the next init
+     * finds it non-NULL and silently keeps the previous cycle's value
+     * rather than re-reading the environment.
+     *
+     * THIS FREE MUST STAY BELOW pmix_rte_finalize(). We only ever free
+     * the string; the directory itself is removed by pmix_ptl_close(),
+     * which runs inside pmix_rte_finalize() and does so only if it
+     * created the directory. But the second guard - the one in
+     * pmix_os_dirpath_destroy() - decides by comparing its path against
+     * THIS string, and reads a NULL here as "the caller has no system
+     * tmpdir of its own", which is the ordinary case for a client or
+     * tool and takes the *unconditional* rmdir arm. Freeing this while
+     * any session-directory cleanup can still run would therefore turn
+     * a guard into an rmdir of a system-defined directory. */
+    if (NULL != pmix_server_globals.system_tmpdir) {
+        free(pmix_server_globals.system_tmpdir);
+        pmix_server_globals.system_tmpdir = NULL;
+    }
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "pmix:server finalize complete");
@@ -1205,7 +1248,7 @@ static void _register_nspace(int sd, short args, void *cbdata)
     pmix_kval_t *kv;
     pmix_proc_t proc;
 
-    PMIX_ACQUIRE_OBJECT(caddy);
+    PMIX_ACQUIRE_OBJECT(cd);
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "pmix:server _register_nspace %s",
@@ -1236,8 +1279,22 @@ static void _register_nspace(int sd, short args, void *cbdata)
          * requests it */
         gds = pmix_globals.mypeer->nptr->compat.gds;
         if (NULL != gds && NULL != gds->store) {
+            /* default the target to the job level. A PMIX_PROC_INFO_ARRAY
+             * narrows it to the rank that array describes, but the other
+             * arms below are job-level updates that carry no rank of their
+             * own - and they used to store against whatever this variable
+             * happened to hold, which was stack garbage unless a proc-info
+             * array had come earlier in the same call */
+            PMIX_LOAD_PROCID(&proc, cd->proc.nspace, PMIX_RANK_WILDCARD);
             for (i=0; i < cd->ninfo; i++) {
                 if (PMIX_CHECK_KEY(&cd->info[i], PMIX_PROC_INFO_ARRAY)) {
+                    if (NULL == cd->info[i].value.data.darray ||
+                        NULL == cd->info[i].value.data.darray->array ||
+                        0 == cd->info[i].value.data.darray->size) {
+                        /* nothing to describe a rank with */
+                        rc = PMIX_ERR_BAD_PARAM;
+                        goto release;
+                    }
                     iptr = (pmix_info_t*)cd->info[i].value.data.darray->array;
                     ninfo = cd->info[i].value.data.darray->size;
                     /* the first position is the rank */
@@ -1263,7 +1320,13 @@ static void _register_nspace(int sd, short args, void *cbdata)
                         goto release;
                     }
                     PMIX_VALUE_XFER(rc, kv->value, &cd->info[i].value);
-                    gds->store(&proc, PMIX_GLOBAL, kv);
+                    if (PMIX_SUCCESS == rc) {
+                        /* capture the store's own status - it was being
+                         * discarded, leaving the check below to re-read the
+                         * transfer's result and report success for a store
+                         * that had failed */
+                        rc = gds->store(&proc, PMIX_GLOBAL, kv);
+                    }
                     PMIX_RELEASE(kv); // maintain refcount
                     if (PMIX_SUCCESS != rc) {
                         goto release;
@@ -1516,12 +1579,14 @@ void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc)
         if ((NULL != peer && NULL != peer->info
              && PMIX_CHECK_NAMES(&peer->info->pname, &dlcd->proc))
             || (NULL != proc && PMIX_CHECK_PROCID(proc, &dlcd->proc))) {
-            /* cleanup this request */
-            pmix_list_remove_item(&pmix_server_globals.local_reqs, &dlcd->super);
-            /* we can release the dlcd item here because we are not
-             * releasing the tracker held by the host - we are only
-             * releasing one item on that tracker */
-            PMIX_RELEASE(dlcd);
+            /* The proc this request is waiting on has departed, so the
+             * data is never coming. Tell everyone parked on it rather than
+             * dropping the tracker on the floor: each parked request holds
+             * its own reference on the tracker and owns the server caddy of
+             * the client behind it, so releasing the tracker alone left it
+             * alive but unreachable and left those clients waiting on a
+             * reply nobody would ever send. */
+            pmix_server_fail_local_reqs(dlcd, PMIX_ERR_LOST_CONNECTION);
         }
     }
 
@@ -1552,7 +1617,12 @@ void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc)
                     p = 0;
                     for (m = 0; m < ncd->ntargets; m++) {
                         if (tgt != &ncd->targets[m]) {
-                            memcpy(&tgs[p], &ncd->targets[n], sizeof(pmix_proc_t));
+                            /* copy the target this iteration is looking at -
+                             * indexing by n copied the ONE target being
+                             * removed into every surviving slot, so the
+                             * notification came out addressed to N-1 copies
+                             * of the proc that had just gone away */
+                            memcpy(&tgs[p], &ncd->targets[m], sizeof(pmix_proc_t));
                             ++p;
                         }
                     }
@@ -1922,6 +1992,16 @@ static void _register_resources(int sd, short args, void *cbdata)
          * a data array of info about that proc */
         PMIX_LIST_FOREACH(ept, &endpts, pmix_info_caddy_t) {
             // contains an array of proc info
+            if (NULL == ept->info->value.data.darray ||
+                NULL == ept->info->value.data.darray->array ||
+                2 > ept->info->value.data.darray->size) {
+                /* the procID and the scope occupy the first two positions,
+                 * so anything shorter than that describes nothing and
+                 * indexing it would read past the array the host gave us */
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                rc = PMIX_ERR_BAD_PARAM;
+                continue;
+            }
             pinfo = (pmix_info_t*)ept->info->value.data.darray->array;
             npinfo = ept->info->value.data.darray->size;
             // procID is in the first position
@@ -2011,7 +2091,10 @@ static void _register_resources(int sd, short args, void *cbdata)
             PMIX_DESTRUCT(&bkt);
             /* get the next one */
             cnt = 1;
-            PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, &jobinfo, &bo, &cnt, PMIX_BYTE_OBJECT);
+            /* the same peer that opened this buffer has to keep reading it -
+             * myserver is repointed while a launcher-spawned server attaches
+             * to its parent, so the two are not interchangeable here */
+            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &jobinfo, &bo, &cnt, PMIX_BYTE_OBJECT);
         }
         if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
             PMIX_ERROR_LOG(rc);
@@ -2019,6 +2102,10 @@ static void _register_resources(int sd, short args, void *cbdata)
     }
 
 release:
+    /* both scratch lists own the caddies appended to them above and were
+     * being dropped on the floor - on the normal path as well as this one */
+    PMIX_LIST_DESTRUCT(&grpinfo);
+    PMIX_LIST_DESTRUCT(&endpts);
     cd->opcbfunc(rc, cd->cbdata);
     PMIX_RELEASE(cd);
 }
@@ -3068,6 +3155,11 @@ depart:
         } else {
             cd->setupcbfunc(rc, fcd->info, fcd->ninfo, cd->cbdata, _setup_op, fcd);
         }
+    } else if (NULL != fcd) {
+        /* nobody to hand the results to, so nobody will call _setup_op to
+         * give them back either - the caddy and the info array assembled
+         * into it are ours to release */
+        _setup_op(rc, fcd);
     }
 
     /* cleanup memory */
@@ -3499,6 +3591,10 @@ static void clct(int sd, short args, void *cbdata)
 report:
     if (NULL != cd->cbfunc.infocbfunc) {
         cd->cbfunc.infocbfunc(rc, cd->info, cd->ninfo, cd->cbdata, cirelease, cd);
+    } else {
+        /* no callback means nobody will ever call cirelease, so the caddy
+         * and the info array converted into it are ours to give back */
+        cirelease(cd);
     }
     PMIX_LIST_DESTRUCT(&inventory);
     return;
@@ -3677,6 +3773,7 @@ static void psetdef(int sd, short args, void *cbdata)
     pmix_data_array_t *darray;
     pmix_proc_t *ptr;
     pmix_pset_t *ps;
+    pmix_status_t rc;
 
     PMIX_ACQUIRE_OBJECT(cd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
@@ -3693,8 +3790,13 @@ static void psetdef(int sd, short args, void *cbdata)
     ptr = (pmix_proc_t *) darray->array;
     memcpy(ptr, cd->procs, cd->nprocs * sizeof(pmix_proc_t));
 
-    PMIx_Notify_event(PMIX_PROCESS_SET_DEFINE, &pmix_globals.myid, PMIX_RANGE_LOCAL,
-                      mydat->info,  mydat->ninfo, release_info, (void *) mydat);
+    /* a notification that is refused will never reach release_info, so
+     * hand the payload back ourselves in that case */
+    rc = PMIx_Notify_event(PMIX_PROCESS_SET_DEFINE, &pmix_globals.myid, PMIX_RANGE_LOCAL,
+                           mydat->info, mydat->ninfo, release_info, (void *) mydat);
+    if (PMIX_SUCCESS != rc) {
+        release_info(rc, mydat);
+    }
 
     /* now record the process set */
     ps = PMIX_NEW(pmix_pset_t);
@@ -3750,6 +3852,7 @@ static void psetdel(int sd, short args, void *cbdata)
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
     mydata_t *mydat;
     pmix_pset_t *ps;
+    pmix_status_t rc;
 
     PMIX_ACQUIRE_OBJECT(cd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
@@ -3760,8 +3863,12 @@ static void psetdel(int sd, short args, void *cbdata)
     PMIX_INFO_LOAD(&mydat->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
     PMIX_INFO_LOAD(&mydat->info[1], PMIX_PSET_NAME, cd->nspace, PMIX_STRING);
 
-    PMIx_Notify_event(PMIX_PROCESS_SET_DELETE, &pmix_globals.myid, PMIX_RANGE_LOCAL, mydat->info,
-                      mydat->ninfo, release_info, (void *) mydat);
+    /* see the matching note in psetdef */
+    rc = PMIx_Notify_event(PMIX_PROCESS_SET_DELETE, &pmix_globals.myid, PMIX_RANGE_LOCAL,
+                           mydat->info, mydat->ninfo, release_info, (void *) mydat);
+    if (PMIX_SUCCESS != rc) {
+        release_info(rc, mydat);
+    }
 
     /* now find this process set */
     PMIX_LIST_FOREACH (ps, &pmix_server_globals.psets, pmix_pset_t) {
@@ -4953,7 +5060,13 @@ static void alloc_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, 
     /* need to thread-shift this callback as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        /* nothing we can do beyond honoring the release contract -
+         * the host handed us its data along with the function that
+         * gives it back, and dropping both here strands it for the
+         * life of the host process */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         return;
     }
     scd->status = status;
@@ -5041,7 +5154,13 @@ static void query_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, 
     /* need to thread-shift this callback as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        /* nothing we can do beyond honoring the release contract -
+         * the host handed us its data along with the function that
+         * gives it back, and dropping both here strands it for the
+         * life of the host process */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         return;
     }
     scd->status = status;
@@ -5134,7 +5253,13 @@ static void sessctrl_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninf
     /* need to thread-shift this callback as it accesses global data */
     scdwrapper = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scdwrapper) {
-        /* nothing we can do */
+        /* nothing we can do beyond honoring the release contract -
+         * the host handed us its data along with the function that
+         * gives it back, and dropping both here strands it for the
+         * life of the host process */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         return;
     }
     scdwrapper->status = status;
@@ -5231,7 +5356,13 @@ static void jctrl_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, 
     /* need to thread-shift this callback as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        /* nothing we can do beyond honoring the release contract -
+         * the host handed us its data along with the function that
+         * gives it back, and dropping both here strands it for the
+         * life of the host process */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         return;
     }
     scd->status = status;
@@ -5316,7 +5447,13 @@ static void monitor_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo
     /* need to thread-shift this callback as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        /* nothing we can do beyond honoring the release contract -
+         * the host handed us its data along with the function that
+         * gives it back, and dropping both here strands it for the
+         * life of the host process */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         return;
     }
     scd->status = status;

--- a/src/server/pmix_server_connect.c
+++ b/src/server/pmix_server_connect.c
@@ -250,7 +250,12 @@ static void connect_timeout(int sd, short args, void *cbdata)
         trk->op_cbfunc(PMIX_ERR_TIMEOUT, trk);
         return; // the cbfunc will have cleaned up the tracker
     }
+    /* no completion function was ever attached, so tear the tracker down
+     * ourselves - which means unlinking it from the collectives list first.
+     * Being on that list is not a reference; releasing while still linked
+     * leaves a dangling entry that the next sweep walks into. */
     trk->event_active = false;
+    pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
     PMIX_RELEASE(trk);
 }
 
@@ -264,6 +269,7 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
     pmix_info_t *info = NULL, *iptr, endpt;
     size_t nprocs, ninfo, n, ninf;
     pmix_server_trkr_t *trk;
+    uint32_t tmo;
     struct timeval tv = {0, 0};
 
     pmix_output_verbose(2, pmix_server_globals.connect_output,
@@ -333,8 +339,14 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
             if (0 == strncmp(info[n].key, PMIX_TIMEOUT, PMIX_MAX_KEYLEN)) {
                 /* use the type-tolerant accessor rather than a raw union
                  * read so any integer type for the timeout is accepted,
-                 * matching the fence family */
-                PMIx_Value_get_number(&info[n].value, &tv.tv_sec, PMIX_UINT32);
+                 * matching the fence family. Convert through a uint32_t of
+                 * its own: the accessor writes exactly the width of the
+                 * requested type, so handing it the address of a wider
+                 * time_t would fill only half the field - the wrong half
+                 * on a big-endian host. */
+                if (PMIX_SUCCESS == PMIx_Value_get_number(&info[n].value, &tmo, PMIX_UINT32)) {
+                    tv.tv_sec = tmo;
+                }
                 break;
             }
         }
@@ -344,12 +356,14 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
     if (NULL == (trk = pmix_server_get_tracker(NULL, procs, nprocs, PMIX_CONNECTNB_CMD))) {
         /* we don't have this tracker yet, so get a new one */
         if (NULL == (trk = pmix_server_new_tracker(NULL, procs, nprocs, PMIX_CONNECTNB_CMD))) {
-            /* only if a bozo error occurs */
+            /* only if a bozo error occurs. Do NOT drive the completion
+             * function here: it takes a tracker, not this caddy, and there
+             * is no tracker to give it. Returning the error is enough - the
+             * switchyard answers this caller and releases the caddy, so the
+             * client cannot hang. Handing it the caddy read a
+             * pmix_server_caddy_t as a pmix_server_trkr_t and then released
+             * the caddy a second time. */
             PMIX_ERROR_LOG(PMIX_ERROR);
-            /* DO NOT HANG */
-            if (NULL != cbfunc) {
-                cbfunc(PMIX_ERROR, cd);
-            }
             rc = PMIX_ERROR;
             goto cleanup;
         }

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -575,7 +575,12 @@ static void fence_timeout(int sd, short args, void *cbdata)
         trk->modexcbfunc(PMIX_ERR_TIMEOUT, NULL, 0, trk, NULL, NULL);
         return; // the cbfunc will have cleaned up the tracker
     }
+    /* no completion function was ever attached, so tear the tracker down
+     * ourselves - which means unlinking it from the collectives list first.
+     * Being on that list is not a reference; releasing while still linked
+     * leaves a dangling entry that the next sweep walks into. */
     trk->event_active = false;
+    pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
     PMIX_RELEASE(trk);
 }
 
@@ -905,7 +910,7 @@ cleanup:
 }
 
 pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
-                                pmix_modex_cbfunc_t modexcbfunc, pmix_op_cbfunc_t opcbfunc)
+                                pmix_modex_cbfunc_t modexcbfunc)
 {
     int32_t cnt;
     pmix_status_t rc;
@@ -918,6 +923,7 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     pmix_buffer_t bucket;
     pmix_info_t *info = NULL;
     size_t ninfo = 0, ninf, n;
+    uint32_t tmo;
     struct timeval tv = {0, 0};
 
     pmix_output_verbose(2, pmix_server_globals.fence_output,
@@ -982,12 +988,17 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
             if (PMIX_CHECK_KEY(&info[n], PMIX_COLLECT_DATA)) {
                 collect_data = PMIX_INFO_TRUE(&info[n]);
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
-                rc = PMIx_Value_get_number(&info[n].value, &tv.tv_sec, PMIX_UINT32);
+                /* convert through a uint32_t of its own: the accessor
+                 * writes exactly the width of the requested type, so
+                 * handing it the address of a wider time_t would fill only
+                 * half the field - the wrong half on a big-endian host */
+                rc = PMIx_Value_get_number(&info[n].value, &tmo, PMIX_UINT32);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_PROC_FREE(procs, nprocs);
                     PMIX_INFO_FREE(info, ninfo);
                     return rc;
                 }
+                tv.tv_sec = tmo;
             }
         }
     }
@@ -996,12 +1007,12 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     if (NULL == (trk = pmix_server_get_tracker(NULL, procs, nprocs, PMIX_FENCENB_CMD))) {
         /* If no tracker was found - create and initialize it once */
         if (NULL == (trk = pmix_server_new_tracker(NULL, procs, nprocs, PMIX_FENCENB_CMD))) {
-            /* only if a bozo error occurs */
+            /* only if a bozo error occurs. Do NOT drive opcbfunc here: it
+             * releases the caddy and answers the client, and we then return
+             * an error, so the switchyard would release the same caddy and
+             * answer the same client a second time. Returning the error on
+             * its own is what keeps the client from hanging. */
             PMIX_ERROR_LOG(PMIX_ERROR);
-            /* DO NOT HANG */
-            if (NULL != opcbfunc) {
-                opcbfunc(PMIX_ERROR, cd);
-            }
             rc = PMIX_ERROR;
             PMIX_INFO_FREE(info, ninfo);
             goto cleanup;

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -106,6 +106,26 @@ static void relfn(void *cbdata)
     }
 }
 
+/* Discard a local dmodex tracker that we created for a request we then
+ * failed to launch. Each parked requester on loc_reqs holds its own
+ * reference on the tracker, so simply releasing the tracker's creation
+ * reference leaves it (and every request on it) alive but unreachable -
+ * off the local_reqs list, so no later resolve can ever drain or free it,
+ * and with each request still holding the server caddy pointer that the
+ * switchyard is about to free. Drain the requests first. We do not invoke
+ * their callbacks: the only requester on a freshly created tracker is the
+ * caller whose error return makes the switchyard answer it. */
+static void discard_local_tracker(pmix_dmdx_local_t *lcd)
+{
+    pmix_dmdx_request_t *req;
+
+    while (NULL != (req = (pmix_dmdx_request_t *) pmix_list_remove_first(&lcd->loc_reqs))) {
+        PMIX_RELEASE(req);
+    }
+    pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
+    PMIX_RELEASE(lcd);
+}
+
 static pmix_status_t defer_response(char *nspace, pmix_rank_t rank, char *key,
                                     pmix_server_caddy_t *cd, bool localonly,
                                     pmix_modex_cbfunc_t cbfunc, void *cbdata,
@@ -162,6 +182,8 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
     bool refresh_cache = false;
     bool scope_given = false;
     bool keyprovided = false;
+    bool found = false;
+    uint32_t tmo;
     struct timeval tv = {0, 0};
     pmix_buffer_t pbkt;
     pmix_cb_t cb;
@@ -240,7 +262,16 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
              * or request it from someone else */
             localonly = PMIX_INFO_TRUE(&cd->info[n]);
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_TIMEOUT)) {
-            tv.tv_sec = cd->info[n].value.data.uint32;
+            /* use the type-tolerant accessor rather than a raw union read
+             * so any integer type for the timeout is accepted, matching
+             * the fence/connect/group families. Convert through a uint32_t
+             * of its own: the accessor writes exactly the width of the
+             * requested type, so handing it the address of a wider time_t
+             * would fill only half the field - the wrong half on a
+             * big-endian host. */
+            if (PMIX_SUCCESS == PMIx_Value_get_number(&cd->info[n].value, &tmo, PMIX_UINT32)) {
+                tv.tv_sec = tmo;
+            }
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GET_REFRESH_CACHE)) {
             refresh_cache = PMIX_INFO_TRUE(&cd->info[n]);
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_DATA_SCOPE)) {
@@ -436,6 +467,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
             local = true;
         } else {
             /* see if this proc is one of our local ones */
+            found = false;
             PMIX_LIST_FOREACH (iptr, &nptr->ranks, pmix_rank_info_t) {
                 if (rank == iptr->pname.rank) {
                     if (0 > iptr->peerid) {
@@ -451,10 +483,17 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
                         return rc;
                     }
                     local = true;
+                    found = true;
                     break;
                 }
             }
-            if (NULL == pmix_pointer_array_get_item(&pmix_server_globals.clients, iptr->peerid)) {
+            /* only consult iptr when the loop actually matched a rank - a
+             * loop that ran to completion leaves iptr pointing at the list
+             * sentinel, and reading peerid out of that is an out-of-bounds
+             * read whose garbage value could index a live client slot and
+             * wrongly mark a remote rank as local */
+            if (found &&
+                NULL == pmix_pointer_array_get_item(&pmix_server_globals.clients, iptr->peerid)) {
                 /* this must be a remote rank */
                 local = false;
             }
@@ -638,15 +677,13 @@ request:
         rc = pmix_host_server.direct_modex(&lcd->proc, cd->info, cd->ninfo, dmdx_cbfunc, lcd);
         if (PMIX_SUCCESS != rc) {
             /* may have a function entry but not support the request */
-            pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
-            PMIX_RELEASE(lcd);
+            discard_local_tracker(lcd);
         }
     } else {
         pmix_output_verbose(2, pmix_server_globals.get_output, "%s:%d NO SERVER SUPPORT",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank);
         /* if we don't have direct modex feature, just respond with "not found" */
-        pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
-        PMIX_RELEASE(lcd);
+        discard_local_tracker(lcd);
         rc = PMIX_ERR_NOT_FOUND;
     }
 
@@ -992,7 +1029,10 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank, 
         PMIX_BYTE_OBJECT_DESTRUCT(&bo); // data has been copied
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_DESTRUCT(&pbkt);
+            /* do NOT destruct pbkt here - the complete label unloads it,
+             * and unloading an already-destructed buffer hands the caller
+             * a freed pointer to pass on and free again. The sibling error
+             * paths above correctly destruct only the inner pkt. */
             PMIX_DESTRUCT(&cb);
             goto complete;
         }
@@ -1009,6 +1049,12 @@ complete:
         return rc;
     }
 
+    /* nothing is being passed back, so nothing will call relfn for us -
+     * the buffer may still carry the job-level data packed above (the
+     * cross-namespace case), and that allocation is ours to free */
+    if (NULL != data) {
+        free(data);
+    }
     return PMIX_ERR_NOT_FOUND;
 }
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -126,6 +126,27 @@ static void discard_local_tracker(pmix_dmdx_local_t *lcd)
     PMIX_RELEASE(lcd);
 }
 
+/* Retire a local dmodex tracker whose target is never going to answer -
+ * the proc it names has departed - telling every parked requester so, and
+ * then discarding the tracker. This is the variant callers outside this
+ * file need: unlike discard_local_tracker above, the parked requesters
+ * here are OTHER local procs that nobody else is going to answer, so
+ * dropping the tracker without invoking their callbacks hangs each of
+ * them and strands the server caddy each one holds. */
+void pmix_server_fail_local_reqs(pmix_dmdx_local_t *lcd, pmix_status_t status)
+{
+    pmix_dmdx_request_t *req;
+
+    while (NULL != (req = (pmix_dmdx_request_t *) pmix_list_remove_first(&lcd->loc_reqs))) {
+        if (NULL != req->cbfunc) {
+            req->cbfunc(status, NULL, 0, req->cbdata, NULL, NULL);
+        }
+        PMIX_RELEASE(req);
+    }
+    pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
+    PMIX_RELEASE(lcd);
+}
+
 static pmix_status_t defer_response(char *nspace, pmix_rank_t rank, char *key,
                                     pmix_server_caddy_t *cd, bool localonly,
                                     pmix_modex_cbfunc_t cbfunc, void *cbdata,

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -526,7 +526,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
         }
     }
 
-    // preserve the group id
+    // preserve the group id - every early return below must free it
     id = strdup(blk->id);
     op = blk->grpop;
 
@@ -540,6 +540,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
             }
             PMIX_RELEASE(scd);
             PMIX_LIST_DESTRUCT(&grpinfo);
+            free(id);
             return;
         }
         /* Each list member points to a pmix_info_t that contains
@@ -558,6 +559,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                     }
                     PMIX_RELEASE(scd);
                     PMIX_LIST_DESTRUCT(&grpinfo);
+                    free(id);
                     return;
                 }
             } else {
@@ -573,6 +575,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                         }
                         PMIX_RELEASE(scd);
                         PMIX_LIST_DESTRUCT(&grpinfo);
+                        free(id);
                         return;
                     }
                 }
@@ -726,9 +729,10 @@ static void grpcbfunc(pmix_status_t status,
     /* need to thread-shift this callback as it accesses global data */
     scd = PMIX_NEW(grp_shifter_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        /* nothing we can do - but honor the release contract with the
+         * host's own release data, not the block we were handed */
         if (NULL != relfn) {
-            relfn(cbdata);
+            relfn(relcbd);
         }
         return;
     }
@@ -937,17 +941,15 @@ static pmix_status_t aggregate_info(grp_block_t *blk)
                         // the numbers must match
                         rc = PMIx_Value_get_number(&blk->info[m].value, &bt, PMIX_SIZE);
                         if (PMIX_SUCCESS != rc) {
-                            PMIX_LIST_DESTRUCT(&ilist);
-                            return rc;
+                            goto bailout;
                         }
                         rc = PMIx_Value_get_number(&trk->info[n].value, &bt2, PMIX_SIZE);
                         if (PMIX_SUCCESS != rc) {
-                            PMIX_LIST_DESTRUCT(&ilist);
-                            return rc;
+                            goto bailout;
                         }
                         if (bt != bt2) {
-                            PMIX_LIST_DESTRUCT(&ilist);
-                            return PMIX_ERR_BAD_PARAM;
+                            rc = PMIX_ERR_BAD_PARAM;
+                            goto bailout;
                         }
                     } else if (PMIX_CHECK_KEY(&blk->info[m], PMIX_PROC_INFO_ARRAY) ||
                                PMIX_CHECK_KEY(&blk->info[m], PMIX_GROUP_INFO)) {
@@ -1006,6 +1008,14 @@ static pmix_status_t aggregate_info(grp_block_t *blk)
     PMIX_LIST_DESTRUCT(&ilist);
     PMIX_LIST_DESTRUCT(&plist);
     return PMIX_SUCCESS;
+
+bailout:
+    /* both scratch lists have to come down on the error paths too - the
+     * bootstrap-mismatch returns used to drop only ilist and leak every
+     * proc entry accumulated in plist */
+    PMIX_LIST_DESTRUCT(&ilist);
+    PMIX_LIST_DESTRUCT(&plist);
+    return rc;
 }
 
 /* we are being called from the PMIx server's switchyard function,
@@ -1016,10 +1026,10 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     pmix_peer_t *peer = (pmix_peer_t *) cd->peer;
     int32_t cnt;
     pmix_status_t rc;
-    char *grpid;
+    char *grpid = NULL;
     pmix_proc_t *procs = NULL;
     pmix_info_t *info = NULL;
-    size_t n, ninfo, ninf, nprocs;
+    size_t n, ninfo = 0, ninf, nprocs = 0;
     grp_block_t *blk;
     grp_trk_t *trk;
     bool need_cxtid = false;
@@ -1062,7 +1072,6 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         PMIX_BFROPS_UNPACK(rc, peer, buf, procs, &cnt, PMIX_PROC);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_PROC_FREE(procs, nprocs);
             goto error;
         }
     } else {
@@ -1238,7 +1247,16 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     return PMIX_SUCCESS;
 
 error:
-   if (NULL != info) {
+    /* nothing has been handed to a tracker yet on any path that lands
+     * here, so everything we unpacked is still ours to free - the group id
+     * and the participant array used to leak on every malformed request */
+    if (NULL != grpid) {
+        free(grpid);
+    }
+    if (NULL != procs) {
+        PMIX_PROC_FREE(procs, nprocs);
+    }
+    if (NULL != info) {
         PMIX_INFO_FREE(info, ninfo);
     }
     return rc;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1227,8 +1227,14 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
             memcpy(prev->affected, affected, naffected * sizeof(pmix_proc_t));
         }
         pmix_list_append(&reginfo->peers, &prev->super);
-        rc = PMIX_OPERATION_SUCCEEDED;
-        goto cleanup;
+        /* fall through rather than returning here: a default handler must
+         * still be given any matching notification already sitting in the
+         * cache, and _check_cached_events has a dedicated arm for exactly
+         * this case (scd->codes == NULL matches every non-nondefault event).
+         * Returning early meant a default handler silently missed every
+         * event cached before it registered. The loops below are no-ops
+         * with ncodes == 0, and the trailing else branch schedules the
+         * cached-event check and returns PMIX_OPERATION_SUCCEEDED. */
     }
 
     /* store the event registration info so we can call the registered
@@ -1355,8 +1361,9 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
                 return PMIX_ERR_NOT_AVAILABLE;
             }
 
-            PMIX_RETAIN(peer);
-            scd->peer = peer;
+            /* scd->peer was already set (with its retain) above - taking a
+             * second reference here leaked one on every registration the
+             * host completed atomically */
             scd->procs = affected;
             scd->nprocs = naffected;
             scd->opcbfunc = NULL;
@@ -1922,7 +1929,16 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
     }
     cd->cbdata = cbdata;
 
+    /* construct every local list up front so that a single cleanup at the
+     * exit label covers all of them - the bad-param and no-memory paths in
+     * the directive scan below used to jump past their destructors and
+     * leak whatever cleanup entries had already been cached. Draining a
+     * list twice is harmless (PMIX_LIST_DESTRUCT leaves it re-initialized),
+     * so the mid-function destructs can stay where they are. */
     PMIX_CONSTRUCT(&epicache, pmix_list_t);
+    PMIX_CONSTRUCT(&cachedirs, pmix_list_t);
+    PMIX_CONSTRUCT(&cachefiles, pmix_list_t);
+    PMIX_CONSTRUCT(&ignorefiles, pmix_list_t);
 
     /* unpack the number of targets */
     cnt = 1;
@@ -2012,10 +2028,6 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
 
     /* if this includes a request for post-termination cleanup, we handle
      * that request ourselves */
-    PMIX_CONSTRUCT(&cachedirs, pmix_list_t);
-    PMIX_CONSTRUCT(&cachefiles, pmix_list_t);
-    PMIX_CONSTRUCT(&ignorefiles, pmix_list_t);
-
     cnt = 0; // track how many infos are cleanup related
     for (n = 0; n < cd->ninfo; n++) {
         if (PMIX_CHECK_KEY(&cd->info[n], PMIX_REGISTER_CLEANUP)) {
@@ -2182,11 +2194,17 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
         goto exit;
     }
     PMIX_LIST_DESTRUCT(&epicache);
+    PMIX_LIST_DESTRUCT(&cachedirs);
+    PMIX_LIST_DESTRUCT(&cachefiles);
+    PMIX_LIST_DESTRUCT(&ignorefiles);
     return PMIX_SUCCESS;
 
 exit:
     PMIX_RELEASE(cd);
     PMIX_LIST_DESTRUCT(&epicache);
+    PMIX_LIST_DESTRUCT(&cachedirs);
+    PMIX_LIST_DESTRUCT(&cachefiles);
+    PMIX_LIST_DESTRUCT(&ignorefiles);
     return rc;
 }
 
@@ -2486,6 +2504,13 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer, pmix_buffer_t *buf,
          * switchyard to release the cd object */
         return PMIX_SUCCESS;
     }
+    if (PMIX_SUCCESS == rc) {
+        /* the host accepted the request and now owns cd - it will release
+         * it when it invokes the callback. Falling through to the exit
+         * label here would free the caddy out from under the host and
+         * leave the callback operating on freed memory. */
+        return PMIX_SUCCESS;
+    }
 
 exit:
     PMIX_RELEASE(cd);
@@ -2567,6 +2592,11 @@ pmix_status_t pmix_server_iofdereg(pmix_peer_t *peer, pmix_buffer_t *buf,
         cbfunc(PMIX_SUCCESS, cd);
         /* returning other than SUCCESS will cause the
          * switchyard to release the cd object */
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_SUCCESS == rc) {
+        /* the host accepted the request and now owns cd - see the
+         * matching note in pmix_server_iofreg */
         return PMIX_SUCCESS;
     }
 
@@ -2713,8 +2743,13 @@ static void _fabric_response(int sd, short args, void *cbdata)
     pmix_query_caddy_t *qcd = (pmix_query_caddy_t *) cbdata;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    qcd->cbfunc(PMIX_SUCCESS, qcd->info, qcd->ninfo, qcd->cbdata, NULL, NULL);
-    PMIX_RELEASE(qcd);
+    /* qcd->cbfunc is the switchyard's fabric_cbfunc, which expects the
+     * query caddy - not the server caddy hanging off qcd->cbdata. Handing
+     * it qcd->cbdata made it read a pmix_server_caddy_t as a
+     * pmix_query_caddy_t and dereference the resulting garbage pointer.
+     * The callback chain owns qcd (and its info array) from here on, so
+     * we must not release it a second time. */
+    qcd->cbfunc(PMIX_SUCCESS, qcd->info, qcd->ninfo, qcd, NULL, NULL);
 }
 
 static void frcbfunc(pmix_status_t status, void *cbdata)
@@ -2758,7 +2793,6 @@ pmix_status_t pmix_server_fabric_register(pmix_server_caddy_t *cd, pmix_buffer_t
     PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &qcd->ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(qcd);
         goto exit;
     }
     /* unpack the directives */
@@ -2768,7 +2802,6 @@ pmix_status_t pmix_server_fabric_register(pmix_server_caddy_t *cd, pmix_buffer_t
         PMIX_BFROPS_UNPACK(rc, cd->peer, buf, qcd->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(qcd);
             goto exit;
         }
     }
@@ -2818,9 +2851,14 @@ pmix_status_t pmix_server_fabric_register(pmix_server_caddy_t *cd, pmix_buffer_t
     return PMIX_SUCCESS;
 
 exit:
+    /* every path reaching here failed before handing qcd to an async
+     * callback, so release it - and the reference it took on the server
+     * caddy, which the query caddy's destructor knows nothing about. The
+     * switchyard releases the caddy's own reference on our error return. */
     if (NULL != qcd) {
         PMIX_RELEASE(qcd);
     }
+    PMIX_RELEASE(cd);
     return rc;
 }
 
@@ -2846,6 +2884,7 @@ pmix_status_t pmix_server_fabric_update(pmix_server_caddy_t *cd, pmix_buffer_t *
         return PMIX_ERR_NOMEM;
     }
     PMIX_RETAIN(cd);
+    qcd->cbfunc = cbfunc;
     qcd->cbdata = cd;
 
     /* unpack the fabric index */
@@ -2897,9 +2936,11 @@ pmix_status_t pmix_server_fabric_update(pmix_server_caddy_t *cd, pmix_buffer_t *
 
 exit:
     /* every path reaching here failed before handing qcd to an async
-     * callback, so release it (and its retained server caddy) here.
+     * callback, so release it - and the reference it took on the server
+     * caddy, which the query caddy's destructor knows nothing about.
      * The sibling pmix_server_fabric_register does the same. */
     PMIX_RELEASE(qcd);
+    PMIX_RELEASE(cd);
     return rc;
 }
 
@@ -2966,7 +3007,9 @@ pmix_status_t pmix_server_device_dists(pmix_server_caddy_t *cd,
     /* if the cpuset is NULL, see if we know the binding of the requesting process */
     if (NULL == cpuset.bitmap) {
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        cb.key = strdup(PMIX_CPUSET);
+        /* the cb destructor does not own cb.key, so point it at the
+         * string constant rather than a strdup that nothing would free */
+        cb.key = PMIX_CPUSET;
         PMIX_LOAD_PROCID(&proc, cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
         cb.proc = &proc;
         cb.scope = PMIX_LOCAL;
@@ -2976,7 +3019,20 @@ pmix_status_t pmix_server_device_dists(pmix_server_caddy_t *cd,
             PMIX_DESTRUCT(&cb);
             goto cleanup;
         }
+        if (0 == pmix_list_get_size(&cb.kvs)) {
+            /* a "successful" fetch that returned nothing - pmix_list_get_first
+             * would hand back the list sentinel, not NULL, so guard on the
+             * size before dereferencing it */
+            rc = PMIX_ERR_NOT_FOUND;
+            PMIX_DESTRUCT(&cb);
+            goto cleanup;
+        }
         kv = (pmix_kval_t*)pmix_list_get_first(&cb.kvs);
+        if (NULL == kv->value || PMIX_STRING != kv->value->type) {
+            rc = PMIX_ERR_INVALID_VAL;
+            PMIX_DESTRUCT(&cb);
+            goto cleanup;
+        }
         rc = pmix_hwloc_parse_cpuset_string(kv->value->data.string, &cpuset);
         if (PMIX_SUCCESS != rc) {
             PMIX_DESTRUCT(&cb);
@@ -3042,14 +3098,23 @@ pmix_status_t pmix_server_refresh_cache(pmix_server_caddy_t *cd,
     cb.scope = PMIX_REMOTE;
     cb.copy = false;
     PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+    /* the fetch reports its result through the macro's status argument -
+     * cb.status is left at its constructed default, so packing that told
+     * the client SUCCESS even when nothing was found */
+    cb.status = rc;
 
     // pack it up
     pbkt = PMIX_NEW(pmix_buffer_t);
+    if (NULL == pbkt) {
+        PMIX_DESTRUCT(&cb);
+        return PMIX_ERR_NOMEM;
+    }
     // start with the status
     PMIX_BFROPS_PACK(rc, cd->peer, pbkt, &cb.status, 1, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(pbkt);
+        PMIX_DESTRUCT(&cb);
         return rc;
     }
     PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
@@ -3057,6 +3122,7 @@ pmix_status_t pmix_server_refresh_cache(pmix_server_caddy_t *cd,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(pbkt);
+            PMIX_DESTRUCT(&cb);
             return rc;
         }
     }

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -263,8 +263,7 @@ PMIX_EXPORT pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *bu
 PMIX_EXPORT pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf);
 
 PMIX_EXPORT pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
-                                            pmix_modex_cbfunc_t modexcbfunc,
-                                            pmix_op_cbfunc_t opcbfunc);
+                                            pmix_modex_cbfunc_t modexcbfunc);
 
 PMIX_EXPORT pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc,
                                           void *cbdata);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -257,6 +257,14 @@ PMIX_EXPORT pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank
                                                pmix_status_t status, pmix_scope_t scope,
                                                pmix_dmdx_local_t *lcd);
 
+/* Fail every requester parked on this direct-modex tracker with the given
+ * status, then unlink and release the tracker. Each parked request holds
+ * its own reference on the tracker and owns the server caddy of the client
+ * waiting behind it, so a caller that simply releases the tracker leaks
+ * both and leaves those clients waiting forever. */
+PMIX_EXPORT void pmix_server_fail_local_reqs(pmix_dmdx_local_t *lcd,
+                                             pmix_status_t status);
+
 PMIX_EXPORT pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
 

--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -198,13 +198,20 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
     PMIX_INFO_LOAD(&info[2], PMIX_HOSTNAME, nd, PMIX_STRING);
 
     if (0 == pmix_nslen(nspace)) {
-        // asking for a complete list of peers
-        rc = PMIX_ERR_DATA_VALUE_NOT_FOUND;
+        // asking for a complete list of peers. Seed the *returned* status,
+        // not the scratch rc that the very next fetch overwrites - an
+        // aggregate search that found nothing used to answer SUCCESS with
+        // zero peers instead of reporting that nothing was found.
+        ret = PMIX_ERR_DATA_VALUE_NOT_FOUND;
         np = 0;
 
         /* cycle across all known nspaces and aggregate the results */
         PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
             PMIX_LOAD_NSPACE(proc.nspace, ns->nspace);
+            /* restart each namespace from UNDEF: the wildcard retry below
+             * mutates proc.rank, and leaving it mutated denied every
+             * subsequent namespace its own first-choice lookup */
+            proc.rank = PMIX_RANK_UNDEF;
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
             if (PMIX_SUCCESS != rc) {
                 if (PMIX_RANK_UNDEF == proc.rank) {
@@ -291,6 +298,10 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
             }
             PMIx_Argv_free(tmp);
             ret = PMIX_SUCCESS;
+        } else if (NULL != tmp) {
+            /* entries were collected but none of them yielded a rank -
+             * the array is still ours to free */
+            PMIx_Argv_free(tmp);
         }
         PMIX_DESTRUCT(&cb);
         goto done;

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -71,7 +71,8 @@ These run anywhere and are the bulk of the suite: `compress`, `preg`,
 `bfrops_malformed`, `bfrops_get_number`, `bfrops_null_object`,
 `bfrops_helpers`, `info_support`, `iof_pattern`,
 `hwloc_datatype`, `tracker_match`, `trk_complete`, `collective_status`,
-`collect_job_info`, `progress_threads`, `runtime_init`, `pmix_log`.
+`collect_job_info`, `progress_threads`, `runtime_init`, `pmix_log`,
+`server_get`.
 
 **Singleton client tests** — call the real public API in a process that
 comes up with no server. `client_cycle` (init/finalize cycling),
@@ -283,6 +284,50 @@ under either, so it cannot fail on them. That half is
 [`examples/datatypes.c`](../../examples/datatypes.c), driven across
 separate nodes by
 [`contrib/dockerswarm/run-bfrops-tests.sh`](../../contrib/dockerswarm/AGENTS.md).
+
+### `server_get` — the server-side `PMIx_Get` regression test
+
+[`server_get.c`](server_get.c) comes up as a PMIx server with a stub host
+module that deliberately has **no** `direct_modex` entry point, registers
+an nspace whose job size (4) exceeds its local size (2), and then calls
+`pmix_server_get()` directly. That combination is what puts the two
+behaviors it asserts on one code path.
+
+The first is **local-vs-remote classification**: a target rank that is
+not one of our local ranks must be classified remote. The rank walk used
+to consult its `PMIX_LIST_FOREACH` variable after the loop had run to
+completion — i.e. after it pointed at the list sentinel — and read a peer
+id out of it, then used that garbage as an index into the client array.
+
+**Be clear about what those cases are worth**: they pin the behavior, they
+do not reproduce the defect. The stale read stays inside the enclosing
+`pmix_namespace_t`, so it is undefined behavior that no sanitizer flags,
+and the value is usually out of range — which accidentally produces the
+right answer. Verified: the test passes against the unfixed library. It is
+here so a rework of the classification cannot regress the answer silently.
+Do not "strengthen" it by asserting something the old code happened to do.
+
+The second is **deferred-request cleanup**, and that one is a leak check.
+A request the server cannot launch must have its tracker fully discarded;
+only the creation reference was being dropped, and since every parked
+requester holds one of its own, the tracker survived unreachable. The
+`local_reqs`-is-empty assertion here was satisfied by the old code too
+(it did unlink the tracker); what it did not do was free it. **Run this
+one under valgrind** — the stranded tracker, its request, its info array
+and its key are what the leak report shows.
+
+Two things about the setup are easy to get wrong and were:
+
+- `PMIx_server_register_nspace`'s second argument is the number of
+  **local** procs, not the job size. Passing the job size makes every
+  rank local, `all_registered` never becomes true, and every case
+  defers instead of classifying — which looks like a library bug.
+- The node map needs **two** nodes. With one node in the map every rank
+  is local however the counts are set, and the decision under test is
+  never taken.
+
+The multi-node half of this file — the actual remote fetch — is
+[`contrib/dockerswarm/run-server-tests.sh`](../../contrib/dockerswarm/AGENTS.md).
 
 ### `runtime_init` — the `src/runtime` bring-up regression test
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace runtime_init
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace runtime_init server_get
 
-TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace runtime_init
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace runtime_init server_get
 
 client_api_SOURCES = \
         client_api.c
@@ -273,4 +273,10 @@ tool_nspace_SOURCES = \
         tool_nspace.c
 tool_nspace_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 tool_nspace_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+server_get_SOURCES = \
+        server_get.c
+server_get_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+server_get_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/unit/server_get.c
+++ b/test/unit/server_get.c
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for the server side of PMIx_Get - pmix_server_get()
+ * in src/server/pmix_server_get.c - and the deferred-request bookkeeping it
+ * owns on pmix_server_globals.local_reqs.
+ *
+ * The process comes up as a PMIx server with a stub host module that
+ * deliberately provides no direct_modex entry point, then registers an
+ * nspace whose job size is larger than its local size. That combination is
+ * what puts the two behaviors under test on the same code path:
+ *
+ *   local-vs-remote classification
+ *      A target rank that is not one of our local ranks must be classified
+ *      remote. The rank walk used to consult the loop variable after the
+ *      loop had run to completion, i.e. after it had been left pointing at
+ *      the list sentinel, and read a peer id out of it; whatever that
+ *      garbage index happened to name in the client array decided the
+ *      answer. When it named a live slot the request was treated as local
+ *      and parked to wait for a commit that is never coming.
+ *
+ *      Be clear about what this half is worth: it pins the behavior, it
+ *      does not reproduce the defect. The stale read stays inside the
+ *      enclosing pmix_namespace_t, so it is undefined behavior that no
+ *      sanitizer flags, and the value it picks up is usually out of range
+ *      - which accidentally produces the right answer. These cases fail
+ *      only when the garbage lands on a live client slot. They are here so
+ *      that a future rework of the classification cannot regress the
+ *      answer silently, not as a before/after reproducer.
+ *
+ *   deferred-request cleanup
+ *      When the request cannot be launched - no host direct_modex support,
+ *      or the host rejects the up-call - the tracker created to park it has
+ *      to be fully discarded. Each parked requester holds its own reference
+ *      on that tracker, so dropping only the creation reference left the
+ *      tracker alive but unreachable: off local_reqs, so no later resolve
+ *      could ever drain or free it, and still holding the caddy pointer the
+ *      switchyard was about to free. The assertion here is that local_reqs
+ *      is empty afterwards - which the old code also satisfied, because it
+ *      did unlink the tracker; what it did not do was free it. So run this
+ *      one under valgrind: the stranded tracker, its request, its info
+ *      array and its key are what the leak report shows.
+ *
+ * Test cases:
+ *
+ *   remote rank, no direct_modex   -> PMIX_ERR_NOT_FOUND, nothing parked
+ *   unknown nspace, no direct_modex-> PMIX_ERR_NOT_FOUND, nothing parked
+ *   unknown nspace + IMMEDIATE     -> PMIX_ERR_NOT_FOUND, nothing parked
+ *   local rank not yet connected,
+ *      + IMMEDIATE                 -> PMIX_ERR_NOT_FOUND, nothing parked
+ *   WILDCARD rank                  -> job-level data handed to the callback
+ *
+ * Every case additionally asserts that the request left local_reqs empty,
+ * because a server that parks a request it can never answer hangs the
+ * calling client rather than failing it.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/include/pmix_globals.h"
+#include "src/mca/bfrops/bfrops.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define GETUT_NSPACE  "server-get-ut"
+#define GETUT_NPROCS  4
+#define GETUT_NLOCAL  2   /* ranks 0 and 1 are ours; 2 and 3 are not */
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* what the modex callback recorded */
+static bool cb_fired = false;
+static pmix_status_t cb_status = PMIX_SUCCESS;
+static size_t cb_ndata = 0;
+
+/* Stand-in for the switchyard's get_cbfunc. The contract is the same:
+ * whoever calls it owns answering the client and releasing the caddy, and
+ * the release function (if any) frees the returned payload. */
+static void get_cbfunc(pmix_status_t status, const char *data, size_t ndata,
+                       void *cbdata, pmix_release_cbfunc_t relfn, void *relcbd)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t *) cbdata;
+
+    cb_fired = true;
+    cb_status = status;
+    cb_ndata = ndata;
+    (void) data;
+    if (NULL != relfn) {
+        relfn(relcbd);
+    }
+    PMIX_RELEASE(cd);
+}
+
+/* Build the wire form of a GET request: nspace, rank, ninfo, info[],
+ * and - when one is given - the key. */
+static pmix_buffer_t *build_get_request(const char *nspace, pmix_rank_t rank,
+                                        const char *key, pmix_info_t *info,
+                                        size_t ninfo)
+{
+    pmix_buffer_t *buf;
+    pmix_status_t rc;
+    char *cptr = (char *) nspace;
+
+    buf = PMIX_NEW(pmix_buffer_t);
+    if (NULL == buf) {
+        return NULL;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &cptr, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return NULL;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &rank, 1, PMIX_PROC_RANK);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return NULL;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return NULL;
+    }
+    if (0 < ninfo) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, info, ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(buf);
+            return NULL;
+        }
+    }
+    if (NULL != key) {
+        cptr = (char *) key;
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &cptr, 1, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(buf);
+            return NULL;
+        }
+    }
+    return buf;
+}
+
+/* Drive one server-side GET. Returns what pmix_server_get() returned; the
+ * caddy is released here on the error return exactly as the switchyard
+ * does, and by the callback otherwise. */
+static pmix_status_t do_get(const char *nspace, pmix_rank_t rank,
+                            const char *key, pmix_info_t *info, size_t ninfo)
+{
+    pmix_server_caddy_t *cd;
+    pmix_buffer_t *buf;
+    pmix_status_t rc;
+
+    cb_fired = false;
+    cb_status = PMIX_SUCCESS;
+    cb_ndata = 0;
+
+    buf = build_get_request(nspace, rank, key, info, ninfo);
+    if (NULL == buf) {
+        return PMIX_ERR_NOMEM;
+    }
+
+    cd = PMIX_NEW(pmix_server_caddy_t);
+    if (NULL == cd) {
+        PMIX_RELEASE(buf);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_RETAIN(pmix_globals.mypeer);
+    cd->peer = pmix_globals.mypeer;
+    cd->hdr.tag = 0;
+
+    rc = pmix_server_get(buf, get_cbfunc, cd);
+    if (PMIX_SUCCESS != rc) {
+        /* the switchyard owns the caddy on a non-success return */
+        PMIX_RELEASE(cd);
+    }
+    PMIX_RELEASE(buf);
+    return rc;
+}
+
+/* Register an nspace with GETUT_NPROCS ranks of which only the first
+ * GETUT_NLOCAL are on this node, then register those as clients so the
+ * nspace reaches all_registered and the rank walk has something to walk. */
+static pmix_status_t register_job(void)
+{
+    pmix_info_t info[4];
+    pmix_nspace_t ns;
+    pmix_proc_t proc;
+    pmix_status_t rc;
+    char *noderegex = NULL, *ppnregex = NULL, *nodelist = NULL;
+    uint32_t nprocs = GETUT_NPROCS;
+    pmix_rank_t r;
+
+    /* two nodes: ours holds ranks 0 and 1, a second node holds 2 and 3.
+     * A single-node map would make every rank local and the local-vs-remote
+     * decision this test is about would never be taken. */
+    if (0 > asprintf(&nodelist, "%s,server-get-ut-elsewhere", pmix_globals.hostname)) {
+        return PMIX_ERR_NOMEM;
+    }
+    PMIx_generate_regex(nodelist, &noderegex);
+    PMIx_generate_ppn("0,1;2,3", &ppnregex);
+
+    PMIX_INFO_LOAD(&info[0], PMIX_NODE_MAP, noderegex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&info[1], PMIX_PROC_MAP, ppnregex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&info[2], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&info[3], PMIX_UNIV_SIZE, &nprocs, PMIX_UINT32);
+
+    PMIX_LOAD_NSPACE(ns, GETUT_NSPACE);
+    /* the second argument is the number of LOCAL procs, not the job size */
+    rc = PMIx_server_register_nspace(ns, GETUT_NLOCAL, info, 4, NULL, NULL);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_INFO_DESTRUCT(&info[2]);
+    PMIX_INFO_DESTRUCT(&info[3]);
+    free(noderegex);
+    free(ppnregex);
+    free(nodelist);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+
+    for (r = 0; r < GETUT_NLOCAL; r++) {
+        PMIX_LOAD_PROCID(&proc, GETUT_NSPACE, r);
+        rc = PMIx_server_register_client(&proc, geteuid(), getegid(), NULL, NULL, NULL);
+        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+            return rc;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+static bool nothing_parked(void)
+{
+    return (0 == pmix_list_get_size(&pmix_server_globals.local_reqs));
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_status_t rc;
+    pmix_info_t imm;
+    bool flag = true;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "server_get: server-side PMIx_Get unit tests\n");
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    /* the stub module has no direct_modex, which is the configuration these
+     * tests need - assert it rather than assume it */
+    if (NULL != pmix_host_server.direct_modex) {
+        fprintf(stderr, "test setup error: host module advertises direct_modex\n");
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    rc = register_job();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "register_job failed: %s\n", PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    /* --- a rank that is not one of ours is remote ------------------- */
+    rc = do_get(GETUT_NSPACE, 3, "some.remote.key", NULL, 0);
+    report("remote rank reports not-found", PMIX_ERR_NOT_FOUND == rc);
+    report("remote rank parks nothing", nothing_parked());
+
+    /* rank 2 is the other non-local one - same answer */
+    rc = do_get(GETUT_NSPACE, 2, "some.remote.key", NULL, 0);
+    report("second remote rank reports not-found", PMIX_ERR_NOT_FOUND == rc);
+    report("second remote rank parks nothing", nothing_parked());
+
+    /* --- an nspace we have never heard of --------------------------- */
+    rc = do_get("no-such-nspace", 0, "some.key", NULL, 0);
+    report("unknown nspace reports not-found", PMIX_ERR_NOT_FOUND == rc);
+    report("unknown nspace parks nothing", nothing_parked());
+
+    /* --- the same, but the caller refuses to wait ------------------- */
+    PMIX_INFO_LOAD(&imm, PMIX_IMMEDIATE, &flag, PMIX_BOOL);
+    rc = do_get("no-such-nspace", 0, "some.key", &imm, 1);
+    report("unknown nspace with IMMEDIATE reports not-found", PMIX_ERR_NOT_FOUND == rc);
+    report("unknown nspace with IMMEDIATE parks nothing", nothing_parked());
+
+    /* --- a local rank that has not connected yet -------------------- */
+    rc = do_get(GETUT_NSPACE, 0, "some.local.key", &imm, 1);
+    report("unconnected local rank with IMMEDIATE reports not-found",
+           PMIX_ERR_NOT_FOUND == rc);
+    report("unconnected local rank with IMMEDIATE parks nothing", nothing_parked());
+    PMIX_INFO_DESTRUCT(&imm);
+
+    /* --- job-level data still comes back ---------------------------- */
+    rc = do_get(GETUT_NSPACE, PMIX_RANK_WILDCARD, PMIX_JOB_SIZE, NULL, 0);
+    report("wildcard get succeeds", PMIX_SUCCESS == rc);
+    report("wildcard get answered the caller", cb_fired && PMIX_SUCCESS == cb_status);
+    report("wildcard get returned a payload", 0 < cb_ndata);
+    report("wildcard get parks nothing", nothing_parked());
+
+    PMIx_server_finalize();
+
+    fprintf(stdout, "server_get: %d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}


### PR DESCRIPTION
A review of `src/server`, covering all seven files line by line, plus the
tests that were missing for the half of this directory a single node
cannot reach.

## Correctness

Three are use-after-free or wrong-object rather than leaks:

- **IOF pull/deregister released the caddy the host had just taken.**
  Both handlers put their error cleanup under a bare `exit:` label and
  then fell into it on the success arm too, so the host's completion
  callback ran on freed memory. Each carried a comment describing the
  discipline the code did not implement.
- **`pmix_server_fabric_register` released its query caddy twice** on a
  malformed request. Related, `_fabric_response` — the path used when the
  `pnet` layer answers a fabric request itself — handed the completion
  function a server caddy where that function casts to a query caddy, and
  `pmix_server_fabric_update` never set that function at all.
- **`pmix_server_get` read a peer id out of a list sentinel.** The rank
  walk consulted its `PMIX_LIST_FOREACH` variable after the loop had run
  to completion, which is the ordinary path for any get whose target is
  not one of our local ranks, and indexed the client array with the
  result. When the garbage named a live slot the request was treated as
  local and parked to wait for a commit that never comes.

Two more produce wrong answers:

- **A notification addressed to several processes came out addressed to
  N-1 copies of the one process being removed from it.** The purge that
  runs when a peer departs rebuilds the target list and indexed the
  surviving array by the loop variable of the *search* that found the
  departing target.
- **A namespace update carrying `PMIX_GROUP_CONTEXT_ID` stored it against
  stack garbage** unless a proc-info array happened to precede it in the
  same call — that identity is only ever assigned by a different arm of
  the same loop. The store's status was then discarded and the check
  below re-read the result of the preceding value copy.

And:

- **Deferred direct-modex trackers were released while their parked
  requests still held references**, leaving them alive but unreachable —
  off the pending list where no later resolve could find them, and still
  holding the caddy the switchyard was about to free. Two sites: the
  failed-launch path in `pmix_server_get`, and the peer purge, where the
  waiters are other local procs who also need to be told rather than
  silently dropped.
- **A default event handler never saw the notification cache.** A
  registration made with no codes returned before reaching it, so an
  event that arrived first was never delivered — even though the cache
  walk has a dedicated arm for exactly that registration.
- **The fence contributor dedup never worked.** The list it checks was
  never appended to, so a clone sharing a rank with its parent had its
  remote data packed into the modex bucket twice, and one tracking object
  was leaked per contributor per fence.
- **`PMIX_TIMEOUT` was read at the wrong width.** `PMIx_Value_get_number`
  writes exactly the type it is told; fence, connect and get passed the
  address of a `time_t` while asking for a 32-bit conversion, filling the
  wrong half on a big-endian host.
- **An optional connect that failed still composed a `PMIX_SERVER_URI`
  out of the connection that did not happen** — undefined behavior in the
  `%s` conversion, and where that survives, a stored URI ending in
  `(null)` that every later lookup hands back.

## Leaks and hygiene

Error-path leaks in the group, job-control, fabric, resolve and
collective paths; reply buffers whose status could not be packed; the
payload already assembled for a cross-namespace get that then found
nothing; the system temporary directory (which also left stale state — a
second `PMIx_server_init` kept the first cycle's value rather than
re-reading the environment); five host callbacks that returned on an
allocation failure without honoring the release function the host gave
them; and the result caddies of `PMIx_server_setup_application` and
`PMIx_server_collect_inventory` when the caller passes no callback.

Also: three sites called a host-supplied release function with something
other than the release data the host gave them; the fence and connect
timeout handlers released a tracker still linked into the collectives
list; the fence and connect handlers drove a completion callback on an
internal error path with no tracker to give it (connect handed it a caddy
instead), after which the switchyard answered and released the same
caller a second time; and two host-supplied data arrays are now screened
for shape before being indexed positionally.

## Tests

- **`test/unit/server_get.c`** — 14 cases driving `pmix_server_get`
  directly against a namespace whose job size exceeds its local size.
  Its header is explicit that the classification cases pin behavior
  rather than reproduce the defect: the stale sentinel read stays inside
  the enclosing namespace object, so no sanitizer flags it and the value
  is usually out of range and accidentally right. Verified — it passes
  against the unfixed library.
- **`contrib/dockerswarm/run-server-tests.sh`** (README §19) — 14 cases
  across ten nodes, one rank per node deliberately, since with two ranks
  on a node a peer's data is answered out of local storage and the whole
  remote path can be broken while the run stays green. Covers direct
  modex, spawn-plus-connect across namespaces, group blocks spanning
  nodes, IOF pull/deregister against a persistent DVM, and a valgrind
  pass on the daemon — the only leak check anywhere in the harness that
  runs against the *server* library, since every other suite valgrinds a
  client.

## Verification

Warning-free build under `--enable-devel-check`. 118 local tests and
`simptest` pass. All 37 multi-node cases across `run-server-tests.sh`,
`run-tests.sh` and `run-group-events.sh` pass against a swarm rebuilt
with these changes.

Six failures in the first swarm run turned out to be pre-existing or
harness assumptions, not regressions — established by checking out
`master`'s `src/server`, rebuilding, and baselining before concluding
anything. The harness bugs (spawn geometry, a relative-path spawn, a
completion marker only rank 0 prints) are fixed and documented.

`src/server/AGENTS.md` gains the invariants this turned up, including a
note that `PMIx_Notify_event` from the progress thread is fine when a
callback is passed — it blocks only when that argument is NULL — so the
three call sites that do it are correct and should not be "fixed".
