### PR TITLE
Fix silent IOF output loss, a progress-thread deadlock, and consolidate stdin forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,6 +295,7 @@ test/unit/rndz_stale
 test/unit/singleton_register
 test/unit/iof_pattern
 test/unit/iof_flow
+test/unit/iof_output
 test/unit/proc_array_id
 test/unit/get_perf
 test/unit/ptl_uri

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -99,8 +99,18 @@ Note the vestigial remnants that are *not* the mechanism:
 used) and were inherited from ORTE. Don't reason about flow control from
 them.
 
-Three more things about the stdin side that are easy to get wrong:
+Four more things about the stdin side that are easy to get wrong:
 
+- **There is exactly one read event on our stdin, and
+  `pmix_iof_setup_stdin_read()` is the only thing that builds it.** Both
+  roles that forward their own stdin go through it — `PMIx_IOF_push` with
+  `PMIX_IOF_PUSH_STDIN`, and a tool given `PMIX_FWD_STDIN` at init — and
+  a second call once the stream is running is a no-op. That is not tidying:
+  `src/tool/pmix_tool.c` used to keep a read event of its own, so a tool
+  told to forward stdin at init and then handed a `PMIX_IOF_PUSH_STDIN`
+  ended up with two read events on fd 0 stealing bytes from each other,
+  and `pmix_iof_flow_control` — which only knows `stdinev_global` — could
+  not suspend a tool's stdin at all.
 - **The SIGCONT event belongs on `evbase`, and it has to be *added*.**
   Its handler is `pmix_iof_stdin_cb`, which resolves `stdinev_global` and
   arms or disarms that read event — all state `evbase` owns — so putting
@@ -116,11 +126,13 @@ Three more things about the stdin side that are easy to get wrong:
   the delete would be the use-after-free it exists to prevent. Note the
   second-init hazard this closes: a stale `stdinev_global` names an event
   registered on a base the previous cycle tore down.
-- **A tool does not use `stdinev_global`.** `src/tool/pmix_tool.c` builds
-  its own file-scope `stdinev`, so in a tool the global stays NULL and
-  `pmix_iof_flow_control` finds nothing of its own to suspend — it can
-  still relay to peers, but it cannot throttle the tool's own stdin. The
-  tool's copy also carries the un-added-`stdinsig` bug described above.
+- **stdin is the application's descriptor, not ours.** The read-event
+  destructor closes only fds above 2, exactly as the write-event
+  destructor does. A read event on a pfexec child's pipe is ours to
+  close; fd 0 is not, and closing it at finalize takes the caller's stdin
+  away. `test/unit/tool_cycle.c` puts a pipe on fd 0, cycles a tool with
+  `PMIX_FWD_STDIN`, and fails on the first cycle if the descriptor is
+  closed or is no longer the same pipe.
 
 ### Output delivery and the end of a stream (`pmix_iof.c`)
 

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -179,22 +179,66 @@ Two related facts worth knowing before you touch that code:
   per source, so this is the obvious thing to cache if detailed tagging
   ever shows up in a profile.
 
-### `process_cache()` cannot forward anything
+### An IOF request a process registers on *itself* has no delivery path
 
-`process_cache()` — and therefore the one-second `delayed_process_cache`
-timer that the blocking form of `PMIx_IOF_pull` arms — is dead in
-practice, and knowing that is worth more than the code. The only requests
-that reach it are the ones `PMIx_IOF_pull` built in this process, and it
-sets `req->requestor` **only** when we are our own server; the requestor
-is then ourselves, so the function's own "never forward to myself" test
-skips every cached entry. A request with no requestor returns at the top.
+`pmix_globals.iof_requests` holds two kinds of entry that look alike and
+are delivered in completely different ways. Knowing which is which is the
+whole of understanding this code:
 
-So cached IO is never delivered to a locally-registered pull. Such a
-request is served through `req->cbfunc` when IO arrives, and the cache has
-no path to that callback. Settle what the right delivery is before making
-this live — and note that the message it builds must carry
-`req->remote_id`, the id *the requestor* knows the request by, not
-`req->local_id`, which indexes our own array.
+- **Registered by a remote peer**, in `pmix_server_ops.c`'s
+  `PMIX_IOF_PULL_CMD` handler. `req->requestor` is that peer, and
+  delivery means packing a message and sending it —
+  `pmix_iof_process_iof()` is the only thing that does this.
+- **Registered by this process**, through its own `PMIx_IOF_pull`.
+  Delivery means invoking `req->cbfunc`.
+
+The second kind only works when the registration was **forwarded
+upstream**. `req->cbfunc` is invoked from exactly three places — the
+`PMIX_PTL_TAG_IOF` receive handlers in `pmix_server.c`, `pmix_client.c`
+and `pmix_tool.c` — and every one of them fires only when a message
+arrives on a socket. A client or tool with a server above it gets that:
+`myreg()` sees a NULL `requestor`, sends `PMIX_IOF_PULL_CMD` upstream, and
+the server later sends matching output back down.
+
+**A process that is its own server does not.** `PMIx_IOF_pull` sets
+`req->requestor = pmix_globals.mypeer` in that case, and from there:
+`pmix_iof_process_iof()` refuses it at its "never forward to myself" test,
+so the live path skips it; and there is no upstream, so no message ever
+arrives and `req->cbfunc` is never called. The registration is inert. The
+output still reaches the terminal, because `_iofdeliver` calls
+`pmix_iof_write_output()` before it walks the request array — but nothing
+is ever handed to the callback the caller registered.
+
+This is a gap, not a regression: it looks like a feature that was started
+and not finished. `requestor` is still load-bearing on that path, though —
+it is what tells `myreg()` not to send a registration upstream to itself.
+
+**None of this affects a peer that registers with us**, which is the case
+that actually matters and which works. Cached output in
+`pmix_server_globals.iof` is delivered to a newly-registered *remote*
+requestor from two places, both through `pmix_iof_process_iof()`:
+
+- `pmix_server_process_iof()` (`src/server/pmix_server_ops.c`) — the
+  spawn-time, per-namespace registration.
+- `_iofreg()` (`src/server/pmix_server.c`) — the completion of a tool's
+  `PMIx_IOF_pull` arriving over the wire. Note *where* it scans: after
+  `PMIX_SERVER_QUEUE_REPLY` has sent the refid back, so the tool cannot
+  be handed IO for a handler id it has not been told yet. Ordering, not a
+  timer, is what solves that.
+
+A third copy of this used to live here as `process_cache()`, reached only
+from `myreg()` and a one-second `delayed_process_cache` timer that the
+blocking `PMIx_IOF_pull` armed. Both only ever carry requests *this*
+process registered, so its own "never forward to myself" test rejected
+every entry and it had never once run. Being unreachable is also how it
+drifted out of step with its twin: it packed `req->local_id` where the
+identical message for the identical receiver needs `req->remote_id` — the
+id *the requestor* knows the request by, not our index into our own
+array. It and the timer are gone. If local delivery is ever wanted, it
+needs a design decision first — what invokes the callback, and whether
+the cache entry is consumed when it does — not a revival of that
+function, whose message-packing shape is wrong for a request that needs a
+callback rather than a socket write.
 
 ### Output-file naming lives here (`pmix_iof.c`)
 

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -99,6 +99,91 @@ Note the vestigial remnants that are *not* the mechanism:
 used) and were inherited from ORTE. Don't reason about flow control from
 them.
 
+Three more things about the stdin side that are easy to get wrong:
+
+- **The SIGCONT event belongs on `evbase`, and it has to be *added*.**
+  Its handler is `pmix_iof_stdin_cb`, which resolves `stdinev_global` and
+  arms or disarms that read event — all state `evbase` owns — so putting
+  the signal on `evauxbase` (which a host may supply as a *different*
+  thread) races the progress thread. And `pmix_event_signal_set` only
+  *assigns* an event; without a matching `pmix_event_add` the handler
+  never runs, which is how a tool started in the background can end up
+  never reading stdin at all after it is foregrounded.
+- **`stdinev_global` and `stdinsig_ev` are process-wide, not per
+  request**, so nothing in the request machinery ever gives them back.
+  `pmix_iof_finalize()` does, and `pmix_rte_finalize` calls it **while
+  the event base is still standing** — after `pmix_progress_thread_stop`
+  the delete would be the use-after-free it exists to prevent. Note the
+  second-init hazard this closes: a stale `stdinev_global` names an event
+  registered on a base the previous cycle tore down.
+- **A tool does not use `stdinev_global`.** `src/tool/pmix_tool.c` builds
+  its own file-scope `stdinev`, so in a tool the global stays NULL and
+  `pmix_iof_flow_control` finds nothing of its own to suspend — it can
+  still relay to peers, but it cannot throttle the tool's own stdin. The
+  tool's copy also carries the un-added-`stdinsig` bug described above.
+
+### Output delivery and the end of a stream (`pmix_iof.c`)
+
+Output arrives at `pmix_iof_write_output()` one `pmix_byte_object_t` at a
+time and leaves through a `pmix_iof_write_event_t` ("the channel"). Three
+invariants govern that path, and all three have been broken in ways that
+lose the user's output *silently*.
+
+- **A zero-byte delivery is an end-of-stream marker, and what it means
+  depends on the sink.** A sink this library opened for one source
+  (`pmix_iof_setup`, fd > 2) is finished: close it and stop, leaving
+  `wev.pending` set so nothing re-arms the event on a descriptor that is
+  gone. The **shared** `pmix_client_globals.iof_stdout` / `iof_stderr`
+  sinks (fd 1 and 2) are fed by *every* source, so one source closing
+  must not stop them — skip the marker and keep draining. Getting this
+  wrong is invisible in testing and total in effect: `wev.pending` stays
+  set with the event un-armed, `write_output_line` only arms the event
+  when `pending` is clear, and every later chunk from every other source
+  sits in the queue until finalize.
+- **`pending` is the arm/disarm interlock, not a status bit.** Any path
+  that returns from `pmix_iof_write_handler` without clearing it is
+  asserting "this channel is done forever".
+- **A stream's last, unterminated line is written when the stream
+  closes.** Non-raw output is split on `'\n'` and the tail is parked on
+  `pmix_server_globals.iof_residuals` until the rest of the line arrives.
+  The zero-byte marker is the last chance to write it, so
+  `pmix_iof_write_output` flushes the matching residual before passing
+  the marker along. Do not rely on the sweeps for this: a server's
+  `pmix_iof_flush_residuals()` at `PMIx_server_finalize` prints it late
+  and out of order, and a client or tool never sweeps that list at all
+  (`iof_sink_destruct` gates `flush_sink_residuals` on being a server).
+
+Two related facts worth knowing before you touch that code:
+
+- `pmix_server_globals.iof_residuals` is **statically initialized**
+  (`PMIX_LIST_STATIC_INIT` in `pmix_server.c`), which is why every role
+  may append to it without a server ever having been initialized.
+- A residual grows without bound for a source that never emits a newline,
+  and each new chunk copies the whole accumulation. That is inherent to
+  "buffer until the line completes"; it is not currently capped.
+- `PMIX_IOF_TAG_DETAILED_OUTPUT` costs **two GDS fetches per line of
+  output** — `pmix_iof_prep_output` looks the source's `PMIX_HOSTNAME`
+  and `PMIX_PROC_PID` up every time it formats one. Both are immutable
+  per source, so this is the obvious thing to cache if detailed tagging
+  ever shows up in a profile.
+
+### `process_cache()` cannot forward anything
+
+`process_cache()` — and therefore the one-second `delayed_process_cache`
+timer that the blocking form of `PMIx_IOF_pull` arms — is dead in
+practice, and knowing that is worth more than the code. The only requests
+that reach it are the ones `PMIx_IOF_pull` built in this process, and it
+sets `req->requestor` **only** when we are our own server; the requestor
+is then ourselves, so the function's own "never forward to myself" test
+skips every cached entry. A request with no requestor returns at the top.
+
+So cached IO is never delivered to a locally-registered pull. Such a
+request is served through `req->cbfunc` when IO arrives, and the cache has
+no path to that callback. Settle what the right delivery is before making
+this live — and note that the message it builds must carry
+`req->remote_id`, the id *the requestor* knows the request by, not
+`req->local_id`, which indexes our own array.
+
 ### Output-file naming lives here (`pmix_iof.c`)
 
 `pmix_iof_setup()` is what opens the per-process output sinks, and it is
@@ -249,7 +334,23 @@ add or edit an entry point:
    a request to `pmix_host_server.*`, the return value decides who
    completes it: `PMIX_SUCCESS` means the host will, anything else
    (including `PMIX_OPERATION_SUCCEEDED`) means you must.
-10. **Caddy fields you did not set are garbage, not zero.** `PMIX_NEW`
+10. **Nothing in here may enter the blocking form of a public API.**
+   This is the top-level "back-end code must never call a `PMIx_*` that
+   thread-shifts" rule, and it has two distinct faces in this directory.
+   *Inside the library*: `PMIx_Notify_event` with a **NULL cbfunc** is
+   its blocking form — it posts a caddy to the progress thread and then
+   `PMIX_WAIT_THREAD`s on it. Every recv callback and every threadshift
+   handler here already runs on that thread, so the caddy can never fire
+   and the progress thread is dead for the life of the process. Pass a
+   do-nothing completion instead; `pmix_pfexec.c` and `psensor/file` are
+   the reference. *At the entry points*: a **host** can call a blocking
+   `PMIx_*` from inside a PMIx callback, which is the same deadlock from
+   the other side. Guard every blocking path with
+   `pmix_progress_thread_check_blocking("<api name>")` and return
+   `PMIX_ERR_WOULD_BLOCK` — a tool that deregisters from inside its own
+   IOF delivery callback is doing exactly this, and the guard turns a
+   permanent hang into a diagnostic.
+11. **Caddy fields you did not set are garbage, not zero.** `PMIX_NEW`
    allocates with `malloc`, so every field a constructor skips starts as
    whatever was on the heap. `scon()`/`qcon()` did not initialize
    `status`, and `chcon()` in `pmix_pfexec.c` did not initialize
@@ -348,6 +449,18 @@ Two suites cover this directory specifically, and they split the same way
   the IOF flag parser and XML escaper, and `PMIx_Register_attributes`.
   Several of its cases segfault against an unfixed library rather than
   merely failing — which is the point.
+- [`test/unit/iof_output.c`](../../test/unit/iof_output.c) — the IOF
+  output path, driven by standing a pipe up in place of stdout and
+  stderr and handing the library output through
+  `PMIx_server_IOF_deliver`. It covers the end-of-stream invariants
+  above: that a zero-byte marker from one source does not silence the
+  shared channel for every other source, and that a last line with no
+  newline is written when the stream closes. Both failures are silent
+  against an unfixed library — the output simply never appears — so the
+  test asserts on bytes read back out of the pipe, not on return codes.
+- [`test/unit/iof_flow.c`](../../test/unit/iof_flow.c) — the stdin half:
+  XOFF stops the reading, XON restarts it, nothing is lost across a
+  suspension. See the flow-control rules above.
 - [`contrib/dockerswarm/run-common-tests.sh`](../../contrib/dockerswarm/run-common-tests.sh)
   — the connected half. Query/log/job-control/allocation/monitor/IOF with
   the ranks behind *different* PMIx servers. The monitor cases are the

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -272,7 +272,7 @@ static void myreg(int sd, short args, void *cbdata)
 
     if (NULL != req->requestor) {
         // local request as we are a server
-        /* if there is a regsitration callback function, call it */
+        /* if there is a registration callback function, call it */
         if (NULL != req->regcbfunc) {
             req->regcbfunc(req->status, req->local_id, req->cbdata);
             // process any cached IO
@@ -1640,7 +1640,7 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
                  * the pointer, so the kval has to carry a value at all */
                 if (NULL != kv && NULL != kv->value &&
                     PMIX_SUCCESS == PMIx_Value_get_number(kv->value, &pid, PMIX_PID)) {
-                    pmix_asprintf(&pidstring, "%u", pid);
+                    pmix_asprintf(&pidstring, "%u", (unsigned int) pid);
                 } else {
                     pidstring = strdup("unknown");
                 }
@@ -1741,7 +1741,7 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
                 /* see the note on the xml form of this above */
                 if (NULL != kv && NULL != kv->value &&
                     PMIX_SUCCESS == PMIx_Value_get_number(kv->value, &pid, PMIX_PID)) {
-                    pmix_asprintf(&pidstring, "%u", pid);
+                    pmix_asprintf(&pidstring, "%u", (unsigned int) pid);
                 } else {
                     pidstring = strdup("unknown");
                 }
@@ -1978,7 +1978,7 @@ process:
     /* add this data to the write list for this fd */
     pmix_list_append(&channel->outputs, &output->super);
 
-    if (copystdout){
+    if (copystdout) {
         copy = PMIX_NEW(pmix_iof_write_output_t);
         copy->data = (char *) malloc(output->numbytes);
         memcpy(copy->data, output->data, output->numbytes);
@@ -1988,7 +1988,7 @@ process:
             PMIX_IOF_SINK_ACTIVATE(&pmix_client_globals.iof_stdout.wev);
         }
     }
-    if (copystderr){
+    if (copystderr) {
         copy = PMIX_NEW(pmix_iof_write_output_t);
         copy->data = (char *) malloc(output->numbytes);
         memcpy(copy->data, output->data, output->numbytes);
@@ -2190,10 +2190,9 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
         if (PMIX_FWD_STDOUT_CHANNEL & stream) {
             channel = &pmix_client_globals.iof_stdout.wev;
         } else {
-            if(!myflags.merge) {
+            if (!myflags.merge) {
                 channel = &pmix_client_globals.iof_stderr.wev;
-            }
-            else {
+            } else {
                 channel = &pmix_client_globals.iof_stdout.wev;
             }
         }
@@ -2309,14 +2308,14 @@ static void flush_sink_residuals(pmix_iof_sink_t *sink)
     pmix_list_t *residuals = &pmix_server_globals.iof_residuals;
 
     PMIX_LIST_FOREACH_SAFE(res, next, residuals, pmix_iof_residual_t) {
-        if(res->channel != &sink->wev){
+        if (res->channel != &sink->wev) {
             continue;
         }
-        if(PMIX_SUCCESS == rc){
+        if (PMIX_SUCCESS == rc) {
             rc = write_output_line(&res->name, res->channel, &res->flags,
                                    res->stream, res->copystdout,
                                    res->copystderr, &res->bo);
-            if(PMIX_SUCCESS != rc) {
+            if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
             }
         }
@@ -2813,6 +2812,7 @@ void pmix_iof_read_local_handler(int sd, short args, void *cbdata)
     pmix_iof_push_caddy_t *cd;
     int fd;
     pmix_pfexec_child_t *child = (pmix_pfexec_child_t *) rev->childproc;
+    pmix_pfexec_child_t *tgt;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(rev);
@@ -2885,11 +2885,16 @@ void pmix_iof_read_local_handler(int sd, short args, void *cbdata)
      * anything else */
     if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
         if (rev == stdinev_global && NULL != rev->targets) {
-            PMIX_LIST_FOREACH(child, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
-                if (PMIX_CHECK_PROCID(&child->proc, &rev->targets[0])) {
+            /* a separate variable: "child" is this read event's own
+             * child, and the code above still means it */
+            PMIX_LIST_FOREACH(tgt, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
+                if (PMIX_CHECK_PROCID(&tgt->proc, &rev->targets[0])) {
                     /* send the input to that target */
-                    rc = write_output_line(&child->proc, &child->stdinsink.wev, NULL,
+                    rc = write_output_line(&tgt->proc, &tgt->stdinsink.wev, NULL,
                                            PMIX_FWD_STDIN_CHANNEL, false, false, &bo);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                    }
                     goto reactivate;
                 }
             }

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -656,6 +656,100 @@ void pmix_iof_finalize(void)
     }
 }
 
+/* Start reading our own stdin into stdinev_global, arming the SIGCONT
+ * handler when we are looking at a terminal.
+ *
+ * Both of the roles that forward their own stdin come through here:
+ * PMIx_IOF_push with PMIX_IOF_PUSH_STDIN, and a tool told PMIX_FWD_STDIN
+ * at init. They used to keep a copy each and the copies drifted - the
+ * tool's never added its SIGCONT event (so a backgrounded tool never
+ * resumed reading), never gave its read event back, and kept it in a
+ * file-scope struct of its own that pmix_iof_flow_control cannot see, so
+ * nothing could suspend a tool's stdin. Sharing stdinev_global also
+ * enforces the thing that matters in its own right: one read event per
+ * descriptor. Two of them on fd 0 steal bytes from each other.
+ */
+pmix_status_t pmix_iof_setup_stdin_read(int fd, pmix_proc_t procs[], size_t nprocs,
+                                        pmix_info_t directives[], size_t ndirs)
+{
+    int flags;
+
+    if (NULL != stdinev_global) {
+        /* we are already reading it - see above */
+        return PMIX_SUCCESS;
+    }
+    pmix_globals.pushstdin = true;
+
+    /* We don't want to set nonblocking on our
+     * stdio stream.  If we do so, we set the file descriptor to
+     * non-blocking for everyone that has that file descriptor, which
+     * includes everyone else in our shell pipeline chain.  (See
+     * http://lists.freebsd.org/pipermail/freebsd-hackers/2005-January/009742.html).
+     * This causes things like "prun -np 1 big_app | cat" to lose
+     * output, because cat's stdout is then ALSO non-blocking and cat
+     * isn't built to deal with that case (same with almost all other
+     * unix text utils).
+     */
+    if (0 != fd) {
+        if ((flags = fcntl(fd, F_GETFL, 0)) < 0) {
+            pmix_output(pmix_client_globals.iof_output,
+                        "[%s:%d]: fcntl(F_GETFL) failed with errno=%d\n",
+                        __FILE__, __LINE__, errno);
+        } else {
+            flags |= O_NONBLOCK;
+            if (0 != fcntl(fd, F_SETFL, flags)) {
+                pmix_output(pmix_client_globals.iof_output,
+                            "[%s:%d]: fcntl(F_SETFL) failed with errno=%d\n",
+                            __FILE__, __LINE__, errno);
+            }
+        }
+    }
+
+    if (isatty(fd)) {
+        /* We should avoid trying to read from stdin if we
+         * have a terminal, but are backgrounded.  Catch the
+         * signals that are commonly used when we switch
+         * between being backgrounded and not.  If the
+         * filedescriptor is not a tty, don't worry about it
+         * and always stay connected.
+         *
+         * The handler resolves and manipulates stdinev_global and its
+         * libevent registration, both of which belong to evbase - so the
+         * signal event goes there too rather than on evauxbase, which a
+         * host may have supplied as a separate thread. And it has to be
+         * *added*: setting a signal event only assigns it.
+         */
+        pmix_event_signal_set(pmix_globals.evbase, &stdinsig_ev, SIGCONT,
+                              pmix_iof_stdin_cb, NULL);
+        if (0 == pmix_event_add(&stdinsig_ev, NULL)) {
+            stdinsig_active = true;
+        }
+
+        /* setup a read event to read stdin, but don't activate it yet. The
+         * dst_name indicates who should receive the stdin. If that recipient
+         * doesn't do a corresponding pull, however, then the stdin will
+         * be dropped upon receipt at the local daemon
+         */
+        PMIX_IOF_READ_EVENT(&stdinev_global, procs, nprocs, directives, ndirs, fd,
+                            pmix_iof_read_local_handler, false);
+
+        /* check to see if we want the stdin read event to be
+         * active - we will always at least define the event,
+         * but may delay its activation
+         */
+        if (pmix_iof_stdin_check(fd)) {
+            PMIX_IOF_READ_ACTIVATE(stdinev_global);
+        }
+    } else {
+        /* if we are not looking at a tty, just setup a read event
+         * and activate it
+         */
+        PMIX_IOF_READ_EVENT(&stdinev_global, procs, nprocs, directives, ndirs, fd,
+                            pmix_iof_read_local_handler, true);
+    }
+    return PMIX_SUCCESS;
+}
+
 static void stdincbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata)
 {
@@ -713,7 +807,7 @@ static void exec_push(int sd, short args, void *cbdata)
     pmix_status_t rc = PMIX_SUCCESS;
     size_t n;
     bool begincollecting, stopcollecting;
-    int flags, fd = fileno(stdin);
+    int fd = fileno(stdin);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (NULL == cb->bo) {
@@ -727,76 +821,8 @@ static void exec_push(int sd, short args, void *cbdata)
                     /* add these targets to our list */
                     if (!pmix_globals.pushstdin) {
                         /* not already collecting, so start */
-                        pmix_globals.pushstdin = true;
-                        /* We don't want to set nonblocking on our
-                         * stdio stream.  If we do so, we set the file descriptor to
-                         * non-blocking for everyone that has that file descriptor, which
-                         * includes everyone else in our shell pipeline chain.  (See
-                         * http://lists.freebsd.org/pipermail/freebsd-hackers/2005-January/009742.html).
-                         * This causes things like "prun -np 1 big_app | cat" to lose
-                         * output, because cat's stdout is then ALSO non-blocking and cat
-                         * isn't built to deal with that case (same with almost all other
-                         * unix text utils).
-                         */
-                        if (0 != fd) {
-                            if ((flags = fcntl(fd, F_GETFL, 0)) < 0) {
-                                pmix_output(pmix_client_globals.iof_output,
-                                            "[%s:%d]: fcntl(F_GETFL) failed with errno=%d\n",
-                                            __FILE__, __LINE__, errno);
-                            } else {
-                                flags |= O_NONBLOCK;
-                                if (0 != fcntl(fd, F_SETFL, flags)) {
-                                    pmix_output(pmix_client_globals.iof_output,
-                                                "[%s:%d]: fcntl(F_SETFL) failed with errno=%d\n",
-                                                __FILE__, __LINE__, errno);
-                                }
-                            }
-                        }
-                        if (isatty(fd)) {
-                            /* We should avoid trying to read from stdin if we
-                             * have a terminal, but are backgrounded.  Catch the
-                             * signals that are commonly used when we switch
-                             * between being backgrounded and not.  If the
-                             * filedescriptor is not a tty, don't worry about it
-                             * and always stay connected.
-                             */
-                            /* the handler resolves and manipulates
-                             * stdinev_global and its libevent registration,
-                             * both of which belong to evbase - so the signal
-                             * event goes there too rather than on evauxbase,
-                             * which a host may have supplied as a separate
-                             * thread. And it has to be *added*: setting a
-                             * signal event only assigns it, so without this
-                             * a tool started in the background never resumes
-                             * reading stdin when it is foregrounded */
-                            pmix_event_signal_set(pmix_globals.evbase, &stdinsig_ev, SIGCONT,
-                                                  pmix_iof_stdin_cb, NULL);
-                            if (0 == pmix_event_add(&stdinsig_ev, NULL)) {
-                                stdinsig_active = true;
-                            }
-
-                            /* setup a read event to read stdin, but don't activate it yet. The
-                             * dst_name indicates who should receive the stdin. If that recipient
-                             * doesn't do a corresponding pull, however, then the stdin will
-                             * be dropped upon receipt at the local daemon
-                             */
-                            PMIX_IOF_READ_EVENT(&stdinev_global, cb->procs, cb->nprocs, cb->directives,
-                                                cb->ndirs, fd, pmix_iof_read_local_handler, false);
-
-                            /* check to see if we want the stdin read event to be
-                             * active - we will always at least define the event,
-                             * but may delay its activation
-                             */
-                            if (pmix_iof_stdin_check(fd)) {
-                                PMIX_IOF_READ_ACTIVATE(stdinev_global);
-                            }
-                        } else {
-                            /* if we are not looking at a tty, just setup a read event
-                             * and activate it
-                             */
-                            PMIX_IOF_READ_EVENT(&stdinev_global, cb->procs, cb->nprocs, cb->directives,
-                                                cb->ndirs, fd, pmix_iof_read_local_handler, true);
-                        }
+                        pmix_iof_setup_stdin_read(fd, cb->procs, cb->nprocs,
+                                                  cb->directives, cb->ndirs);
                     }
                 } else {
                     if (pmix_globals.pushstdin) {

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -35,6 +35,7 @@
 #include "src/common/pmix_pfexec.h"
 #include "src/mca/ptl/ptl.h"
 #include "src/mca/ptl/base/base.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_basename.h"
@@ -132,6 +133,23 @@ static void process_cache(int sd, short args, void *cbdata)
     if (NULL == req->requestor) {
         return;
     }
+    /* and nothing to forward to a peer that has no identity yet or has
+     * already gone - the same two screens pmix_iof_process_iof applies
+     * before it reaches into requestor->info */
+    if (NULL == req->requestor->info || req->requestor->finalized) {
+        return;
+    }
+
+    /* NOTE: the forwarding below is currently unreachable, and knowing
+     * that is worth more than the code. The only requests that get here
+     * are the ones PMIx_IOF_pull built in this process, and it sets
+     * requestor only when we are our own server - in which case the
+     * requestor IS us, so the "never forward to myself" test below skips
+     * every entry. A request with no requestor returned above. So the
+     * delayed cache scan the blocking form of PMIx_IOF_pull arms delivers
+     * nothing: such a request is served through req->cbfunc when the IO
+     * arrives, and cached IO has no path to that callback. Settle what
+     * the right delivery is before making this live. */
 
     PMIX_LIST_FOREACH_SAFE (iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
         /* if the channels don't match, then ignore it */
@@ -175,8 +193,15 @@ static void process_cache(int sd, short args, void *cbdata)
                 PMIX_RELEASE(msg);
                 return;
             }
-            /* provide the local handler ID */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, &req->local_id, 1, PMIX_SIZE);
+            /* Provide the handler ID *the requestor* knows this request
+             * by. The receiver uses it as an index into its own
+             * iof_requests array, so it has to be remote_id - local_id is
+             * our index into ours, and names a different request entirely.
+             * pmix_iof_process_iof, which packs the identical message for
+             * the identical receiver, gets this right. (Nothing reaches
+             * this today - see the note below - which is how the two
+             * drifted apart.) */
+            PMIX_BFROPS_PACK(rc, req->requestor, msg, &req->remote_id, 1, PMIX_SIZE);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_RELEASE(msg);
@@ -221,10 +246,28 @@ static void myreg(int sd, short args, void *cbdata)
     pmix_cmd_t cmd = PMIX_IOF_PULL_CMD;
     pmix_buffer_t *msg = NULL;
     pmix_status_t rc;
+    int idx;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     // store the request
-    req->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
+    idx = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
+    if (0 > idx) {
+        /* the array could not be grown, so the request was never stored -
+         * there is no local id to hand back and nothing to remove. The
+         * negative return must not be passed off as one: it lands in a
+         * size_t, goes on the wire to the server as a huge value, and is
+         * reported to the caller as the handle of a live registration */
+        req->local_id = SIZE_MAX;
+        req->status = PMIX_ERR_NOMEM;
+        if (NULL != req->regcbfunc) {
+            req->regcbfunc(req->status, req->local_id, req->cbdata);
+            PMIX_RELEASE(req);
+        } else {
+            PMIX_WAKEUP_THREAD(&req->lock);
+        }
+        return;
+    }
+    req->local_id = (size_t) idx;
     req->status = PMIX_SUCCESS;
 
     if (NULL != req->requestor) {
@@ -344,6 +387,15 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
      * array to copy from */
     if (0 == nprocs || NULL == procs) {
         return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* the blocking form posts to the progress thread and then waits on
+     * it, so calling it FROM that thread - from an event handler, or
+     * from the IOF delivery callback itself - is waiting for ourselves,
+     * and the progress thread never runs again. Say so instead, exactly
+     * as the server-side IOF entry points do */
+    if (NULL == regcbfunc && pmix_progress_thread_check_blocking("PMIx_IOF_pull")) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     req = PMIX_NEW(pmix_iof_req_t);
@@ -493,6 +545,10 @@ static void mydereg(int sd, short args, void *cbdata)
 
     /* pack the remote handler ID */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &remote_id, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
 
     pmix_output_verbose(2, pmix_client_globals.iof_output,
                         "pmix:iof_dereg sending to server");
@@ -543,6 +599,13 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_deregister(size_t iofhdlr, const pmix_info_t 
         return PMIX_ERR_UNREACH;
     }
 
+    /* see the note on PMIx_IOF_pull - a tool that decides it has seen
+     * enough output and deregisters from inside its own IOF callback is
+     * calling this from the progress thread */
+    if (NULL == cbfunc && pmix_progress_thread_check_blocking("PMIx_IOF_deregister")) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     // need to threadshift to access global data
     cd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == cd) {
@@ -565,7 +628,33 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_deregister(size_t iofhdlr, const pmix_info_t 
 }
 
 static pmix_event_t stdinsig_ev;
+static bool stdinsig_active = false;
 static pmix_iof_read_event_t *stdinev_global = NULL;
+
+/* Give back what the stdin machinery here holds process-wide.
+ *
+ * Both of these live for the life of the library rather than of a
+ * request, so nothing else ever released them. The read event was simply
+ * leaked; worse, a second PMIx_Init would build another one over the top
+ * of the pointer while the first still named an event registered on the
+ * base the previous cycle tore down - which anything reaching
+ * stdinev_global in between (a flow-control request, say) would walk.
+ *
+ * Called from pmix_rte_finalize, which runs it while the event base is
+ * still standing - deleting these afterwards would be the very
+ * use-after-free it exists to prevent.
+ */
+void pmix_iof_finalize(void)
+{
+    if (stdinsig_active) {
+        pmix_event_del(&stdinsig_ev);
+        stdinsig_active = false;
+    }
+    if (NULL != stdinev_global) {
+        PMIX_RELEASE(stdinev_global);
+        stdinev_global = NULL;
+    }
+}
 
 static void stdincbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata)
@@ -671,8 +760,20 @@ static void exec_push(int sd, short args, void *cbdata)
                              * filedescriptor is not a tty, don't worry about it
                              * and always stay connected.
                              */
-                            pmix_event_signal_set(pmix_globals.evauxbase, &stdinsig_ev, SIGCONT,
+                            /* the handler resolves and manipulates
+                             * stdinev_global and its libevent registration,
+                             * both of which belong to evbase - so the signal
+                             * event goes there too rather than on evauxbase,
+                             * which a host may have supplied as a separate
+                             * thread. And it has to be *added*: setting a
+                             * signal event only assigns it, so without this
+                             * a tool started in the background never resumes
+                             * reading stdin when it is foregrounded */
+                            pmix_event_signal_set(pmix_globals.evbase, &stdinsig_ev, SIGCONT,
                                                   pmix_iof_stdin_cb, NULL);
+                            if (0 == pmix_event_add(&stdinsig_ev, NULL)) {
+                                stdinsig_active = true;
+                            }
 
                             /* setup a read event to read stdin, but don't activate it yet. The
                              * dst_name indicates who should receive the stdin. If that recipient
@@ -843,6 +944,11 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntar
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* see the note on PMIx_IOF_pull */
+    if (NULL == cbfunc && pmix_progress_thread_check_blocking("PMIx_IOF_push")) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     // need to threadshift this request to process it since it accesses
@@ -1099,10 +1205,16 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
                 free(outdir);
                 return NULL;
             }
-            /* define a sink to that file descriptor */
+            /* define a sink to that file descriptor. It is tagged with
+             * stddiag as well as stderr because that is where stddiag is
+             * written (see pmix_iof_write_output): a sink that claims only
+             * stderr is never matched by the stddiag lookup, so every
+             * stddiag chunk would build another sink - re-opening this same
+             * file O_TRUNC and discarding what is already in it */
             snk = PMIX_NEW(pmix_iof_sink_t);
             PMIX_IOF_SINK_DEFINE(snk, &src, fdout,
-                                 PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
+                                 PMIX_FWD_STDERR_CHANNEL | PMIX_FWD_STDDIAG_CHANNEL,
+                                 pmix_iof_write_handler);
             pmix_list_append(&nptr->sinks, &snk->super);
             free(outdir);
             return &snk->wev;
@@ -1127,6 +1239,12 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
                 /* setup the file */
                 pmix_asprintf(&outfile, "%s.%s.%0*u.out", nptr->iof_flags.file,
                               nptr->nspace, numdigs, rank);
+            }
+            /* pmix_asprintf leaves the pointer NULL when it fails, and
+             * everything below this point takes the name apart */
+            if (NULL == outfile) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                return NULL;
             }
             /* ensure the directory the file lands in exists.  This is taken
              * from the FINAL name, not from the name we were handed: a
@@ -1174,6 +1292,10 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
                 pmix_asprintf(&outfile, "%s.%s.%0*u.err", nptr->iof_flags.file,
                               nptr->nspace, numdigs, rank);
             }
+            if (NULL == outfile) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                return NULL;
+            }
             /* see the note on the stdout sink above */
             outdir = pmix_dirname(outfile);
             rc = pmix_os_dirpath_create(outdir, S_IRWXU | S_IRGRP | S_IXGRP);
@@ -1190,10 +1312,12 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
                 PMIX_ERROR_LOG(PMIX_ERR_FILE_OPEN_FAILURE);
                 return NULL;
             }
-            /* define a sink to that file descriptor */
+            /* see the note on the directory sink above for why stddiag is
+             * tagged here too */
             snk = PMIX_NEW(pmix_iof_sink_t);
             PMIX_IOF_SINK_DEFINE(snk, &src, fdout,
-                                 PMIX_FWD_STDERR_CHANNEL, pmix_iof_write_handler);
+                                 PMIX_FWD_STDERR_CHANNEL | PMIX_FWD_STDDIAG_CHANNEL,
+                                 pmix_iof_write_handler);
             pmix_list_append(&nptr->sinks, &snk->super);
             return &snk->wev;
         }
@@ -1236,6 +1360,12 @@ void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags)
          * is not a string must be ignored rather than strdup'd from
          * whatever else shares the union */
         if (PMIX_STRING == info->value.type && NULL != info->value.data.string) {
+            /* this walks an array the caller composed, so the key can
+             * appear more than once - the last one wins, but only if the
+             * one before it is given back first */
+            if (NULL != flags->file) {
+                free(flags->file);
+            }
             flags->file = strdup(info->value.data.string);
             flags->set = true;
             flags->local_output = true;
@@ -1244,6 +1374,10 @@ void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags)
     } else if (PMIX_CHECK_KEY(info, PMIX_IOF_OUTPUT_TO_DIRECTORY) ||
                PMIX_CHECK_KEY(info, PMIX_OUTPUT_TO_DIRECTORY)) {
         if (PMIX_STRING == info->value.type && NULL != info->value.data.string) {
+            /* see the note on the file case above */
+            if (NULL != flags->directory) {
+                free(flags->directory);
+            }
             flags->directory = strdup(info->value.data.string);
             flags->set = true;
             flags->local_output = true;
@@ -1475,11 +1609,19 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                if (NULL != kv) {  // should never be NULL
+                /* the union must not be read until the type says which
+                 * member is live, and a string member may legitimately be
+                 * NULL - "unknown" is what this reports for a hostname it
+                 * cannot get, so use it here too rather than strdup(NULL) */
+                if (NULL != kv && NULL != kv->value &&
+                    PMIX_STRING == kv->value->type &&
+                    NULL != kv->value->data.string) {
                     cptr = strdup(kv->value->data.string);
-                    PMIX_RELEASE(kv);
                 } else {
                     cptr = strdup("unknown");
+                }
+                if (NULL != kv) {
+                    PMIX_RELEASE(kv);
                 }
             } else {
                 cptr = strdup("unknown");
@@ -1494,16 +1636,16 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                if (NULL != kv) { // should never be NULL
-                    rc = PMIx_Value_get_number(kv->value, &pid, PMIX_PID);
-                    PMIX_RELEASE(kv);
-                    if (PMIX_SUCCESS != rc) {
-                        pidstring = strdup("unknown");
-                    } else {
-                        pmix_asprintf(&pidstring, "%u", pid);
-                    }
+                /* PMIx_Value_get_number reads value->type without screening
+                 * the pointer, so the kval has to carry a value at all */
+                if (NULL != kv && NULL != kv->value &&
+                    PMIX_SUCCESS == PMIx_Value_get_number(kv->value, &pid, PMIX_PID)) {
+                    pmix_asprintf(&pidstring, "%u", pid);
                 } else {
                     pidstring = strdup("unknown");
+                }
+                if (NULL != kv) {
+                    PMIX_RELEASE(kv);
                 }
             } else {
                 pidstring = strdup("unknown");
@@ -1569,11 +1711,19 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                if (NULL != kv) {  // should never be NULL
+                /* the union must not be read until the type says which
+                 * member is live, and a string member may legitimately be
+                 * NULL - "unknown" is what this reports for a hostname it
+                 * cannot get, so use it here too rather than strdup(NULL) */
+                if (NULL != kv && NULL != kv->value &&
+                    PMIX_STRING == kv->value->type &&
+                    NULL != kv->value->data.string) {
                     cptr = strdup(kv->value->data.string);
-                    PMIX_RELEASE(kv);
                 } else {
                     cptr = strdup("unknown");
+                }
+                if (NULL != kv) {
+                    PMIX_RELEASE(kv);
                 }
             } else {
                 cptr = strdup("unknown");
@@ -1588,16 +1738,15 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb2);
             if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                 kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
-                if (NULL != kv) {  // should never be NULL
-                    rc = PMIx_Value_get_number(kv->value, &pid, PMIX_PID);
-                    PMIX_RELEASE(kv);
-                    if (PMIX_SUCCESS != rc) {
-                        pidstring = strdup("unknown");
-                    } else {
-                        pmix_asprintf(&pidstring, "%u", pid);
-                    }
+                /* see the note on the xml form of this above */
+                if (NULL != kv && NULL != kv->value &&
+                    PMIX_SUCCESS == PMIx_Value_get_number(kv->value, &pid, PMIX_PID)) {
+                    pmix_asprintf(&pidstring, "%u", pid);
                 } else {
                     pidstring = strdup("unknown");
+                }
+                if (NULL != kv) {
+                    PMIX_RELEASE(kv);
                 }
             } else {
                 pidstring = strdup("unknown");
@@ -1627,10 +1776,24 @@ pmix_byte_object_t* pmix_iof_prep_output(const pmix_proc_t *name,
     /* if we are to timestamp output, start the tag with that */
     if (myflags->timestamp) {
         time_t mytime;
-        /* get the timestamp */
+        char tod[32];
+        size_t tslen;
+        /* ctime() renders into a process-wide static buffer, and the
+         * newline strip below then writes into it - so this would corrupt
+         * the result of any ctime/asctime the application is holding on
+         * another thread. ctime_r gives us our own buffer (26 bytes is
+         * the defined maximum) and is allowed to decline a time it cannot
+         * represent rather than hand back a NULL to index into */
         time(&mytime);
-        cptr = ctime(&mytime);
-        cptr[strlen(cptr) - 1] = '\0'; /* remove trailing newline */
+        if (NULL == ctime_r(&mytime, tod)) {
+            pmix_snprintf(tod, sizeof(tod), "unknown");
+        } else {
+            tslen = strlen(tod);
+            if (0 < tslen && '\n' == tod[tslen - 1]) {
+                tod[tslen - 1] = '\0'; /* remove trailing newline */
+            }
+        }
+        cptr = tod;
 
         if (myflags->xml && !myflags->tag && !myflags->rank) {
             pmix_snprintf(timestamp, PMIX_IOF_BASE_TAG_MAX,
@@ -1848,6 +2011,37 @@ process:
     return PMIX_SUCCESS;
 }
 
+/* Write out whatever we were holding for this source and stream because
+ * it had no newline yet.
+ *
+ * The end of a stream is the last chance to do that - nothing more is
+ * coming, so an unterminated final line has to go out now or not at all.
+ * It used to go out "not at all": the zero-byte marker took an early exit
+ * that never looked at the residual list, so the bytes sat there until
+ * something else swept it. A server sweeps it in PMIx_server_finalize,
+ * which at least prints the line, but out of order and at shutdown; a
+ * client or tool never sweeps it, so a rank whose last write did not end
+ * in a newline simply lost that write. */
+static void flush_residual(const pmix_proc_t *name, pmix_iof_channel_t stream)
+{
+    pmix_iof_residual_t *res, *next;
+    pmix_status_t rc;
+
+    PMIX_LIST_FOREACH_SAFE(res, next, &pmix_server_globals.iof_residuals, pmix_iof_residual_t) {
+        if (!PMIX_CHECK_PROCID(name, &res->name) || !(stream & res->stream)) {
+            continue;
+        }
+        rc = write_output_line(&res->name, res->channel, &res->flags,
+                               res->stream, res->copystdout, res->copystderr,
+                               &res->bo);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+        pmix_list_remove_item(&pmix_server_globals.iof_residuals, &res->super);
+        PMIX_RELEASE(res);
+    }
+}
+
 /* What to format output with when the namespace it came from has nothing to
  * say about it. A tool that has a spawn in flight has already parsed that
  * spawn's directives (see stash_spawn_iof_flags() in pmix_client_spawn.c);
@@ -2011,8 +2205,12 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
                          PMIx_IOF_channel_string(stream), PMIX_NAME_PRINT(name),
                          (NULL == channel) ? -1 : channel->fd);
 
-    /* zero bytes can just be passed along */
+    /* zero bytes can just be passed along - but not before anything we
+     * were holding back for the last, still-unterminated line, as this
+     * is the end of the stream and there will be no later chunk to
+     * complete it */
     if (0 == bo->size) {
+        flush_residual(name, stream);
         rc = write_output_line(name, channel, &myflags, stream,
                                false, false, bo);
         return rc;
@@ -2168,13 +2366,25 @@ void pmix_iof_write_handler(int sd, short args, void *cbdata)
     while (NULL != (item = pmix_list_remove_first(&wev->outputs))) {
         output = (pmix_iof_write_output_t *) item;
         if (0 == output->numbytes) {
-            /* don't reactivate the event */
+            /* the source that fed this marker has closed its stream */
             PMIX_RELEASE(output);
-            if (2 < wev->fd) {  // close the channel
+            if (2 < wev->fd) {
+                /* a sink of our own making, fed by exactly that one
+                 * source: close the channel and stop. "pending" is
+                 * deliberately left set so nothing re-arms the event on a
+                 * descriptor that is gone */
                 close(wev->fd);
                 wev->fd = -1;
+                return;
             }
-            return;
+            /* a shared stdout/stderr channel is fed by every source we
+             * output for, so one of them closing must not stop it. Skip
+             * the marker and keep draining: returning here would leave
+             * "pending" set with the event un-armed, and since
+             * write_output_line only activates the event when "pending"
+             * is clear, every later chunk from every other source would
+             * sit in this list unwritten until finalize */
+            continue;
         }
         num_written = write(wev->fd, output->data, output->numbytes);
         if (num_written < 0) {
@@ -2286,6 +2496,18 @@ void pmix_iof_stdin_cb(int sd, short args, void *cbdata)
     }
 }
 
+/* PMIx_Notify_event with a NULL cbfunc is its BLOCKING form: it posts a
+ * caddy to the progress thread and then PMIX_WAIT_THREADs on it. The
+ * callback below already runs on that thread, so waiting there is
+ * waiting for ourselves - the caddy can never fire, and the progress
+ * thread is dead for the life of the process. Handing it a do-nothing
+ * completion takes the non-blocking path instead, which is what every
+ * other in-library notifier does (see pmix_pfexec.c, psensor/file). */
+static void iof_ntfy_cbfunc(pmix_status_t status, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(status, cbdata);
+}
+
 static void iof_stdin_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
                              pmix_buffer_t *buf, void *cbdata)
 {
@@ -2327,7 +2549,7 @@ static void iof_stdin_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         if (PMIX_ERR_IOF_COMPLETE != ret) {
             /* generate an IOF-failed event so the tool knows */
             PMIx_Notify_event(PMIX_ERR_IOF_FAILURE, &pmix_globals.myid, PMIX_RANGE_PROC_LOCAL, NULL,
-                              0, NULL, NULL);
+                              0, iof_ntfy_cbfunc, NULL);
         }
         return;
     }
@@ -2865,7 +3087,12 @@ static void iof_read_event_destruct(pmix_iof_read_event_t *rev)
     if (rev->active) {
         pmix_event_del(&rev->ev);
     }
-    if (0 <= rev->fd) {
+    /* Only close a descriptor we opened. The read events this library
+     * builds are either on a pipe it created (pfexec's children) or on
+     * fileno(stdin), which belongs to the application - taking the
+     * caller's stdin away when the library shuts down is not ours to do.
+     * The write-event destructor guards itself the same way. */
+    if (2 < rev->fd) {
         pmix_output_verbose(20, pmix_client_globals.iof_output, "%s iof: closing fd %d",
                              PMIX_NAME_PRINT(&pmix_globals.myid), rev->fd);
         close(rev->fd);

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -116,130 +116,6 @@ report:
     return;
 }
 
-static void process_cache(int sd, short args, void *cbdata)
-{
-    pmix_iof_req_t *req = (pmix_iof_req_t *) cbdata;
-    pmix_iof_cache_t *iof, *ionext;
-    bool found;
-    size_t n;
-    pmix_status_t rc;
-    pmix_buffer_t *msg;
-    PMIX_HIDE_UNUSED_PARAMS(sd, args);
-
-    /* a request registered by a client or a launcher that has an
-     * upstream server carries no requestor peer - its IO is delivered
-     * through its own callback when the message arrives, not by
-     * packing one here - so there is nothing for us to forward */
-    if (NULL == req->requestor) {
-        return;
-    }
-    /* and nothing to forward to a peer that has no identity yet or has
-     * already gone - the same two screens pmix_iof_process_iof applies
-     * before it reaches into requestor->info */
-    if (NULL == req->requestor->info || req->requestor->finalized) {
-        return;
-    }
-
-    /* NOTE: the forwarding below is currently unreachable, and knowing
-     * that is worth more than the code. The only requests that get here
-     * are the ones PMIx_IOF_pull built in this process, and it sets
-     * requestor only when we are our own server - in which case the
-     * requestor IS us, so the "never forward to myself" test below skips
-     * every entry. A request with no requestor returned above. So the
-     * delayed cache scan the blocking form of PMIx_IOF_pull arms delivers
-     * nothing: such a request is served through req->cbfunc when the IO
-     * arrives, and cached IO has no path to that callback. Settle what
-     * the right delivery is before making this live. */
-
-    PMIX_LIST_FOREACH_SAFE (iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
-        /* if the channels don't match, then ignore it */
-        if (!(iof->channel & req->channels)) {
-            continue;
-        }
-        /* never forward back to the source! This can happen if the source
-         * is a launcher */
-        if (PMIX_CHECK_NAMES(&iof->source, &req->requestor->info->pname)) {
-            continue;
-        }
-        /* never forward to myself */
-        if (PMIX_CHECK_NAMES(&req->requestor->info->pname, &pmix_globals.myid)) {
-            continue;
-        }
-        /* if the source does not match the request, then ignore it */
-        found = false;
-        for (n = 0; n < req->nprocs; n++) {
-            if (PMIX_CHECK_PROCID(&iof->source, &req->procs[n])) {
-                found = true;
-                break;
-            }
-        }
-        if (found) {
-            /* setup the msg */
-            if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
-                PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
-                return;
-            }
-            /* provide the source */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->source, 1, PMIX_PROC);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                return;
-            }
-            /* provide the channel */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->channel, 1, PMIX_IOF_CHANNEL);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                return;
-            }
-            /* Provide the handler ID *the requestor* knows this request
-             * by. The receiver uses it as an index into its own
-             * iof_requests array, so it has to be remote_id - local_id is
-             * our index into ours, and names a different request entirely.
-             * pmix_iof_process_iof, which packs the identical message for
-             * the identical receiver, gets this right. (Nothing reaches
-             * this today - see the note below - which is how the two
-             * drifted apart.) */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, &req->remote_id, 1, PMIX_SIZE);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                return;
-            }
-            /* pack the number of info's provided */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, &iof->ninfo, 1, PMIX_SIZE);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                return;
-            }
-            /* if some were provided, then pack them too */
-            if (0 < iof->ninfo) {
-                PMIX_BFROPS_PACK(rc, req->requestor, msg, iof->info, iof->ninfo, PMIX_INFO);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(msg);
-                    return;
-                }
-            }
-            /* pack the data */
-            PMIX_BFROPS_PACK(rc, req->requestor, msg, iof->bo, 1, PMIX_BYTE_OBJECT);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                return;
-            }
-            /* send it to the requestor */
-            PMIX_PTL_SEND_ONEWAY(rc, req->requestor, msg, PMIX_PTL_TAG_IOF);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-            }
-        }
-    }
-}
-
 static void myreg(int sd, short args, void *cbdata)
 {
     pmix_iof_req_t *req = (pmix_iof_req_t *) cbdata;
@@ -275,8 +151,6 @@ static void myreg(int sd, short args, void *cbdata)
         /* if there is a registration callback function, call it */
         if (NULL != req->regcbfunc) {
             req->regcbfunc(req->status, req->local_id, req->cbdata);
-            // process any cached IO
-            process_cache(0, 0, req);
         } else {
             PMIX_WAKEUP_THREAD(&req->lock);
         }
@@ -435,9 +309,6 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
         pmix_status_t status;
         PMIX_WAIT_THREAD(&req->lock);
         if (PMIX_SUCCESS == req->status) {
-            // we don't want the IO to arrive before we return from
-            // this call, so delay it a little
-            PMIX_THREADSHIFT_DELAY(req, process_cache, 1.0);
             return PMIX_OPERATION_SUCCEEDED;
         } else {
             // the request failed and myreg removed it from the

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -265,9 +265,19 @@ static inline bool pmix_iof_fd_always_ready(int fd)
     } while (0);
 
 
-/* Release the process-wide stdin read event and SIGCONT handler this
- * file owns. Must be called while the event base is still up - i.e.
- * from pmix_rte_finalize, not after it. */
+/* Start reading our own stdin and forwarding it, arming the SIGCONT
+ * handler if the descriptor is a terminal. Every role that forwards its
+ * own stdin uses this - PMIx_IOF_push with PMIX_IOF_PUSH_STDIN, and a
+ * tool given PMIX_FWD_STDIN at init - so that there is exactly one read
+ * event on the descriptor and pmix_iof_flow_control can find it. Calling
+ * it again once the stream is running is a no-op. "procs"/"directives"
+ * may be NULL; they name who the stdin is destined for.
+ *
+ * pmix_iof_finalize() releases that read event and the SIGCONT handler.
+ * It must be called while the event base is still up - i.e. from
+ * pmix_rte_finalize, not after it. */
+PMIX_EXPORT pmix_status_t pmix_iof_setup_stdin_read(int fd, pmix_proc_t procs[], size_t nprocs,
+                                                    pmix_info_t directives[], size_t ndirs);
 PMIX_EXPORT void pmix_iof_finalize(void);
 
 PMIX_EXPORT pmix_status_t pmix_iof_write_output(const pmix_proc_t *name, pmix_iof_channel_t stream,

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -265,7 +265,10 @@ static inline bool pmix_iof_fd_always_ready(int fd)
     } while (0);
 
 
-PMIX_EXPORT pmix_status_t pmix_iof_flush(void);
+/* Release the process-wide stdin read event and SIGCONT handler this
+ * file owns. Must be called while the event base is still up - i.e.
+ * from pmix_rte_finalize, not after it. */
+PMIX_EXPORT void pmix_iof_finalize(void);
 
 PMIX_EXPORT pmix_status_t pmix_iof_write_output(const pmix_proc_t *name, pmix_iof_channel_t stream,
                                                 const pmix_byte_object_t *bo);

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -185,6 +185,11 @@ void pmix_rte_finalize(void)
         }
     }
     PMIX_DESTRUCT(&pmix_globals.notifications);
+    /* the stdin read event and SIGCONT handler in src/common/pmix_iof.c
+     * are process-wide and outlive every request, so nothing else gives
+     * them back. This has to happen while the event base is still up -
+     * pmix_progress_thread_stop below is what frees it. */
+    pmix_iof_finalize();
     for (i = 0; i < pmix_globals.iof_requests.size; i++) {
         req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests, i);
         if (NULL != req) {

--- a/src/tool/AGENTS.md
+++ b/src/tool/AGENTS.md
@@ -127,9 +127,8 @@ call. Then, in order: send `PMIX_FINALIZE_CMD` to the server with a
 5-second timer guard (`fin_timeout`/`finwait_cbfunc`) and clear
 `pmix_globals.connected` however that went, kill any `pfexec`-launched
 children (launcher/server only, **before** the progress thread stops
-because killing needs it), delete the file-scope events init registered
-(stdin read, SIGCONT, keepalive pipe — **while their bases still
-exist**), stop the progress thread, dump and destruct the static IOF
+because killing needs it), delete the keepalive-pipe event and close its
+descriptor (**while its base still exists**), stop the progress thread, dump and destruct the static IOF
 sinks, release the client peer/pending lists, stop listening, release the
 server clients array, close `pnet`/`pmdl`, `PMIX_LIST_DESTRUCT` every
 `pmix_server_globals` list that `pmix_server_initialize` builds, free the
@@ -149,10 +148,12 @@ Three subtleties the current code documents inline and you must keep:
   pointer would silently ignore a changed `PMIX_SERVER_TMPDIR` on the
   next cycle. The many `PMIX_LIST_DESTRUCT`s exist for the same
   re-init-cleanliness reason (a tool may init→finalize→init).
-- The event teardown is guarded by file-scope booleans
-  (`stdin_setup`, `stdinsig_setup`, `keepalive_fd`) rather than
-  re-derived, because `PMIX_FWD_STDIN` and `PMIX_KEEPALIVE_PIPE` were
-  directives to *init* and finalize cannot see them.
+- The keepalive-pipe teardown is guarded by a file-scope `keepalive_fd`
+  rather than re-derived, because `PMIX_KEEPALIVE_PIPE` was a directive
+  to *init* and finalize cannot see it. The stdin read event and its
+  SIGCONT handler need no such bookkeeping here — they belong to
+  `src/common/pmix_iof.c`, and `pmix_iof_finalize()` releases them from
+  inside `pmix_rte_finalize`.
 
 ## The multi-server model
 
@@ -295,6 +296,19 @@ unpacking, exactly as the client recv callbacks do.
 
 ## Invariants and gotchas
 
+- **Stdin forwarding is the library's, not this file's.** A tool given
+  `PMIX_FWD_STDIN` calls `pmix_iof_setup_stdin_read()` and nothing more.
+  This file used to build a read event of its own in a file-scope
+  `pmix_iof_read_event_t`, and every way that could drift, it did: its
+  SIGCONT event was assigned but never added to a base (so a backgrounded
+  tool never resumed reading once foregrounded), the read event was never
+  released (so it and its libevent registration survived into the next
+  `PMIx_tool_init`, naming a base that had been torn down), it was
+  invisible to `pmix_iof_flow_control` — which only knows the library's
+  `stdinev_global` — so nothing could suspend a tool's stdin, and a later
+  `PMIx_IOF_push` would build a *second* read event on fd 0 that stole
+  bytes from the first. Do not reintroduce a private one. See the stdin
+  section of [`src/common/AGENTS.md`](../common/AGENTS.md).
 - **A tool's `myserver` may be itself.** On the do-not-connect /
   connect-optional / disconnected paths, `myserver` points at
   `pmix_globals.mypeer` and `pmix_globals.connected` is unset. Guard
@@ -333,15 +347,17 @@ unpacking, exactly as the client recv callbacks do.
   the whole library. Record a failure and keep tearing down.
 - **`pmix_event_signal_set` is `event_assign`, not `event_add`.** It
   only initializes the event; without a following `pmix_event_add` the
-  handler is never installed. The tool's SIGCONT/stdin handler was in
-  that state for a long time and silently did nothing.
+  handler is never installed. Both this file's SIGCONT/stdin handler and
+  the library's were in that state for a long time and silently did
+  nothing.
 - **Anything init registers on an event base, finalize has to take
-  down** — the stdin read event, the SIGCONT event, the keepalive-pipe
-  event. `pmix_rte_finalize` destroys the bases underneath them, and the
-  two that are file-scope statics are re-`PMIX_CONSTRUCT`ed by the next
-  init. Note the one trap in that teardown: `pmix_iof_read_event_t`'s
-  destructor closes whatever fd it holds, and the tool's is the
-  application's own **stdin** — clear the field before destructing.
+  down**, because `pmix_rte_finalize` destroys the bases underneath them.
+  What is left here is the keepalive-pipe event; the stdin read event and
+  its SIGCONT handler moved to `src/common/pmix_iof.c` and are released
+  by `pmix_iof_finalize()`. Note the trap that teardown carries either
+  way: `pmix_iof_read_event_t`'s destructor closes the descriptor it
+  holds, and for stdin that is the application's own — which is why the
+  destructor now closes only descriptors above 2.
 - **`pmix_server_globals.module_set` is a global that no finalize
   resets.** `PMIx_tool_init` clears it where it memsets
   `pmix_host_server`, so the two always agree; without that a cycling
@@ -424,14 +440,19 @@ named are the ones that fail against the unfixed library.
    installed**, because `pmix_event_signal_set` is `event_assign` and
    nothing added the event. A tool that is backgrounded and then resumed
    never reconsidered its stdin. Not unit-testable — it needs a tty — so
-   there is no regression test; the sibling defect in
-   `src/common/pmix_iof.c` is **still open**, see below.
+   there is no regression test. The identical defect in
+   `src/common/pmix_iof.c` is fixed too, and this file no longer has a
+   copy of its own to keep in step: see the stdin bullet under
+   *Invariants and gotchas*.
 10. **FIXED — init's file-scope events were never taken down.** The stdin
     read event, the SIGCONT event and the keepalive-pipe event all
     survived finalize; the keepalive pipe's descriptor leaked one per
-    init/finalize cycle. **`test/unit/tool_cycle`** now runs a second pass
-    with `PMIX_FWD_STDIN` and asserts the library did not close the
-    caller's stdin on the way out.
+    init/finalize cycle. Only the keepalive pipe is still this file's to
+    release. **`test/unit/tool_cycle`** runs a second pass with
+    `PMIX_FWD_STDIN` that stands a pipe on fd 0 and asserts, after every
+    finalize, that fd 0 is still open **and still that same pipe** — an
+    is-it-open test alone passes if the library closes it and something
+    later in the cycle is handed the descriptor back.
 11. **FIXED — `PMIx_tool_set_server_module` was refused on every cycle
     after the first**, because nothing resets
     `pmix_server_globals.module_set`. **`test/unit/tool_api`.**
@@ -465,12 +486,6 @@ named are the ones that fail against the unfixed library.
 
 ### Still open
 
-- **`src/common/pmix_iof.c` has the same missing `pmix_event_add` for
-  its SIGCONT handler** (`stdinsig_ev`), and never releases
-  `stdinev_global` either. It is the same defect as item 9 one directory
-  over, but fixing it properly needs a teardown hook in `src/common` that
-  this review did not design.
-  [openpmix#4100](https://github.com/openpmix/openpmix/issues/4100).
 - **The tool's event cache in `_notify_complete` looks unreachable, and
   `src/client` has no equivalent branch at all.** See item 14 and
   [openpmix#4101](https://github.com/openpmix/openpmix/issues/4101).

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -77,20 +77,15 @@
 
 #define PMIX_MAX_RETRIES 10
 
-static pmix_event_t stdinsig, parentdied;
-static pmix_iof_read_event_t stdinev;
+static pmix_event_t parentdied;
 static pmix_proc_t myparent;
 
-/* These three record which of the file-scope events above this init cycle
- * actually set up, so finalize can take them back down again. They are
- * statics rather than locals because finalize cannot re-derive the
- * answer: PMIX_FWD_STDIN and PMIX_KEEPALIVE_PIPE were directives to
- * *init*. Leaving an event registered past finalize leaves it pointing at
- * an event base pmix_rte_finalize has destroyed, and leaves the next
- * init's PMIX_CONSTRUCT running over a live object - which loses that
- * cycle's stdin descriptor. */
-static bool stdin_setup = false;
-static bool stdinsig_setup = false;
+/* Records the descriptor PMIX_KEEPALIVE_PIPE named, so finalize can take
+ * that event back down and close it. It is a static rather than a local
+ * because finalize cannot re-derive the answer - the pipe was a directive
+ * to *init*. (The stdin read event and its SIGCONT handler need no such
+ * bookkeeping here: they belong to src/common/pmix_iof.c, and
+ * pmix_iof_finalize releases them from pmix_rte_finalize.) */
 static int keepalive_fd = -1;
 
 static void _pdiedcb(pmix_status_t status, void *cbdata)
@@ -1006,72 +1001,22 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
     pmix_pointer_array_set_item(&pmix_globals.iof_requests, 0, iofreq);
 
     if (fwd_stdin) {
-        /* setup the read - we don't want to set nonblocking on our
-         * stdio stream.  If we do so, we set the file descriptor to
-         * non-blocking for everyone that has that file descriptor, which
-         * includes everyone else in our shell pipeline chain.  (See
-         * http://lists.freebsd.org/pipermail/freebsd-hackers/2005-January/009742.html).
-         * This causes things like "prun -np 1 big_app | cat" to lose
-         * output, because cat's stdout is then ALSO non-blocking and cat
-         * isn't built to deal with that case (same with almost all other
-         * unix text utils).*/
+        /* Hand this to the library rather than building a read event of
+         * our own. This file used to keep a private one, and every way
+         * that could drift from src/common/pmix_iof.c's copy, it did: its
+         * SIGCONT event went un-added so a backgrounded tool never
+         * resumed reading, its teardown had to be bolted on separately,
+         * and - the two that a local fix cannot reach -
+         * pmix_iof_flow_control only knows the library's stdinev_global,
+         * so nothing could suspend a tool's own stdin, and a later
+         * PMIx_IOF_push would build a *second* read event on fd 0 that
+         * stole bytes from the first. One read event per descriptor, and
+         * one place that knows how to build it. */
         fd = fileno(stdin);
-        if (isatty(fd)) {
-            /* We should avoid trying to read from stdin if we
-             * have a terminal, but are backgrounded.  Catch the
-             * signals that are commonly used when we switch
-             * between being backgrounded and not.  If the
-             * filedescriptor is not a tty, don't worry about it
-             * and always stay connected.
-             */
-            pmix_event_signal_set(pmix_globals.evauxbase, &stdinsig, SIGCONT,
-                                  pmix_iof_stdin_cb, &stdinev);
-            /* pmix_event_signal_set only ASSIGNS the event - it is
-             * event_assign, not event_add - so without this the handler is
-             * never installed and a tool that is backgrounded and then
-             * resumed never reconsiders its stdin */
-            pmix_event_add(&stdinsig, NULL);
-            stdinsig_setup = true;
-
-            /* setup a read event to read stdin, but don't activate it yet. The
-             * dst_name indicates who should receive the stdin. If that recipient
-             * doesn't do a corresponding pull, however, then the stdin will
-             * be dropped upon receipt at the local daemon
-             */
-            PMIX_CONSTRUCT(&stdinev, pmix_iof_read_event_t);
-            stdinev.fd = fd;
-            stdinev.always_readable = pmix_iof_fd_always_ready(fd);
-            if (stdinev.always_readable) {
-                pmix_event_evtimer_set(pmix_globals.evbase, &stdinev.ev,
-                                       pmix_iof_read_local_handler, &stdinev);
-            } else {
-                pmix_event_set(pmix_globals.evbase, &stdinev.ev, fd, PMIX_EV_READ,
-                               pmix_iof_read_local_handler, &stdinev);
-            }
-            /* check to see if we want the stdin read event to be
-             * active - we will always at least define the event,
-             * but may delay its activation
-             */
-            if (pmix_iof_stdin_check(fd)) {
-                PMIX_IOF_READ_ACTIVATE(&stdinev);
-            }
-        } else {
-            /* if we are not looking at a tty, just setup a read event
-             * and activate it
-             */
-            PMIX_CONSTRUCT(&stdinev, pmix_iof_read_event_t);
-            stdinev.fd = fd;
-            stdinev.always_readable = pmix_iof_fd_always_ready(fd);
-            if (stdinev.always_readable) {
-                pmix_event_evtimer_set(pmix_globals.evbase, &stdinev.ev,
-                                       pmix_iof_read_local_handler, &stdinev);
-            } else {
-                pmix_event_set(pmix_globals.evbase, &stdinev.ev, fd, PMIX_EV_READ,
-                               pmix_iof_read_local_handler, &stdinev);
-            }
-            PMIX_IOF_READ_ACTIVATE(&stdinev);
+        rc = pmix_iof_setup_stdin_read(fd, NULL, 0, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
         }
-        stdin_setup = true;
     }
 
     /* fill in our local
@@ -1814,19 +1759,6 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
      * into a state where its base has been destroyed under it - and, for
      * the two that are re-armed on a later init, into a PMIX_CONSTRUCT
      * over a live object. */
-    if (stdin_setup) {
-        if (stdinsig_setup) {
-            pmix_event_del(&stdinsig);
-            stdinsig_setup = false;
-        }
-        /* Hand the destructor an already-closed descriptor: it closes
-         * whatever fd it finds, and ours is the caller's own stdin.
-         * Finalizing the PMIx library must not close the application's
-         * standard input out from under it. */
-        stdinev.fd = -1;
-        PMIX_DESTRUCT(&stdinev);
-        stdin_setup = false;
-    }
     if (0 <= keepalive_fd) {
         pmix_event_del(&parentdied);
         close(keepalive_fd);

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get
 
 client_api_SOURCES = \
         client_api.c
@@ -260,8 +260,14 @@ iof_flow_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 iof_flow_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+iof_output_SOURCES = \
+        iof_output.c
+iof_output_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+iof_output_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress compress_block preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow proc_array_id get_perf
+	rm -f compress compress_block preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf
 
 ptl_uri_SOURCES = \
         ptl_uri.c

--- a/test/unit/iof_output.c
+++ b/test/unit/iof_output.c
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * IOF output delivery: what happens at the end of a stream.
+ *
+ * A source that closes its output is announced by a zero-byte delivery.
+ * Two things used to go wrong when one arrived, and both of them are
+ * silent - the output simply never appears:
+ *
+ *  - The shared stdout/stderr sinks (fd 1 and fd 2) are fed by every
+ *    source a server outputs for, but the write handler treated a
+ *    zero-byte marker as "this channel is finished": it returned with
+ *    the sink still flagged "pending" and its write event un-armed.
+ *    Since output is only ever queued-and-armed when "pending" is clear,
+ *    every later chunk from every other source then sat in the queue
+ *    unwritten until finalize.
+ *
+ *  - Output that does not end in a newline is held back as a "residual"
+ *    until the rest of the line shows up. The end of the stream is the
+ *    last chance to write it, and the zero-byte path did not look: a
+ *    server flushed it at finalize (late, and out of order) and a client
+ *    or tool never flushed it at all.
+ *
+ * This drives the real path by standing a pipe up in place of stdout and
+ * another in place of stderr, then handing the library output through
+ * PMIx_server_IOF_deliver.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#define WAIT_USEC    20000
+#define WAIT_TRIES   250
+#define SETTLE_TRIES 25
+#define BUFSIZE      4096
+
+static FILE *out = NULL; /* the real stdout, saved before we take it */
+static int rfd = -1;     /* read end of the pipe standing in for stdout */
+static int efd = -1;     /* read end of the pipe standing in for stderr */
+static int failures = 0;
+
+static void report(const char *what, bool pass)
+{
+    fprintf(out, "%-62s : %s\n", what, pass ? "PASS" : "FAIL");
+    fflush(out);
+    if (!pass) {
+        ++failures;
+    }
+}
+
+/* Collect what shows up on a captured stream, stopping once we have
+ * "want" bytes or run out of patience. Returns the byte count; the
+ * result is NUL-terminated so it can be compared as a string. */
+static size_t collect(int fd, char *buf, size_t want)
+{
+    size_t got = 0;
+    int i;
+    ssize_t n;
+
+    for (i = 0; i < WAIT_TRIES && got < want; i++) {
+        n = read(fd, &buf[got], BUFSIZE - 1 - got);
+        if (0 < n) {
+            got += (size_t) n;
+            continue;
+        }
+        usleep(WAIT_USEC);
+    }
+    buf[got] = '\0';
+    return got;
+}
+
+/* Give the progress thread a good run at whatever we handed it, for the
+ * cases where the assertion is that nothing comes out yet. */
+static size_t settle(int fd, char *buf)
+{
+    size_t got = 0;
+    int i;
+    ssize_t n;
+
+    for (i = 0; i < SETTLE_TRIES; i++) {
+        usleep(WAIT_USEC);
+        n = read(fd, &buf[got], BUFSIZE - 1 - got);
+        if (0 < n) {
+            got += (size_t) n;
+        }
+    }
+    buf[got] = '\0';
+    return got;
+}
+
+static bool deliver(const pmix_proc_t *src, pmix_iof_channel_t channel,
+                    const char *data, size_t len)
+{
+    pmix_byte_object_t bo;
+    pmix_status_t rc;
+
+    bo.bytes = (char *) data;
+    bo.size = len;
+    rc = PMIx_server_IOF_deliver(src, channel, &bo, NULL, 0, NULL, NULL);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(out, "PMIx_server_IOF_deliver failed: %s\n", PMIx_Error_string(rc));
+        fflush(out);
+        return false;
+    }
+    return true;
+}
+
+/* nothing here reaches a host upcall - the module only has to exist */
+static pmix_server_module_t mymodule = {.push_stdin = NULL};
+
+/* replace "fd" with the write end of a fresh pipe, handing back a
+ * non-blocking read end */
+static int capture(int fd)
+{
+    int pipefd[2];
+
+    if (0 != pipe(pipefd)) {
+        fprintf(out, "pipe failed: %s\n", strerror(errno));
+        return -1;
+    }
+    if (0 > dup2(pipefd[1], fd)) {
+        fprintf(out, "dup2 failed: %s\n", strerror(errno));
+        return -1;
+    }
+    close(pipefd[1]);
+    if (0 > fcntl(pipefd[0], F_SETFL, O_NONBLOCK)) {
+        fprintf(out, "fcntl failed: %s\n", strerror(errno));
+        return -1;
+    }
+    return pipefd[0];
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_proc_t src;
+    int savedout;
+    char buf[BUFSIZE];
+    size_t got;
+    (void) argc;
+    (void) argv;
+
+    /* keep a handle on the real stdout before we take it away, so the
+     * results can still be reported */
+    fflush(stdout);
+    savedout = dup(fileno(stdout));
+    if (0 > savedout) {
+        fprintf(stderr, "dup of stdout failed: %s\n", strerror(errno));
+        return 1;
+    }
+    out = fdopen(savedout, "w");
+    if (NULL == out) {
+        fprintf(stderr, "fdopen failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    fprintf(out, "\n=== PMIx IOF output delivery unit test ===\n\n");
+    fflush(out);
+
+    /* the sinks are built on fd 1 and fd 2 during server init, so the
+     * substitution has to be in place before that runs */
+    fflush(stderr);
+    rfd = capture(fileno(stdout));
+    efd = capture(fileno(stderr));
+    if (0 > rfd || 0 > efd) {
+        return 1;
+    }
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(out, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* ---- baseline: a complete line is written out ---- */
+    PMIX_LOAD_PROCID(&src, "outtest", 0);
+    if (!deliver(&src, PMIX_FWD_STDOUT_CHANNEL, "alpha\n", 6)) {
+        PMIx_server_finalize();
+        return 1;
+    }
+    got = collect(rfd, buf, 6);
+    report("a complete line reaches stdout", 6 == got && 0 == strcmp(buf, "alpha\n"));
+
+    /* ---- one source closing must not silence the shared channel ---- */
+    if (!deliver(&src, PMIX_FWD_STDOUT_CHANNEL, NULL, 0)) {
+        PMIx_server_finalize();
+        return 1;
+    }
+    PMIX_LOAD_PROCID(&src, "outtest", 1);
+    if (!deliver(&src, PMIX_FWD_STDOUT_CHANNEL, "beta\n", 5)) {
+        PMIx_server_finalize();
+        return 1;
+    }
+    got = collect(rfd, buf, 5);
+    report("stdout still flows after another source closed",
+           5 == got && 0 == strcmp(buf, "beta\n"));
+
+    /* and the sink has to stay usable, not just take one more write */
+    if (!deliver(&src, PMIX_FWD_STDOUT_CHANNEL, "gamma\n", 6)) {
+        PMIx_server_finalize();
+        return 1;
+    }
+    got = collect(rfd, buf, 6);
+    report("and keeps flowing for every chunk after that",
+           6 == got && 0 == strcmp(buf, "gamma\n"));
+
+    /* ---- an unterminated last line is written when the stream ends ---- */
+    PMIX_LOAD_PROCID(&src, "outtest", 2);
+    if (!deliver(&src, PMIX_FWD_STDOUT_CHANNEL, "no-newline-here", 15)) {
+        PMIx_server_finalize();
+        return 1;
+    }
+    got = settle(rfd, buf);
+    report("a partial line is held back until the line completes", 0 == got);
+
+    if (!deliver(&src, PMIX_FWD_STDOUT_CHANNEL, NULL, 0)) {
+        PMIx_server_finalize();
+        return 1;
+    }
+    got = collect(rfd, buf, 15);
+    report("the partial line is written out when the stream closes",
+           15 == got && 0 == strcmp(buf, "no-newline-here"));
+
+    /* ---- stderr is a separate shared sink, and behaves the same ---- */
+    PMIX_LOAD_PROCID(&src, "outtest", 3);
+    if (!deliver(&src, PMIX_FWD_STDERR_CHANNEL, NULL, 0) ||
+        !deliver(&src, PMIX_FWD_STDERR_CHANNEL, "delta\n", 6)) {
+        PMIx_server_finalize();
+        return 1;
+    }
+    got = collect(efd, buf, 6);
+    report("stderr still flows after a source closed",
+           6 == got && 0 == strcmp(buf, "delta\n"));
+
+    PMIx_server_finalize();
+    close(rfd);
+    close(efd);
+
+    fprintf(out, "\n%s\n", (0 == failures) ? "ALL PASSED" : "FAILURES DETECTED");
+    fflush(out);
+    return (0 == failures) ? 0 : 1;
+}

--- a/test/unit/tool_cycle.c
+++ b/test/unit/tool_cycle.c
@@ -43,6 +43,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #define DEFAULT_CYCLES 1200
@@ -58,6 +59,7 @@ int main(int argc, char **argv)
     long ncycles = DEFAULT_CYCLES;
     long i;
     int nfail = 0;
+    struct stat stdin_before;
 
     if (1 < argc) {
         ncycles = strtol(argv[1], NULL, 10);
@@ -122,18 +124,46 @@ int main(int argc, char **argv)
     }
 
     /* Now the same cycle with PMIX_FWD_STDIN, which is a different init
-     * and a different teardown: it constructs a file-scope
-     * pmix_iof_read_event_t over our stdin and registers it (plus, on a
-     * tty, a SIGCONT handler) on the event bases. Those are statics, so
-     * a cycle that does not take them back down leaves the next
-     * PMIX_CONSTRUCT running over a live object - losing that cycle's
-     * descriptor - and leaves an event registered on a base
-     * pmix_rte_finalize has already destroyed.
+     * and a different teardown: it has the library build a read event
+     * over our stdin and register it (plus, on a tty, a SIGCONT handler)
+     * on the event base. Both are process-wide, so a cycle that does not
+     * take them back down leaves an event registered on a base
+     * pmix_rte_finalize has already destroyed, and leaves the next init
+     * building a second read event on the same descriptor.
+     *
+     * Two rules meet on that descriptor, and the second is why this
+     * stands a pipe of its own on fd 0 rather than trusting whatever the
+     * caller's stdin happens to be:
+     *
+     *  - stdin belongs to the *application*. The library did not open
+     *    fd 0 and must not close it at shutdown; only descriptors it
+     *    opened itself are its to close.
+     *  - "still open" is not enough to prove that. If the library closes
+     *    fd 0 and anything later in the same cycle opens a descriptor,
+     *    fd 0 is handed straight back and an is-it-open test passes. So
+     *    compare the identity of what is on fd 0, not just its presence.
+     *
+     * Nothing is ever written to the pipe, so the read event stays quiet.
      *
      * Far fewer cycles than above: this one is about the teardown
      * existing at all, and every cycle re-reads the same stdin. */
+    if (0 == nfail) {
+        int pipefd[2];
+
+        if (0 != pipe(pipefd) || 0 > dup2(pipefd[0], STDIN_FILENO)) {
+            fprintf(stderr, "stdin cycles: could not put a pipe on stdin\n");
+            nfail = 1;
+        } else {
+            close(pipefd[0]);
+            if (0 != fstat(STDIN_FILENO, &stdin_before)) {
+                fprintf(stderr, "stdin cycles: fstat of stdin failed\n");
+                nfail = 1;
+            }
+        }
+    }
     for (i = 0; 0 == nfail && i < STDIN_CYCLES; i++) {
         pmix_info_t sinfo[2];
+        struct stat stdin_after;
 
         PMIX_INFO_LOAD(&sinfo[0], PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
         PMIX_INFO_LOAD(&sinfo[1], PMIX_FWD_STDIN, NULL, PMIX_BOOL);
@@ -153,9 +183,16 @@ int main(int argc, char **argv)
             nfail = 1;
             break;
         }
-        /* the library must not have closed our stdin on the way out */
-        if (0 > fcntl(STDIN_FILENO, F_GETFD)) {
+        /* the library must not have closed our stdin on the way out, and
+         * what is on fd 0 must still be the pipe we put there */
+        if (0 != fstat(STDIN_FILENO, &stdin_after)) {
             fprintf(stderr, "stdin cycle %ld: finalize closed our stdin\n", i);
+            nfail = 1;
+            break;
+        }
+        if (stdin_before.st_dev != stdin_after.st_dev ||
+            stdin_before.st_ino != stdin_after.st_ino) {
+            fprintf(stderr, "stdin cycle %ld: fd 0 is no longer our pipe\n", i);
             nfail = 1;
             break;
         }


### PR DESCRIPTION
A review of `src/common/pmix_iof.c` — the deferred half of the stdin work
noted in 53d5f3e5 ("that one is left for a separate change"), plus the
output path alongside it.

### The three that matter

All three are silent: nothing is logged, no error is returned, the output
just never appears.

**A zero-byte delivery from one source silenced stdout for every other
source.** It marks the end of a stream. The write handler treated it as
"this channel is finished" and returned with the sink still flagged
`pending` and its write event un-armed — correct for a sink we opened for
that one source, wrong for the shared fd 1 / fd 2 sinks that every source
feeds. Since output is only queued-and-armed when `pending` is clear, one
rank closing left every later chunk from every other rank sitting in the
queue until finalize.

**An unterminated last line was dropped.** Output that does not end in a
newline is parked on the residual list until the rest of the line
arrives, and the zero-byte path never looked there. A server swept the
list at `PMIx_server_finalize`, so the line appeared late and out of
order; a client or tool never sweeps it at all.

**`iof_stdin_cbfunc` deadlocked the progress thread.** It raised
`PMIX_ERR_IOF_FAILURE` through `PMIx_Notify_event` with a NULL cbfunc —
the blocking form, which posts a caddy to the progress thread and waits
on it. That callback already runs on that thread, so the caddy could
never fire and the whole progress thread died. Reachable from any server
answering a stdin push with an ordinary error. It now passes a
do-nothing completion, as every other in-library notifier does. For the
same hazard from the caller's side, the three blocking IOF entry points
now check `pmix_progress_thread_check_blocking` the way the server-side
IOF entry points already do.

### The rest

- The SIGCONT handler in `src/common` was assigned but never added, and
  sat on `evauxbase` while manipulating state `evbase` owns.
- `stdinev_global` / `stdinsig_ev` were never released; `pmix_iof_finalize`
  gives them back from `pmix_rte_finalize`, while the base still exists.
  The read-event destructor no longer closes fds 0-2 — a read event on
  stdin is built on the application's descriptor.
- A file sink for the non-stdout case is now tagged stddiag as well as
  stderr; tagged stderr alone it never matched the stddiag lookup, so
  every stddiag chunk built another sink, re-opening the same file
  `O_TRUNC`.
- `ctime()` renders into a process-wide static that the newline strip then
  wrote into; use `ctime_r`.
- GDS values are type/NULL-screened before `strdup` and before
  `PMIx_Value_get_number`, which reads `value->type` unscreened.
- `pmix_pointer_array_add`'s failure return is no longer passed off as a
  handler id.
- Assorted: a repeated `OUTPUT_TO_FILE` leaked the previous `strdup`, an
  unchecked pack in `mydereg`, an unchecked file-name `asprintf`, and a
  declared-but-undefined `pmix_iof_flush()`.

### Tool stdin forwarding

`PMIx_tool_init` kept a private read event as a copy of what
`pmix_iof.c` does for `PMIX_IOF_PUSH_STDIN`. 53d5f3e5 fixed that copy's
SIGCONT and teardown in place; this replaces the copy. The two things a
local fix cannot reach: `pmix_iof_flow_control` only knows
`stdinev_global`, so nothing could suspend a tool's own stdin, and a tool
that forwarded stdin at init and later got a `PMIX_IOF_PUSH_STDIN` ended
up with two read events on fd 0 stealing bytes from each other. Both
callers now go through `pmix_iof_setup_stdin_read()`, which is idempotent,
so there is one read event per descriptor by construction and the tool
inherits the SIGCONT handling and the `pmix_iof_finalize` teardown.

### Dead code

`process_cache()` walked the cached-IO list and packed a message to the
request's requestor. It was reached only from `myreg()` and the
one-second timer the blocking `PMIx_IOF_pull` armed, both of which only
carry requests this process registered on itself — so its own "never
forward to myself" test rejected every entry and the loop had never run.
Being unreachable is also why it had drifted: it packed `req->local_id`
where the identical message for the identical receiver needs
`req->remote_id`. Nothing is lost with it — cached output reaches a newly
registered *remote* requestor from `pmix_server_process_iof()` and from
`_iofreg()`, the latter scanning after the refid reply has gone out,
which is what the deleted timer was reaching for.

What remains is a gap rather than a regression, recorded in AGENTS.md: an
IOF request a process registers on *itself* has no delivery path at all.

### Tests

- `test/unit/iof_output.c` (new) stands pipes on stdout and stderr and
  drives `PMIx_server_IOF_deliver`. Four of its six cases fail against
  the unfixed library.
- `test/unit/tool_cycle.c`'s `PMIX_FWD_STDIN` pass now puts a pipe on
  fd 0 and checks after every finalize that fd 0 is still open **and
  still that same pipe** — an is-it-open test alone passes if the library
  closes it and something later in the cycle is handed the descriptor
  back. It fails on cycle 0 if the read-event destructor may close fd 0.

Build is warning-free; `make check` passes except for three failures that
are present on master without this branch: `compress_block` (segfaults on
a NULL module entry, verified by reverting this branch's library sources)
and the two `test/python` `run_*.sh` (the extension resolves libpmix from
the install prefix, which needs a `make install`).