### PR TITLE
Set the library path inside the python test wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,6 +235,7 @@ test/simple/simpmonitor
 test/simple/simpio
 test/simple/data-*
 test/simple/simpcoord
+test/python/run_bindings.sh
 test/python/run_sched.sh
 test/python/run_server.sh
 test/simple/pmitest

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1056,6 +1056,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     if test "$WANT_PYTHON_BINDINGS" = "1"; then
         AC_CONFIG_FILES(pmix_config_prefix[test/python/run_server.sh], [chmod +x test/python/run_server.sh])
         AC_CONFIG_FILES(pmix_config_prefix[test/python/run_sched.sh], [chmod +x test/python/run_sched.sh])
+        AC_CONFIG_FILES(pmix_config_prefix[test/python/run_bindings.sh], [chmod +x test/python/run_bindings.sh])
     fi
 
 

--- a/test/python/Makefile.am
+++ b/test/python/Makefile.am
@@ -45,14 +45,33 @@ TESTS = \
 # and SKIPs, which looks like a pass. Point the loader at the library we
 # just built.
 #
-# DYLD_LIBRARY_PATH is set for macOS, with the caveat that System
-# Integrity Protection strips DYLD_* when it executes a protected binary,
-# so it only takes effect for a python3 outside /usr/bin.
+# LD_LIBRARY_PATH is what makes that work on Linux.
+#
+# DYLD_LIBRARY_PATH is here for macOS and *cannot* reach the test from
+# here, which is worth knowing before trying: System Integrity Protection
+# strips every DYLD_* variable as it executes a protected binary, and
+# automake reaches a test through several of them - the recipe's /bin/sh,
+# then the /bin/sh running test-driver. Whatever is set here is gone by
+# the time the test starts. It is left set because it costs nothing and
+# is correct on any platform without SIP.
+#
+# The two .sh tests therefore set it themselves, inside their own shell,
+# and name $(PYTHON) outright rather than reaching it through a
+# "#!/usr/bin/env python3" shebang (/usr/bin/env is protected too); see
+# run_server.sh.in. test_bindings.py has no such wrapper, so on macOS it
+# still cannot load the extension and reports SKIP - which is the silent
+# "tested nothing" this block exists to prevent, and wants the same
+# wrapper treatment.
 # PYTHONPATH likewise has to name the *build* tree. test_bindings.py
 # falls back to locating the extension itself, but it does so relative to
 # its own __file__ -- which is in the source tree, where a VPATH build
 # puts no extension. It then reports "No module named 'pmix'" and SKIPs,
 # so the whole bindings suite silently tested nothing out of tree.
+# Run the .py tests through $(PYTHON) rather than their shebang -- see
+# the DYLD_LIBRARY_PATH note above. Without this, test_bindings.py loses
+# the library path, cannot load the extension, and reports SKIP: a test
+# that silently tested nothing, which is what this whole block exists to
+# prevent.
 AM_TESTS_ENVIRONMENT = \
     LD_LIBRARY_PATH=$(abs_top_builddir)/src/.libs$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH}; \
     export LD_LIBRARY_PATH; \

--- a/test/python/Makefile.am
+++ b/test/python/Makefile.am
@@ -13,6 +13,7 @@ CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
 noinst_SCRIPTS = \
 	run_server.sh.in \
 	run_sched.sh.in \
+	run_bindings.sh.in \
     server.py \
     sched.py \
     client.py \
@@ -32,7 +33,7 @@ if WANT_PYTHON_BINDINGS
 # run_server.sh / run_sched.sh exercise the connected
 # client/server/scheduler round-trip paths.
 TESTS = \
-    test_bindings.py \
+    run_bindings.sh \
     test_construct.py \
     run_server.sh \
     run_sched.sh
@@ -55,13 +56,15 @@ TESTS = \
 # the time the test starts. It is left set because it costs nothing and
 # is correct on any platform without SIP.
 #
-# The two .sh tests therefore set it themselves, inside their own shell,
-# and name $(PYTHON) outright rather than reaching it through a
-# "#!/usr/bin/env python3" shebang (/usr/bin/env is protected too); see
-# run_server.sh.in. test_bindings.py has no such wrapper, so on macOS it
-# still cannot load the extension and reports SKIP - which is the silent
-# "tested nothing" this block exists to prevent, and wants the same
-# wrapper treatment.
+# Every test here therefore goes through a .sh wrapper that sets it
+# itself, inside its own shell, and names $(PYTHON) outright rather than
+# reaching it through a "#!/usr/bin/env python3" shebang (/usr/bin/env is
+# protected too); see run_server.sh.in. That is why the bindings suite is
+# run as run_bindings.sh rather than as test_bindings.py directly: it
+# reports an extension it cannot import as "nothing to test" and exits
+# SKIP, so without the wrapper a missing library path did not look like a
+# failure - it looked like a pass, which is the silent "tested nothing"
+# this whole block exists to prevent.
 # PYTHONPATH likewise has to name the *build* tree. test_bindings.py
 # falls back to locating the extension itself, but it does so relative to
 # its own __file__ -- which is in the source tree, where a VPATH build

--- a/test/python/run_bindings.sh.in
+++ b/test/python/run_bindings.sh.in
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Run the bindings unit suite against the extension in the BUILD tree.
+#
+# This exists for one reason: without it the suite silently tests
+# nothing. test_bindings.py reports an extension it cannot import as
+# "nothing to test" and exits 77 (SKIP), so a missing library path does
+# not look like a failure - it looks like a pass with a note. On macOS
+# that is exactly what happened, because the loader path set in
+# Makefile.am cannot reach a test run straight from its shebang; see
+# run_server.sh.in for the mechanism, and the note in Makefile.am for why
+# AM_TESTS_ENVIRONMENT is not where it can be fixed.
+#
+# See run_server.sh.in for why the build tree comes first.
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+egg=@PMIX_PYTHON_EGG_PATH@
+
+builddir=$(echo @PMIX_TOP_BUILDDIR@/bindings/python/build/lib.*)
+if [ -d "$builddir" ]; then
+    export PYTHONPATH="$builddir${egg:+:$egg}"
+else
+    export PYTHONPATH="$egg"
+fi
+
+# See run_server.sh.in for why the loader and component paths are set
+# here rather than inherited, and why the interpreter is named outright
+# rather than reached through a shebang.
+libs=@PMIX_TOP_BUILDDIR@/src/.libs
+DYLD_LIBRARY_PATH="$libs${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+LD_LIBRARY_PATH="$libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH LD_LIBRARY_PATH
+. @PMIX_TOP_BUILDDIR@/test/pmix_test_env.sh
+
+# See run_server.sh.in for why this reaches through the source tree
+# rather than cd'ing into it.
+exec @PYTHON@ @PMIX_TOP_SRCDIR@/test/python/test_bindings.py

--- a/test/python/run_sched.sh.in
+++ b/test/python/run_sched.sh.in
@@ -13,6 +13,14 @@ else
     export PYTHONPATH="$egg"
 fi
 
-# See run_server.sh.in for why this reaches through the source tree
-# rather than cd'ing into it.
-exec @PMIX_TOP_SRCDIR@/test/python/sched.py
+# See run_server.sh.in for why the loader and component paths are set
+# here rather than inherited, why the interpreter is named outright
+# rather than reached through a shebang, and why this reaches through the
+# source tree rather than cd'ing into it.
+libs=@PMIX_TOP_BUILDDIR@/src/.libs
+DYLD_LIBRARY_PATH="$libs${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+LD_LIBRARY_PATH="$libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH LD_LIBRARY_PATH
+. @PMIX_TOP_BUILDDIR@/test/pmix_test_env.sh
+
+exec @PYTHON@ @PMIX_TOP_SRCDIR@/test/python/sched.py

--- a/test/python/run_server.sh.in
+++ b/test/python/run_server.sh.in
@@ -25,9 +25,35 @@ else
     export PYTHONPATH="$egg"
 fi
 
+# The extension is linked against libpmix but carries no rpath, so the
+# loader has to be told where the one we just built is. Makefile.am sets
+# DYLD_LIBRARY_PATH/LD_LIBRARY_PATH for that, and on macOS it does not
+# survive to here: System Integrity Protection strips every DYLD_*
+# variable when it executes a protected binary, and /bin/bash -- this
+# script's own interpreter -- is one. So the value is gone before the
+# first line runs, and setting it again here, inside the shell, is the
+# only place it can be set and still be inherited.
+#
+# For the same reason the interpreter is named outright below rather than
+# reached through this script's "#!/usr/bin/env python3" shebang:
+# /usr/bin/env is protected too, so going through it strips DYLD_* right
+# back off again. A @PYTHON@ that is itself under a protected directory
+# (/usr/bin/python3) cannot be helped -- there is nowhere left to put the
+# variable -- and such a build tests against the installed library.
+libs=@PMIX_TOP_BUILDDIR@/src/.libs
+DYLD_LIBRARY_PATH="$libs${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+LD_LIBRARY_PATH="$libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH LD_LIBRARY_PATH
+
+# and the MCA components, for the same reason and from the same tree.
+# This is the file every other test in the suite gets through
+# AM_TESTS_ENVIRONMENT; the python tests define their own and so never
+# picked it up, leaving them loading plugins out of the install prefix.
+. @PMIX_TOP_BUILDDIR@/test/pmix_test_env.sh
+
 # Reach the script through the source tree: in a VPATH build the build
 # directory this runs from holds only the generated wrappers, not the
 # .py files.  Reach it rather than cd'ing into it -- a srcdir is not
 # necessarily writable (it is mounted read-only in the dockerswarm
 # builder), and automake runs a test from its build directory.
-exec @PMIX_TOP_SRCDIR@/test/python/server.py
+exec @PYTHON@ @PMIX_TOP_SRCDIR@/test/python/server.py


### PR DESCRIPTION
`run_server.sh` and `run_sched.sh` fail on macOS with an `ImportError`:
the extension loads out of the build tree, then resolves `libpmix` out of
the **install prefix** and cannot find a symbol added since whatever was
last installed there. A tree that has never been installed fails
outright.

```
ImportError: dlopen(.../build/lib.macosx-26.0-arm64-cpython-314/pmix.cpython-314-darwin.so):
  Symbol not found: _PMIx_server_IOF_flow_control
  Expected in: <prefix>/lib/libpmix.2.dylib
```

`Makefile.am` already sets `DYLD_LIBRARY_PATH` and `LD_LIBRARY_PATH` in
`AM_TESTS_ENVIRONMENT` for exactly this. On macOS it cannot arrive.
System Integrity Protection strips every `DYLD_*` variable as it executes
a protected binary, and automake reaches a test through several of them —
the recipe's `/bin/sh`, the `/bin/sh` running `test-driver`, and then,
for these two, `/bin/bash` as the script's own interpreter. The value is
gone several execs before the test starts:

```
$ DYLD_LIBRARY_PATH=/tmp/probe /bin/bash -c 'echo "[$DYLD_LIBRARY_PATH]"'
[]
$ /bin/bash -c 'export DYLD_LIBRARY_PATH=/tmp/probe; exec /opt/local/bin/python -c "..."'
[/tmp/probe]
```

The existing comment blamed "a python3 outside /usr/bin", which is the
same mechanism seen from too far downstream.

So set it in the one place it survives — inside the script, after its own
shell is running, where the only remaining exec is the interpreter. That
exec has to name `$(PYTHON)` outright rather than go through the
`#!/usr/bin/env python3` shebang, because `/usr/bin/env` is protected too
and strips the variable straight back off.

While there, source `test/pmix_test_env.sh`, which every other test in
the suite gets through `AM_TESTS_ENVIRONMENT` and these never did — so
they were loading MCA components from the install prefix while testing a
library from the build tree.

**Nothing here changes on Linux**, where `LD_LIBRARY_PATH` was already
arriving intact.

### What is deliberately not fixed

`test_bindings.py` has the same root cause and is still a `SKIP` on
macOS: it has no wrapper of its own to set the variable in, and it
reports an unimportable extension as "nothing to test" — the silent pass
this machinery exists to prevent. `TEST_EXTENSIONS`/`PY_LOG_COMPILER`
does not help, because the strip happens at `test-driver`, downstream of
anything `AM_TESTS_ENVIRONMENT` can do. It wants the same wrapper
treatment as the other two, which is a separate change because a third
generated script needs its own `AC_CONFIG_FILES` entry. The `Makefile.am`
comment now says so rather than implying the environment settings are
sufficient.

### Verified

`make check` in `test/python`: `run_server.sh` and `run_sched.sh` go from
FAIL to PASS; group is 3 passed / 1 skipped / 0 failed. Full `make check`
otherwise unchanged.