### PR TITLE
Always take the wildcard second look when resolving peers

### DIFF
--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -214,14 +214,14 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
             proc.rank = PMIX_RANK_UNDEF;
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
             if (PMIX_SUCCESS != rc) {
-                if (PMIX_RANK_UNDEF == proc.rank) {
-                    // try again with wildcard
-                    proc.rank = PMIX_RANK_WILDCARD;
-                    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-                    if (PMIX_SUCCESS != rc) {
-                        continue;
-                    }
-                } else {
+                /* try again with wildcard - the fetch takes a const proc
+                 * and so cannot have altered the rank we just set, but
+                 * the rank does matter to the gds: only a wildcard reaches
+                 * the job-level table, where an older peer (or a tool
+                 * registering itself) records its local peers */
+                proc.rank = PMIX_RANK_WILDCARD;
+                PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+                if (PMIX_SUCCESS != rc) {
                     continue;
                 }
             }
@@ -327,30 +327,27 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
         PMIX_DESTRUCT(&cb);
         goto done;
     }
-    if (PMIX_ERR_DATA_VALUE_NOT_FOUND == ret) {
-        // found the namespace and node, but the
-        // host did not provide the information
-        PMIX_DESTRUCT(&cb);
-        goto done;
+    /* Get here on any other error - most commonly
+     * PMIX_ERR_DATA_VALUE_NOT_FOUND, meaning the node is known to this
+     * namespace but the host recorded no list of peers against it. Take
+     * a second look with a wildcard rank before answering. The fetch
+     * takes a const proc and so cannot have altered the rank we set
+     * above, but the rank does matter to the gds: only a wildcard
+     * reaches the job-level table, which is where an older peer - or a
+     * tool that registered itself - records its local peers. The
+     * aggregate branch above always took this second look; a request
+     * naming a single namespace used to give up first, so the same
+     * server could answer the same question two different ways. */
+    rc = ret; // remember what the first, more specific, look said
+    proc.rank = PMIX_RANK_WILDCARD;
+    PMIX_GDS_FETCH_KV(ret, pmix_globals.mypeer, &cb);
+    if (PMIX_SUCCESS == ret) {
+        goto process;
     }
-    // get here if we see a different error
-    if (PMIX_RANK_UNDEF == proc.rank) {
-        // try again with wildcard
-        proc.rank = PMIX_RANK_WILDCARD;
-        PMIX_GDS_FETCH_KV(ret, pmix_globals.mypeer, &cb);
-        if (PMIX_SUCCESS == ret) {
-            goto process;
-        }
-        if (PMIX_ERR_NOT_FOUND == ret) {
-            // found the namespace, but the node is
-            // not present on that namespace - the
-            // default response is correct
-            ret = PMIX_SUCCESS;
-        }
-        // couldn't find it
-        PMIX_DESTRUCT(&cb);
-        goto done;
-    }
+    // the second look added nothing, so report the first answer
+    ret = rc;
+    PMIX_DESTRUCT(&cb);
+    goto done;
 
 process:
     /* sanity check */


### PR DESCRIPTION
Both halves of `pmix_server_locally_resolve_peers` fetch the node's
`PMIX_LOCAL_PEERS` at rank `UNDEF` and, if that comes up empty, retry at rank
`WILDCARD`. The retry matters: the gds fetch reaches the job-level table only
for a wildcard rank, and that is where an older peer — or a tool registering
itself, as `src/tool/pmix_tool.c` does — records its local peers.

Both retries were guarded by a test of `proc.rank` against `PMIX_RANK_UNDEF`,
but the fetch takes a `const pmix_proc_t *` and no gds module alters it, so the
rank could only be the `UNDEF` each branch had just assigned. The guards were
therefore tautologies, and the arms they selected against — an `else` that
skipped the namespace, and a fall-through into the `process:` label — were
unreachable.

Coverity read the dead `else` as evidence that the wildcard assignment was
never consumed (CID 505101). It *is* consumed, by the fetch on the very next
line through `cb.proc`, so the CID is a false positive and should be marked as
such — but the guard made that hard to see.

Drop both guards. In the single-namespace branch that also means
`PMIX_ERR_DATA_VALUE_NOT_FOUND` — the node is known but carries no peer list,
and the one status for which the retry does something different in
`pmix_gds_hash_fetch` (`NOT_FOUND` is explicitly excluded from its `doover`
fallback) — now falls into the retry instead of returning ahead of it. The
aggregate branch always retried on it, so the same server could answer the same
question two ways depending on whether the caller named a namespace. When the
second look finds nothing, the first look's status is still what gets reported,
so no existing client-visible outcome changes.

### Testing

Rebuilt warning-free under `--enable-devel-check`; `make check` in `test/`
passes (121/121) with a fresh `TMPDIR`; `test/simple/run_simptest.sh` OK.

No new test. `resolve_peers` is already covered by `test/test_resolve_peers.c`
and `test/unit/client_api`, but none of them can reach the new arm: constructing
a namespace whose node entry exists *without* `PMIX_LOCAL_PEERS` while the
job-level table has one requires state no in-tree component produces through the
public server API.