### PR TITLE
Screen the pcompress entry points compress_block calls

### DIFF
--- a/test/unit/compress_block.c
+++ b/test/unit/compress_block.c
@@ -121,12 +121,25 @@ int main(int argc, char **argv)
 
     CHECK(ziplen < len, "compress returned true but the result is not smaller");
 
-    /* the 4-byte prefix must report the inflated size without inflating */
-    bo.bytes = (char *) zip;
-    bo.size = ziplen;
-    CHECK(len == pmix_compress.get_decompressed_size(&bo),
-          "get_decompressed_size gave %zu, expected %zu",
-          pmix_compress.get_decompressed_size(&bo), len);
+    /* the 4-byte prefix must report the inflated size without inflating.
+     *
+     * Screen the entry point first. A module fills in only the subset it
+     * implements, and components are run-time-loadable, so the plugin
+     * that got selected can be older than the libpmix that loaded it -
+     * which is what any partial upgrade produces, and every module built
+     * before July 2026 left this one NULL. Calling it blind is a jump to
+     * address zero, and a test that segfaults reports nothing at all.
+     * This is the same screen bfrops applies at its own call sites. */
+    if (NULL == pmix_compress.get_decompressed_size) {
+        fprintf(stdout, "NOTE: selected component has no get_decompressed_size; "
+                        "skipping the size-prefix check\n");
+    } else {
+        bo.bytes = (char *) zip;
+        bo.size = ziplen;
+        CHECK(len == pmix_compress.get_decompressed_size(&bo),
+              "get_decompressed_size gave %zu, expected %zu",
+              pmix_compress.get_decompressed_size(&bo), len);
+    }
 
     /* --- and must round-trip exactly ----------------------------------- */
     CHECK(PMIx_Data_decompress(zip, ziplen, &back, &backlen),
@@ -183,17 +196,30 @@ int main(int argc, char **argv)
     }
     str[len] = '\0';
 
-    if (pmix_compress.compress_string(str, &zip, &ziplen)) {
+    /* every one of these is screened for the same reason as the size
+     * entry point above */
+    if (NULL != pmix_compress.compress_string &&
+        pmix_compress.compress_string(str, &zip, &ziplen)) {
         bo.bytes = (char *) zip;
         bo.size = ziplen;
-        CHECK(len + 1 == pmix_compress.get_decompressed_strlen(&bo),
-              "get_decompressed_strlen gave %zu, expected %zu",
-              pmix_compress.get_decompressed_strlen(&bo), len + 1);
-        CHECK(pmix_compress.decompress_string(&strback, zip, ziplen),
-              "decompress_string refused its own output");
-        if (NULL != strback) {
-            CHECK(0 == strcmp(strback, str), "string round-trip altered the payload");
-            free(strback);
+        if (NULL == pmix_compress.get_decompressed_strlen) {
+            fprintf(stdout, "NOTE: selected component has no "
+                            "get_decompressed_strlen; skipping that check\n");
+        } else {
+            CHECK(len + 1 == pmix_compress.get_decompressed_strlen(&bo),
+                  "get_decompressed_strlen gave %zu, expected %zu",
+                  pmix_compress.get_decompressed_strlen(&bo), len + 1);
+        }
+        if (NULL == pmix_compress.decompress_string) {
+            fprintf(stdout, "NOTE: selected component compresses strings but "
+                            "cannot inflate them; skipping the round-trip\n");
+        } else {
+            CHECK(pmix_compress.decompress_string(&strback, zip, ziplen),
+                  "decompress_string refused its own output");
+            if (NULL != strback) {
+                CHECK(0 == strcmp(strback, str), "string round-trip altered the payload");
+                free(strback);
+            }
         }
         free(zip);
         zip = NULL;


### PR DESCRIPTION
`test/unit/compress_block` segfaults (exit 139, no output at all) when
the selected pcompress component leaves an entry point `NULL`:

```
frame #0: 0x0000000000000000
```

It calls `pmix_compress.get_decompressed_size` and the three string entry
points straight off the module. A module fills in only the subset it
implements, so any of those may be `NULL` — and components are
run-time-loadable, so the plugin that gets selected can be older than the
`libpmix` that loaded it. That is what any partial upgrade produces, and
every module built before July 2026 left `get_decompressed_size` and
`get_decompressed_strlen` `NULL`. An install prefix holding one of those
is enough to reproduce it.

Screen each of them, which is what `bfrops` already does at its own call
sites — `decompressed_size()` / `decompressed_strlen()` in
`bfrop_base_fns.c` exist for exactly this. Here the screen prints what it
found and skips that one assertion rather than answering 0, so an entry
point the loaded component does not have shows up in the log instead of
being read as a wrong answer:

```
compressed 4194304 -> 2564783 (ratio 0.6115)
NOTE: selected component has no get_decompressed_size; skipping the size-prefix check
declined incompressible input, as it should
NOTE: selected component has no get_decompressed_strlen; skipping that check
COMPRESS BLOCK TEST: PASSED
```

Verified against a stale installed plugin — segfault before, pass after —
and with the full `make check`.

---

*Earlier revision of this PR changed `pmix_compress_base_select` to fold
the winning module in field by field so that `pmix_compress` never held a
`NULL`. That was the wrong fix: a field-by-field copy has to be updated
every time the module struct changes and is silent when it is not. The
guard belongs at the call site.*