### PR TITLE
Deep review of src/tool: fix an init hang, several leaks, and the multi-server/relay semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,6 +298,8 @@ test/unit/get_perf
 test/unit/ptl_uri
 test/unit/ptl_handshake
 test/unit/tool_nspace
+test/unit/tool_rndz
+test/unit/tool_api
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl

--- a/.gitignore
+++ b/.gitignore
@@ -302,6 +302,7 @@ test/unit/tool_nspace
 test/unit/tool_rndz
 test/unit/tool_api
 test/unit/tool_evcache
+test/unit/tool_relay
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl

--- a/.gitignore
+++ b/.gitignore
@@ -301,6 +301,7 @@ test/unit/ptl_handshake
 test/unit/tool_nspace
 test/unit/tool_rndz
 test/unit/tool_api
+test/unit/tool_evcache
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl
 test/unit/run_toolcycle.pl

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ examples/resolve
 examples/multi_nspace_group
 examples/pub2
 examples/toolqry
+examples/toolswitch
 examples/simple_resolve
 examples/pubstress
 examples/monitor

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -30,6 +30,7 @@ two disagree, the README wins, and please fix this file.
 | `run-ptl-tests.sh` | The `src/mca/ptl` transport over real sockets between real hosts: interface selection, node-local rendezvous discovery, a tool attaching across nodes, the inbound message-size ceiling, an exhausted port range (README §17) |
 | `run-runtime-tests.sh` | The `src/runtime` bring-up/tear-down suite in the optimized configuration and on Linux — where the progress thread's CPU-affinity path exists at all — plus that path driven through a real `PMIx_Init`, and node identity across real servers (README §18) |
 | `run-server-tests.sh` | `src/server` — the server-role half of libpmix — across separate servers: direct modex, cross-namespace get, group blocks spanning nodes, IOF pull/dereg against a persistent DVM, and a valgrind pass on the daemon (README §19) |
+| `run-tool-tests.sh` | `src/tool` — the tool-role half of libpmix — with the tool and its servers on different nodes: switching the primary between two independent DVMs, a remote server dying, IOF relayed to a tool from other nodes, and the only valgrind pass the tool library gets (README §20) |
 | `swarm-common.sh` | **Sourced, never executed.** `$PMIX_SWARM` naming and the one copy of `cleanup_swarm` |
 
 ## Things that will bite you
@@ -152,6 +153,21 @@ two disagree, the README wins, and please fix this file.
   PRRTE's read `/src/prrte/src/prted/pmix/...`, which separates them
   cleanly. The image carries no valgrind, so the stage installs it into
   the one node it needs at run time and skips if there is no network.
+
+- **A PMIx server binds LOOPBACK unless remote connections were asked
+  for.** So does PRRTE's, and a loopback URI is unreachable from another
+  node by construction — which turns every cross-node tool stage into a
+  skip. `run-tool-tests.sh` starts its DVMs with
+  `PRTE_MCA_pmix_remote_connections=1` (the PRRTE-side parameter that
+  becomes the `PMIX_SERVER_REMOTE_CONNECTIONS` directive) for exactly this
+  reason. `run-ptl-tests.sh` predates that discovery and still reports the
+  skip. If a stage starts saying "listener is on loopback", that variable
+  is what is missing — it is not a PRRTE bug.
+
+- **`prterun` has no `--dvm-uri`; `prun` does.** A stage that wants a
+  tool attached to a *persistent* DVM has to use `prun`. `prterun` brings
+  up a DVM of its own, and handing it `--dvm-uri` fails the command line
+  with an unrelated-looking usage error.
 
 - **The build volume outlives your branch.** `pmix-build` persists
   across runs and across checkouts, so a tree in it can be older than

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -1344,14 +1344,18 @@ not this suite's business.
 
 ### What this deliberately does not cover
 
-**The tool-to-tool relay in `src/tool/pmix_tool_ops.c`
+**The forwarding half of `src/tool/pmix_tool_ops.c`
 (`pmix_tool_relay_op` / `tool_switchyard`).** That path needs a third
 party: a tool that has connected to *another tool* as its primary server
 and then sends it a command the receiving tool cannot service itself
-(today only `PMIX_SPAWNNB_CMD`), which the receiving tool must forward to
-a real server. PRRTE's launchers do not arrange that shape, so nothing
-here reaches it — and neither does `make check`. It is the one file in
-`src/tool` with no automated coverage at all.
+(today only `PMIX_SPAWNNB_CMD`), which the receiving tool must forward
+**on to a real server**. PRRTE's launchers do not arrange that shape, so
+nothing here reaches it.
+
+`test/unit/tool_relay` covers the other arm of the same decision — the
+receiving tool has *no* server, so it fork/execs the job itself — which
+is what makes the relay's "am I attached?" test observable. The
+forward-to-a-real-server arm remains uncovered anywhere.
 
 ### macOS mode
 

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -1259,3 +1259,106 @@ The image carries no valgrind (it is a build image, and it is shared with
 the other swarm, so rebuilding it to add a package moves it under that
 swarm's feet). The stage installs valgrind into the one node it needs at
 run time and skips cleanly if there is no network to do that with.
+
+---
+
+## 20. The `src/tool` suite (`run-tool-tests.sh`)
+
+```sh
+./run-tool-tests.sh linux     # the swarm
+./run-tool-tests.sh macos     # single-host subset
+```
+
+`src/tool` is the tool-role half of `libpmix`. A tool is the only PMIx
+role that holds connections to **several servers at once** and picks
+which of them is *primary* — the one that services queries, spawns and
+notifications that are not directed anywhere in particular. That choice
+is the whole subject of the directory: `pmix_tool_retry_attach`,
+`pmix_tool_retry_set`, `disc` and `getsrvrs` each repoint
+`pmix_client_globals.myserver` while the peer objects are simultaneously
+held in `pmix_server_globals.clients`, and their reference accounting has
+to balance exactly against `PMIx_tool_finalize`.
+
+`test/simple/tool_server_switch` (run by `make check` through
+`test/unit/run_toolswitch.pl`) already drives that API in a loop, and it
+is a good *bookkeeping* test. But both of its servers are on one host,
+and everything the switch is **for** is invisible in that configuration:
+
+- both connections are loopback, so a server that is unreachable because
+  it is on another machine cannot be produced at all;
+- a request answered by "the other server" never leaves the host, so
+  nothing distinguishes a correct primary-server choice from a wrong one
+  that reaches a server anyway;
+- the IOF a tool receives is generated on its own node, so
+  `tool_iof_handler` never sees a payload that was relayed daemon to
+  daemon before it arrived.
+
+So every stage here puts the tool and at least one of its servers on
+**different nodes**.
+
+### Two DVMs, not one
+
+The suite brings up two *independent* DVMs — one headed on `node1`, one
+headed on `node2` — rather than one DVM spanning both. Within a single
+DVM the tool would have to be handed some non-head daemon's URI, and
+nothing publishes those; two heads each report their own through
+`--report-uri`.
+
+### `PRTE_MCA_pmix_remote_connections=1` is load-bearing
+
+A PMIx server binds a **loopback** interface unless remote connections
+were asked for, and a loopback URI is unreachable from another node by
+construction. Both DVMs are therefore started with
+`PRTE_MCA_pmix_remote_connections=1`, which is the PRRTE-side MCA
+parameter that becomes the `PMIX_SERVER_REMOTE_CONNECTIONS` directive on
+`PMIx_server_init`. Without it every cross-node stage skips itself and
+the suite proves nothing — which is exactly what `run-ptl-tests.sh`
+reports when it meets a loopback URI. If a stage here starts skipping
+with "listener is on loopback", that variable is what is missing.
+
+| Stage | What it drives |
+|-------|----------------|
+| `toolswitch` | `examples/toolswitch.c`: a tool whose *local* server is `node1`'s daemon and whose second server is a daemon on `node2`, cycling attach-as-primary → `get_servers` → `set_server(local/self/remote)` → `disconnect` → `finalize`, five times. Each cycle re-inits, so it is also the re-init path with a real **remote** peer in the clients array. The `PMIx_Query_info_nb` in the middle is the part that needs two hosts: the same call has to travel to a different machine depending on which server is primary at the time. |
+| `valgrind-tool` | The same program under valgrind — the only leak coverage `src/tool` has anywhere (see below). |
+| remote server death | `pterm` kills DVM B out from under a tool on `node1` attached to it by URI. The tool must notice and unwind rather than hang. The node-local version of this is in `run-ptl-tests.sh` §17; here the close is a real socket close from another host. |
+| tool IOF across nodes | `prun` attached to the persistent DVM **is** a tool, so every byte it prints arrived through `tool_iof_handler`. The job is placed on `node3`/`node4`, which the tool is not on, so each payload was relayed by a daemon other than the tool's own. The assertion is that output arrives from *two* distinct nodes: one would mean the tool only ever received its own node's output. |
+
+`prun`, not `prterun`, for the IOF stage: `prterun` brings up a DVM of
+its own, while `prun --dvm-uri` attaches to the persistent one as a tool,
+which is the shape we want. (`prterun` also has no `--dvm-uri` option and
+fails the command line outright.)
+
+### The valgrind stage
+
+Every other suite valgrinds a client, and a client never executes
+`src/tool` at all; `run-server-tests.sh` valgrinds the daemon, which does
+not either. This is the only place the tool library is leak-checked, and
+the only place it is leak-checked with real remote peers being attached,
+switched between, and released.
+
+The same two mechanics as §19 apply: `--fullpath-after=` so frames carry
+full paths (PRRTE ships basenames that collide with ours), and only
+*definitely lost* blocks whose allocation stack passes through `src/tool`
+are failed on — `libpmix` and `prte` both leak at exit in ways that are
+not this suite's business.
+
+### What this deliberately does not cover
+
+**The tool-to-tool relay in `src/tool/pmix_tool_ops.c`
+(`pmix_tool_relay_op` / `tool_switchyard`).** That path needs a third
+party: a tool that has connected to *another tool* as its primary server
+and then sends it a command the receiving tool cannot service itself
+(today only `PMIX_SPAWNNB_CMD`), which the receiving tool must forward to
+a real server. PRRTE's launchers do not arrange that shape, so nothing
+here reaches it — and neither does `make check`. It is the one file in
+`src/tool` with no automated coverage at all.
+
+### macOS mode
+
+One host means both servers are loopback, so the remote half of the suite
+is not reproducible. What the native mode still does is bring up two
+independent DVMs on this machine, which gives the tool two *distinct*
+servers — so the attach/switch/disconnect reference accounting runs for
+real. It runs `toolswitch -q` (queries skipped: a second DVM on the same
+host answers out of the same state as the first). Do not let it stand in
+for the linux mode.

--- a/contrib/dockerswarm/run-tool-tests.sh
+++ b/contrib/dockerswarm/run-tool-tests.sh
@@ -70,15 +70,17 @@
 #     gets, and it is the only one that gets it with real remote peers
 #     attached and detached.
 #
-# WHAT THIS DOES NOT COVER, and no other suite does either:
+# WHAT THIS DOES NOT COVER:
 #
-#   * the tool-to-tool relay in src/tool/pmix_tool_ops.c
-#     (pmix_tool_relay_op / tool_switchyard).  That path needs a THIRD
-#     party -- a tool that has connected to another tool as its primary
-#     server and then sends it a spawn, which the receiving tool must
-#     forward to a real server.  PRRTE's launchers do not arrange that
-#     shape, so nothing here reaches it; saying so is more useful than
-#     implying the tool library is fully covered.
+#   * the RELAY half of src/tool/pmix_tool_ops.c -- a tool that has
+#     connected to another tool as its primary server sending it a spawn
+#     which the receiving tool forwards ON to a real server.  PRRTE's
+#     launchers do not arrange that shape, so nothing here reaches it.
+#     test/unit/tool_relay covers the other half of the same decision
+#     (the receiving tool has NO server, so it fork/execs the job
+#     itself), which is what makes the relay's "am I attached?" test
+#     observable at all; the forward-to-a-real-server arm remains
+#     uncovered anywhere.
 #
 # Prints PASS/FAIL per case and a summary; exits non-zero if anything failed.
 

--- a/contrib/dockerswarm/run-tool-tests.sh
+++ b/contrib/dockerswarm/run-tool-tests.sh
@@ -1,0 +1,464 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Exercise src/tool -- the tool-role half of libpmix -- against servers
+# that are really on different nodes.
+#
+#   ./run-tool-tests.sh linux    # in the 10-container swarm
+#                                #   (requires: ./build.sh && docker compose up -d)
+#   ./run-tool-tests.sh macos    # single-host subset natively
+#                                #   (requires: ./build.sh macos)
+#
+# WHY THIS IS A MULTI-NODE TEST
+#
+# A tool is the only PMIx role that holds connections to SEVERAL servers at
+# once and picks which of them is "primary" -- the one that services
+# queries, spawns and notifications that are not directed anywhere in
+# particular.  That is the whole subject of src/tool:
+# pmix_tool_retry_attach, pmix_tool_retry_set, disc and getsrvrs each
+# repoint pmix_client_globals.myserver while the peer objects are also held
+# in pmix_server_globals.clients, and their reference accounting has to
+# balance exactly against PMIx_tool_finalize.
+#
+# test/simple/tool_server_switch already drives that API in a loop, and it
+# is a good bookkeeping test -- but both of its servers are on ONE host.
+# Everything the switch is FOR is invisible in that configuration:
+#
+#   * both connections are loopback, so a server that is unreachable
+#     because it is on another machine cannot be produced at all;
+#   * a request answered by "the other server" never leaves the host, so
+#     nothing distinguishes a correct primary-server choice from a wrong
+#     one that happens to reach a server anyway;
+#   * the IOF a tool receives is generated on its own node, so
+#     tool_iof_handler never sees a payload that was relayed daemon to
+#     daemon before it arrived.
+#
+# So every stage here puts the tool and at least one of its servers on
+# DIFFERENT nodes.
+#
+# What the stages reach that `make check` cannot:
+#
+#   * toolswitch -- a tool whose local server is node1's daemon and whose
+#     second server is a daemon on node2, cycling
+#     attach-as-primary -> get_servers -> set_server(local/self/remote) ->
+#     disconnect -> finalize.  Each cycle re-inits, so it is also the
+#     re-init path with a real remote peer in the clients array rather
+#     than a loopback one.  The queries in the middle are the part that
+#     needs two hosts: the same PMIx_Query_info_nb has to travel to a
+#     different machine depending on which server is primary at the time.
+#   * IOF forwarded to a tool from ranks on several other nodes.  prterun
+#     IS a tool; running it against a persistent DVM with ranks on nodes
+#     it is not on means every byte it prints arrived through
+#     tool_iof_handler after being relayed by a daemon that is not the
+#     tool's own.  On one node the output never leaves the machine.
+#     (prun, not prterun: prterun brings up a DVM of its own, while prun
+#     attaches to the persistent one as a tool, which is the shape we
+#     want.)
+#   * a tool whose REMOTE primary server dies.  The node-local version of
+#     this lives in run-ptl-tests.sh; across nodes the drop is a real
+#     socket close from another host rather than a peer vanishing inside
+#     the same kernel.
+#   * a valgrind pass on the tool itself.  Every other suite valgrinds a
+#     client or (in run-server-tests.sh) the daemon; a client never runs
+#     src/tool at all, so this is the only leak coverage the tool library
+#     gets, and it is the only one that gets it with real remote peers
+#     attached and detached.
+#
+# WHAT THIS DOES NOT COVER, and no other suite does either:
+#
+#   * the tool-to-tool relay in src/tool/pmix_tool_ops.c
+#     (pmix_tool_relay_op / tool_switchyard).  That path needs a THIRD
+#     party -- a tool that has connected to another tool as its primary
+#     server and then sends it a spawn, which the receiving tool must
+#     forward to a real server.  PRRTE's launchers do not arrange that
+#     shape, so nothing here reaches it; saying so is more useful than
+#     implying the tool library is fully covered.
+#
+# Prints PASS/FAIL per case and a summary; exits non-zero if anything failed.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+# RUN/ON, cleanup_swarm, swarm_up_or_die and the swarm naming (PMIX_SWARM,
+# NODE, IMAGE, VOLUME) all live in swarm-common.sh.
+. "$(dirname "$0")/swarm-common.sh"
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+# The examples this runner drives.
+#   toolswitch - the multi-server model across nodes (see the header)
+#   tool       - attach by URI / by nspace, used for the lost-server case
+TOOL_EXAMPLES="${TOOL_EXAMPLES:-toolswitch tool}"
+
+# See run-server-tests.sh: these are COMPILED in a throwaway builder
+# container and RUN in the long-lived node containers, so they must link the
+# PMIx that build.sh installed into the shared volume -- the only tree that
+# is the same in both.
+PMIX_PREFIX=/opt/prte/pmix
+TESTDIR=/opt/prte/tests-tool
+
+# The DVMs report their URIs to files on the NODE's own filesystem: the
+# shared volume is mounted read-only in the node containers, and
+# --report-uri to a path in it fails silently.  Deliberately not named
+# pmix*, which is the glob cleanup_swarm sweeps out of /tmp.
+URI_A=/tmp/toolsuite-a.uri
+URI_B=/tmp/toolsuite-b.uri
+
+OUT=""
+RC=0
+
+# Poll for a --report-uri file rather than guessing how long the DVM takes
+# to write it: --daemonize returns as soon as the DVM is forked.
+# $1 = node number, $2 = path
+wait_for_uri() {
+    local i
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        ON "$1" "test -s $2" && return 0
+        sleep 2
+    done
+    return 1
+}
+
+# Pull the address out of "<nspace>.<rank>;tcp4://<addr>:<port>", split from
+# the back the way pmix_ptl_base_parse_uri does.
+uri_addr() { local a="${1#*//}"; echo "${a%%:*}"; }
+
+########################################################################
+# Linux: the 10-node swarm.
+########################################################################
+
+test_linux() {
+    local rc uri_a uri_b addr_b nodecount
+
+    swarm_up_or_die
+
+    banner "preflight: install present in shared volume"
+    if RUN 'command -v prterun prte pterm >/dev/null'; then
+        ok "prterun/prte/pterm on PATH"
+    else
+        bad "tools missing -- did ./build.sh run?"; return
+    fi
+
+    if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+        bad "build volume $VOLUME missing -- run ./build.sh first"
+        return
+    fi
+
+    # The nodes are long-lived containers while the install they read is
+    # replaced under them, so a node predating the current image runs a
+    # different PMIx than the builder container compiles against.
+    banner "preflight: containers are running the current image"
+    local imgid cimg imgn stalenodes=""
+    imgid=$(docker images --no-trunc --format '{{.ID}}' "$IMAGE" 2>/dev/null | head -1)
+    for imgn in $(seq 1 10); do
+        cimg=$(docker inspect "$NODE$imgn" --format '{{.Image}}' 2>/dev/null)
+        [ "$cimg" = "$imgid" ] || stalenodes="$stalenodes node$imgn"
+    done
+    if [ -z "$stalenodes" ]; then
+        ok "all 10 containers are on the current $IMAGE"
+    else
+        bad "containers predate $IMAGE:$stalenodes"
+        echo "     Recreate them: ${SWARM_ENV}docker compose up -d --force-recreate" >&2
+        return
+    fi
+
+    banner "preflight: PMIx installed in the shared volume"
+    if ON 1 "test -f $PMIX_PREFIX/include/pmix_common.h"; then
+        ok "PMIx headers/libs under $PMIX_PREFIX"
+    else
+        bad "no $PMIX_PREFIX in the volume -- run ./build.sh first"
+        return
+    fi
+
+    banner "build the tool examples"
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e EXAMPLES="$TOOL_EXAMPLES" \
+        -e PFX="$PMIX_PREFIX" \
+        -e TDIR="$TESTDIR" \
+        "$IMAGE" bash -euo pipefail -c '
+            mkdir -p "$TDIR"
+            for ex in $EXAMPLES; do
+                gcc -O0 -g -o "$TDIR/$ex" "/pmix-src/examples/$ex.c" \
+                    -I"$PFX/include" -I/pmix-src/examples \
+                    -L"$PFX/lib" -lpmix -Wl,-rpath,"$PFX/lib"
+            done
+        '
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        bad "could not build the tool examples (rc=$rc)"
+        return
+    fi
+    ok "built: $TOOL_EXAMPLES"
+
+    # ------------------------------------------------------------------
+    # Two INDEPENDENT DVMs, one headed on node1 and one headed on node2.
+    #
+    # Two DVMs rather than one, because what we want is two servers that a
+    # single tool can hold at the same time and tell apart.  Within one DVM
+    # the tool would have to be handed some non-head daemon's URI, and
+    # nothing publishes those.  Two heads each report their own.
+    # ------------------------------------------------------------------
+    banner "bring up two DVMs on different nodes"
+    cleanup_swarm
+    ON 1 "rm -f $URI_A"; ON 2 "rm -f $URI_B"
+    # PRTE_MCA_pmix_remote_connections=1 is what makes this suite possible.
+    # A PMIx server binds a LOOPBACK interface unless remote connections
+    # were asked for, and a loopback URI is unreachable from another node by
+    # construction -- so without this every cross-node stage below would
+    # skip itself and the suite would prove nothing. It is a PRRTE-side MCA
+    # parameter that ends up as the PMIX_SERVER_REMOTE_CONNECTIONS directive
+    # on PMIx_server_init.
+    ON 1 "export PRTE_ALLOW_RUN_AS_ROOT=1 PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+                 PRTE_MCA_pmix_remote_connections=1;
+          . /opt/prte/env.sh; prte --daemonize --report-uri $URI_A \
+              --host node1:1,node3:1,node4:1 >/tmp/toolsuite-a.log 2>&1" >/dev/null 2>&1
+    ON 2 "export PRTE_ALLOW_RUN_AS_ROOT=1 PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+                 PRTE_MCA_pmix_remote_connections=1;
+          . /opt/prte/env.sh; prte --daemonize --report-uri $URI_B \
+              --host node2:1 >/tmp/toolsuite-b.log 2>&1" >/dev/null 2>&1
+
+    uri_a=""; uri_b=""
+    wait_for_uri 1 "$URI_A" && uri_a="$(ON 1 "cat $URI_A" | head -1 | tr -d '\r')"
+    wait_for_uri 2 "$URI_B" && uri_b="$(ON 2 "cat $URI_B" | head -1 | tr -d '\r')"
+    if [ -z "$uri_a" ] || [ -z "$uri_b" ]; then
+        bad "could not bring up two DVMs (A='${uri_a:-none}' B='${uri_b:-none}')"
+        cleanup_swarm
+        return
+    fi
+    ok "DVM A on node1 and DVM B on node2 both reported a URI"
+    addr_b="$(uri_addr "$uri_b")"
+
+    # ------------------------------------------------------------------
+    # The multi-server model, with the two servers on two hosts.
+    # ------------------------------------------------------------------
+    banner "a tool switching its primary between servers on different nodes"
+    case "$addr_b" in
+        127.*|::1|localhost|"")
+            # A loopback URI is unreachable from node1 by construction.
+            # Whether PRRTE asked for remote connections is PRRTE's
+            # business, so this is a skip with the reason named.
+            skp "toolswitch (DVM B's listener is on loopback: ${addr_b:-unparseable})"
+            skp "toolswitch under valgrind (no remote URI)" ;;
+        *)
+            OUT="$(ON 1 "timeout 180 $TESTDIR/toolswitch -u '$uri_b' -n 5 2>&1")"
+            RC=$?
+            if [ "$RC" = 124 ]; then
+                bad "toolswitch: HUNG"
+            elif echo "$OUT" | grep -qiE 'Segmentation|core dumped|Assertion'; then
+                bad "toolswitch: crashed ($(echo "$OUT" | grep -iE 'Segmentation|core dumped|Assertion' | head -1))"
+            elif [ "$RC" != 0 ]; then
+                bad "toolswitch: exit $RC ($(echo "$OUT" | tr '\n' ' ' | tail -c 300))"
+            elif ! echo "$OUT" | grep -q 'toolswitch: PASS'; then
+                bad "toolswitch: no PASS marker ($(echo "$OUT" | tr '\n' ' ' | tail -c 300))"
+            else
+                ok "toolswitch: attach/switch/disconnect across nodes, 5 cycles"
+            fi
+
+            # ----------------------------------------------------------
+            # The same thing under valgrind.  This is the only leak
+            # coverage src/tool has anywhere, and the only place it runs
+            # with real remote peers being attached and released.
+            #
+            # Only "definitely lost" blocks whose stack names a src/tool
+            # frame are failed on: libpmix and PRRTE both leak at exit in
+            # ways that are not this suite's business, and a whole-process
+            # clean bill would make the stage permanently red and
+            # therefore ignored.
+            # ----------------------------------------------------------
+            banner "tool library under valgrind, with a remote server attached"
+            if ! ON 1 'command -v valgrind >/dev/null 2>&1'; then
+                # The image is a build image, not a debug one, and it is
+                # shared with the other swarm, so rebuilding it to add a
+                # package moves it under that swarm's feet. Install into
+                # the one node we need it on, at run time.
+                ON 1 'apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq valgrind >/dev/null 2>&1' || true
+            fi
+            if ! ON 1 'command -v valgrind >/dev/null 2>&1'; then
+                skp "valgrind-tool (valgrind unavailable and could not be installed)"
+            else
+                ON 1 'rm -f /tmp/toolsuite-vg.log'
+                # --fullpath-after= (empty argument) makes valgrind print
+                # the FULL source path in each frame. Without it a frame
+                # reads "pmix_tool.c:123", which is unmatchable by path --
+                # and PRRTE ships files of its own whose basenames collide
+                # with ours, so a basename match would attribute their
+                # leaks to us.
+                OUT="$(ON 1 "valgrind --leak-check=full --show-leak-kinds=definite \
+                                 --error-exitcode=0 --fullpath-after= \
+                                 --log-file=/tmp/toolsuite-vg.log \
+                                 timeout 300 $TESTDIR/toolswitch -u '$uri_b' -n 2 2>&1")"
+                RC=$?
+                if [ "$RC" = 124 ]; then
+                    bad "valgrind-tool: HUNG"
+                elif [ "$RC" != 0 ]; then
+                    bad "valgrind-tool: the run itself failed (exit $RC): $(echo "$OUT" | tr '\n' ' ' | tail -c 200)"
+                else
+                    local tlleaks
+                    # --show-leak-kinds=definite means the log holds
+                    # definite-leak records and the summary, nothing else,
+                    # so a src/tool frame anywhere in it is a frame in a
+                    # definite leak's allocation stack
+                    tlleaks="$(ON 1 "grep -c 'src/tool/pmix_tool' /tmp/toolsuite-vg.log" 2>/dev/null | tr -dc '0-9')"
+                    tlleaks="${tlleaks:-0}"
+                    if [ "$tlleaks" = 0 ]; then
+                        ok "valgrind-tool: no definite leak attributed to a src/tool frame"
+                    else
+                        bad "valgrind-tool: $tlleaks definite-leak frames in src/tool"
+                        ON 1 'grep -B2 -A12 "definitely lost" /tmp/toolsuite-vg.log | head -60' >&2
+                    fi
+                fi
+            fi ;;
+    esac
+
+    # ------------------------------------------------------------------
+    # A tool whose REMOTE primary server dies.
+    #
+    # The tool must notice the drop and unwind rather than hang.  The
+    # node-local version of this is in run-ptl-tests.sh; here the close
+    # arrives over a socket from another machine, which is the case a
+    # single host cannot produce.
+    # ------------------------------------------------------------------
+    banner "a tool whose server on another node goes away"
+    case "$addr_b" in
+        127.*|::1|localhost|"")
+            skp "remote server death (DVM B's listener is on loopback)" ;;
+        *)
+            # kill DVM B out from under a tool on node1 that is attached
+            # to it by URI
+            ON 2 "( sleep 5; . /opt/prte/env.sh; pterm --dvm-uri '$uri_b' >/dev/null 2>&1 ) &" >/dev/null 2>&1
+            OUT="$(ON 1 "timeout 90 $TESTDIR/tool -u '$uri_b' 2>&1")"
+            RC=$?
+            if [ "$RC" = 124 ]; then
+                bad "remote server death: HUNG (never noticed the drop)"
+            elif echo "$OUT" | grep -qiE 'Segmentation|core dumped|Assertion'; then
+                bad "remote server death: crashed ($(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+            else
+                ok "remote server death: unwound and exited (exit $RC)"
+            fi ;;
+    esac
+
+    # ------------------------------------------------------------------
+    # IOF delivered to a tool from ranks on other nodes.
+    #
+    # prun attaches to the persistent DVM as a TOOL, so every byte it
+    # prints came in through tool_iof_handler.  Point the job at nodes the
+    # tool is NOT on, so each payload was relayed by a daemon other than
+    # the tool's own before it arrived.
+    # ------------------------------------------------------------------
+    banner "IOF forwarded to a tool from ranks on other nodes"
+    if [ -z "$uri_a" ]; then
+        skp "tool IOF across nodes (no DVM)"
+    else
+        OUT="$(ON 1 "export PRTE_ALLOW_RUN_AS_ROOT=1 PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1;
+                     . /opt/prte/env.sh;
+                     timeout 90 prun --dvm-uri '$uri_a' --host node3:1,node4:1 \
+                         -np 2 --map-by node hostname 2>&1")"
+        RC=$?
+        # one distinct hostname per node the ranks landed on: if the tool
+        # only ever received its own node's output we would see one, and
+        # if it received none we would see zero
+        nodecount="$(echo "$OUT" | grep -oE '^[a-z0-9]+' | grep -c 'node[0-9]' || true)"
+        if [ "$RC" = 124 ]; then
+            bad "tool IOF across nodes: HUNG"
+        elif [ "$RC" != 0 ]; then
+            bad "tool IOF across nodes: exit $RC ($(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+        elif [ "$(echo "$OUT" | grep -oE 'node[0-9]+' | sort -u | wc -l | tr -dc '0-9')" -lt 2 ]; then
+            bad "tool IOF across nodes: output arrived from fewer than two nodes ($(echo "$OUT" | tr '\n' ' ' | tail -c 200))"
+        else
+            ok "tool IOF across nodes: output relayed to the tool from both remote nodes"
+        fi
+    fi
+
+    banner "teardown"
+    ON 1 ". /opt/prte/env.sh; pterm --dvm-uri '$uri_a' >/dev/null 2>&1" >/dev/null 2>&1
+    ON 2 ". /opt/prte/env.sh; pterm --dvm-uri '$uri_b' >/dev/null 2>&1" >/dev/null 2>&1
+    cleanup_swarm
+    ON 1 "rm -f $URI_A /tmp/toolsuite-a.log /tmp/toolsuite-vg.log"
+    ON 2 "rm -f $URI_B /tmp/toolsuite-b.log"
+    if [ "$(prted_count 1 2 3 4 5 6 7 8 9 10)" = 0 ]; then
+        ok "no stray prted left behind"
+    else
+        bad "stray prted left behind"
+    fi
+}
+
+########################################################################
+# macOS: natively on this host.
+#
+# One host means one machine, so the whole point of the suite -- a primary
+# server that is somewhere else -- is not reproducible.  What IS worth
+# running natively is the bookkeeping: two independent DVMs on this host
+# give the tool two distinct servers, so the attach/switch/disconnect
+# reference accounting runs for real even though both peers are loopback.
+# Say which of the two this is; do not let it stand in for the linux mode.
+########################################################################
+
+test_macos() {
+    local prefix="$root/../build/master" bin uri_b
+
+    [ -d "$prefix" ] || prefix="/opt/prte/pmix"
+
+    banner "native single-host tool pass"
+    echo "  NOTE: one host means both servers are loopback -- the remote"
+    echo "        half of this suite is NOT covered here. Use the linux mode."
+    if [ ! -x "$prefix/bin/prterun" ] && ! command -v prterun >/dev/null; then
+        skp "no prterun available -- run ./build.sh macos first"
+        return
+    fi
+
+    mac_isolate "$prefix" 2>/dev/null || true
+
+    bin="$MAC_TMP/toolswitch"
+    if ! cc -O0 -g -o "$bin" "$root/examples/toolswitch.c" \
+            -I"$root/include" -I"$root" -I"$root/examples" \
+            -L"$root/src/.libs" -lpmix -Wl,-rpath,"$root/src/.libs" \
+            >/dev/null 2>&1; then
+        skp "toolswitch (would not compile against the in-tree library)"
+        return
+    fi
+
+    "$MAC_BIN/prte" --daemonize --report-uri "$MAC_TMP/a.uri" >/dev/null 2>&1
+    "$MAC_BIN/prte" --daemonize --report-uri "$MAC_TMP/b.uri" >/dev/null 2>&1
+    sleep 5
+    uri_b="$(head -1 "$MAC_TMP/b.uri" 2>/dev/null)"
+    if [ -z "$uri_b" ]; then
+        skp "toolswitch (could not bring up a second DVM)"
+        macpk
+        return
+    fi
+    # -q: a second DVM on the same host answers queries out of the same
+    # state as the first, so the query stage adds nothing here
+    OUT="$("$bin" -u "$uri_b" -n 3 -q 2>&1)"; RC=$?
+    if echo "$OUT" | grep -q 'toolswitch: PASS'; then
+        ok "toolswitch: attach/switch/disconnect bookkeeping against two DVMs"
+    else
+        bad "toolswitch: exit $RC ($(echo "$OUT" | tr '\n' ' ' | tail -c 300))"
+    fi
+    macpk
+}
+
+########################################################################
+
+case "$mode" in
+    linux) test_linux ;;
+    macos) test_macos ;;
+    *) echo "usage: $0 [linux|macos]" >&2; exit 2 ;;
+esac
+
+printf '\n=== summary: %d passed, %d failed, %d skipped ===\n' "$pass" "$fail" "$skip"
+[ "$fail" = 0 ]

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -89,7 +89,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   simple simple_server abort group_die connect_die group_leave \
                   group_destruct_die group_invite group_invite_timeout group_invite_decline \
                   group_invite_abort group_invite_others group_invite_suppress group_invite_nb topology \
-                  spawn_reuse group_badinfo datatypes
+                  spawn_reuse group_badinfo datatypes toolswitch
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -283,6 +283,10 @@ toolqry_SOURCES = toolqry.c examples.h
 toolqry_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 toolqry_LDADD = $(top_builddir)/src/libpmix.la
 
+toolswitch_SOURCES = toolswitch.c examples.h
+toolswitch_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+toolswitch_LDADD = $(top_builddir)/src/libpmix.la
+
 simple_resolve_SOURCES = simple_resolve.c examples.h
 simple_resolve_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simple_resolve_LDADD = $(top_builddir)/src/libpmix.la
@@ -329,4 +333,4 @@ distclean-local:
         group_invite_abort group_invite_suppress group_invite_nb \
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
-        simple simple_server abort datatypes
+        simple simple_server abort datatypes toolswitch

--- a/examples/toolswitch.c
+++ b/examples/toolswitch.c
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Exercise the tool library's multi-server model against servers that are
+ * really on different nodes.
+ *
+ * A tool is the only PMIx role that can hold connections to several
+ * servers at once and choose which of them is "primary" - the one that
+ * services queries, spawns and event notifications that are not directed
+ * anywhere in particular. That machinery lives in src/tool
+ * (pmix_tool_retry_attach, pmix_tool_retry_set, disc, getsrvrs), and each
+ * of those repoints pmix_client_globals.myserver while the peer objects
+ * are also held by pmix_server_globals.clients, so their reference
+ * accounting has to balance exactly against PMIx_tool_finalize.
+ *
+ * Two servers on ONE host will exercise the bookkeeping, but not much
+ * else: both connections are loopback, both peers are reachable for as
+ * long as the process lives, and a query answered by "the other server"
+ * never leaves the machine. Pointing this at daemons on two different
+ * nodes is what makes the primary-server choice observable - the answer
+ * to PMIX_QUERY_NAMESPACES, or to a request for the server's own info,
+ * comes back over a different socket to a different host depending on
+ * which server is primary at the time.
+ *
+ * Usage:
+ *
+ *   toolswitch -u <uri> [-n <cycles>] [-q]
+ *
+ *     -u <uri>     URI of a SECOND server, normally one on another node.
+ *                  Required: without it there is only one server and
+ *                  nothing to switch between.
+ *     -n <cycles>  how many attach/switch/disconnect cycles to run
+ *                  (default 5). Each cycle inits and finalizes the tool
+ *                  library, so the count is also a re-init stress.
+ *     -q           skip the query stage (useful when the servers in play
+ *                  do not answer queries).
+ *
+ * The tool's FIRST server is whatever PMIx_tool_init finds on its own -
+ * normally the daemon on this node, discovered through its rendezvous
+ * file. So run this on a node that has one.
+ *
+ * Exits 0 if every cycle completed, non-zero (with a message on stderr)
+ * on the first failure.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix_tool.h>
+
+#define DEFAULT_CYCLES 5
+/* a typo on the command line must not turn into a run that never ends */
+#define MAX_CYCLES     10000
+
+static char hostname[1024];
+
+static void querycb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
+                    pmix_release_cbfunc_t release_fn, void *release_cbdata)
+{
+    myquery_data_t *mq = (myquery_data_t *) cbdata;
+    EXAMPLES_HIDE_UNUSED_PARAMS(info, ninfo);
+
+    mq->lock.status = status;
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+    DEBUG_WAKEUP_THREAD(&mq->lock);
+}
+
+/* Ask the current primary server something only a server can answer.
+ * The point is not the answer but the round trip: it proves the primary
+ * we just selected is the peer the request actually went to. A server
+ * that does not implement the query interface says so, and that is not a
+ * failure of the switch. */
+static int ask_primary(const char *who)
+{
+    pmix_query_t *query;
+    myquery_data_t mydata;
+    pmix_status_t rc;
+
+    PMIX_QUERY_CREATE(query, 1);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_NAMESPACES);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_QUERY_FREE(query, 1);
+        fprintf(stderr, "toolswitch: could not build the query\n");
+        return 1;
+    }
+
+    DEBUG_CONSTRUCT_LOCK(&mydata.lock);
+    mydata.info = NULL;
+    mydata.ninfo = 0;
+    rc = PMIx_Query_info_nb(query, 1, querycb, (void *) &mydata);
+    if (PMIX_SUCCESS != rc) {
+        DEBUG_DESTRUCT_LOCK(&mydata.lock);
+        PMIX_QUERY_FREE(query, 1);
+        /* the request never left, which IS a switch-path failure */
+        fprintf(stderr, "toolswitch: query to %s could not be sent: %s\n", who,
+                PMIx_Error_string(rc));
+        return 1;
+    }
+    DEBUG_WAIT_THREAD(&mydata.lock);
+    rc = mydata.lock.status;
+    DEBUG_DESTRUCT_LOCK(&mydata.lock);
+    PMIX_QUERY_FREE(query, 1);
+    if (NULL != mydata.info) {
+        PMIX_INFO_FREE(mydata.info, mydata.ninfo);
+    }
+
+    /* PMIX_ERR_NOT_SUPPORTED means we reached a server that does not
+     * answer this query - the round trip still happened */
+    if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_SUPPORTED != rc && PMIX_ERR_NOT_FOUND != rc) {
+        fprintf(stderr, "toolswitch: query to %s failed: %s\n", who, PMIx_Error_string(rc));
+        return 1;
+    }
+    printf("[%s] query answered by %s: %s\n", hostname, who, PMIx_Error_string(rc));
+    return 0;
+}
+
+/* find the entry in the list that is NOT "skip" */
+static int find_other(pmix_proc_t *list, size_t n, pmix_proc_t *skip, pmix_proc_t *found)
+{
+    size_t i;
+
+    for (i = 0; i < n; i++) {
+        if (!PMIX_CHECK_PROCID(&list[i], skip)) {
+            PMIX_LOAD_PROCID(found, list[i].nspace, list[i].rank);
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int one_cycle(long cyc, const char *uri, bool doquery)
+{
+    pmix_proc_t myproc, local, remote, other;
+    pmix_proc_t *servers = NULL;
+    size_t nservers = 0;
+    pmix_info_t info[3];
+    pmix_status_t rc;
+    int itmo = 5;
+
+    /* Each cycle must come up with a fresh identity. A previous cycle's
+     * attach can leave identity variables in our environment, and an
+     * nspace without a rank (or the reverse) is a hard error in init. */
+    unsetenv("PMIX_NAMESPACE");
+    unsetenv("PMIX_RANK");
+
+    rc = PMIx_tool_init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: PMIx_tool_init failed: %s\n", cyc, PMIx_Error_string(rc));
+        return 1;
+    }
+    if (!PMIx_tool_is_connected()) {
+        fprintf(stderr, "cycle %ld: init did not connect us to a server\n", cyc);
+        goto err;
+    }
+
+    /* whatever init found is our local server */
+    rc = PMIx_tool_get_servers(&servers, &nservers);
+    if (PMIX_SUCCESS != rc || 1 != nservers) {
+        fprintf(stderr, "cycle %ld: get_servers after init: rc=%s n=%zu (want 1)\n", cyc,
+                PMIx_Error_string(rc), nservers);
+        goto err;
+    }
+    PMIX_LOAD_PROCID(&local, servers[0].nspace, servers[0].rank);
+    PMIX_PROC_FREE(servers, nservers);
+    servers = NULL;
+    printf("[%s] cycle %ld: local server is %s:%u\n", hostname, cyc, local.nspace, local.rank);
+
+    /* attach to the remote server and make it primary - this is
+     * pmix_tool_retry_attach's switch branch, over a real socket to
+     * another host */
+    PMIX_INFO_LOAD(&info[0], PMIX_SERVER_URI, uri, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_PRIMARY_SERVER, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[2], PMIX_TIMEOUT, &itmo, PMIX_INT);
+    rc = PMIx_tool_attach_to_server(&myproc, &remote, info, 3);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_INFO_DESTRUCT(&info[2]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: attach to remote server failed: %s\n", cyc,
+                PMIx_Error_string(rc));
+        goto err;
+    }
+    printf("[%s] cycle %ld: remote server is %s:%u\n", hostname, cyc, remote.nspace,
+           remote.rank);
+
+    /* the two must be DIFFERENT servers, or the rest of this cycle is
+     * only testing that we can talk to one server twice */
+    if (PMIX_CHECK_PROCID(&local, &remote)) {
+        fprintf(stderr, "cycle %ld: the remote URI resolved to our own local server "
+                "(%s:%u) - point -u at a daemon on another node\n",
+                cyc, local.nspace, local.rank);
+        goto err;
+    }
+
+    rc = PMIx_tool_get_servers(&servers, &nservers);
+    if (PMIX_SUCCESS != rc || 2 != nservers) {
+        fprintf(stderr, "cycle %ld: get_servers after attach: rc=%s n=%zu (want 2)\n", cyc,
+                PMIx_Error_string(rc), nservers);
+        goto err;
+    }
+    /* the primary is documented to be first */
+    if (!PMIX_CHECK_PROCID(&servers[0], &remote)) {
+        fprintf(stderr, "cycle %ld: the new primary is not first in the server list\n", cyc);
+        goto err;
+    }
+    if (0 != find_other(servers, nservers, &remote, &other) ||
+        !PMIX_CHECK_PROCID(&other, &local)) {
+        fprintf(stderr, "cycle %ld: the server list does not hold both servers\n", cyc);
+        goto err;
+    }
+    PMIX_PROC_FREE(servers, nservers);
+    servers = NULL;
+
+    if (doquery && 0 != ask_primary("the remote server")) {
+        goto err;
+    }
+
+    /* switch the primary back to the local server and ask again - the
+     * same call now has to travel to a different host */
+    rc = PMIx_tool_set_server(&local, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: set_server(local) failed: %s\n", cyc,
+                PMIx_Error_string(rc));
+        goto err;
+    }
+    if (doquery && 0 != ask_primary("the local server")) {
+        goto err;
+    }
+
+    /* switch to ourselves: we then have no server at all, and the
+     * library must say so */
+    rc = PMIx_tool_set_server(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: set_server(self) failed: %s\n", cyc,
+                PMIx_Error_string(rc));
+        goto err;
+    }
+    if (PMIx_tool_is_connected()) {
+        fprintf(stderr, "cycle %ld: still 'connected' after pointing at ourselves\n", cyc);
+        goto err;
+    }
+
+    /* and back out to the remote one, which must still be attached */
+    rc = PMIx_tool_set_server(&remote, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: set_server(remote) failed: %s\n", cyc,
+                PMIx_Error_string(rc));
+        goto err;
+    }
+    if (!PMIx_tool_is_connected()) {
+        fprintf(stderr, "cycle %ld: not connected after returning to the remote server\n", cyc);
+        goto err;
+    }
+
+    /* drop the non-primary first, then the primary: disc's two branches */
+    rc = PMIx_tool_disconnect(&local);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: disconnect(local) failed: %s\n", cyc,
+                PMIx_Error_string(rc));
+        goto err;
+    }
+    rc = PMIx_tool_disconnect(&remote);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: disconnect(remote) failed: %s\n", cyc,
+                PMIx_Error_string(rc));
+        goto err;
+    }
+    if (PMIx_tool_is_connected()) {
+        fprintf(stderr, "cycle %ld: still connected after dropping every server\n", cyc);
+        goto err;
+    }
+    rc = PMIx_tool_get_servers(&servers, &nservers);
+    if (PMIX_ERR_UNREACH != rc || 0 != nservers) {
+        fprintf(stderr, "cycle %ld: get_servers with none left: rc=%s n=%zu "
+                "(want PMIX_ERR_UNREACH/0)\n", cyc, PMIx_Error_string(rc), nservers);
+        goto err;
+    }
+
+    rc = PMIx_tool_finalize();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "cycle %ld: PMIx_tool_finalize failed: %s\n", cyc,
+                PMIx_Error_string(rc));
+        return 1;
+    }
+    return 0;
+
+err:
+    if (NULL != servers) {
+        PMIX_PROC_FREE(servers, nservers);
+    }
+    PMIx_tool_finalize();
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    char *uri = NULL;
+    long ncycles = DEFAULT_CYCLES, i;
+    bool doquery = true;
+    int n;
+
+    gethostname(hostname, sizeof(hostname));
+
+    for (n = 1; n < argc; n++) {
+        if (0 == strcmp("-u", argv[n]) || 0 == strcmp("--url", argv[n])) {
+            if (NULL == argv[n + 1]) {
+                fprintf(stderr, "%s requires a URI argument\n", argv[n]);
+                return 1;
+            }
+            uri = argv[++n];
+        } else if (0 == strcmp("-n", argv[n]) || 0 == strcmp("--cycles", argv[n])) {
+            if (NULL == argv[n + 1]) {
+                fprintf(stderr, "%s requires a count argument\n", argv[n]);
+                return 1;
+            }
+            ncycles = strtol(argv[++n], NULL, 10);
+            if (0 >= ncycles || MAX_CYCLES < ncycles) {
+                ncycles = DEFAULT_CYCLES;
+            }
+        } else if (0 == strcmp("-q", argv[n]) || 0 == strcmp("--no-query", argv[n])) {
+            doquery = false;
+        } else {
+            fprintf(stderr, "usage: %s -u <uri of a second server> [-n cycles] [-q]\n", argv[0]);
+            return 1;
+        }
+    }
+    if (NULL == uri) {
+        fprintf(stderr, "usage: %s -u <uri of a second server> [-n cycles] [-q]\n", argv[0]);
+        return 1;
+    }
+
+    printf("[%s] toolswitch: %ld cycles against %s\n", hostname, ncycles, uri);
+    for (i = 0; i < ncycles; i++) {
+        if (0 != one_cycle(i, uri, doquery)) {
+            fprintf(stderr, "toolswitch: FAILED on cycle %ld\n", i);
+            return 1;
+        }
+    }
+    printf("[%s] toolswitch: PASS (%ld cycles)\n", hostname, ncycles);
+    return 0;
+}

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -123,6 +123,25 @@ Host up-calls use a tri-state return convention throughout:
 invoke the completion yourself"; any error = "rejected." Handle all
 three on every up-call site.
 
+**A spawn is relayed when we are attached to a server and fork/exec'd
+when we are not.** `server_switchyard` hands a command from a downstream
+tool to `pmix_tool_relay_op` whenever *we* are a tool, and falls through
+to the logic tree on **both** `PMIX_ERR_NOT_SUPPORTED` ("not a command we
+relay") and `PMIX_ERR_UNREACH` ("no server to relay it to"). The second
+arm is why `pmix_server_spawn` will fork/exec when it has no
+`pmix_host_server.spawn` but `pfexec` is open — the same rule
+`PMIx_Spawn` applies to a launcher's own requests. Two details make the
+gate safe: `pmix_pfexec_base_open()` is called from exactly one place in
+the tree (`PMIx_tool_init`, for a launcher or scheduler), so
+`pmix_pfexec_globals.initialized` really is the "can I fork/exec"
+question and a plain PMIx server is unaffected; and `pmix_tool_relay_op`
+returns both statuses **before** rewinding the buffer, so the
+fall-through keeps the unpack position the `cmd` read left. The pfexec
+arm hands `pmix_pfexec_base_spawn_job` a *second* setup caddy that
+borrows the first one's apps and directives with `copied` left false —
+pfexec releases the caddy it is given, and the arrays belong to the one
+holding the requester's callback. Covered by `test/unit/tool_relay`.
+
 **`PMIX_SUCCESS` from an up-call transfers ownership of the caddy to the
 host.** This is the arm most easily lost, because it is usually the one
 that needs no code: the handler returns and the host's callback does the

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -6339,15 +6339,23 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
                         PMIX_PEER_PRINT(peer),
                         (unsigned int) buf->bytes_used);
 
-    /* if I am a tool, all I can do is relay this to my primary server
-     * if I am connected - if not connected, then I must return an error */
+    /* If I am a tool, relay this to my primary server when I have one.
+     * The rule is relay-if-attached, service-it-myself otherwise - the
+     * same one PMIx_Spawn applies to a launcher's own requests. */
     if (PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
         rc = pmix_tool_relay_op(cmd, peer, buf, tag);
-        if (PMIX_ERR_NOT_SUPPORTED != rc) {
+        if (PMIX_ERR_NOT_SUPPORTED != rc && PMIX_ERR_UNREACH != rc) {
             return rc;
         }
-        /* if the tool relay doesn't support it, let it
-         * be processed by the logic tree */
+        /* Fall through to the logic tree, either because this is not a
+         * command we relay (PMIX_ERR_NOT_SUPPORTED) or because we have no
+         * server to relay it to (PMIX_ERR_UNREACH). A launcher with no
+         * server attached fork/execs a spawn itself from there; a role
+         * that genuinely cannot service the command answers
+         * PMIX_ERR_NOT_SUPPORTED from the handler, which is the right
+         * answer to give the requester anyway. Note pmix_tool_relay_op
+         * returns both of those BEFORE it rewinds the buffer, so our
+         * unpack position is still where the cmd read left it. */
     }
 
     /* if I am a server, then redirect the cmd to the appropriate

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -62,6 +62,7 @@
 #include "src/class/pmix_list.h"
 #include "src/common/pmix_attributes.h"
 #include "src/common/pmix_iof.h"
+#include "src/common/pmix_pfexec.h"
 #include "src/common/pmix_monitor.h"
 #include "src/hwloc/pmix_hwloc.h"
 #include "src/mca/bfrops/base/base.h"
@@ -629,11 +630,23 @@ void pmix_server_spawn_parser(pmix_peer_t *peer,
     }
 }
 
+/* Completion callback for a spawn we fork/exec'd ourselves. pfexec calls
+ * this with the caddy IT owns (and releases on return), so all it does is
+ * hand the result to the normal server completion path, which owns the
+ * caddy holding the requester's callback and does the IOF registration
+ * the requester asked for. */
+static void pfexec_spcbfunc(pmix_status_t status, char nspace[], void *cbdata)
+{
+    pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
+
+    pmix_server_spcbfunc(status, nspace, cd);
+}
+
 pmix_status_t pmix_server_spawn(pmix_peer_t *peer, pmix_buffer_t *buf,
                                 pmix_spawn_cbfunc_t cbfunc,
                                 void *cbdata)
 {
-    pmix_setup_caddy_t *cd;
+    pmix_setup_caddy_t *cd, *fcd;
     int32_t cnt;
     pmix_status_t rc;
     pmix_proc_t proc;
@@ -642,7 +655,14 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer, pmix_buffer_t *buf,
                         "recvd SPAWN from %s",
                         PMIX_PNAME_PRINT(&peer->info->pname));
 
-    if (NULL == pmix_host_server.spawn) {
+    /* Our host is the first choice. Failing that we can still service the
+     * request if we are able to fork/exec it ourselves: a launcher that
+     * has no server attached is expected to launch locally rather than
+     * refuse (the same rule PMIx_Spawn applies to a launcher's own
+     * requests). pfexec is opened only by a launcher or scheduler tool,
+     * so this flag is exactly the "can I fork/exec" question - a plain
+     * PMIx server never has it set and its behavior is unchanged. */
+    if (NULL == pmix_host_server.spawn && !pmix_pfexec_globals.initialized) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
@@ -708,11 +728,34 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer, pmix_buffer_t *buf,
     /* mark that we created the data */
     cd->copied = true;
 
-    /* call the local server */
-    PMIX_LOAD_PROCID(&proc, peer->info->pname.nspace, peer->info->pname.rank);
-    rc = pmix_host_server.spawn(&proc, cd->info, cd->ninfo,
-                                cd->apps, cd->napps,
-                                pmix_server_spcbfunc, cd);
+    if (NULL != pmix_host_server.spawn) {
+        /* call the local server */
+        PMIX_LOAD_PROCID(&proc, peer->info->pname.nspace, peer->info->pname.rank);
+        rc = pmix_host_server.spawn(&proc, cd->info, cd->ninfo,
+                                    cd->apps, cd->napps,
+                                    pmix_server_spcbfunc, cd);
+    } else {
+        /* No host to ask, so fork/exec it ourselves. pfexec takes a caddy
+         * of its own and releases it when the spawn completes, so give it
+         * a second one that BORROWS this one's apps and directives -
+         * "copied" stays false on it so its destructor leaves them to
+         * "cd", which owns them and outlives it. */
+        fcd = PMIX_NEW(pmix_setup_caddy_t);
+        if (NULL == fcd) {
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
+        fcd->info = cd->info;
+        fcd->ninfo = cd->ninfo;
+        fcd->apps = cd->apps;
+        fcd->napps = cd->napps;
+        fcd->spcbfunc = pfexec_spcbfunc;
+        fcd->cbdata = cd;
+        rc = pmix_pfexec_base_spawn_job(fcd);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(fcd);
+        }
+    }
 
 cleanup:
     if (PMIX_SUCCESS != rc) {

--- a/src/tool/AGENTS.md
+++ b/src/tool/AGENTS.md
@@ -253,14 +253,22 @@ our server. That is why `server_switchyard` routing to
 `PMIX_PROC_LAUNCHER` includes the `PMIX_PROC_TOOL` bit: a launcher with a
 server attached *should* pass the request up.
 
-The one place the code does not yet follow the rule is a spawn **proxied
-for a downstream tool** while we have no server: `pmix_tool_relay_op`
-returns `PMIX_ERR_UNREACH`, the switchyard returns it (it falls through
-to the logic tree only on `PMIX_ERR_NOT_SUPPORTED`), and the downstream
-tool gets an error rather than a locally fork/exec'd job. Closing that
-gap means giving `pmix_server_spawn()` a `pfexec` fallback — it currently
-refuses outright when `pmix_host_server.spawn` is NULL — which is a
-`src/server` change, not a `src/tool` one.
+A spawn **proxied for a downstream tool** follows the same rule, and
+used not to: `pmix_tool_relay_op` answers `PMIX_ERR_UNREACH` when we have
+no server, and `server_switchyard` fell through to the logic tree only on
+`PMIX_ERR_NOT_SUPPORTED` — so the downstream tool got an error instead of
+a launched job. The switchyard now falls through on **both**, and
+`pmix_server_spawn()` fork/execs when it has no `pmix_host_server.spawn`
+but `pfexec` is open. Two things make that gate right:
+`pmix_pfexec_base_open()` is called from exactly one place in the tree
+(`PMIx_tool_init`, for a launcher or scheduler), so
+`pmix_pfexec_globals.initialized` *is* the "can I fork/exec" question and
+a plain PMIx server's behavior is unchanged; and `pmix_tool_relay_op`
+returns both of those statuses **before** it rewinds the buffer, so the
+fall-through still has the unpack position the `cmd` read left.
+
+Covered by [`test/unit/tool_relay`](../../test/unit/tool_relay.c), which
+is also the only automated coverage `pmix_tool_ops.c` has.
 
 ## PTL receive callbacks (in `pmix_tool.c`)
 
@@ -467,7 +475,7 @@ named are the ones that fail against the unfixed library.
   `src/client` has no equivalent branch at all.** See item 14 and
   [openpmix#4101](https://github.com/openpmix/openpmix/issues/4101).
 - **The relay assumes both peers negotiated the same bfrops module and
-  buffer type.** `pmix_tool_relay_op` copies the downstream tool's raw
+  buffer type.** (Unchanged by the spawn-fallback work above.) `pmix_tool_relay_op` copies the downstream tool's raw
   payload into a fresh buffer and sends it to `myserver` unchanged, and
   `tool_switchyard` does the reverse. A tool forces the same modules on
   itself and its server, so this holds today — but it is an assumption,
@@ -484,6 +492,7 @@ named are the ones that fail against the unfixed library.
 | `tool_api` | the API surface a single unconnected tool can reach: identity values, `set_server` wait/timeout semantics, the server list of an unconnected tool, malformed directives (in forked children), and a second full cycle that sets a server module again |
 | `tool_rndz` | the whole `PMIX_LAUNCHER_RNDZ_URI` flow against a real server, including the restore of the original primary |
 | `tool_evcache` | affected-process restriction on events delivered to a tool, end to end with two handlers. Its header records that it does **not** reach the caching branch, and why |
+| `tool_relay` | a downstream tool's spawn arriving at a launcher tool with no server of its own: the relay declines, the switchyard falls through, and the launcher fork/execs it. The only automated coverage of `pmix_tool_ops.c` |
 | `tool_nspace` | a connecting tool leaves exactly one namespace object on the server's list |
 | `test/simple/tool_server_switch` (via `run_toolswitch.pl`) | the multi-server switch loop against two servers |
 
@@ -492,9 +501,7 @@ The multi-node half is
 (README §20): the tool and at least one of its servers on **different
 nodes**, driving `examples/toolswitch.c` through attach/switch/disconnect
 across hosts, a remote server dying, IOF relayed to a tool from other
-nodes, and the only valgrind pass `src/tool` gets anywhere. Note what it
-says it does not cover: nothing, anywhere, exercises the tool-to-tool
-relay in `pmix_tool_ops.c`.
+nodes, and the only valgrind pass `src/tool` gets anywhere.
 
 **A test that wants to see `PMIx_tool_init` fail must fork.** See the
 non-unwinding invariant above.

--- a/src/tool/AGENTS.md
+++ b/src/tool/AGENTS.md
@@ -243,6 +243,25 @@ If you add a relayable command, extend `relaycmds` **and** make sure the
 response path round-trips correctly (the spawn case needs the separate
 cbfunc precisely so the response can be intercepted and forwarded).
 
+**The rule for a spawn is: relay it if we are attached to a server;
+otherwise fork/exec it ourselves.** `PMIx_Spawn` already implements
+exactly that for a spawn we issue on our own behalf — see the top of
+`pmix_client_spawn.c`, which sets `forkexec` when we are not connected
+and `PMIX_PEER_IS_LAUNCHER(mypeer)`, and otherwise sends the request to
+our server. That is why `server_switchyard` routing to
+`pmix_tool_relay_op` on `PMIX_PEER_IS_TOOL(mypeer)` is right even though
+`PMIX_PROC_LAUNCHER` includes the `PMIX_PROC_TOOL` bit: a launcher with a
+server attached *should* pass the request up.
+
+The one place the code does not yet follow the rule is a spawn **proxied
+for a downstream tool** while we have no server: `pmix_tool_relay_op`
+returns `PMIX_ERR_UNREACH`, the switchyard returns it (it falls through
+to the logic tree only on `PMIX_ERR_NOT_SUPPORTED`), and the downstream
+tool gets an error rather than a locally fork/exec'd job. Closing that
+gap means giving `pmix_server_spawn()` a `pfexec` fallback — it currently
+refuses outright when `pmix_host_server.spawn` is NULL — which is a
+`src/server` change, not a `src/tool` one.
+
 ## PTL receive callbacks (in `pmix_tool.c`)
 
 These are posted during init and fire on the progress thread:
@@ -442,18 +461,11 @@ named are the ones that fail against the unfixed library.
   its SIGCONT handler** (`stdinsig_ev`), and never releases
   `stdinev_global` either. It is the same defect as item 9 one directory
   over, but fixing it properly needs a teardown hook in `src/common` that
-  this review did not design. Left for a `src/common` change.
-- **Whether a *launcher* should relay a spawn is unsettled.**
-  `server_switchyard` routes to `pmix_tool_relay_op` on
-  `PMIX_PEER_IS_TOOL(mypeer)`, and `PMIX_PROC_LAUNCHER` includes the
-  `PMIX_PROC_TOOL` bit — so a launcher with its own server module, and
-  with `pfexec` open, still relays `PMIX_SPAWNNB_CMD` upstream instead of
-  servicing it. For `prun`, which asks its DVM to spawn, that is
-  arguably right; for a launcher that spawns locally it is not. A more
-  precise guard would be "we have no host module to service it"
-  (`!pmix_server_globals.module_set`), but changing it is a behavioral
-  decision about PRRTE's launchers, not a bug fix. Left alone
-  deliberately.
+  this review did not design.
+  [openpmix#4100](https://github.com/openpmix/openpmix/issues/4100).
+- **The tool's event cache in `_notify_complete` looks unreachable, and
+  `src/client` has no equivalent branch at all.** See item 14 and
+  [openpmix#4101](https://github.com/openpmix/openpmix/issues/4101).
 - **The relay assumes both peers negotiated the same bfrops module and
   buffer type.** `pmix_tool_relay_op` copies the downstream tool's raw
   payload into a fresh buffer and sends it to `myserver` unchanged, and

--- a/src/tool/AGENTS.md
+++ b/src/tool/AGENTS.md
@@ -124,17 +124,22 @@ returning.
 
 Finalize decrements `tool_init_cntr` and only tears down on the last
 call. Then, in order: send `PMIX_FINALIZE_CMD` to the server with a
-5-second timer guard (`fin_timeout`/`finwait_cbfunc`), kill any
-`pfexec`-launched children (launcher/server only, **before** the progress
-thread stops because killing needs it), stop the progress thread, dump
-and destruct the static IOF sinks, release the client peer/pending
-lists, stop listening, release the server clients array, close
-`pnet`/`pmdl`, `PMIX_LIST_DESTRUCT` every `pmix_server_globals` list that
-`pmix_server_initialize` builds, free the tmpdir strings, then
-`pmix_rte_finalize`, release `mypeer`/`myserver`, and
-`pmix_class_finalize`.
+5-second timer guard (`fin_timeout`/`finwait_cbfunc`) and clear
+`pmix_globals.connected` however that went, kill any `pfexec`-launched
+children (launcher/server only, **before** the progress thread stops
+because killing needs it), delete the file-scope events init registered
+(stdin read, SIGCONT, keepalive pipe — **while their bases still
+exist**), stop the progress thread, dump and destruct the static IOF
+sinks, release the client peer/pending lists, stop listening, release the
+server clients array, close `pnet`/`pmdl`, `PMIX_LIST_DESTRUCT` every
+`pmix_server_globals` list that `pmix_server_initialize` builds, free the
+tmpdir strings, then `pmix_rte_finalize`, release `mypeer`/`myserver`,
+and `pmix_class_finalize`.
 
-Two subtleties the current code documents inline and you must keep:
+Nothing in that sequence returns early on an error — see the
+"must not abandon the teardown" invariant below.
+
+Three subtleties the current code documents inline and you must keep:
 
 - It resets `pmix_globals.init_called = false` so a *subsequent*
   `PMIx_tool_init` in the same process starts fresh instead of
@@ -144,6 +149,10 @@ Two subtleties the current code documents inline and you must keep:
   pointer would silently ignore a changed `PMIX_SERVER_TMPDIR` on the
   next cycle. The many `PMIX_LIST_DESTRUCT`s exist for the same
   re-init-cleanliness reason (a tool may init→finalize→init).
+- The event teardown is guarded by file-scope booleans
+  (`stdin_setup`, `stdinsig_setup`, `keepalive_fd`) rather than
+  re-derived, because `PMIX_FWD_STDIN` and `PMIX_KEEPALIVE_PIPE` were
+  directives to *init* and finalize cannot see them.
 
 ## The multi-server model
 
@@ -182,16 +191,33 @@ functions are their thin waiters. `PMIX_ACQUIRE_OBJECT` /
 memory-ordering rules.
 
 > **Refcount discipline when repointing `myserver` is easy to get wrong.**
-> `pmix_tool_retry_set` `PMIX_RETAIN`s the peer before aliasing it into
-> `myserver` (the peer is already owned by the clients array); the init
-> path `PMIX_RETAIN`s the initial server before adding it to the array
-> (line ~838); but `pmix_tool_retry_attach` adds a freshly-`PMIX_NEW`'d
-> peer and aliases `myserver` to it **without** a matching retain. When
-> you touch any of these paths, trace the whole
-> attach → set → disconnect → finalize lifecycle: the array release in
-> finalize and the `PMIX_RELEASE(peer)` in `disc` must exactly balance
-> the retains taken when the peer was installed. This asymmetry is a
-> known audit hazard (see "Known issues").
+> The invariant is: **`myserver` holds its own reference, distinct from
+> the clients-array entry's reference.** Every `myserver = X` is paired
+> with `PMIX_RETAIN(X)` and a `PMIX_RELEASE` of the outgoing `myserver`;
+> finalize releases once per array entry *and* once for the `myserver`
+> global. When you touch any of these paths, trace the whole
+> attach → set → disconnect → finalize lifecycle rather than reasoning
+> about one site.
+
+> **Only a real server goes in the clients array.** On the
+> do-not-connect and failed-optional-connect paths `myserver` is a
+> stand-in peer for *ourselves*, and init deliberately does **not** cache
+> it there (nor take the matching retain). Two reasons, and both bit:
+> `PMIx_tool_get_servers` would otherwise report an unconnected tool as
+> its own server, where the Standard requires `PMIX_ERR_UNREACH`; and
+> that stand-in may carry a **NULL nspace**, which `PMIX_CHECK_NSPACE`
+> treats as a **wildcard**, so it matched the first lookup `disc()` or
+> `pmix_tool_retry_set()` performed for any name at all. That wildcard is
+> the sharpest edge in this file — anywhere you compare a caller-supplied
+> `{nspace,rank}` against a peer, an unnamed argument matches
+> *everything*. `disc()` now refuses one outright.
+
+> **Pointing `myserver` at yourself means you are NOT connected.**
+> `disc()` unsets `pmix_globals.connected` when it drops the primary;
+> `pmix_tool_retry_set`'s "switch back to me" branch must do the same.
+> It used to *set* the flag, and finalize then sent the finalize
+> handshake to our own already-finalized peer, got `PMIX_ERR_UNREACH`,
+> and returned it — before doing any teardown at all.
 
 ## The tool-to-tool relay (`pmix_tool_ops.c`)
 
@@ -268,70 +294,198 @@ unpacking, exactly as the client recv callbacks do.
 - **Prefer a new attribute over a new API**, and give any new API the
   `pmix_info_t info[], size_t ninfo` pair — the tool API already follows
   this (every `PMIx_tool_*` call carries it).
+- **`PMIx_tool_init` does not unwind, and a failed one is terminal for
+  the process.** Every early `return` leaves the one-time-init latch set
+  and the counter bumped, so a caller cannot retry — and cannot finalize
+  either, because finalize refuses when `initialized` is false. This is
+  why the argument screens are at the top and why a test that wants to
+  see init *fail* has to do it in a forked child (see `tool_api.c`).
+- **Finalize must not abandon the teardown.** By the time it can fail it
+  has already dropped `initialized` and the latch, so a caller that saw
+  an error could neither retry nor finalize again — it would simply leak
+  the whole library. Record a failure and keep tearing down.
+- **`pmix_event_signal_set` is `event_assign`, not `event_add`.** It
+  only initializes the event; without a following `pmix_event_add` the
+  handler is never installed. The tool's SIGCONT/stdin handler was in
+  that state for a long time and silently did nothing.
+- **Anything init registers on an event base, finalize has to take
+  down** — the stdin read event, the SIGCONT event, the keepalive-pipe
+  event. `pmix_rte_finalize` destroys the bases underneath them, and the
+  two that are file-scope statics are re-`PMIX_CONSTRUCT`ed by the next
+  init. Note the one trap in that teardown: `pmix_iof_read_event_t`'s
+  destructor closes whatever fd it holds, and the tool's is the
+  application's own **stdin** — clear the field before destructing.
+- **`pmix_server_globals.module_set` is a global that no finalize
+  resets.** `PMIx_tool_init` clears it where it memsets
+  `pmix_host_server`, so the two always agree; without that a cycling
+  tool is refused its server module on every init after the first while
+  the table it would be called through is the all-zero one.
+- **Identity is not only `pmix_globals.myid`.** `PMIx_Get` answers
+  `PMIX_PROCID` and `PMIX_RANK` out of `pmix_globals.myidval` /
+  `myrankval` when the caller passes `PMIX_GET_POINTER_VALUES`.
+  `pmix_rte_init` builds those carrying a NULL nspace and
+  `PMIX_RANK_INVALID`; filling them in is the role's job, and the tool
+  did not until this review.
 
 ## Known issues
 
 Found during review and documented here so they are not "rediscovered"
-as intended behavior.
+as intended behavior. The July 2026 items (1-3) are kept because the
+invariants they establish are still the ones to reason from.
 
 1. **FIXED — `PMIX_PARENT_ID` freed a static in the launcher-rendezvous
-   path.** In `PMIx_tool_init` (the `PMIX_LAUNCHER_RNDZ_URI` block) the
-   code set `kptr->value->data.proc = &myparent;` (a file-scope static)
-   on a `PMIX_PROC`-typed kval and then `PMIX_RELEASE(kptr)` — whose
-   destructor runs `value_destruct` → `proc_free` → `free()` on the
-   static: heap corruption. Now heap-allocates the proc
-   (`PMIX_PROC_CREATE` + `PMIx_Proc_load`), matching
-   `src/server/pmix_server.c`. Note `myparent` is still only ever loaded
+   path.** The code set `kptr->value->data.proc = &myparent;` (a
+   file-scope static) on a `PMIX_PROC`-typed kval and then
+   `PMIX_RELEASE(kptr)` — whose destructor runs `value_destruct` →
+   `proc_free` → `free()` on the static: heap corruption. Now
+   heap-allocates the proc. Note `myparent` is still only ever loaded
    with `{NULL, RANK_UNDEF}` and never populated with a real parent — the
    *server* has the same quirk — so the stored parent id is currently
-   meaningless; that is a separate, benign functional gap, not a crash.
-2. **FIXED — `mypeer->info` was allocated twice.** `PMIx_tool_init`
-   `PMIX_NEW`d `pmix_globals.mypeer->info` once (setting `realuid`/`uid`/
-   `realgid`/`gid`/`pid`), then a second `PMIX_NEW` later overwrote the
-   pointer — orphaning the first `pmix_rank_info_t` (leak) and discarding
-   the identity fields (leaving them zeroed). Now the second allocation
-   is removed; the existing object's `pname` is (re)set in place, so the
-   uid/gid/pid survive. The client (`src/client/pmix_client.c`) is the
-   single-allocation reference.
+   meaningless; a benign functional gap, not a crash.
+2. **FIXED — `mypeer->info` was allocated twice**, orphaning the first
+   `pmix_rank_info_t` and discarding the uid/gid/pid stored on it. The
+   client is the single-allocation reference.
 3. **FIXED — the `myserver`-switch family mismatched the finalize
-   teardown's refcount model, causing a double-free.** The intended
-   invariant (see the `PMIx_tool_init` comment at the
-   `PMIX_RETAIN(myserver)` + clients-array-add, and the finalize teardown
-   that releases *once per clients-array entry* **and** *once for the
-   `myserver` global*) is: **`myserver` holds its own reference, distinct
-   from the clients-array entry's reference.** Three sites violated it:
-   - `pmix_tool_retry_attach` (the `cb->checked`/`PMIX_PRIMARY_SERVER`
-     branch) set `myserver = peer` with **no `PMIX_RETAIN`** and **no
-     release of the outgoing `myserver`**. The new primary then had one
-     reference but two owners (clients array + `myserver`), so
-     `PMIx_tool_finalize` released it twice → **double-free / UAF**, while
-     the previous primary's `myserver` reference leaked. Reachable from
-     `PMIx_tool_attach_to_server` / `PMIx_tool_connect_to_server` with
-     `PMIX_PRIMARY_SERVER`, and from the internal `PMIX_LAUNCHER_RNDZ_URI`
-     path.
-   - `pmix_tool_retry_set` retained the incoming peer but never released
-     the outgoing `myserver` → leaked one reference per switch; its
-     "switch back to me" branch set `myserver = mypeer` with neither a
-     retain of `mypeer` nor a release of the outgoing server.
-   - `disc` released only the clients-array reference when disconnecting
-     the primary, never the outgoing `myserver` reference.
+   teardown's refcount model, causing a double-free.** See the
+   multi-server section above for the invariant. Covered by
+   `test/simple/tool_server_switch` (`make check` via
+   `test/unit/run_toolswitch.pl`).
 
-   The fix has three parts: (a) every `myserver = X` reassignment in
-   `pmix_tool_retry_attach` / `pmix_tool_retry_set` / `disc` is now paired
-   with `PMIX_RETAIN(X)` and a `PMIX_RELEASE` of the outgoing `myserver`
-   (in `disc` the departing primary drops both its `myserver` and
-   clients-array references, via a separate handle since `PMIX_RELEASE`
-   NULLs its argument); (b) `PMIx_tool_finalize` no longer releases
-   `myserver` separately when it aliases `mypeer` (the disconnected-to-self
-   state), which would otherwise free `mypeer` a third time after
-   `pmix_rte_finalize` and the `mypeer` release; and (c) a companion
-   re-init bug where `pmix_ptl_base.uri` was freed but not NULLed on close
-   (`ptl_base_frame.c`), which failed the *next* init's reconnect after an
-   attach-by-URI. The **multi-server switch path is now covered** by
-   `test/simple/tool_server_switch` (make check via
-   `test/unit/run_toolswitch.pl`): two independent servers, a tool child
-   looping attach-as-primary → set_server(self/A/B) → disconnect →
-   finalize. It reproduced the double-free abort before the fix.
+The August 2026 sweep found the following. Each is fixed; the tests
+named are the ones that fail against the unfixed library.
+
+4. **FIXED — the launcher-rendezvous debugger-release registration hung
+   and corrupted an object header.** `evhandler_reg_callbk` cast its
+   `cbdata` to a `pmix_lock_t`, but the registration machinery invokes it
+   with `cd->cbdata`, which the one call site sets to the
+   `pmix_rshift_caddy_t` itself. So it wrote the status over the object
+   header and took a "mutex" that was really the rest of that header —
+   and it left the caddy's own lock, the one `PMIx_tool_init` blocks on,
+   untouched, so init never returned. `src/client` (via `mycbfn`) and
+   `src/server` both had this right; only `src/tool` did not. The block
+   also constructed a `reglock` it never used or destructed, a leftover
+   from the shape this was meant to have. **`test/unit/tool_rndz`**;
+   against the unfixed library it aborts on the object magic-id assert
+   and then hangs.
+5. **FIXED — leaks on the multi-server and rendezvous paths.**
+   `pmix_tool_retry_attach` leaked the URI `connect_to_peer` hands back
+   whenever the new server was not requested as primary;
+   `tool_switchyard` leaked its shift caddy — and the peer reference it
+   holds — when the payload copy failed; the rendezvous caddy never set
+   `infocopy`, so its three directives leaked on every launcher init; the
+   `myserver->info` rank-info was allocated a second time on both
+   self-assign paths (the same defect as item 2, one object over); and
+   `pmix_tool_init_info` released nothing on any of its error paths.
+6. **FIXED — `PMIx_Get` of our own `PMIX_PROCID`/`PMIX_RANK` under
+   `PMIX_GET_POINTER_VALUES` returned garbage.** The tool never populated
+   `pmix_globals.myidval`/`myrankval`. **`test/unit/tool_api`.**
+   `pmix_tool_init_info` also stored `PMIX_RANK` as a `PMIX_INT`; it is a
+   `pmix_rank_t` and must be `PMIX_PROC_RANK`.
+7. **FIXED — `PMIX_WAIT_FOR_CONNECTION` never waited.**
+   `PMIx_tool_set_server` loaded its retry budget straight from
+   `PMIX_TIMEOUT`, so an absent or zero timeout — which the Standard
+   defines as "never time out" — expired on the first retry and reported
+   `PMIX_ERR_NOT_FOUND` rather than the documented `PMIX_ERR_TIMEOUT`.
+   **`test/unit/tool_api`** and `test/simple/tool_server_switch`.
+8. **FIXED — a tool that was not connected reported itself as its own
+   server, and `set_server(self)` claimed we were connected.** See the
+   two notes in the multi-server section; between them, `set_server(self)`
+   followed by `PMIx_tool_finalize` returned `PMIX_ERR_UNREACH` **before
+   any teardown ran at all**. Finalize no longer abandons the teardown on
+   a failed handshake. **`test/unit/tool_api`.**
+9. **FIXED — the SIGCONT handler for forwarded stdin was never
+   installed**, because `pmix_event_signal_set` is `event_assign` and
+   nothing added the event. A tool that is backgrounded and then resumed
+   never reconsidered its stdin. Not unit-testable — it needs a tty — so
+   there is no regression test; the sibling defect in
+   `src/common/pmix_iof.c` is **still open**, see below.
+10. **FIXED — init's file-scope events were never taken down.** The stdin
+    read event, the SIGCONT event and the keepalive-pipe event all
+    survived finalize; the keepalive pipe's descriptor leaked one per
+    init/finalize cycle. **`test/unit/tool_cycle`** now runs a second pass
+    with `PMIX_FWD_STDIN` and asserts the library did not close the
+    caller's stdin on the way out.
+11. **FIXED — `PMIx_tool_set_server_module` was refused on every cycle
+    after the first**, because nothing resets
+    `pmix_server_globals.module_set`. **`test/unit/tool_api`.**
+12. **FIXED — the rendezvous block restored the wrong primary server.**
+    A tool that came up with `PMIX_TOOL_DO_NOT_CONNECT` *and* its own
+    `PMIX_TOOL_NSPACE`/`PMIX_TOOL_RANK` saves its "current server" from a
+    stand-in peer that carries no name, and an empty nspace is a wildcard
+    — so the restore matched the debugger and the launcher carried on with
+    the debugger as its primary. **`test/unit/tool_rndz`** comes up in
+    exactly that configuration.
+13. **FIXED — a late finalize reply woke a destroyed lock.** The
+    five-second guard timer clears `tev.active` and `PMIx_tool_finalize`
+    then destructs the lock, but `finwait_cbfunc` woke it
+    unconditionally. `src/client`'s identically-shaped callback guards on
+    the flag. No test: it needs a server that answers the finalize
+    handshake later than five seconds.
+14. **FIXED (consistency, not an observed failure) —
+    `pmix_tool_notify_recv` never stored the unpacked range on the chain
+    and never ran `pmix_prep_event_chain`.** Those fields are what
+    `_notify_complete` builds a *parked* event out of when no handler
+    matches, so a parked event would carry `PMIX_RANGE_UNDEF` and no
+    affected procs. No arrangement was found that gets a server-forwarded
+    event into that branch — the server filters on the tool's registered
+    codes and affected procs before forwarding — so treat this as keeping
+    the two recv paths saying the same thing.
+15. **FIXED — malformed directives were dereferenced.**
+    `PMIX_TOOL_NSPACE`, `PMIX_SERVER_TMPDIR` and `PMIX_SYSTEM_TMPDIR` each
+    went straight to `strdup()`, so a caller that supplied the key with
+    the wrong type segfaulted the library. **`test/unit/tool_api`**, in
+    forked children (see the non-unwinding note above).
+
+### Still open
+
+- **`src/common/pmix_iof.c` has the same missing `pmix_event_add` for
+  its SIGCONT handler** (`stdinsig_ev`), and never releases
+  `stdinev_global` either. It is the same defect as item 9 one directory
+  over, but fixing it properly needs a teardown hook in `src/common` that
+  this review did not design. Left for a `src/common` change.
+- **Whether a *launcher* should relay a spawn is unsettled.**
+  `server_switchyard` routes to `pmix_tool_relay_op` on
+  `PMIX_PEER_IS_TOOL(mypeer)`, and `PMIX_PROC_LAUNCHER` includes the
+  `PMIX_PROC_TOOL` bit — so a launcher with its own server module, and
+  with `pfexec` open, still relays `PMIX_SPAWNNB_CMD` upstream instead of
+  servicing it. For `prun`, which asks its DVM to spawn, that is
+  arguably right; for a launcher that spawns locally it is not. A more
+  precise guard would be "we have no host module to service it"
+  (`!pmix_server_globals.module_set`), but changing it is a behavioral
+  decision about PRRTE's launchers, not a bug fix. Left alone
+  deliberately.
+- **The relay assumes both peers negotiated the same bfrops module and
+  buffer type.** `pmix_tool_relay_op` copies the downstream tool's raw
+  payload into a fresh buffer and sends it to `myserver` unchanged, and
+  `tool_switchyard` does the reverse. A tool forces the same modules on
+  itself and its server, so this holds today — but it is an assumption,
+  not something the code checks.
+
+## Testing
+
+`make check` coverage for this directory, all under
+[`test/unit`](../../test/unit):
+
+| Program | What it holds down |
+|---------|--------------------|
+| `tool_cycle` | init→finalize cycling, plus a shorter pass with `PMIX_FWD_STDIN` that asserts the library did not close the caller's stdin |
+| `tool_api` | the API surface a single unconnected tool can reach: identity values, `set_server` wait/timeout semantics, the server list of an unconnected tool, malformed directives (in forked children), and a second full cycle that sets a server module again |
+| `tool_rndz` | the whole `PMIX_LAUNCHER_RNDZ_URI` flow against a real server, including the restore of the original primary |
+| `tool_evcache` | affected-process restriction on events delivered to a tool, end to end with two handlers. Its header records that it does **not** reach the caching branch, and why |
+| `tool_nspace` | a connecting tool leaves exactly one namespace object on the server's list |
+| `test/simple/tool_server_switch` (via `run_toolswitch.pl`) | the multi-server switch loop against two servers |
+
+The multi-node half is
+[`contrib/dockerswarm/run-tool-tests.sh`](../../contrib/dockerswarm/README.md)
+(README §20): the tool and at least one of its servers on **different
+nodes**, driving `examples/toolswitch.c` through attach/switch/disconnect
+across hosts, a remote server dying, IOF relayed to a tool from other
+nodes, and the only valgrind pass `src/tool` gets anywhere. Note what it
+says it does not cover: nothing, anywhere, exercises the tool-to-tool
+relay in `pmix_tool_ops.c`.
+
+**A test that wants to see `PMIx_tool_init` fail must fork.** See the
+non-unwinding invariant above.
 
 ## Building
 
@@ -348,11 +502,10 @@ regenerate-the-help-content golden rule does not bite here, unless you
 add a new topic to one of those files.
 
 Smoke-test per the top-level guide: `make check` in `test/`, then
-`./simptest` in `test/simple/`. The tool paths specifically are exercised
-by the tool/debugger programs under `test/simple` (e.g. the
-attach/launcher and IOF tests). Do **not** diagnose functional failures
-against an `--enable-test-build` tree — its shimmed components make
-functional tests misbehave by design (see the top-level guide).
+`./run_simptest.sh` in `test/simple/`. See the Testing section above for
+what specifically covers this directory. Do **not** diagnose functional
+failures against an `--enable-test-build` tree — its shimmed components
+make functional tests misbehave by design (see the top-level guide).
 
 ## When modifying code here
 
@@ -373,3 +526,13 @@ functional tests misbehave by design (see the top-level guide).
 - **Keep it warning-free and portable** under `--enable-devel-check`; use
   the `__pmix_attribute_*__` / `PMIX_HIDE_UNUSED_PARAMS` wrappers rather
   than bare GCC attributes.
+- **Diff against `src/client` and `src/server` before believing a
+  difference is intentional.** Three of the four worst defects this
+  directory has had were drift: a recv callback the client had already
+  fixed, a caddy field the server sets and the tool did not, a guard the
+  client has on an identically-shaped callback. When the same function
+  exists in two of the three roles, read all of them.
+- **Screen a directive's value type before using it.** The recurring
+  application-facing crash here is a `strdup()` of
+  `info[n].value.data.string` for a key the caller supplied with the
+  wrong type. Check `PMIX_STRING == .type` and non-NULL first.

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1680,11 +1680,19 @@ static void finwait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr, buf);
 
     pmix_output_verbose(2, pmix_globals.debug_output, "pmix:tool finwait_cbfunc received");
+    /* The wakeup belongs INSIDE the active test, which is the whole point
+     * of the flag. If the guard timer has already fired, PMIx_tool_finalize
+     * has come back out of its wait and destructed this lock - and it is a
+     * stack object in a frame that is still running the rest of the
+     * teardown, so a reply that arrives late would take a destroyed mutex
+     * rather than fault on freed memory. That is exactly the case the timer
+     * exists for: a server too slow or too wedged to answer. src/client's
+     * identically-shaped finwait_cbfunc guards it. */
     if (tev->active) {
         tev->active = false;
         pmix_event_del(&tev->ev); // stop the timer
+        PMIX_WAKEUP_THREAD(&tev->lock);
     }
-    PMIX_WAKEUP_THREAD(&tev->lock);
 }
 
 PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -398,14 +398,28 @@ static void job_data(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     PMIX_WAKEUP_THREAD(&cb->lock);
 }
 
-/* event handler registration callback */
+/* Event handler registration callback.
+ *
+ * The registration path (pmix_internal_reg_event_hdlr) invokes this with
+ * cd->cbdata, and the only caller here sets cd->cbdata to the caddy
+ * itself - so cbdata is the pmix_rshift_caddy_t, NOT a bare pmix_lock_t.
+ * Casting it to a lock would write the status over the object header and
+ * take a "mutex" that is really part of that header, and it would leave
+ * the caddy's own lock - the one the caller blocks on - untouched, so the
+ * init would hang. Mirror the internal mycbfn()/src/server/pmix_server.c
+ * version: record the handler index (or the failure) as the status and
+ * wake the caddy's lock. */
 static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
 {
-    pmix_lock_t *lock = (pmix_lock_t *) cbdata;
-    PMIX_HIDE_UNUSED_PARAMS(evhandler_ref);
+    pmix_rshift_caddy_t *cd = (pmix_rshift_caddy_t *) cbdata;
 
-    lock->status = status;
-    PMIX_WAKEUP_THREAD(lock);
+    PMIX_ACQUIRE_OBJECT(cd);
+    if (PMIX_SUCCESS == status) {
+        cd->status = evhandler_ref;
+    } else {
+        cd->status = status;
+    }
+    PMIX_WAKEUP_THREAD(&cd->lock);
 }
 
 static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
@@ -474,7 +488,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     pmix_buffer_t *req;
     pmix_cmd_t cmd;
     pmix_iof_req_t *iofreq;
-    pmix_lock_t reglock, releaselock;
+    pmix_lock_t releaselock;
     bool outputio = true;
     pmix_kval_t *kptr;
     pmix_rshift_caddy_t *cd;
@@ -781,9 +795,15 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
             pmix_globals.myid.rank = 0;
             nspace_given = false;
             rank_given = false;
-            /* also setup the client myserver to point to ourselves */
+            /* also setup the client myserver to point to ourselves. Fill in
+             * the rank_info object we already allocated above rather than
+             * allocating a second one - a fresh PMIX_NEW here would orphan
+             * the first (the peer destructor only releases the pointer it
+             * finds, so the original object would leak) */
             pmix_client_globals.myserver->nptr->nspace = strdup(pmix_globals.myid.nspace);
-            pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
+            if (NULL != pmix_client_globals.myserver->info->pname.nspace) {
+                free(pmix_client_globals.myserver->info->pname.nspace);
+            }
             pmix_client_globals.myserver->info->pname.nspace = strdup(pmix_globals.myid.nspace);
             pmix_client_globals.myserver->info->pname.rank = pmix_globals.myid.rank;
             pmix_client_globals.myserver->info->uid = pmix_globals.uid;
@@ -822,15 +842,25 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
             pmix_globals.myid.rank = 0;
             nspace_given = false;
             rank_given = false;
-            /* also setup the client myserver to point to ourselves */
+            /* also setup the client myserver to point to ourselves. Fill in
+             * the rank_info object we already allocated above rather than
+             * allocating a second one - a fresh PMIX_NEW here would orphan
+             * the first (the peer destructor only releases the pointer it
+             * finds, so the original object would leak) */
             pmix_client_globals.myserver->nptr->nspace = strdup(pmix_globals.myid.nspace);
-            pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
+            if (NULL != pmix_client_globals.myserver->info->pname.nspace) {
+                free(pmix_client_globals.myserver->info->pname.nspace);
+            }
             pmix_client_globals.myserver->info->pname.nspace = strdup(pmix_globals.myid.nspace);
             pmix_client_globals.myserver->info->pname.rank = pmix_globals.myid.rank;
             pmix_client_globals.myserver->info->uid = pmix_globals.uid;
             pmix_client_globals.myserver->info->gid = pmix_globals.gid;
             // set the type of the server to be our own
             PMIX_SET_PEER_TYPE(pmix_client_globals.myserver, ptype.type);
+            /* ensure we are marked as not connected - the flag is a global
+             * that a prior init/finalize cycle in this process may have
+             * left set */
+            pmix_atomic_unset_bool(&pmix_globals.connected);
             /* mark us as not connecting to avoid asking for our job info */
             do_not_connect = true;
         }
@@ -840,9 +870,23 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     PMIX_LOAD_PROCID(&wildcard, pmix_globals.myid.nspace, PMIX_RANK_WILDCARD);
     /* pass back the ID */
     PMIX_LOAD_PROCID(proc, pmix_globals.myid.nspace, pmix_globals.myid.rank);
-    /* cache the server in case we later want to call "set_server" on it */
-    PMIX_RETAIN(pmix_client_globals.myserver);
-    pmix_pointer_array_add(&pmix_server_globals.clients, pmix_client_globals.myserver);
+    /* Cache the server in case we later want to call "set_server" on it.
+     * Note the guard: on the do-not-connect and failed-optional-connect
+     * paths "myserver" is a stand-in peer for *ourselves*, not a server we
+     * reached, and the clients array is the tool's list of known servers.
+     * Caching ourselves there makes PMIx_tool_get_servers report us as our
+     * own server (the Standard says report PMIX_ERR_UNREACH when there is
+     * none), and - worse - that stand-in may carry a NULL nspace, which
+     * PMIX_CHECK_NSPACE treats as a wildcard, so it would match the first
+     * lookup that disc()/pmix_tool_retry_set() performed for any name.
+     * pmix_tool_retry_set has its own "switching back to me" branch and
+     * does not need to find us in the array. The retain pairs with the
+     * per-entry release in PMIx_tool_finalize; when we skip both, the
+     * separate myserver release there still balances the PMIX_NEW. */
+    if (pmix_atomic_check_bool(&pmix_globals.connected)) {
+        PMIX_RETAIN(pmix_client_globals.myserver);
+        pmix_pointer_array_add(&pmix_server_globals.clients, pmix_client_globals.myserver);
+    }
 
     /* load into our own peer object */
     if (NULL == pmix_globals.mypeer->nptr->nspace) {
@@ -858,6 +902,13 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     }
     pmix_globals.mypeer->info->pname.nspace = strdup(pmix_globals.myid.nspace);
     pmix_globals.mypeer->info->pname.rank = pmix_globals.myid.rank;
+    /* record our identity in the pre-built values PMIx_Get hands back when
+     * asked for PMIX_PROCID/PMIX_RANK with PMIX_GET_POINTER_VALUES. These
+     * are allocated by pmix_rte_init with a NULL nspace and RANK_INVALID;
+     * without this the tool answers those two queries with garbage. */
+    PMIX_LOAD_PROCID(pmix_globals.myidval.data.proc, pmix_globals.myid.nspace,
+                     pmix_globals.myid.rank);
+    pmix_globals.myrankval.data.rank = pmix_globals.myid.rank;
     /* if we are acting as a server, then setup the global recv */
     if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer) ||
         PMIX_PEER_IS_SCHEDULER(pmix_globals.mypeer)) {
@@ -978,6 +1029,10 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, req, job_data, (void *) &cb);
         if (PMIX_SUCCESS != rc) {
+            /* the transport refused the message without taking it, so the
+             * recv callback will never fire - unwind both here */
+            PMIX_RELEASE(req);
+            PMIX_DESTRUCT(&cb);
             return rc;
         }
         /* wait for the data to return */
@@ -1065,6 +1120,10 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         cbptr = PMIX_NEW(pmix_cb_t);
         cbptr->info = iptr;
         cbptr->ninfo = 3;
+        /* the caddy's destructor releases its info array only when
+         * infocopy says the array is its own - say so, or the three
+         * directives (one of them carrying a strdup'd URI) are leaked */
+        cbptr->infocopy = true;
         PMIX_THREADSHIFT(cbptr, pmix_tool_retry_attach);
 
         PMIX_WAIT_THREAD(&cbptr->lock);
@@ -1103,6 +1162,10 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
         PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, req, job_data, (void *) &cb);
         if (PMIX_SUCCESS != rc) {
+            /* the transport refused the message without taking it, so the
+             * recv callback will never fire - unwind both here */
+            PMIX_RELEASE(req);
+            PMIX_DESTRUCT(&cb);
             return rc;
         }
         /* wait for the data to return */
@@ -1115,7 +1178,6 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
 
         /* if the value was found, then we need to wait for debugger attach here */
         /* register for the debugger release notification */
-        PMIX_CONSTRUCT_LOCK(&reglock);
         PMIX_CONSTRUCT_LOCK(&releaselock);
         PMIX_INFO_LOAD(&evinfo[0], PMIX_EVENT_RETURN_OBJECT, &releaselock, PMIX_POINTER);
         PMIX_INFO_LOAD(&evinfo[1], PMIX_EVENT_HDLR_NAME, "WAIT-FOR-RELEASE", PMIX_STRING);
@@ -1196,12 +1258,14 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     }
     PMIX_RELEASE(kptr); // maintain accounting
 
-    /* our rank */
+    /* our rank - PMIX_RANK is a pmix_rank_t, so it must be stored as
+     * PMIX_PROC_RANK. A tool that stored it as a plain int handed every
+     * PMIx_Get of its own rank back with the wrong type */
     kptr = PMIX_NEW(pmix_kval_t);
     kptr->key = strdup(PMIX_RANK);
     PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_INT;
-    kptr->value->data.integer = 0;
+    kptr->value->type = PMIX_PROC_RANK;
+    kptr->value->data.rank = pmix_globals.myid.rank;
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
@@ -1523,7 +1587,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_FINALIZE_CMD;
-    pmix_status_t rc;
+    pmix_status_t rc, ret = PMIX_SUCCESS;
     pmix_tool_timeout_t tev;
     struct timeval tv = {5, 0};
     int n, i;
@@ -1558,38 +1622,56 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
 
         /* setup a cmd message to notify the PMIx
          * server that we are normally terminating */
+        /* Note that nothing below this point aborts the teardown. We have
+         * already dropped the initialized flag and the one-time-init
+         * latch, so a caller that saw an error here could neither retry
+         * nor finalize again - it would simply leak the entire library.
+         * A server that cannot be told we are leaving is worth reporting,
+         * not worth stranding our own state over, so failures here are
+         * recorded and the teardown runs to completion. */
         msg = PMIX_NEW(pmix_buffer_t);
         /* pack the cmd */
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
-            return rc;
-        }
-        /* setup a timer to protect ourselves should the server be unable
-         * to answer for some reason */
-        PMIX_CONSTRUCT_LOCK(&tev.lock);
-        pmix_event_assign(&tev.ev, pmix_globals.evbase, -1, 0, fin_timeout, &tev);
-        tev.active = true;
-        PMIX_POST_OBJECT(&tev);
-        pmix_event_add(&tev.ev, &tv);
-        PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, finwait_cbfunc, (void *) &tev);
-        if (PMIX_SUCCESS != rc) {
-            if (tev.active) {
-                pmix_event_del(&tev.ev);
+            ret = rc;
+        } else {
+            /* setup a timer to protect ourselves should the server be
+             * unable to answer for some reason */
+            PMIX_CONSTRUCT_LOCK(&tev.lock);
+            pmix_event_assign(&tev.ev, pmix_globals.evbase, -1, 0, fin_timeout, &tev);
+            tev.active = true;
+            PMIX_POST_OBJECT(&tev);
+            pmix_event_add(&tev.ev, &tv);
+            PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, finwait_cbfunc,
+                               (void *) &tev);
+            if (PMIX_SUCCESS != rc) {
+                /* the transport refused the message without taking it, so
+                 * the recv callback will never fire - unwind everything we
+                 * set up for it */
+                if (tev.active) {
+                    tev.active = false;
+                    pmix_event_del(&tev.ev);
+                }
+                PMIX_DESTRUCT_LOCK(&tev.lock);
+                PMIX_RELEASE(msg);
+                ret = rc;
+            } else {
+                /* wait for the ack to return */
+                PMIX_WAIT_THREAD(&tev.lock);
+                PMIX_DESTRUCT_LOCK(&tev.lock);
+
+                if (tev.active) {
+                    pmix_event_del(&tev.ev);
+                }
+                pmix_output_verbose(2, pmix_globals.debug_output,
+                                    "pmix:tool finalize sync received");
             }
-            return rc;
         }
-
-        /* wait for the ack to return */
-        PMIX_WAIT_THREAD(&tev.lock);
-        PMIX_DESTRUCT_LOCK(&tev.lock);
-
-        if (tev.active) {
-            pmix_event_del(&tev.ev);
-        }
-        pmix_output_verbose(2, pmix_globals.debug_output, "pmix:tool finalize sync received");
     }
+    /* whatever happened above, we are on our way out */
+    pmix_atomic_unset_bool(&pmix_globals.connected);
 
     /* Note the check on the pfexec framework itself rather than on our
      * peer type. Init only opens it for a launcher or scheduler, but a
@@ -1698,7 +1780,9 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     /* finalize the class/object system */
     pmix_class_finalize();
 
-    return PMIX_SUCCESS;
+    /* the library is fully down either way; "ret" only reports whether we
+     * managed to tell our server about it */
+    return ret;
 }
 
 bool PMIx_tool_is_connected(void)
@@ -1803,14 +1887,19 @@ void pmix_tool_retry_attach(int sd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
             }
+        } else {
+            /* connect_to_peer hands back a heap-allocated URI on every
+             * success - only the branch above consumes it, so free it here
+             * when this server is not becoming our primary */
+            free(suri);
         }
 
     } else {
         PMIX_RELEASE(peer);
     }
 
-    PMIX_WAKEUP_THREAD(&cb->lock);
     PMIX_POST_OBJECT(cb);
+    PMIX_WAKEUP_THREAD(&cb->lock);
     return;
 }
 
@@ -1962,8 +2051,15 @@ static void getsrvrs(int sd, short args, void *cbdata)
 
     /* get servers */
     PMIX_CONSTRUCT(&srvrs, pmix_list_t);
-    /* put our current active server at the front */
-    if (pmix_globals.mypeer != pmix_client_globals.myserver) {
+    /* Put our current active server at the front - but only if we have
+     * one. A tool that came up with PMIX_TOOL_DO_NOT_CONNECT, or whose
+     * optional connect failed, or that has disconnected its primary,
+     * points myserver at a peer standing in for itself; that is not a
+     * server we hold a connection to, and the Standard requires
+     * PMIX_ERR_UNREACH (which the empty-list path below returns) when
+     * there is none. */
+    if (pmix_atomic_check_bool(&pmix_globals.connected) &&
+        pmix_globals.mypeer != pmix_client_globals.myserver) {
         ps = PMIX_NEW(pmix_proclist_t);
         PMIX_LOAD_PROCID(&ps->proc, pmix_client_globals.myserver->info->pname.nspace,
                          pmix_client_globals.myserver->info->pname.rank);
@@ -2063,7 +2159,13 @@ void pmix_tool_retry_set(int sd, short args, void *cbdata)
         }
         PMIX_RETAIN(pmix_globals.mypeer);
         pmix_client_globals.myserver = pmix_globals.mypeer;
-        pmix_atomic_set_bool(&pmix_globals.connected);
+        /* pointing our active server at ourselves means we no longer have
+         * a server, which is exactly the state disc() leaves behind when
+         * it drops the primary - mark it the same way. Claiming to be
+         * connected here would send the finalize handshake (and anything
+         * else guarded on this flag, such as pmix_tool_relay_op) to our
+         * own already-finalized peer. */
+        pmix_atomic_unset_bool(&pmix_globals.connected);
         goto done;
     }
 
@@ -2082,11 +2184,15 @@ void pmix_tool_retry_set(int sd, short args, void *cbdata)
     if (NULL == peer) {
         /* do they want us to wait? */
         if (cb->checked) {
-            /* have we timed out? */
+            /* cb->status carries the remaining budget, counted in 0.25sec
+             * retry intervals; PMIx_tool_set_server loads it with INT_MAX
+             * when no (or a zero) PMIX_TIMEOUT was given, as the Standard
+             * defines that to mean "never time out" */
             --cb->status;
             if (cb->status < 0) {
-                cb->status = PMIX_ERR_NOT_FOUND;
+                cb->status = PMIX_ERR_TIMEOUT;
                 PMIX_WAKEUP_THREAD(&cb->lock);
+                PMIX_POST_OBJECT(cb);
                 return;
             }
             PMIX_THREADSHIFT_DELAY(cb, pmix_tool_retry_set, 0.25);
@@ -2131,6 +2237,7 @@ pmix_status_t PMIx_tool_set_server(const pmix_proc_t *server,
     pmix_status_t rc;
     pmix_cb_t *cb;
     size_t n;
+    int timeout = 0; // zero means "never time out" per the Standard
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
@@ -2140,16 +2247,25 @@ pmix_status_t PMIx_tool_set_server(const pmix_proc_t *server,
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    if (NULL == server) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* threadshift this so we can access global structures */
     cb = PMIX_NEW(pmix_cb_t);
     cb->proc = (pmix_proc_t *) server;
-    for (n = 0; n < ninfo; n++) {
+    for (n = 0; NULL != info && n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
-            cb->status = 4 * info[n].value.data.integer;
+            timeout = info[n].value.data.integer;
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_WAIT_FOR_CONNECTION)) {
             cb->checked = PMIX_INFO_TRUE(&info[n]);
         }
     }
+    /* pmix_tool_retry_set counts this down once per 0.25sec retry. An
+     * absent or zero PMIX_TIMEOUT means the operation is never to time
+     * out - leaving the budget at zero would instead make the very first
+     * retry expire, so a "wait for connection" request would never wait */
+    cb->status = (0 < timeout) ? (4 * timeout) : INT_MAX;
     PMIX_THREADSHIFT(cb, pmix_tool_retry_set);
 
     /* wait for completion */

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -262,6 +262,26 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
         range = PMIX_RANGE_LOCAL;
     }
+    /* Record the range on the chain, and translate the directives the
+     * event carried into the chain's own fields, the way the client's
+     * equivalent (pmix_client_notify_recv) always has. It matters because
+     * of what happens when no handler matches: _notify_complete parks the
+     * event for a handler that registers later, and it builds that parked
+     * copy out of chain->range, chain->nondefault, chain->targets and
+     * chain->affected. Left at their constructed defaults, the parked
+     * event has PMIX_RANGE_UNDEF and no affected procs - restrictions
+     * every later check then accepts.
+     *
+     * Be clear about the reach of this: no arrangement was found that
+     * gets a server-forwarded event into that branch, because the server
+     * filters on the tool's registered codes and affected procs before it
+     * forwards anything, so a mismatched event never arrives to be
+     * parked. This keeps the two recv paths saying the same thing and
+     * makes the branch right if it is ever entered; it is not a fix for
+     * an observed failure. */
+    chain->range = range;
+    pmix_prep_event_chain(chain, chain->info, ninfo, false);
+
     if (PMIX_RANGE_LOCAL != range && pmix_atomic_check_bool(&pmix_globals.connected) &&
         !(PMIX_CHECK_NSPACE(peer->nptr->nspace, pmix_client_globals.myserver->nptr->nspace) &&
           peer->info->pname.rank == pmix_client_globals.myserver->info->pname.rank)) {
@@ -817,8 +837,15 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    /* setup the function pointers */
+    /* Setup the function pointers. The "have we been given a module"
+     * latch has to be cleared with them: it is a global that no finalize
+     * resets, so a tool that cycles init -> set_server_module ->
+     * finalize -> init would find the latch still set and
+     * PMIx_tool_set_server_module would refuse - leaving us claiming to
+     * have a host module while the table we would call through is the
+     * all-zero one we just wrote. */
     memset(&pmix_host_server, 0, sizeof(pmix_server_module_t));
+    pmix_server_globals.module_set = false;
 
     if (do_not_connect) {
         /* ensure we mark that we are not connected */

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -81,6 +81,18 @@ static pmix_event_t stdinsig, parentdied;
 static pmix_iof_read_event_t stdinev;
 static pmix_proc_t myparent;
 
+/* These three record which of the file-scope events above this init cycle
+ * actually set up, so finalize can take them back down again. They are
+ * statics rather than locals because finalize cannot re-derive the
+ * answer: PMIX_FWD_STDIN and PMIX_KEEPALIVE_PIPE were directives to
+ * *init*. Leaving an event registered past finalize leaves it pointing at
+ * an event base pmix_rte_finalize has destroyed, and leaves the next
+ * init's PMIX_CONSTRUCT running over a live object - which loses that
+ * cycle's stdin descriptor. */
+static bool stdin_setup = false;
+static bool stdinsig_setup = false;
+static int keepalive_fd = -1;
+
 static void _pdiedcb(pmix_status_t status, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
@@ -545,10 +557,17 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
         for (n = 0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&info[n], PMIX_TOOL_DO_NOT_CONNECT)) {
                 do_not_connect = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strncmp(info[n].key, PMIX_TOOL_NSPACE, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TOOL_NSPACE)) {
                 if (NULL != nspace) {
                     /* cannot define it twice */
                     free(nspace);
+                    return PMIX_ERR_BAD_PARAM;
+                }
+                /* screen the value before strdup'ing it: a directive that
+                 * names a string and carries none is an application error,
+                 * and must be reported as one rather than dereferenced */
+                if (PMIX_STRING != info[n].value.type || NULL == info[n].value.data.string) {
+                    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
                     return PMIX_ERR_BAD_PARAM;
                 }
                 nspace = strdup(info[n].value.data.string);
@@ -568,11 +587,28 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
                     PMIX_SET_PROC_TYPE(&ptype, PMIX_PROC_SCHEDULER);
                 }
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
+                /* same screen as PMIX_TOOL_NSPACE above - the guards below
+                 * only refill these when they are NULL, so a bad value has
+                 * to be refused rather than left half-applied */
+                if (PMIX_STRING != info[n].value.type || NULL == info[n].value.data.string) {
+                    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                    if (NULL != nspace) {
+                        free(nspace);
+                    }
+                    return PMIX_ERR_BAD_PARAM;
+                }
                 if (NULL != pmix_server_globals.tmpdir) {
                     free(pmix_server_globals.tmpdir);
                 }
                 pmix_server_globals.tmpdir = strdup(info[n].value.data.string);
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
+                if (PMIX_STRING != info[n].value.type || NULL == info[n].value.data.string) {
+                    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                    if (NULL != nspace) {
+                        free(nspace);
+                    }
+                    return PMIX_ERR_BAD_PARAM;
+                }
                 if (NULL != pmix_server_globals.system_tmpdir) {
                     free(pmix_server_globals.system_tmpdir);
                 }
@@ -660,11 +696,12 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     /* if we were given a keepalive pipe, register an
      * event to capture the event */
     if (NULL != (evar = getenv("PMIX_KEEPALIVE_PIPE"))) {
-        rc = strtol(evar, NULL, 10);
-        pmix_event_set(pmix_globals.evbase, &parentdied, rc, PMIX_EV_READ, pdiedfn, NULL);
+        keepalive_fd = strtol(evar, NULL, 10);
+        pmix_event_set(pmix_globals.evbase, &parentdied, keepalive_fd, PMIX_EV_READ,
+                       pdiedfn, NULL);
         pmix_event_add(&parentdied, NULL);
         pmix_unsetenv("PMIX_KEEPALIVE_PIPE", &environ);
-        pmix_fd_set_cloexec(rc); // don't let children inherit this
+        pmix_fd_set_cloexec(keepalive_fd); // don't let children inherit this
     }
 
     /* if we were given a name, then set it now */
@@ -962,6 +999,12 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
              */
             pmix_event_signal_set(pmix_globals.evauxbase, &stdinsig, SIGCONT,
                                   pmix_iof_stdin_cb, &stdinev);
+            /* pmix_event_signal_set only ASSIGNS the event - it is
+             * event_assign, not event_add - so without this the handler is
+             * never installed and a tool that is backgrounded and then
+             * resumed never reconsiders its stdin */
+            pmix_event_add(&stdinsig, NULL);
+            stdinsig_setup = true;
 
             /* setup a read event to read stdin, but don't activate it yet. The
              * dst_name indicates who should receive the stdin. If that recipient
@@ -1001,6 +1044,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
             }
             PMIX_IOF_READ_ACTIVATE(&stdinev);
         }
+        stdin_setup = true;
     }
 
     /* fill in our local
@@ -1254,6 +1298,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1269,6 +1314,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1282,6 +1328,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1295,6 +1342,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1308,6 +1356,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1321,6 +1370,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1334,6 +1384,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1347,6 +1398,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1360,6 +1412,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1374,6 +1427,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1387,6 +1441,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1400,6 +1455,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1413,6 +1469,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1426,6 +1483,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1435,10 +1493,11 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     kptr->key = strdup(PMIX_LOCAL_RANK);
     PMIX_VALUE_CREATE(kptr->value, 1);
     kptr->value->type = PMIX_UINT16;
-    kptr->value->data.uint32 = 0;
+    kptr->value->data.uint16 = 0;
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1457,6 +1516,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1475,6 +1535,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1489,6 +1550,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &wildcard, PMIX_INTERNAL, kptr);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(kptr);
         return rc;
     }
     PMIX_RELEASE(kptr); // maintain accounting
@@ -1504,6 +1566,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
         PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(kptr);
             return rc;
         }
         PMIX_RELEASE(kptr); // maintain accounting
@@ -1515,6 +1578,7 @@ PMIX_EXPORT pmix_status_t pmix_tool_init_info(void)
         PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(kptr);
             return rc;
         }
         PMIX_RELEASE(kptr); // maintain accounting
@@ -1695,6 +1759,30 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
             PMIX_DESTRUCT_LOCK(&lock);
         }
         pmix_pfexec_base_close();
+    }
+
+    /* Take down the file-scope events init may have registered, while the
+     * bases they are on still exist. Each one has to go, or it survives
+     * into a state where its base has been destroyed under it - and, for
+     * the two that are re-armed on a later init, into a PMIX_CONSTRUCT
+     * over a live object. */
+    if (stdin_setup) {
+        if (stdinsig_setup) {
+            pmix_event_del(&stdinsig);
+            stdinsig_setup = false;
+        }
+        /* Hand the destructor an already-closed descriptor: it closes
+         * whatever fd it finds, and ours is the caller's own stdin.
+         * Finalizing the PMIx library must not close the application's
+         * standard input out from under it. */
+        stdinev.fd = -1;
+        PMIX_DESTRUCT(&stdinev);
+        stdin_setup = false;
+    }
+    if (0 <= keepalive_fd) {
+        pmix_event_del(&parentdied);
+        close(keepalive_fd);
+        keepalive_fd = -1;
     }
 
     /* wait here until all active events have been processed */
@@ -1962,8 +2050,8 @@ static void disc(int sd, short args, void *cbdata)
     if (NULL == cb->proc) {
         pmix_atomic_unset_bool(&pmix_globals.connected);
         cb->status = PMIX_SUCCESS;
-        PMIX_WAKEUP_THREAD(&cb->lock);
         PMIX_POST_OBJECT(cb);
+        PMIX_WAKEUP_THREAD(&cb->lock);
         return;
     }
 
@@ -1982,8 +2070,8 @@ static void disc(int sd, short args, void *cbdata)
     }
     if (NULL == peer) {
         cb->status = PMIX_ERR_NOT_FOUND;
-        PMIX_WAKEUP_THREAD(&cb->lock);
         PMIX_POST_OBJECT(cb);
+        PMIX_WAKEUP_THREAD(&cb->lock);
         return;
     }
 
@@ -2006,9 +2094,8 @@ static void disc(int sd, short args, void *cbdata)
     PMIX_RELEASE(peer);
 
     cb->status = PMIX_SUCCESS;
-    PMIX_WAKEUP_THREAD(&cb->lock);
-
     PMIX_POST_OBJECT(cb);
+    PMIX_WAKEUP_THREAD(&cb->lock);
     return;
 }
 
@@ -2025,6 +2112,8 @@ pmix_status_t PMIx_tool_disconnect(const pmix_proc_t *server)
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* disc() dereferences this whenever it is not NULL; a NULL server is
+     * the documented "just mark me disconnected" form */
     cb = PMIX_NEW(pmix_cb_t);
     cb->proc = (pmix_proc_t *) server;
     PMIX_THREADSHIFT(cb, disc);
@@ -2089,8 +2178,8 @@ static void getsrvrs(int sd, short args, void *cbdata)
         cb->nprocs = 0;
         cb->procs = NULL;
         PMIX_DESTRUCT(&srvrs);
-        PMIX_WAKEUP_THREAD(&cb->lock);
         PMIX_POST_OBJECT(cb);
+        PMIX_WAKEUP_THREAD(&cb->lock);
         return;
     }
 
@@ -2107,8 +2196,8 @@ static void getsrvrs(int sd, short args, void *cbdata)
     cb->status = PMIX_SUCCESS;
     PMIX_LIST_DESTRUCT(&srvrs);
 
-    PMIX_WAKEUP_THREAD(&cb->lock);
     PMIX_POST_OBJECT(cb);
+    PMIX_WAKEUP_THREAD(&cb->lock);
     return;
 }
 pmix_status_t PMIx_tool_get_servers(pmix_proc_t *servers[], size_t *nservers)
@@ -2122,6 +2211,11 @@ pmix_status_t PMIx_tool_get_servers(pmix_proc_t *servers[], size_t *nservers)
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* both OUT parameters are written unconditionally below */
+    if (NULL == servers || NULL == nservers) {
+        return PMIX_ERR_BAD_PARAM;
     }
 
     cb = PMIX_NEW(pmix_cb_t);
@@ -2191,15 +2285,17 @@ void pmix_tool_retry_set(int sd, short args, void *cbdata)
             --cb->status;
             if (cb->status < 0) {
                 cb->status = PMIX_ERR_TIMEOUT;
-                PMIX_WAKEUP_THREAD(&cb->lock);
                 PMIX_POST_OBJECT(cb);
+                PMIX_WAKEUP_THREAD(&cb->lock);
                 return;
             }
             PMIX_THREADSHIFT_DELAY(cb, pmix_tool_retry_set, 0.25);
         } else {
             /* no - so just return failure */
             cb->status = PMIX_ERR_UNREACH;
+            PMIX_POST_OBJECT(cb);
             PMIX_WAKEUP_THREAD(&cb->lock);
+            return;
         }
         PMIX_POST_OBJECT(cb);
         return;
@@ -2207,10 +2303,10 @@ void pmix_tool_retry_set(int sd, short args, void *cbdata)
 
     /* if this is the current active server, then ignore the request */
     if (peer == pmix_client_globals.myserver) {
-        pmix_atomic_set_bool(&pmix_globals.connected ); // just ensure we mark ourselves as connected
+        pmix_atomic_set_bool(&pmix_globals.connected); // just ensure we mark ourselves as connected
         cb->status = PMIX_SUCCESS;
-        PMIX_WAKEUP_THREAD(&cb->lock);
         PMIX_POST_OBJECT(cb);
+        PMIX_WAKEUP_THREAD(&cb->lock);
         return;
     }
 
@@ -2226,8 +2322,8 @@ void pmix_tool_retry_set(int sd, short args, void *cbdata)
 
 done:
     cb->status = PMIX_SUCCESS;
-    PMIX_WAKEUP_THREAD(&cb->lock);
     PMIX_POST_OBJECT(cb);
+    PMIX_WAKEUP_THREAD(&cb->lock);
     return;
 }
 

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1178,11 +1178,24 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     /* see if they gave us a rendezvous URI to which we are to call back */
     evar = getenv("PMIX_LAUNCHER_RNDZ_URI");
     if (NULL != evar) {
-        /* attach to the specified server so it can
-         * tell us what we are to do - save our
-         * current server for now */
-        PMIX_LOAD_PROCID(&myserver, pmix_client_globals.myserver->info->pname.nspace,
-                         pmix_client_globals.myserver->info->pname.rank);
+        /* Attach to the specified server so it can tell us what we are to
+         * do - save our current server first, so we can go back to it once
+         * the debugger releases us.
+         *
+         * If we have no server, "back to it" means back to ourselves, and
+         * we have to say so with our own id. The stand-in peer that
+         * myserver points at on the do-not-connect path may carry no name
+         * at all (the self-assign block is skipped when the caller
+         * supplied PMIX_TOOL_NSPACE/RANK), and PMIX_CHECK_NSPACE treats an
+         * empty nspace as a wildcard - so restoring by that name would
+         * match whichever server the array happened to hold first, and
+         * quietly leave the debugger as our primary. */
+        if (pmix_atomic_check_bool(&pmix_globals.connected)) {
+            PMIX_LOAD_PROCID(&myserver, pmix_client_globals.myserver->info->pname.nspace,
+                             pmix_client_globals.myserver->info->pname.rank);
+        } else {
+            PMIX_LOAD_PROCID(&myserver, pmix_globals.myid.nspace, pmix_globals.myid.rank);
+        }
         PMIX_INFO_CREATE(iptr, 3);
         PMIX_INFO_LOAD(&iptr[0], PMIX_SERVER_URI, evar, PMIX_STRING);
         rc = 2; // give us two seconds to connect
@@ -2077,6 +2090,17 @@ static void disc(int sd, short args, void *cbdata)
     if (NULL == cb->proc) {
         pmix_atomic_unset_bool(&pmix_globals.connected);
         cb->status = PMIX_SUCCESS;
+        PMIX_POST_OBJECT(cb);
+        PMIX_WAKEUP_THREAD(&cb->lock);
+        return;
+    }
+
+    /* An unnamed server matches everything: PMIX_CHECK_NSPACE treats an
+     * invalid nspace as a wildcard, so the walk below would drop whichever
+     * server happens to be first in the array. Naming no server is not a
+     * way to disconnect an arbitrary one. */
+    if (PMIX_NSPACE_INVALID(cb->proc->nspace)) {
+        cb->status = PMIX_ERR_BAD_PARAM;
         PMIX_POST_OBJECT(cb);
         PMIX_WAKEUP_THREAD(&cb->lock);
         return;

--- a/src/tool/pmix_tool_ops.c
+++ b/src/tool/pmix_tool_ops.c
@@ -127,6 +127,9 @@ static void tool_switchyard(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(relay);
+        /* the caddy owns a reference on the requesting peer - releasing it
+         * here is what gives that reference back */
+        PMIX_RELEASE(s);
         return;
     }
     PMIX_SERVER_QUEUE_REPLY(rc, s->peer, tag, relay);

--- a/test/simple/tool_server_switch.c
+++ b/test/simple/tool_server_switch.c
@@ -285,10 +285,46 @@ static int tool_one_cycle(long cyc, const char *burl)
         fprintf(stderr, "cycle %ld: disconnect(A) failed: %s\n", cyc, PMIx_Error_string(rc));
         goto err;
     }
+    /* A is gone now, so asking to switch to it with
+     * PMIX_WAIT_FOR_CONNECTION must poll for the whole PMIX_TIMEOUT and
+     * then report PMIX_ERR_TIMEOUT. The retry budget used to be loaded
+     * straight from the timeout, so an absent or zero timeout expired on
+     * the first retry - a wait request that never waited - and the expiry
+     * was reported as PMIX_ERR_NOT_FOUND rather than the documented
+     * PMIX_ERR_TIMEOUT. */
+    itmo = 1;
+    PMIX_INFO_LOAD(&info[0], PMIX_WAIT_FOR_CONNECTION, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[1], PMIX_TIMEOUT, &itmo, PMIX_INT);
+    rc = PMIx_tool_set_server(&srvrA, info, 2);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    if (PMIX_ERR_TIMEOUT != rc) {
+        fprintf(stderr, "cycle %ld: set_server(A, wait) after disconnect: %s (want "
+                "PMIX_ERR_TIMEOUT)\n", cyc, PMIx_Error_string(rc));
+        goto err;
+    }
+    /* the failed wait must have left B as our primary */
+    if (!PMIx_tool_is_connected()) {
+        fprintf(stderr, "cycle %ld: lost our primary server to a failed wait\n", cyc);
+        goto err;
+    }
+
     /* disconnect B, the primary: disc primary branch (myserver -> self) */
     rc = PMIx_tool_disconnect(&srvrB);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "cycle %ld: disconnect(B) failed: %s\n", cyc, PMIx_Error_string(rc));
+        goto err;
+    }
+    /* having dropped our primary we are no longer connected to anything,
+     * and the server list must say so rather than reporting ourselves */
+    if (PMIx_tool_is_connected()) {
+        fprintf(stderr, "cycle %ld: still connected after dropping the primary\n", cyc);
+        goto err;
+    }
+    rc = PMIx_tool_get_servers(&servers, &nservers);
+    if (PMIX_ERR_UNREACH != rc || 0 != nservers) {
+        fprintf(stderr, "cycle %ld: get_servers with no servers: rc=%s n=%zu (want "
+                "PMIX_ERR_UNREACH/0)\n", cyc, PMIx_Error_string(rc), nservers);
         goto err;
     }
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace runtime_init server_get
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api runtime_init server_get
 
-TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace runtime_init server_get
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api runtime_init server_get
 
 client_api_SOURCES = \
         client_api.c
@@ -273,6 +273,18 @@ tool_nspace_SOURCES = \
         tool_nspace.c
 tool_nspace_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 tool_nspace_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+tool_rndz_SOURCES = \
+        tool_rndz.c
+tool_rndz_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+tool_rndz_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+tool_api_SOURCES = \
+        tool_api.c
+tool_api_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+tool_api_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 server_get_SOURCES = \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache runtime_init server_get
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get
 
-TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache runtime_init server_get
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get
 
 client_api_SOURCES = \
         client_api.c
@@ -291,6 +291,12 @@ tool_evcache_SOURCES = \
         tool_evcache.c
 tool_evcache_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 tool_evcache_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+tool_relay_SOURCES = \
+        tool_relay.c
+tool_relay_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+tool_relay_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 server_get_SOURCES = \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api runtime_init server_get
+check_PROGRAMS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache runtime_init server_get
 
-TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api runtime_init server_get
+TESTS = client_api common_api compress preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache runtime_init server_get
 
 client_api_SOURCES = \
         client_api.c
@@ -285,6 +285,12 @@ tool_api_SOURCES = \
         tool_api.c
 tool_api_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 tool_api_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+tool_evcache_SOURCES = \
+        tool_evcache.c
+tool_evcache_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+tool_evcache_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 server_get_SOURCES = \

--- a/test/unit/tool_api.c
+++ b/test/unit/tool_api.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit test for the parts of the tool API that a single, unconnected tool
+ * can exercise on its own: the identity it publishes, the state of its
+ * server list before anything has been attached, and the argument
+ * handling of the entry points.
+ *
+ * The tool comes up with PMIX_TOOL_DO_NOT_CONNECT, so it self-assigns an
+ * identity of "<hostname>:<pid>" rank 0, points its "server" back at
+ * itself, and needs no launcher or rendezvous - which keeps this inside
+ * "make check".
+ *
+ * Two of the properties checked here were broken.
+ *
+ * PMIx_Get(NULL, PMIX_PROCID) and PMIx_Get(NULL, PMIX_RANK) are answered
+ * out of pmix_globals.myidval / myrankval when the caller asks for
+ * PMIX_GET_POINTER_VALUES - the library hands back a pointer to those
+ * pre-built values rather than allocating. pmix_rte_init creates them
+ * carrying a NULL nspace and PMIX_RANK_INVALID, and it is each role's job
+ * to fill them in once its identity is settled. src/client did; src/tool
+ * never did, so a tool asking for its own process ID that way got
+ * garbage, silently and only on that one code path.
+ *
+ * PMIx_tool_set_server with PMIX_WAIT_FOR_CONNECTION is required to poll
+ * for the named server "up to any specified PMIX_TIMEOUT", where a zero
+ * or absent timeout means never time out. The retry budget was loaded
+ * from the timeout directly, so with no timeout it started at zero, the
+ * first retry decremented it below zero, and the call reported failure
+ * without ever having waited - and reported it as PMIX_ERR_NOT_FOUND
+ * rather than the documented PMIX_ERR_TIMEOUT.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_tool.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed, const char *detail)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s (%s)\n", name, detail);
+        ++nfail;
+    }
+}
+
+/* elapsed seconds between two gettimeofday samples */
+static double elapsed(struct timeval *start, struct timeval *end)
+{
+    return (double) (end->tv_sec - start->tv_sec)
+           + ((double) (end->tv_usec - start->tv_usec) / 1000000.0);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc, bogus;
+    pmix_proc_t *servers = NULL;
+    size_t nservers = 0;
+    pmix_info_t tinfo, dirs[2];
+    pmix_value_t *val = NULL;
+    pmix_status_t rc;
+    struct timeval start, end;
+    double secs;
+    int itmo = 1;
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "\n=== tool API unit test ===\n\n");
+
+    /* keep the run hermetic no matter what the caller's environment
+     * points at - with DO_NOT_CONNECT we will not dial out, but a
+     * half-set identity pair in the environment is a hard error in init */
+    unsetenv("PMIX_NAMESPACE");
+    unsetenv("PMIX_RANK");
+    unsetenv("PMIX_SERVER_URI");
+    unsetenv("PMIX_SERVER_URI2");
+    unsetenv("PMIX_SERVER_URI3");
+    unsetenv("PMIX_SERVER_URI21");
+    unsetenv("PMIX_SERVER_URI41");
+    unsetenv("PMIX_SERVER_URI51");
+    unsetenv("PMIX_LAUNCHER_RNDZ_URI");
+
+    /* the entry points must refuse to run before init rather than
+     * dereference the state init would have built */
+    rc = PMIx_tool_set_server_module(NULL);
+    report("set_server_module before init returns PMIX_ERR_INIT", PMIX_ERR_INIT == rc,
+           PMIx_Error_string(rc));
+    rc = PMIx_tool_get_servers(&servers, &nservers);
+    report("get_servers before init returns PMIX_ERR_INIT", PMIX_ERR_INIT == rc,
+           PMIx_Error_string(rc));
+
+    PMIX_INFO_LOAD(&tinfo, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+    rc = PMIx_tool_init(&myproc, &tinfo, 1);
+    PMIX_INFO_DESTRUCT(&tinfo);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    report("tool init self-assigned an identity", 0 < strlen(myproc.nspace), "empty nspace");
+
+    /* a do-not-connect tool points its server at itself and is not
+     * "connected" in the sense the library reports */
+    report("do-not-connect tool reports itself as not connected", !PMIx_tool_is_connected(),
+           "reported as connected");
+
+    /* ---------------------------------------------------------------
+     * identity as reported through the pointer-value fast path
+     * --------------------------------------------------------------- */
+    PMIX_INFO_LOAD(&dirs[0], PMIX_GET_POINTER_VALUES, NULL, PMIX_BOOL);
+    rc = PMIx_Get(NULL, PMIX_PROCID, dirs, 1, &val);
+    if (PMIX_SUCCESS != rc || NULL == val) {
+        report("PMIx_Get(PMIX_PROCID) with pointer values succeeds", 0,
+               PMIx_Error_string(rc));
+    } else {
+        report("PMIx_Get(PMIX_PROCID) with pointer values succeeds", 1, NULL);
+        report("that PROCID carries our own nspace and rank",
+               PMIX_PROC == val->type && NULL != val->data.proc
+                   && PMIX_CHECK_PROCID(val->data.proc, &myproc),
+               "the pre-built value was never filled in by the tool");
+        /* the library owns this one - it handed back a pointer to its
+         * own static value, so there is nothing to release */
+        val = NULL;
+    }
+
+    rc = PMIx_Get(NULL, PMIX_RANK, dirs, 1, &val);
+    if (PMIX_SUCCESS != rc || NULL == val) {
+        report("PMIx_Get(PMIX_RANK) with pointer values succeeds", 0, PMIx_Error_string(rc));
+    } else {
+        report("PMIx_Get(PMIX_RANK) with pointer values succeeds", 1, NULL);
+        report("that RANK is our own rank",
+               PMIX_PROC_RANK == val->type && val->data.rank == myproc.rank,
+               "the pre-built value was never filled in by the tool");
+        val = NULL;
+    }
+    PMIX_INFO_DESTRUCT(&dirs[0]);
+
+    /* the same two queries taken the ordinary (allocating) way have
+     * always worked - check them so a regression in one is told apart
+     * from a regression in both */
+    rc = PMIx_Get(NULL, PMIX_PROCID, NULL, 0, &val);
+    report("PMIx_Get(PMIX_PROCID) without pointer values agrees",
+           PMIX_SUCCESS == rc && NULL != val && PMIX_PROC == val->type
+               && NULL != val->data.proc && PMIX_CHECK_PROCID(val->data.proc, &myproc),
+           PMIx_Error_string(rc));
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+        val = NULL;
+    }
+
+    /* ---------------------------------------------------------------
+     * the server list of a tool that has not attached to anything
+     * --------------------------------------------------------------- */
+    rc = PMIx_tool_get_servers(&servers, &nservers);
+    report("get_servers on an unconnected tool reports no servers",
+           PMIX_ERR_UNREACH == rc && 0 == nservers, PMIx_Error_string(rc));
+    if (NULL != servers) {
+        PMIX_PROC_FREE(servers, nservers);
+        servers = NULL;
+    }
+
+    /* ---------------------------------------------------------------
+     * set_server argument handling and wait semantics
+     * --------------------------------------------------------------- */
+    rc = PMIx_tool_set_server(NULL, NULL, 0);
+    report("set_server(NULL) is rejected", PMIX_ERR_BAD_PARAM == rc, PMIx_Error_string(rc));
+
+    /* switching to ourselves is always legal and needs no directives */
+    rc = PMIx_tool_set_server(&myproc, NULL, 0);
+    report("set_server(self) succeeds", PMIX_SUCCESS == rc, PMIx_Error_string(rc));
+
+    /* a server we have never heard of, with no wait requested, fails
+     * immediately */
+    PMIX_LOAD_PROCID(&bogus, "no-such-server", 0);
+    gettimeofday(&start, NULL);
+    rc = PMIx_tool_set_server(&bogus, NULL, 0);
+    gettimeofday(&end, NULL);
+    secs = elapsed(&start, &end);
+    report("set_server on an unknown server without a wait fails at once",
+           PMIX_ERR_UNREACH == rc && 0.5 > secs, PMIx_Error_string(rc));
+
+    /* asking to wait must actually wait, and must report the expiry as
+     * PMIX_ERR_TIMEOUT. One second of budget is consumed in 0.25sec
+     * retries, so allow generous slack on the upper bound and require
+     * only that it did not return immediately */
+    PMIX_INFO_LOAD(&dirs[0], PMIX_WAIT_FOR_CONNECTION, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&dirs[1], PMIX_TIMEOUT, &itmo, PMIX_INT);
+    gettimeofday(&start, NULL);
+    rc = PMIx_tool_set_server(&bogus, dirs, 2);
+    gettimeofday(&end, NULL);
+    PMIX_INFO_DESTRUCT(&dirs[0]);
+    PMIX_INFO_DESTRUCT(&dirs[1]);
+    secs = elapsed(&start, &end);
+    report("set_server with PMIX_WAIT_FOR_CONNECTION reports PMIX_ERR_TIMEOUT",
+           PMIX_ERR_TIMEOUT == rc, PMIx_Error_string(rc));
+    report("...and it waited for the timeout rather than failing at once", 0.5 <= secs,
+           "returned immediately - the retry budget was never loaded");
+
+    /* ---------------------------------------------------------------
+     * disconnect of something we are not connected to
+     * --------------------------------------------------------------- */
+    rc = PMIx_tool_disconnect(&bogus);
+    report("disconnect from an unknown server reports PMIX_ERR_NOT_FOUND",
+           PMIX_ERR_NOT_FOUND == rc, PMIx_Error_string(rc));
+
+    rc = PMIx_tool_finalize();
+    report("tool finalized cleanly", PMIX_SUCCESS == rc, PMIx_Error_string(rc));
+
+    /* and the entry points refuse again once the library is down */
+    rc = PMIx_tool_get_servers(&servers, &nservers);
+    report("get_servers after finalize returns PMIX_ERR_INIT", PMIX_ERR_INIT == rc,
+           PMIx_Error_string(rc));
+
+    fprintf(stdout, "\n%d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/tool_api.c
+++ b/test/unit/tool_api.c
@@ -45,6 +45,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 static int npass = 0;
@@ -58,6 +60,55 @@ static void report(const char *name, int passed, const char *detail)
     } else {
         fprintf(stdout, "  FAIL: %s (%s)\n", name, detail);
         ++nfail;
+    }
+}
+
+/* A malformed directive must be refused, not dereferenced. This has to
+ * run in a CHILD: PMIx_tool_init does not unwind, and a failed one leaves
+ * the one-time-init latch set, so a process that has tried a bad init
+ * cannot then do a good one. Exit codes: 0 = refused with
+ * PMIX_ERR_BAD_PARAM, 1 = accepted, 2 = some other error. A crash shows
+ * up as a signal, which is the case that used to happen. */
+static int bad_directive_child(const char *key)
+{
+    pmix_proc_t myproc;
+    pmix_info_t binfo;
+    pmix_status_t rc;
+    bool flag = true;
+
+    /* the key names a string; hand it a bool instead */
+    PMIX_INFO_LOAD(&binfo, key, &flag, PMIX_BOOL);
+    rc = PMIx_tool_init(&myproc, &binfo, 1);
+    if (PMIX_SUCCESS == rc) {
+        PMIx_tool_finalize();
+        return 1;
+    }
+    return (PMIX_ERR_BAD_PARAM == rc) ? 0 : 2;
+}
+
+static void check_bad_directive(const char *key)
+{
+    pid_t child;
+    int status = 0;
+    char name[128];
+
+    snprintf(name, sizeof(name), "a malformed %s is refused, not dereferenced", key);
+    child = fork();
+    if (0 > child) {
+        report(name, 0, "fork failed");
+        return;
+    }
+    if (0 == child) {
+        _exit(bad_directive_child(key));
+    }
+    waitpid(child, &status, 0);
+    if (!WIFEXITED(status)) {
+        report(name, 0, "the tool died on a signal");
+    } else if (0 != WEXITSTATUS(status)) {
+        report(name, 0, (1 == WEXITSTATUS(status)) ? "init accepted it"
+                                                   : "init failed with the wrong status");
+    } else {
+        report(name, 1, NULL);
     }
 }
 
@@ -105,6 +156,11 @@ int main(int argc, char **argv)
     rc = PMIx_tool_get_servers(&servers, &nservers);
     report("get_servers before init returns PMIX_ERR_INIT", PMIX_ERR_INIT == rc,
            PMIx_Error_string(rc));
+
+    /* these fork, so they must run before we bring the library up */
+    check_bad_directive(PMIX_TOOL_NSPACE);
+    check_bad_directive(PMIX_SERVER_TMPDIR);
+    check_bad_directive(PMIX_SYSTEM_TMPDIR);
 
     PMIX_INFO_LOAD(&tinfo, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
     rc = PMIx_tool_init(&myproc, &tinfo, 1);
@@ -167,6 +223,10 @@ int main(int argc, char **argv)
     /* ---------------------------------------------------------------
      * the server list of a tool that has not attached to anything
      * --------------------------------------------------------------- */
+    rc = PMIx_tool_get_servers(NULL, &nservers);
+    report("get_servers with a NULL array pointer is rejected", PMIX_ERR_BAD_PARAM == rc,
+           PMIx_Error_string(rc));
+
     rc = PMIx_tool_get_servers(&servers, &nservers);
     report("get_servers on an unconnected tool reports no servers",
            PMIX_ERR_UNREACH == rc && 0 == nservers, PMIx_Error_string(rc));

--- a/test/unit/tool_api.c
+++ b/test/unit/tool_api.c
@@ -39,6 +39,7 @@
 #include "src/include/pmix_config.h"
 
 #include "include/pmix.h"
+#include "include/pmix_server.h"
 #include "include/pmix_tool.h"
 
 #include <stdio.h>
@@ -51,6 +52,10 @@
 
 static int npass = 0;
 static int nfail = 0;
+
+/* an empty module is enough: nothing here calls through it, and the
+ * point is whether the library accepts one at all */
+static pmix_server_module_t mymodule = {0};
 
 static void report(const char *name, int passed, const char *detail)
 {
@@ -279,6 +284,10 @@ int main(int argc, char **argv)
     report("disconnect from an unknown server reports PMIX_ERR_NOT_FOUND",
            PMIX_ERR_NOT_FOUND == rc, PMIx_Error_string(rc));
 
+    /* a tool may be handed a server module after the fact */
+    rc = PMIx_tool_set_server_module(&mymodule);
+    report("set_server_module accepted after init", PMIX_SUCCESS == rc, PMIx_Error_string(rc));
+
     rc = PMIx_tool_finalize();
     report("tool finalized cleanly", PMIX_SUCCESS == rc, PMIx_Error_string(rc));
 
@@ -286,6 +295,25 @@ int main(int argc, char **argv)
     rc = PMIx_tool_get_servers(&servers, &nservers);
     report("get_servers after finalize returns PMIX_ERR_INIT", PMIX_ERR_INIT == rc,
            PMIx_Error_string(rc));
+
+    /* ---------------------------------------------------------------
+     * a second cycle has to be able to do everything the first did.
+     * The "module has been set" latch is a global that no finalize
+     * resets, so a tool that cycles used to be refused its module on
+     * every init after the first - while init had already zeroed the
+     * table it would be called through.
+     * --------------------------------------------------------------- */
+    PMIX_INFO_LOAD(&tinfo, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+    rc = PMIx_tool_init(&myproc, &tinfo, 1);
+    PMIX_INFO_DESTRUCT(&tinfo);
+    report("second tool init succeeds", PMIX_SUCCESS == rc, PMIx_Error_string(rc));
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_tool_set_server_module(&mymodule);
+        report("set_server_module accepted again on the second cycle", PMIX_SUCCESS == rc,
+               PMIx_Error_string(rc));
+        rc = PMIx_tool_finalize();
+        report("second tool finalize succeeds", PMIX_SUCCESS == rc, PMIx_Error_string(rc));
+    }
 
     fprintf(stdout, "\n%d passed, %d failed\n", npass, nfail);
     return (0 == nfail) ? 0 : 1;

--- a/test/unit/tool_api.c
+++ b/test/unit/tool_api.c
@@ -284,6 +284,13 @@ int main(int argc, char **argv)
     report("disconnect from an unknown server reports PMIX_ERR_NOT_FOUND",
            PMIX_ERR_NOT_FOUND == rc, PMIx_Error_string(rc));
 
+    /* an unnamed server is a wildcard to PMIX_CHECK_NSPACE, so it would
+     * otherwise drop whichever server the array held first */
+    PMIX_LOAD_PROCID(&bogus, NULL, 0);
+    rc = PMIx_tool_disconnect(&bogus);
+    report("disconnect from an unnamed server is rejected", PMIX_ERR_BAD_PARAM == rc,
+           PMIx_Error_string(rc));
+
     /* a tool may be handed a server module after the fact */
     rc = PMIx_tool_set_server_module(&mymodule);
     report("set_server_module accepted after init", PMIX_SUCCESS == rc, PMIx_Error_string(rc));

--- a/test/unit/tool_cycle.c
+++ b/test/unit/tool_cycle.c
@@ -39,11 +39,16 @@
 #include "include/pmix.h"
 #include "include/pmix_tool.h"
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #define DEFAULT_CYCLES 1200
+/* the stdin-forwarding pass is about the teardown existing, not about
+ * volume - keep it short so the default run stays quick */
+#define STDIN_CYCLES   20
 
 int main(int argc, char **argv)
 {
@@ -116,8 +121,49 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Now the same cycle with PMIX_FWD_STDIN, which is a different init
+     * and a different teardown: it constructs a file-scope
+     * pmix_iof_read_event_t over our stdin and registers it (plus, on a
+     * tty, a SIGCONT handler) on the event bases. Those are statics, so
+     * a cycle that does not take them back down leaves the next
+     * PMIX_CONSTRUCT running over a live object - losing that cycle's
+     * descriptor - and leaves an event registered on a base
+     * pmix_rte_finalize has already destroyed.
+     *
+     * Far fewer cycles than above: this one is about the teardown
+     * existing at all, and every cycle re-reads the same stdin. */
+    for (i = 0; 0 == nfail && i < STDIN_CYCLES; i++) {
+        pmix_info_t sinfo[2];
+
+        PMIX_INFO_LOAD(&sinfo[0], PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&sinfo[1], PMIX_FWD_STDIN, NULL, PMIX_BOOL);
+        rc = PMIx_tool_init(&myproc, sinfo, 2);
+        PMIX_INFO_DESTRUCT(&sinfo[0]);
+        PMIX_INFO_DESTRUCT(&sinfo[1]);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "stdin cycle %ld: PMIx_tool_init failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+        rc = PMIx_tool_finalize();
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "stdin cycle %ld: PMIx_tool_finalize failed: %s\n", i,
+                    PMIx_Error_string(rc));
+            nfail = 1;
+            break;
+        }
+        /* the library must not have closed our stdin on the way out */
+        if (0 > fcntl(STDIN_FILENO, F_GETFD)) {
+            fprintf(stderr, "stdin cycle %ld: finalize closed our stdin\n", i);
+            nfail = 1;
+            break;
+        }
+    }
+
     if (0 == nfail) {
-        fprintf(stdout, "Completed %ld tool init/finalize cycles: PASS\n\n", ncycles);
+        fprintf(stdout, "Completed %ld tool init/finalize cycles (%d with stdin "
+                "forwarding): PASS\n\n", ncycles, STDIN_CYCLES);
     } else {
         fprintf(stdout, "tool init/finalize cycling: FAIL\n\n");
     }

--- a/test/unit/tool_evcache.c
+++ b/test/unit/tool_evcache.c
@@ -42,7 +42,9 @@
  * before forwarding, so an event no handler wants does not arrive at the
  * tool at all and is never parked. Instrumenting _notify_complete during
  * this run shows it called exactly once, with PMIX_SUCCESS. Do not
- * assume a change to that branch is covered here.
+ * assume a change to that branch is covered here. Whether that branch is
+ * reachable at all - src/client has no equivalent - is
+ * openpmix#4101.
  */
 
 #include "src/include/pmix_config.h"

--- a/test/unit/tool_evcache.c
+++ b/test/unit/tool_evcache.c
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * End-to-end coverage for the affected-process restriction on events
+ * delivered to a tool.
+ *
+ * A tool receives events through pmix_tool_notify_recv (src/tool), which
+ * unpacks them and hands them to the local event machinery. This drives
+ * that path with two handlers that ask about different processes, and
+ * asserts that each sees only what it asked for: handler B, registered
+ * for process Z, must not be given the event about process Y that was
+ * already in flight, and must be given the one about Z.
+ *
+ * The ordering is what makes the first half an assertion rather than a
+ * race:
+ *
+ *   1. the tool registers handler A, restricted to process X. A PMIx
+ *      server does not forward a tool codes it has registered no
+ *      interest in, so without A the test code never leaves the server;
+ *   2. the server notifies the code about process Y, and waits for its
+ *      own completion callback so the message is really on the wire;
+ *   3. the tool makes a blocking round trip to the server. The
+ *      notification and the reply travel the same socket in order, so by
+ *      the time the reply is in hand the notification has been dealt
+ *      with. No sleep, no polling;
+ *   4. the tool registers handler B, restricted to process Z, and B must
+ *      not fire;
+ *   5. the server notifies the code about Z, and B must fire - so the
+ *      test cannot pass by never delivering anything at all.
+ *
+ * WHAT THIS DOES NOT REACH, and it is worth knowing before extending it.
+ * The original target was the tool's *cached*-event path: when no
+ * handler matches, _notify_complete parks the event for a handler that
+ * registers later, and it builds the parked copy out of chain->range and
+ * chain->affected - which pmix_tool_notify_recv never filled in. But the
+ * server filters on the tool's registered codes and affected procs
+ * before forwarding, so an event no handler wants does not arrive at the
+ * tool at all and is never parked. Instrumenting _notify_complete during
+ * this run shows it called exactly once, with PMIX_SUCCESS. Do not
+ * assume a change to that branch is covered here.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+#include "include/pmix_tool.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/ptl/base/base.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* a code with no meaning to the library, so nothing else reacts to it */
+#define TEST_CODE   (PMIX_EXTERNAL_ERR_BASE - 42)
+#define TOOL_NSPACE "tool-evcache-tool"
+/* three processes that are not the tool and not each other */
+#define NS_X "tool-evcache-x"
+#define NS_Y "tool-evcache-y"
+#define NS_Z "tool-evcache-z"
+
+/* how long the tool waits to be sure a handler did NOT fire */
+#define QUIET_SECS  2
+/* and how long it will wait for the one that must */
+#define LOUD_SECS   20
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed, const char *detail)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s (%s)\n", name, detail);
+        ++nfail;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* the server                                                         */
+/* ------------------------------------------------------------------ */
+
+static void tool_connected_fn(pmix_info_t *info, size_t ninfo,
+                              pmix_tool_connection_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_proc_t proc;
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
+
+    PMIX_LOAD_PROCID(&proc, TOOL_NSPACE, 0);
+    cbfunc(PMIX_SUCCESS, &proc, cbdata);
+}
+
+static pmix_server_module_t mymodule = {
+    .tool_connected = tool_connected_fn
+};
+
+/* ------------------------------------------------------------------ */
+/* the tool                                                           */
+/* ------------------------------------------------------------------ */
+
+static volatile int nfired_a = 0;
+static volatile int nfired_b = 0;
+
+/* handler A exists only to make the server forward the code to us */
+static void hdlr_a(size_t evhdlr_registration_id, pmix_status_t status,
+                   const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                   pmix_info_t results[], size_t nresults,
+                   pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo, results,
+                            nresults);
+
+    ++nfired_a;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* handler B is the one under test */
+static void hdlr_b(size_t evhdlr_registration_id, pmix_status_t status,
+                   const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                   pmix_info_t results[], size_t nresults,
+                   pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo, results,
+                            nresults);
+
+    ++nfired_b;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void reg_cbfunc(pmix_status_t status, size_t refid, void *cbdata)
+{
+    pmix_status_t *sp = (pmix_status_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(refid);
+
+    *sp = status;
+}
+
+/* wait up to secs for *counter to reach want; return what it reached */
+static int wait_for_fires(volatile int *counter, int want, int secs)
+{
+    int i;
+
+    for (i = 0; i < secs * 10; i++) {
+        if (*counter >= want) {
+            break;
+        }
+        usleep(100000);
+    }
+    return *counter;
+}
+
+/* register one handler for TEST_CODE restricted to "affected", and block
+ * until the registration has been acknowledged */
+static pmix_status_t register_for(pmix_proc_t *affected, pmix_notification_fn_t fn)
+{
+    pmix_info_t rinfo;
+    pmix_status_t code = TEST_CODE;
+    pmix_status_t regstatus = PMIX_ERR_WOULD_BLOCK;
+    int i;
+
+    PMIX_INFO_LOAD(&rinfo, PMIX_EVENT_AFFECTED_PROC, affected, PMIX_PROC);
+    PMIx_Register_event_handler(&code, 1, &rinfo, 1, fn, reg_cbfunc, (void *) &regstatus);
+    /* the acknowledgement arrives on the progress thread. Note the info
+     * array stays alive across the wait: the library does not copy it */
+    for (i = 0; i < 400 && PMIX_ERR_WOULD_BLOCK == regstatus; i++) {
+        usleep(50000);
+    }
+    PMIX_INFO_DESTRUCT(&rinfo);
+    return regstatus;
+}
+
+/* A blocking round trip to the server. Its only job is ordering: the
+ * notification the server sent before this went out travels the same
+ * socket, so it has been received and processed by the time we return.
+ *
+ * A query rather than a PMIx_Get: a get for a key nobody has posted does
+ * not come back at all - it parks until the key appears, which is the
+ * documented behaviour and would simply hang here. Our test server
+ * implements no query interface, so this returns PMIX_ERR_NOT_SUPPORTED
+ * as soon as the server has looked at it, which is exactly the round
+ * trip we want. */
+static void round_trip(void)
+{
+    pmix_query_t *query;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    pmix_status_t rc;
+
+    PMIX_QUERY_CREATE(query, 1);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_NAMESPACES);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_QUERY_FREE(query, 1);
+        return;
+    }
+    (void) PMIx_Query_info(query, 1, &results, &nresults);
+    PMIX_QUERY_FREE(query, 1);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+}
+
+static int run_tool(int urifd, int readyfd, int gofd)
+{
+    char uri[2048];
+    ssize_t n;
+    pmix_proc_t myproc, procx, procz;
+    pmix_info_t tinfo;
+    pmix_status_t rc;
+    char c = 'r';
+    int ret = 1, fires;
+
+    n = read(urifd, uri, sizeof(uri) - 1);
+    if (0 >= n) {
+        return 1;
+    }
+    uri[n] = '\0';
+
+    PMIX_INFO_LOAD(&tinfo, PMIX_SERVER_URI, uri, PMIX_STRING);
+    rc = PMIx_tool_init(&myproc, &tinfo, 1);
+    PMIX_INFO_DESTRUCT(&tinfo);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "  tool: PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* Handler A, restricted to X. Its job is to make the server forward
+     * TEST_CODE to us at all - a server does not send a tool codes it
+     * has registered no interest in, and an event that never arrives is
+     * never cached. */
+    PMIX_LOAD_PROCID(&procx, NS_X, 0);
+    rc = register_for(&procx, hdlr_a);
+    if (0 > rc) {
+        fprintf(stderr, "  tool: could not register handler A: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* tell the server we are ready, and wait for it to say the
+     * notification about Y has gone out */
+    if (1 != write(readyfd, &c, 1) || 1 != read(gofd, &c, 1)) {
+        goto done;
+    }
+
+    /* order ourselves behind that notification: when this returns, the
+     * event about Y has been received, matched against handler A (which
+     * wants X), found wanting, and parked */
+    round_trip();
+
+    if (0 != nfired_a) {
+        fprintf(stderr, "  tool: handler A fired for an event about a process it did "
+                "not ask about\n");
+        goto done;
+    }
+
+    /* Handler B, restricted to Z. Registering it replays the cache. The
+     * parked event is about Y, so B must not see it. */
+    PMIX_LOAD_PROCID(&procz, NS_Z, 0);
+    rc = register_for(&procz, hdlr_b);
+    if (0 > rc) {
+        fprintf(stderr, "  tool: could not register handler B: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+
+    fires = wait_for_fires(&nfired_b, 1, QUIET_SECS);
+    if (0 != fires) {
+        fprintf(stderr, "  tool: the cached event about %s was replayed to a handler that "
+                "asked only about %s\n", NS_Y, NS_Z);
+        goto done;
+    }
+    fprintf(stdout, "  tool: cached event kept its affected-process restriction\n");
+
+    /* now ask for one that IS about Z, so a library that delivers
+     * nothing at all cannot pass this test */
+    if (1 != write(readyfd, &c, 1)) {
+        goto done;
+    }
+    fires = wait_for_fires(&nfired_b, 1, LOUD_SECS);
+    if (1 > fires) {
+        fprintf(stderr, "  tool: the event about %s never reached handler B\n", NS_Z);
+        goto done;
+    }
+    fprintf(stdout, "  tool: the event handler B asked for was delivered\n");
+    ret = 0;
+
+done:
+    PMIx_tool_finalize();
+    return ret;
+}
+
+/* ------------------------------------------------------------------ */
+
+static volatile int notified = 0;
+
+static void opcbfunc(pmix_status_t status, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(status, cbdata);
+    ++notified;
+}
+
+/* send one TEST_CODE event naming "affected" as the affected process,
+ * and do not return until the library says it is done with it */
+static void notify_about(pmix_proc_t *affected)
+{
+    pmix_info_t info;
+    int i, was = notified;
+
+    PMIX_INFO_LOAD(&info, PMIX_EVENT_AFFECTED_PROC, affected, PMIX_PROC);
+    PMIx_Notify_event(TEST_CODE, &pmix_globals.myid, PMIX_RANGE_LOCAL, &info, 1,
+                      opcbfunc, NULL);
+    /* PMIx_Notify_event is non-blocking and does NOT copy the directives -
+     * the caller has to keep them alive until the callback fires. Freeing
+     * this array here is a use-after-free inside the library's own
+     * progress thread, and it segfaults there rather than here. */
+    for (i = 0; i < 200 && notified == was; i++) {
+        usleep(50000);
+    }
+    PMIX_INFO_DESTRUCT(&info);
+}
+
+static int wait_readable(int fd, int secs)
+{
+    fd_set rd;
+    struct timeval tv;
+
+    FD_ZERO(&rd);
+    FD_SET(fd, &rd);
+    tv.tv_sec = secs;
+    tv.tv_usec = 0;
+    return (0 < select(fd + 1, &rd, NULL, NULL, &tv));
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_info_t sinfo[2];
+    pmix_proc_t procy, procz;
+    char *uri;
+    int uripipe[2], readypipe[2], gopipe[2];
+    pid_t child;
+    int status = 0;
+    bool flag = true;
+    char c = 'g';
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== tool cached-event restriction unit test ===\n\n");
+
+
+    if (0 != pipe(uripipe) || 0 != pipe(readypipe) || 0 != pipe(gopipe)) {
+        fprintf(stderr, "pipe() failed\n");
+        return 1;
+    }
+
+    /* fork before touching PMIx so neither side inherits an initialized
+     * library */
+    child = fork();
+    if (0 > child) {
+        fprintf(stderr, "fork() failed\n");
+        return 1;
+    }
+    if (0 == child) {
+        close(uripipe[1]);
+        close(readypipe[0]);
+        close(gopipe[1]);
+        _exit(run_tool(uripipe[0], readypipe[1], gopipe[0]));
+    }
+
+    close(uripipe[0]);
+    close(readypipe[1]);
+    close(gopipe[0]);
+
+    PMIX_INFO_LOAD(&sinfo[0], PMIX_SERVER_TOOL_SUPPORT, &flag, PMIX_BOOL);
+    PMIX_INFO_LOAD(&sinfo[1], PMIX_SERVER_NSPACE, "tool-evcache-server", PMIX_STRING);
+    rc = PMIx_server_init(&mymodule, sinfo, 2);
+    PMIX_INFO_DESTRUCT(&sinfo[0]);
+    PMIX_INFO_DESTRUCT(&sinfo[1]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        goto reap;
+    }
+
+    /* hand the tool our contact information - read straight off the
+     * listener, as this test is white-box anyway */
+    uri = pmix_ptl_base.listener.uri;
+    if (NULL == uri) {
+        report("server published its URI", 0, "listener has no URI");
+        goto done;
+    }
+    if ((ssize_t) strlen(uri) != write(uripipe[1], uri, strlen(uri))) {
+        report("tool received the URI", 0, "short write");
+        goto done;
+    }
+    close(uripipe[1]);
+    uripipe[1] = -1;
+
+    if (!wait_readable(readypipe[0], 30) || 1 != read(readypipe[0], &c, 1)) {
+        report("tool connected", 0, "tool never reported ready");
+        goto done;
+    }
+    report("tool connected", 1, NULL);
+
+    /* the event the tool must not replay to handler B: it is about Y,
+     * and by the time B registers it has been parked */
+    PMIX_LOAD_PROCID(&procy, NS_Y, 0);
+    notify_about(&procy);
+    if (1 != write(gopipe[1], &c, 1)) {
+        report("first notification released the tool", 0, "short write");
+        goto done;
+    }
+    close(gopipe[1]);
+    gopipe[1] = -1;
+    report("server notified an event about a process no handler wants", 1, NULL);
+
+    /* the tool tells us when it is satisfied nothing was replayed */
+    if (!wait_readable(readypipe[0], 60) || 1 != read(readypipe[0], &c, 1)) {
+        report("cached event keeps its affected-process restriction", 0,
+               "the tool saw it replayed, or died");
+        goto done;
+    }
+    report("cached event keeps its affected-process restriction", 1, NULL);
+
+    /* and now one handler B must receive */
+    PMIX_LOAD_PROCID(&procz, NS_Z, 0);
+    notify_about(&procz);
+    report("server notified an event about the process B asked about", 1, NULL);
+
+done:
+    PMIx_server_finalize();
+
+reap:
+    if (0 <= uripipe[1]) {
+        close(uripipe[1]);
+    }
+    if (0 <= gopipe[1]) {
+        close(gopipe[1]);
+    }
+    close(readypipe[0]);
+    waitpid(child, &status, 0);
+    if (!WIFEXITED(status) || 0 != WEXITSTATUS(status)) {
+        report("tool saw exactly the events it asked for", 0, "tool exited non-zero");
+    } else {
+        report("tool saw exactly the events it asked for", 1, NULL);
+    }
+
+    fprintf(stdout, "\n%d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/tool_relay.c
+++ b/test/unit/tool_relay.c
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression test for what a tool does with a spawn request sent to it by
+ * ANOTHER tool - the one path through src/tool/pmix_tool_ops.c, and the
+ * only case in which a tool's server switchyard is ever entered.
+ *
+ * A tool has no clients of its own, but another tool can connect to it as
+ * that tool's primary server (a debugger fork/exec'ing a launcher is the
+ * motivating case). When the downstream tool sends a command the
+ * receiving tool cannot service itself, server_switchyard() hands it to
+ * pmix_tool_relay_op().
+ *
+ * The rule is: relay it if we are attached to a server, service it
+ * ourselves otherwise. PMIx_Spawn has always applied that rule to a
+ * launcher's own requests - see the top of pmix_client_spawn.c, which
+ * sets "forkexec" when it is not connected and we are a launcher. The
+ * proxied path did not: pmix_tool_relay_op answered PMIX_ERR_UNREACH,
+ * the switchyard returned it (it fell through to the logic tree only on
+ * PMIX_ERR_NOT_SUPPORTED), and the downstream tool got an error instead
+ * of a launched job - even though the receiving launcher had pfexec open
+ * and was perfectly able to run it.
+ *
+ * So this test builds exactly that shape, with nothing attached upstream:
+ *
+ *   parent - a LAUNCHER tool with PMIX_TOOL_DO_NOT_CONNECT, so it starts
+ *            a listener and opens pfexec but has no server of its own.
+ *            It publishes its URI and then just waits;
+ *   child  - a plain tool whose PMIX_SERVER_URI is the parent, which
+ *            calls PMIx_Spawn.
+ *
+ * The child's spawn reaches the parent as PMIX_SPAWNNB_CMD, finds no
+ * server to relay to, and must be fork/exec'd by the parent. A pass is
+ * the child getting PMIX_SUCCESS and a namespace back; against the
+ * unfixed library it gets PMIX_ERR_UNREACH.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_tool.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/ptl/base/base.h"
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* the child must not outlive a wedged parent */
+#define CHILD_ALARM_SECS 60
+
+/* something that exists on every platform this builds on and exits at
+ * once - the test is about who launches it, not what it does */
+#define SPAWNEE "/usr/bin/true"
+#define SPAWNEE_ALT "/bin/true"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed, const char *detail)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s (%s)\n", name, detail);
+        ++nfail;
+    }
+}
+
+static void clear_env(void)
+{
+    unsetenv("PMIX_NAMESPACE");
+    unsetenv("PMIX_RANK");
+    unsetenv("PMIX_SERVER_URI");
+    unsetenv("PMIX_SERVER_URI2");
+    unsetenv("PMIX_SERVER_URI3");
+    unsetenv("PMIX_SERVER_URI21");
+    unsetenv("PMIX_SERVER_URI41");
+    unsetenv("PMIX_SERVER_URI51");
+    unsetenv("PMIX_LAUNCHER_RNDZ_URI");
+}
+
+/* ------------------------------------------------------------------ */
+/* the downstream tool                                                */
+/* ------------------------------------------------------------------ */
+
+/* child exit codes, so the parent can say what went wrong */
+#define D_OK        0
+#define D_NOURI     1
+#define D_INITFAIL  2
+#define D_UNREACH   3   /* the pre-fix answer */
+#define D_SPAWNFAIL 4
+#define D_NONSPACE  5
+
+static int run_downstream(int urifd)
+{
+    char uri[2048];
+    ssize_t n;
+    pmix_proc_t myproc;
+    pmix_info_t tinfo[3];
+    pmix_rank_t trank;
+    pmix_app_t *app;
+    pmix_nspace_t child;
+    pmix_status_t rc;
+    int ret;
+
+    n = read(urifd, uri, sizeof(uri) - 1);
+    if (0 >= n) {
+        return D_NOURI;
+    }
+    uri[n] = '\0';
+
+    alarm(CHILD_ALARM_SECS);
+    clear_env();
+
+    /* Bring our own identity. A tool acting as a server has no
+     * "tool_connected" upcall to hand one out - that is a host module's
+     * job and a tool has no host - so the PTL accepts a downstream tool
+     * only when it does not need an id (see process_tool_request in
+     * ptl_base_connection_hdlr.c). Asking for one is refused with
+     * PMIX_ERR_NOT_SUPPORTED before any of this test's subject is
+     * reached. */
+    PMIX_INFO_LOAD(&tinfo[0], PMIX_SERVER_URI, uri, PMIX_STRING);
+    PMIX_INFO_LOAD(&tinfo[1], PMIX_TOOL_NSPACE, "tool-relay-downstream", PMIX_STRING);
+    trank = 0;
+    PMIX_INFO_LOAD(&tinfo[2], PMIX_TOOL_RANK, &trank, PMIX_PROC_RANK);
+    rc = PMIx_tool_init(&myproc, tinfo, 3);
+    PMIX_INFO_DESTRUCT(&tinfo[0]);
+    PMIX_INFO_DESTRUCT(&tinfo[1]);
+    PMIX_INFO_DESTRUCT(&tinfo[2]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "  downstream: PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
+        return D_INITFAIL;
+    }
+
+    PMIX_APP_CREATE(app, 1);
+    app[0].cmd = strdup((0 == access(SPAWNEE, X_OK)) ? SPAWNEE : SPAWNEE_ALT);
+    app[0].argv = (char **) malloc(2 * sizeof(char *));
+    app[0].argv[0] = strdup(app[0].cmd);
+    app[0].argv[1] = NULL;
+    app[0].maxprocs = 1;
+
+    memset(child, 0, sizeof(child));
+    rc = PMIx_Spawn(NULL, 0, app, 1, child);
+    PMIX_APP_FREE(app, 1);
+
+    if (PMIX_ERR_UNREACH == rc) {
+        /* this is the defect: our upstream tool has no server of its own,
+         * so it refused rather than launching for us */
+        fprintf(stderr, "  downstream: spawn refused with PMIX_ERR_UNREACH - the "
+                "upstream launcher did not fall back to fork/exec\n");
+        ret = D_UNREACH;
+    } else if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "  downstream: PMIx_Spawn failed: %s\n", PMIx_Error_string(rc));
+        ret = D_SPAWNFAIL;
+    } else if (0 == strlen(child)) {
+        fprintf(stderr, "  downstream: spawn succeeded but returned no namespace\n");
+        ret = D_NONSPACE;
+    } else {
+        fprintf(stdout, "  downstream: spawn succeeded, job is %s\n", child);
+        ret = D_OK;
+    }
+
+    PMIx_tool_finalize();
+    return ret;
+}
+
+/* ------------------------------------------------------------------ */
+
+static const char *why(int code)
+{
+    switch (code) {
+    case D_NOURI:     return "never received the upstream URI";
+    case D_INITFAIL:  return "could not connect to the upstream tool";
+    case D_UNREACH:   return "spawn refused with PMIX_ERR_UNREACH - no fork/exec fallback";
+    case D_SPAWNFAIL: return "spawn failed";
+    case D_NONSPACE:  return "spawn returned no namespace";
+    default:          return "tool died on a signal";
+    }
+}
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc;
+    pmix_info_t tinfo[2];
+    pmix_status_t rc;
+    char *uri;
+    int uripipe[2];
+    pid_t child;
+    int status = 0;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== tool-to-tool spawn relay unit test ===\n\n");
+
+    if (0 != pipe(uripipe)) {
+        fprintf(stderr, "pipe() failed\n");
+        return 1;
+    }
+
+    /* fork before touching PMIx so neither side inherits an initialized
+     * library */
+    child = fork();
+    if (0 > child) {
+        fprintf(stderr, "fork() failed\n");
+        return 1;
+    }
+    if (0 == child) {
+        close(uripipe[1]);
+        _exit(run_downstream(uripipe[0]));
+    }
+    close(uripipe[0]);
+
+    clear_env();
+
+    /* A LAUNCHER, so we start a listener and open pfexec, and
+     * DO_NOT_CONNECT so we have no server of our own - which is what
+     * makes the downstream tool's spawn unrelayable. */
+    PMIX_INFO_LOAD(&tinfo[0], PMIX_LAUNCHER, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&tinfo[1], PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+    rc = PMIx_tool_init(&myproc, tinfo, 2);
+    PMIX_INFO_DESTRUCT(&tinfo[0]);
+    PMIX_INFO_DESTRUCT(&tinfo[1]);
+    if (PMIX_SUCCESS != rc) {
+        report("upstream launcher initialized", 0, PMIx_Error_string(rc));
+        goto reap;
+    }
+    report("upstream launcher initialized", 1, NULL);
+    report("upstream launcher has no server of its own", !PMIx_tool_is_connected(),
+           "it is connected to something - the relay would be taken instead");
+
+    /* hand the downstream tool our contact information - read straight
+     * off the listener, as this test is white-box anyway */
+    uri = pmix_ptl_base.listener.uri;
+    if (NULL == uri) {
+        report("upstream launcher published its URI", 0,
+               "no listener - a launcher must start one");
+        goto done;
+    }
+    report("upstream launcher published its URI", 1, NULL);
+    if ((ssize_t) strlen(uri) != write(uripipe[1], uri, strlen(uri))) {
+        report("downstream tool received the URI", 0, "short write");
+        goto done;
+    }
+    close(uripipe[1]);
+    uripipe[1] = -1;
+
+done:
+    /* stay up until the downstream tool is finished: our progress thread
+     * is what services its connection and its spawn */
+    waitpid(child, &status, 0);
+    child = -1;
+    if (!WIFEXITED(status)) {
+        report("downstream tool's spawn was serviced", 0, "tool died on a signal");
+    } else if (D_OK != WEXITSTATUS(status)) {
+        report("downstream tool's spawn was serviced", 0, why(WEXITSTATUS(status)));
+    } else {
+        report("downstream tool's spawn was serviced", 1, NULL);
+    }
+
+    rc = PMIx_tool_finalize();
+    report("upstream launcher finalized cleanly", PMIX_SUCCESS == rc, PMIx_Error_string(rc));
+
+reap:
+    if (0 <= uripipe[1]) {
+        close(uripipe[1]);
+    }
+    if (0 < child) {
+        kill(child, SIGKILL);
+        waitpid(child, &status, 0);
+    }
+
+    fprintf(stdout, "\n%d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/tool_rndz.c
+++ b/test/unit/tool_rndz.c
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression test for the tool's launcher-rendezvous path - the block in
+ * PMIx_tool_init that runs when PMIX_LAUNCHER_RNDZ_URI is set in the
+ * environment.
+ *
+ * That is how a debugger drives a launcher it fork/exec'd: the launcher
+ * attaches to the URI the debugger handed it, makes that connection its
+ * primary server, pulls whatever job info the debugger has for it,
+ * registers a one-shot handler for PMIX_DEBUGGER_RELEASE, and then blocks
+ * inside init until the debugger fires that event. Only then does init
+ * restore the launcher's original primary server and return.
+ *
+ * The registration in the middle of that sequence is the interesting
+ * part, and it was broken. It does not go through
+ * PMIx_Register_event_handler; it fills in a pmix_rshift_caddy_t by hand,
+ * thread-shifts it to pmix_internal_reg_event_hdlr, and blocks on the
+ * caddy's own lock. The registration machinery acknowledges by calling
+ * cd->evregcbfn(status, index, cd->cbdata) - and cd->cbdata is the caddy.
+ * The tool's callback nonetheless cast that pointer to a pmix_lock_t,
+ * which
+ *
+ *   - wrote the status over the head of the object (a pmix_lock_t leads
+ *     with its status field, a pmix_object_t with its class pointer and
+ *     magic id), and took a "mutex" that was really the rest of that
+ *     header, and
+ *   - left the caddy's real lock - the one init blocks on - untouched,
+ *     so PMIx_tool_init never came back.
+ *
+ * src/client and src/server both got this right (they use the caddy, not
+ * a lock); only src/tool did not.
+ *
+ * The test therefore drives the whole flow for real: the parent is a PMIx
+ * server standing in for the debugger, and the child is a tool that comes
+ * up with PMIX_LAUNCHER_RNDZ_URI pointing at it. A hang inside the child's
+ * init - the pre-fix behavior - is caught by the child's alarm and by the
+ * parent's bounded wait, and shows up as a failed child rather than a
+ * stuck "make check".
+ *
+ * The child also asserts what the rendezvous block is supposed to have
+ * left behind: the debugger is a known server, PMIX_PARENT_ID has been
+ * stored, and the primary server has been restored to what it was before
+ * the rendezvous.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+#include "include/pmix_tool.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/ptl/base/base.h"
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* how long the child gives the whole rendezvous before declaring a hang */
+#define CHILD_ALARM_SECS 40
+/* how long the parent keeps re-firing the release before giving up */
+#define PARENT_TRIES     60
+#define PARENT_WAIT_USEC 500000
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed, const char *detail)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s (%s)\n", name, detail);
+        ++nfail;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* the "debugger" - a plain PMIx server                               */
+/* ------------------------------------------------------------------ */
+
+static void tool_connected_fn(pmix_info_t *info, size_t ninfo,
+                              pmix_tool_connection_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_proc_t proc;
+    PMIX_HIDE_UNUSED_PARAMS(info, ninfo);
+
+    /* accept the tool under a name of our choosing - the launcher does
+     * not care what it is called here, only that the connection works */
+    PMIX_LOAD_PROCID(&proc, "tool-rndz-launcher", 0);
+    cbfunc(PMIX_SUCCESS, &proc, cbdata);
+}
+
+static pmix_server_module_t mymodule = {
+    .tool_connected = tool_connected_fn
+};
+
+/* ------------------------------------------------------------------ */
+/* the "launcher" - a tool that rendezvouses back to the debugger      */
+/* ------------------------------------------------------------------ */
+
+static int run_tool(int urifd, int readyfd)
+{
+    char uri[2048];
+    ssize_t n;
+    pmix_proc_t myproc, before, *servers = NULL;
+    size_t nservers = 0, i;
+    pmix_info_t tinfo;
+    pmix_value_t *val = NULL;
+    pmix_status_t rc;
+    int ret = 1;
+    bool found;
+    char c = 'r';
+
+    n = read(urifd, uri, sizeof(uri) - 1);
+    if (0 >= n) {
+        fprintf(stderr, "  tool: could not read the server URI\n");
+        return 1;
+    }
+    uri[n] = '\0';
+
+    /* a hang in init is the failure mode we are testing for, so make
+     * sure it terminates us instead of the harness */
+    alarm(CHILD_ALARM_SECS);
+
+    /* nothing in our environment may point us at a server: we want the
+     * self-assigned identity of a do-not-connect tool, so that the only
+     * connection init makes is the rendezvous one */
+    unsetenv("PMIX_NAMESPACE");
+    unsetenv("PMIX_RANK");
+    unsetenv("PMIX_SERVER_URI");
+    unsetenv("PMIX_SERVER_URI2");
+    unsetenv("PMIX_SERVER_URI3");
+    unsetenv("PMIX_SERVER_URI21");
+    unsetenv("PMIX_SERVER_URI41");
+    unsetenv("PMIX_SERVER_URI51");
+
+    /* this is what a debugger sets before fork/exec'ing its launcher */
+    setenv("PMIX_LAUNCHER_RNDZ_URI", uri, 1);
+
+    PMIX_INFO_LOAD(&tinfo, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+    rc = PMIx_tool_init(&myproc, &tinfo, 1);
+    PMIX_INFO_DESTRUCT(&tinfo);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "  tool: PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    /* getting here at all is the point of the test: with the broken
+     * registration callback, init never returned */
+    alarm(0);
+    PMIX_LOAD_PROCID(&before, myproc.nspace, myproc.rank);
+
+    /* the rendezvous server must be on our list of known servers, and
+     * it must not be us */
+    rc = PMIx_tool_get_servers(&servers, &nservers);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "  tool: get_servers failed: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    found = false;
+    for (i = 0; i < nservers; i++) {
+        if (!PMIX_CHECK_PROCID(&servers[i], &before)) {
+            found = true;
+        }
+    }
+    if (!found) {
+        fprintf(stderr, "  tool: rendezvous server is not on the server list\n");
+        goto done;
+    }
+
+    /* the rendezvous block stores PMIX_PARENT_ID on the way through */
+    rc = PMIx_Get(&myproc, PMIX_PARENT_ID, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc || NULL == val || PMIX_PROC != val->type) {
+        fprintf(stderr, "  tool: PMIX_PARENT_ID was not stored: %s\n",
+                PMIx_Error_string(rc));
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+    }
+    if (NULL != servers) {
+        PMIX_PROC_FREE(servers, nservers);
+    }
+    /* let the parent know we made it all the way through init */
+    if (0 == ret && 1 != write(readyfd, &c, 1)) {
+        ret = 1;
+    }
+    if (PMIX_SUCCESS != PMIx_tool_finalize()) {
+        fprintf(stderr, "  tool: PMIx_tool_finalize failed\n");
+        ret = 1;
+    }
+    return ret;
+}
+
+/* ------------------------------------------------------------------ */
+
+static void opcbfunc(pmix_status_t status, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(status, cbdata);
+}
+
+/* wait up to usec for the fd to become readable. Returns 1 if it did */
+static int wait_readable(int fd, long usec)
+{
+    fd_set rd;
+    struct timeval tv;
+
+    FD_ZERO(&rd);
+    FD_SET(fd, &rd);
+    tv.tv_sec = usec / 1000000;
+    tv.tv_usec = usec % 1000000;
+    return (0 < select(fd + 1, &rd, NULL, NULL, &tv));
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_info_t sinfo[2];
+    char *uri;
+    int uripipe[2], readypipe[2];
+    pid_t child;
+    int status = 0, i;
+    bool flag = true, ready = false;
+    char c;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== tool launcher-rendezvous unit test ===\n\n");
+
+    if (0 != pipe(uripipe) || 0 != pipe(readypipe)) {
+        fprintf(stderr, "pipe() failed\n");
+        return 1;
+    }
+
+    /* fork before touching PMIx so neither side inherits an initialized
+     * library - a forked child of an initialized server has a copy of its
+     * state but none of its threads */
+    child = fork();
+    if (0 > child) {
+        fprintf(stderr, "fork() failed\n");
+        return 1;
+    }
+    if (0 == child) {
+        close(uripipe[1]);
+        close(readypipe[0]);
+        _exit(run_tool(uripipe[0], readypipe[1]));
+    }
+
+    close(uripipe[0]);
+    close(readypipe[1]);
+
+    PMIX_INFO_LOAD(&sinfo[0], PMIX_SERVER_TOOL_SUPPORT, &flag, PMIX_BOOL);
+    PMIX_INFO_LOAD(&sinfo[1], PMIX_SERVER_NSPACE, "tool-rndz-debugger", PMIX_STRING);
+    rc = PMIx_server_init(&mymodule, sinfo, 2);
+    PMIX_INFO_DESTRUCT(&sinfo[0]);
+    PMIX_INFO_DESTRUCT(&sinfo[1]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        goto reap;
+    }
+
+    /* hand the launcher our contact information. Read it straight off
+     * the listener - this test is white-box anyway */
+    uri = pmix_ptl_base.listener.uri;
+    if (NULL == uri) {
+        report("debugger published its URI", 0, "listener has no URI");
+        goto done;
+    }
+    report("debugger published its URI", 1, NULL);
+    if ((ssize_t) strlen(uri) != write(uripipe[1], uri, strlen(uri))) {
+        report("launcher received the URI", 0, "short write");
+        goto done;
+    }
+    close(uripipe[1]);
+    uripipe[1] = -1;
+
+    /* Fire the release until the launcher tells us it is through init.
+     * We cannot observe the moment its handler is registered from out
+     * here, and firing early is harmless: an event that arrives before
+     * any handler matches is cached and replayed when one registers. */
+    for (i = 0; i < PARENT_TRIES; i++) {
+        PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, &pmix_globals.myid, PMIX_RANGE_LOCAL,
+                          NULL, 0, opcbfunc, NULL);
+        if (wait_readable(readypipe[0], PARENT_WAIT_USEC)) {
+            if (1 == read(readypipe[0], &c, 1)) {
+                ready = true;
+            }
+            break;
+        }
+    }
+    report("launcher completed PMIx_tool_init after the debugger release", ready,
+           "init never returned - the rendezvous registration never woke it");
+
+done:
+    PMIx_server_finalize();
+
+reap:
+    if (0 <= uripipe[1]) {
+        close(uripipe[1]);
+    }
+    close(readypipe[0]);
+    if (!ready) {
+        /* it is wedged in init - do not leave it behind */
+        kill(child, SIGKILL);
+    }
+    waitpid(child, &status, 0);
+    if (!WIFEXITED(status) || 0 != WEXITSTATUS(status)) {
+        report("launcher checked its rendezvous state and finalized cleanly", 0,
+               "tool exited non-zero");
+    } else {
+        report("launcher checked its rendezvous state and finalized cleanly", 1, NULL);
+    }
+
+    fprintf(stdout, "\n%d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/tool_rndz.c
+++ b/test/unit/tool_rndz.c
@@ -117,8 +117,9 @@ static int run_tool(int urifd, int readyfd)
     ssize_t n;
     pmix_proc_t myproc, before, *servers = NULL;
     size_t nservers = 0, i;
-    pmix_info_t tinfo;
+    pmix_info_t tinfo[3];
     pmix_value_t *val = NULL;
+    pmix_rank_t trank;
     pmix_status_t rc;
     int ret = 1;
     bool found;
@@ -150,9 +151,22 @@ static int run_tool(int urifd, int readyfd)
     /* this is what a debugger sets before fork/exec'ing its launcher */
     setenv("PMIX_LAUNCHER_RNDZ_URI", uri, 1);
 
-    PMIX_INFO_LOAD(&tinfo, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
-    rc = PMIx_tool_init(&myproc, &tinfo, 1);
-    PMIX_INFO_DESTRUCT(&tinfo);
+    /* Come up with an identity of our own as well as DO_NOT_CONNECT.
+     * That combination is deliberate: it is the one case where the
+     * stand-in peer "myserver" points at is left with no name at all
+     * (init only fills one in when the caller supplied none), and the
+     * rendezvous block has to restore our primary server by name once the
+     * debugger releases us. An empty name is a wildcard to
+     * PMIX_CHECK_NSPACE, so getting this wrong leaves the debugger as our
+     * primary - which the connected check after init catches. */
+    PMIX_INFO_LOAD(&tinfo[0], PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&tinfo[1], PMIX_TOOL_NSPACE, "tool-rndz-launcher-self", PMIX_STRING);
+    trank = 0;
+    PMIX_INFO_LOAD(&tinfo[2], PMIX_TOOL_RANK, &trank, PMIX_PROC_RANK);
+    rc = PMIx_tool_init(&myproc, tinfo, 3);
+    PMIX_INFO_DESTRUCT(&tinfo[0]);
+    PMIX_INFO_DESTRUCT(&tinfo[1]);
+    PMIX_INFO_DESTRUCT(&tinfo[2]);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "  tool: PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
         return 1;
@@ -161,6 +175,15 @@ static int run_tool(int urifd, int readyfd)
      * registration callback, init never returned */
     alarm(0);
     PMIX_LOAD_PROCID(&before, myproc.nspace, myproc.rank);
+
+    /* the rendezvous block made the debugger our primary server and then
+     * had to put things back; we asked not to connect to anything, so
+     * "back" means back to ourselves */
+    if (PMIx_tool_is_connected()) {
+        fprintf(stderr, "  tool: the debugger is still our primary server - init did "
+                "not restore it\n");
+        goto done;
+    }
 
     /* the rendezvous server must be on our list of known servers, and
      * it must not be us */


### PR DESCRIPTION
A deep review of `src/tool`, run as repeated review-and-fix rounds until a
round found nothing. Twelve defects, the tests that hold them down, a
multi-node suite for the directory, and a refreshed `AGENTS.md`.

## The one that matters most

**`PMIx_tool_init` hung, and corrupted an object header on the way.**

The launcher-rendezvous block — `PMIX_LAUNCHER_RNDZ_URI`, which is how a
debugger drives a launcher it fork/exec'd — registers its
`PMIX_DEBUGGER_RELEASE` handler by hand-filling a `pmix_rshift_caddy_t` and
blocking on that caddy's lock. The registration machinery acknowledges with
`cd->evregcbfn(status, index, cd->cbdata)`, and the one call site sets
`cd->cbdata` to the caddy itself. `evhandler_reg_callbk` nonetheless cast it
to a `pmix_lock_t`, which

- wrote the status over the head of the object (a `pmix_lock_t` leads with
  its status field, a `pmix_object_t` with its class pointer and magic id)
  and took a "mutex" that was really the rest of that header, and
- left the caddy's real lock — the one init blocks on — untouched, so init
  never came back.

`src/client` (via `mycbfn`) and `src/server` both had this right; only
`src/tool` did not. `test/unit/tool_rndz` drives the whole flow against a
real server; against the unfixed library it aborts on the object magic-id
assert and then hangs.

## The rest

**Correctness**

- `pmix_tool_retry_set` marked us *connected* when switching the primary back
  to ourselves — the state `disc()` marks as disconnected. Finalize then sent
  its handshake to our own already-finalized peer, got `PMIX_ERR_UNREACH`,
  and returned it **before any teardown ran at all**. Finalize no longer
  abandons the teardown on a failed handshake: by that point it has dropped
  the `initialized` flag and the one-time-init latch, so a caller that saw an
  error could neither retry nor finalize again.
- `PMIX_WAIT_FOR_CONNECTION` never waited. The retry budget was loaded
  straight from `PMIX_TIMEOUT`, so an absent or zero timeout — which the
  Standard defines as "never time out" — expired on the first retry, and the
  expiry was reported as `PMIX_ERR_NOT_FOUND` rather than the documented
  `PMIX_ERR_TIMEOUT`.
- `PMIx_tool_get_servers` reported an unconnected tool as its own server,
  where the Standard requires `PMIX_ERR_UNREACH`. Init no longer caches the
  self stand-in peer in the clients array — where its NULL nspace also made
  it a **wildcard** match for `disc()` and `set_server`, since
  `PMIX_CHECK_NSPACE` treats an unnamed nspace as matching everything.
- The rendezvous block restored the wrong primary server for a tool that came
  up with `PMIX_TOOL_DO_NOT_CONNECT` *and* its own
  `PMIX_TOOL_NSPACE`/`PMIX_TOOL_RANK`: same wildcard, so the restore matched
  the debugger and the launcher silently carried on with the debugger as its
  primary.
- The SIGCONT handler for forwarded stdin was never installed —
  `pmix_event_signal_set` is `event_assign`, not `event_add` — so a tool
  backgrounded and then resumed never reconsidered its stdin.
- A late finalize reply woke an already-destroyed lock: the five-second guard
  timer clears `tev.active` and finalize destructs the lock, but
  `finwait_cbfunc` woke it unconditionally. `src/client`'s identically-shaped
  callback guards on the flag.
- `PMIx_Get` of our own `PMIX_PROCID`/`PMIX_RANK` under
  `PMIX_GET_POINTER_VALUES` returned garbage — the tool never populated
  `pmix_globals.myidval`/`myrankval`. `pmix_tool_init_info` also stored
  `PMIX_RANK` as a `PMIX_INT`; it is a `pmix_rank_t`.
- `PMIx_tool_set_server_module` was refused on every cycle after the first,
  because nothing resets `pmix_server_globals.module_set` — while init had
  already zeroed the table it would be called through.
- `PMIX_TOOL_NSPACE`, `PMIX_SERVER_TMPDIR` and `PMIX_SYSTEM_TMPDIR` went
  straight to `strdup()`, so an application supplying the key with the wrong
  type segfaulted the library.

**Leaks** — the URI `connect_to_peer` returns when the new server is not
made primary; `tool_switchyard`'s shift caddy and the peer reference it
holds on a failed payload copy; the rendezvous caddy's three directives
(`infocopy` was never set); a duplicate `myserver->info` on both self-assign
paths; every `pmix_tool_init_info` error path; and none of init's file-scope
events were ever taken down, so the keepalive pipe leaked a descriptor per
init/finalize cycle.

## Consistency: relay if attached, fork/exec if not

`PMIx_Spawn` has always applied that rule to a launcher's own requests. A
spawn **proxied for a downstream tool** did not: `pmix_tool_relay_op` answers
`PMIX_ERR_UNREACH` when we have no server, `server_switchyard` fell through
to the logic tree only on `PMIX_ERR_NOT_SUPPORTED`, and the downstream tool
got an error instead of a launched job — even though the receiving launcher
had `pfexec` open and could have run it.

The switchyard now falls through on both statuses, and `pmix_server_spawn`
fork/execs when it has no `pmix_host_server.spawn` but `pfexec` is open. Two
things make that gate safe: `pmix_pfexec_base_open()` is called from exactly
one place in the tree (`PMIx_tool_init`, for a launcher or scheduler), so
`pmix_pfexec_globals.initialized` really is the "can I fork/exec" question
and a plain PMIx server is unaffected; and `pmix_tool_relay_op` returns both
statuses **before** it rewinds the buffer, so the fall-through keeps the
unpack position the `cmd` read left.

## Tests

`make check` goes from 55 to 59 unit programs. Each new one was verified by
reverting its fix and watching it fail:

| Program | Holds down |
|---------|-----------|
| `tool_rndz` | the whole rendezvous flow against a real server, plus the primary-server restore |
| `tool_api` | identity values, wait/timeout semantics, the server list of an unconnected tool, malformed directives (in forked children — a failed `PMIx_tool_init` cannot be followed by a good one in the same process), and a second full cycle that sets a server module again |
| `tool_relay` | a downstream tool's spawn at a launcher with no server: the relay declines, the switchyard falls through, the launcher fork/execs it. The first automated coverage `pmix_tool_ops.c` has ever had |
| `tool_evcache` | the affected-process restriction on events delivered to a tool, end to end with two handlers |
| `tool_cycle` | gains a `PMIX_FWD_STDIN` pass asserting the library did not close the caller's stdin |
| `test/simple/tool_server_switch` | gains the timeout and empty-server-list assertions |

New `contrib/dockerswarm/run-tool-tests.sh` (README §20) puts the tool and at
least one of its servers on **different nodes**: `examples/toolswitch.c`
through attach/switch/disconnect across hosts, a remote server dying, IOF
relayed to a tool from other nodes, and the only valgrind pass `src/tool`
gets anywhere. Both DVMs start with `PRTE_MCA_pmix_remote_connections=1` — a
PMIx server binds loopback unless remote connections were asked for, and a
loopback URI is unreachable from another node by construction, so without it
every cross-node stage skips itself and the suite proves nothing.

## Honest about what is not covered

- The **forward-to-a-real-server** arm of `pmix_tool_ops.c` still has no
  coverage anywhere; PRRTE's launchers do not arrange that shape.
- One fix is consistency, not a repair: `pmix_tool_notify_recv` now stores
  the unpacked range on the chain and runs `pmix_prep_event_chain`, matching
  the client. Those fields feed the *cached*-event branch, and I could not
  construct a case that reaches it, because the server filters on registered
  codes and affected procs before forwarding. Whether that branch is
  reachable at all — `src/client` has no equivalent — is
  openpmix#4101.
- The same missing `pmix_event_add` (and an unreleased `stdinev_global`)
  exists in `src/common/pmix_iof.c`; fixing it properly needs a teardown hook
  in that layer that this review did not design. openpmix#4100.

## Verification

`make check` clean (59 unit programs plus the rest of the tree). Warning-free
under `--enable-devel-check`. Because this also touches `src/server`, both
swarm suites were re-run against a rebuilt volume: `run-tool-tests.sh` 10/10
and `run-server-tests.sh` 14/14, with both valgrind stages clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
