### PR TITLE
Deep review of src/client: spawn and topology, plus a reconciliation of the review notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,6 +285,7 @@ test/unit/event_chain
 test/unit/hwloc_datatype
 test/unit/progress_threads
 test/unit/runtime_init
+test/unit/resolve_api
 test/unit/server_get
 test/unit/info_support
 test/unit/rndz_stale

--- a/.gitignore
+++ b/.gitignore
@@ -286,6 +286,7 @@ test/unit/hwloc_datatype
 test/unit/progress_threads
 test/unit/runtime_init
 test/unit/resolve_api
+test/unit/spawn_api
 test/unit/server_get
 test/unit/info_support
 test/unit/rndz_stale

--- a/docs/man/man3/PMIx_Resolve_nodes.3.rst
+++ b/docs/man/man3/PMIx_Resolve_nodes.3.rst
@@ -91,8 +91,8 @@ negative value corresponding to a PMIx error constant is returned, including:
   library's progress engine has been stopped.
 * ``PMIX_ERR_UNREACH`` |mdash| the connection to the local PMIx server was lost
   while servicing the request.
-* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid response was received while servicing
-  the request.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| ``nodelist`` was ``NULL``, or an invalid
+  response was received while servicing the request.
 
 Any other negative value indicates an appropriate error condition. PMIx error
 constants are defined in ``pmix_common.h``.

--- a/docs/man/man3/PMIx_Resolve_peers.3.rst
+++ b/docs/man/man3/PMIx_Resolve_peers.3.rst
@@ -97,8 +97,8 @@ constant is returned, including:
   library's progress engine has been stopped.
 * ``PMIX_ERR_UNREACH`` |mdash| the connection to the local PMIx server was lost
   while servicing the request.
-* ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid response was received while servicing
-  the request.
+* ``PMIX_ERR_BAD_PARAM`` |mdash| either ``procs`` or ``nprocs`` was ``NULL``,
+  or an invalid response was received while servicing the request.
 
 Any other negative value indicates an appropriate error condition. PMIx error
 constants are defined in ``pmix_common.h``.

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -7,6 +7,51 @@ series, in reverse chronological order.
 7.0.0 -- TBD
 ------------
 Detailed changes since v6.1.0:
+ - PMIx_Spawn and PMIx_Spawn_nb no longer treat a non-NULL job_info
+   pointer carrying a zero ninfo as an empty directive list. Such a call
+   failed the whole spawn with PMIX_ERR_EMPTY, a status naming nothing
+   the caller had done wrong; (info, ninfo) is a pair and a zero count
+   means "no directives" whatever the pointer is
+ - PMIx_Spawn no longer writes into the caller's const pmix_app_t apps[].
+   An app may declare its directives by terminating them with an
+   end-marked info rather than setting ninfo, and the count worked out
+   from that scan was stored back into the caller's array - which
+   segfaults for a caller whose apps sit in read-only storage
+ - An app-level PMIX_SETUP_APP_ENVARS directive is now honored for every
+   app that carries one. Only the first such app was served, because the
+   per-app harvest set the flag meaning "the job-level directive already
+   covered every app" - so an MPMD spawn whose second app asked for its
+   own programming model's envars silently got none. This affects the
+   roles that have a pmdl framework open: tool, launcher and server
+ - PMIx_Compute_distances no longer reports device distances it does not
+   have. The reply handler took the count the server said it was sending
+   rather than the count that arrived, so an application could be handed
+   entries that were never written - zeroed, so a caller reading uuid
+   found a NULL. The distance array and its count now agree on every
+   path, including the failure ones
+ - PMIx_Resolve_peers and PMIx_Resolve_nodes no longer crash on a node
+   that hosts none of a namespace's processes, and report the documented
+   empty result - PMIX_SUCCESS with a NULL array and a zero count -
+   rather than PMIX_ERR_NOMEM. Both the client and server halves of the
+   computation had this
+ - PMIx_Lookup no longer reports a result count larger than the number of
+   entries it actually unpacked
+ - PMIx_Fabric_update now reports a refresh the server never completed as
+   a failure instead of returning PMIX_SUCCESS with the caller's
+   pmix_fabric_t left stale
+ - A group reference that expands to no members at all is now rejected
+   with PMIX_ERR_NOT_FOUND rather than yielding a NULL participant array
+   that the caller then indexes
+ - PMIx_Group_invite and PMIx_Group_invite_nb no longer race their own
+   observer registration. An invitation could resolve inside the
+   registration call, after which the setup path was still writing to a
+   tracker the announcement chain already owned - which lost a
+   PMIX_GROUP_OPTIONAL directive, armed a timer on freed memory, and in
+   the non-blocking form used the tracker after it had been released
+ - A PMIx_Get answered on the caller's thread that then declines the
+   short-circuit no longer leaves its fetched entries behind for the
+   ordinary path to inherit, which turned a scalar get into a
+   PMIX_DATA_ARRAY
  - A PMIx_Get for a reserved key that is not held locally is now allowed
    to reach the host environment. The client used to force PMIX_IMMEDIATE
    onto any such request, which confines the search to what the local

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1150,9 +1150,59 @@ and every early exit has to set it. No automated coverage: a singleton
 returns `PMIX_ERR_UNREACH` at the `connected` gate long before the PTL
 round-trip, and no in-tree host implements `pmix_server_module_t.fabric`.
 
+**A short-circuit that declines must leave the caddy as clean as it
+found it.** `try_local_fetch()` in `pmix_client_get.c` answers a get on
+the caller's thread when the GDS module says its store is safe to read
+there, and returns false to mean "not answered, take the ordinary path".
+Its failed-*fetch* return drains `cb->kvs` and rebuilds it for exactly
+that reason. Its failed-*`process_values()`* return did not — and
+`process_values()` does not drain the list either, since on the path it
+is written for the kval stays alive to own the value. So a decline after
+a **successful** fetch fell through to `get_data()` with the fetched
+entries still on `cb->kvs`, and `get_data()`'s own `PMIX_GDS_FETCH_KV`
+appends to that same list. That matters because `process_values()`
+distinguishes "the value" from "an aggregate of everything this proc
+put" by **counting** the list: one stale entry turns a scalar `PMIx_Get`
+into a `PMIX_DATA_ARRAY`. It now drains on both returns.
+
+Nothing leaks either way — `cbdes()` destructs `kvs` — which is why this
+is a wrong-answer bug rather than a leak, and why it would not show up
+under valgrind. Reachability is narrow: `process_values()` declines only
+on a malformed `PMIX_QUALIFIED_VALUE` in the datastore (see the fifth
+sweep — not producible by a local `PMIx_Put`) or an allocation failure.
+The rule to carry is the one the function's own comment already
+states: **a short-circuit is never a partial one.** If you add an early
+return to it, ask what state the slow path is about to inherit.
+
 Far more useful is what was examined and **rejected**, because each one
 looks like a defect until you chase it down. Do not re-open these
 without new evidence.
+
+- **`PMIX_ACQUIRE_OBJECT(cb)` sitting above the line that assigns `cb`**
+  — in `_value_cbfunc()` and `get_data()` — is not a read of an
+  uninitialized pointer. The macro is `#define PMIX_ACQUIRE_OBJECT(o)
+  pmix_atomic_rmb()` ([`pmix_threads.h`](../threads/pmix_threads.h)): it
+  discards its argument entirely, so the operand is never evaluated.
+  Reordered here for readability, but do not go looking for a bug behind
+  the same shape elsewhere in the tree.
+- **`PMIx_Value_get_number(kv->value, …)` is called without a NULL check
+  on `kv->value`** at the nodeid, appnum and sessionid fetches in
+  `get_data()`, and that function dereferences `value->type` as its
+  first act. The hostname fetch beside them *does* check. Left alone
+  because nothing demonstrates a local GDS fetch producing a kval with a
+  NULL value — `pmix_kval_t.value` is documented as legitimately
+  NULL-able by [`src/mca/bfrops/AGENTS.md`](../mca/bfrops/AGENTS.md),
+  but that is about what arrives off the wire through `pack_kval`, and
+  these three read the local datastore. If you decide to close it, the
+  screen belongs in `PMIx_Value_get_number` rather than at three call
+  sites here, since every other caller in the tree is equally exposed.
+- **`strdup(pmix_globals.hostname)` in `get_data()`'s invalid-rank
+  branch is unguarded** where the branch above it tests
+  `NULL != pmix_globals.hostname` first. It is safe:
+  [`pmix_rte_init`](../runtime/pmix_init.c) resolves the hostname from
+  the directive, then `PMIX_HOSTNAME`, then `gethostname()`, so the
+  field is non-NULL for the entire life of an initialized library. The
+  guarded sibling is being defensive, not covering a real state.
 
 - **A client's `PMIx_Fabric_deregister` never tells the server, and
   cannot.** There is no `PMIX_FABRIC_DEREGISTER_CMD` — the command enum

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -949,13 +949,12 @@ to assume):*
   whose group we have already forgotten. Recovering would mean putting it
   back under the lock; leaving is terminal in practice, so this is
   recorded rather than restructured.
-- `invite_setup()` registers the answer observer before it has finished
-  populating the tracker (the range info, the timer). If every invitee
-  were already dead, a cached `PMIX_PROC_TERMINATED` replay could resolve
-  the invitation from the progress thread while the caller's thread is
-  still in `invite_setup`. The membership and flags it needs *are* in
-  place before registration, so this is narrow, and no invitee can accept
-  before the invitation is sent.
+- `invite_setup()` registered the answer observer before it had finished
+  populating the tracker. **Closed by the eighth sweep** — the directive
+  scan, the range info and the timer are all established before the
+  registration now, and that sweep's section explains why registering an
+  observer is a *publication*. Left here only as a pointer, because this
+  entry sat under "not changed" for four sweeps after it had been fixed.
 
 ## Defects found in the August 2026 review (fifth sweep — the union sweep)
 
@@ -1575,16 +1574,30 @@ alone:
 
 *Noted, not changed — do not re-open these without new evidence:*
 
-- **`PMIX_NEW` is not NULL-checked anywhere in this directory**, for
-  buffers or for caddies, and that is the convention rather than an
-  oversight in this file. The earlier sweeps flagged unchecked
-  `PMIX_INFO_CREATE` and `PMIX_PROC_CREATE` repeatedly and never flagged
-  `PMIX_NEW`. Adding checks here alone would be the inconsistency.
+- **`PMIX_NEW` is checked in some of this directory and not others, and
+  which you are looking at is not a convention — it is an open
+  inconsistency.** This entry used to assert that `PMIX_NEW` "is not
+  NULL-checked anywhere in this directory" and that adding a check would
+  therefore be the odd one out. **That is false, and it was false when it
+  was written.** Of the 81 `PMIX_NEW` sites in `src/client`, 14 are
+  followed immediately by `if (PMIX_UNLIKELY(NULL == …))` — six tracker
+  allocations in `pmix_client_group.c` and eight in `pmix_client.c`,
+  including `req = PMIX_NEW(pmix_buffer_t)` at
+  [`pmix_client.c`](pmix_client.c):395, which is the very "buffers" case
+  the old entry said nobody checked. Meanwhile `pmix_client_spawn.c`
+  leaves both its caddy and its message unchecked.
+
+  Do not read either half as settled. Deciding the convention and making
+  the directory consistent is tracked work, not something to resolve
+  ad hoc in whichever file you happen to be editing — and in particular
+  do not cite this entry as a reason to leave a new `PMIX_NEW`
+  unchecked, which is what it was used for.
 - **`pa[np].rank = strtoul(p[m], NULL, 10)` validates nothing** — a
   non-numeric token yields rank 0 and a value past `UINT32_MAX` truncates
-  silently. There are fourteen such sites in the tree, including the exact
-  mirror of this line in `pmix_server_resolve.c`. If this is ever worth
-  closing it wants a shared helper, not a screen here.
+  silently. There are ten such sites in the tree, including the exact
+  mirror of this line in `pmix_server_resolve.c`. (This entry said
+  fourteen; ten is what the tree holds.) If this is ever worth closing it
+  wants a shared helper, not a screen here.
 - **`kv->value` is dereferenced without a NULL check** at all four
   datastore reads. `pmix_kval_t.value` is legitimately NULL-able off the
   wire (see [`src/mca/bfrops/AGENTS.md`](../mca/bfrops/AGENTS.md)), but
@@ -1671,12 +1684,17 @@ other.
   returns between the two actually free what the caddy already holds.
 
   This is the class the earlier sweeps have consistently closed
-  (`respeer()`, `construct_msg()`, `construct_cbfunc()`). It is **not** an
-  invitation to check `PMIX_NEW`, and the unchecked `strdup()` /
-  `PMIx_Argv_copy()` / `PMIx_Argv_prepend_nosize()` results in the same
-  loop are deliberately left: hardening this function against allocation
-  failure end-to-end is a separate piece of work, and doing half of it is
-  worse than none.
+  (`respeer()`, `construct_msg()`, `construct_cbfunc()`). The unchecked
+  `strdup()` / `PMIx_Argv_copy()` / `PMIx_Argv_prepend_nosize()` results
+  in the same loop are deliberately left: hardening this function against
+  allocation failure end-to-end is a separate piece of work, and doing
+  half of it is worse than none.
+
+  **This sweep also left `fcd = PMIX_NEW(pmix_setup_caddy_t)` and
+  `msg = PMIX_NEW(pmix_buffer_t)` unchecked on the strength of the ninth
+  sweep's claim that `PMIX_NEW` is never checked in this directory. That
+  claim was wrong** — see the corrected entry under the ninth sweep — so
+  treat this as an open decision rather than a considered one.
 
 *Noted, not changed — do not re-open these without new evidence:*
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -436,6 +436,19 @@ segfaulted before. See [`test/unit/AGENTS.md`](../../test/unit/AGENTS.md).
 > "fix" a group parameter check by hoisting it above the state checks
 > just to make it testable — the ordering is the convention here.
 
+**Tier 1b — `test/unit/resolve_api.c` (in `make check`).** The one
+place in `make check` that reaches the *local computation* behind
+`PMIx_Resolve_peers`/`PMIx_Resolve_nodes` rather than just their argument
+checks. It comes up as a server with a stub host module — no `query`
+entry point, so both APIs fall through their host branch to the
+thread-shifted local path — and registers two namespaces on this one
+node, one with peers here and one whose `PMIX_LOCAL_PEERS` is explicitly
+the empty string. That is the input behind the ninth sweep's findings.
+Note the second namespace must be registered with a node-info array and
+**no proc map**: the map-driven derivation in `store_map()` replaces a
+host-supplied `PMIX_LOCAL_PEERS`, so a proc map would overwrite the value
+under test.
+
 **Tier 1a — `test/unit/run_grpinviteothers.pl` (in `make check`).**
 Drives `examples/group_invite_others` through `test/simple/simptest`:
 four clients, with rank 0 inviting ranks 1..3 and *not* joining. That
@@ -1433,6 +1446,156 @@ them. The thirteen `run_grp*.pl` tests do cover the reordered
 `invite_setup` end-to-end through `simptest` — construct, invite,
 invite-nb, join, decline, leave, destruct, both timeout cases, both abort
 cases, and the suppression case — and all pass.
+
+## Defects found in the August 2026 review (ninth sweep — `pmix_client_resolve.c`)
+
+Five lenses over the resolve pair. Almost everything found is one fact
+wearing four hats, so learn the fact rather than the four sites.
+
+**`PMIx_Argv_split()` returns NULL for a string with no tokens, not an
+empty array** — see `pmix_bfrops_base_tma_argv_split_inter()`, whose loop
+never runs for an empty source. Every list this file gets out of the
+datastore can legitimately be the **empty string**, because a namespace's
+map can name a node it placed nothing on, and `store_map()` records
+`PMIX_LOCAL_PEERS` for such a node as `strdup("")`. The `NULL == string`
+guards that are everywhere in this file do **not** cover that state; they
+are a different one. Three sites indexed the NULL:
+
+- `resolve_peers()`'s aggregate walk recorded an `"nspace:"` entry for the
+  empty namespace and then split every recorded entry back apart to fill
+  the proc array — a SIGSEGV on the progress thread, taken as soon as any
+  *other* namespace contributed a proc and made the transfer pass run.
+  Entries are now counted before they are recorded, so an empty one is
+  never recorded at all.
+- `resolve_nodes()`'s aggregate walk did the same with `PMIX_NODE_LIST`.
+  That one is hardening rather than a reproduced defect: `PMIX_NODE_LIST`
+  is derived by joining the node map, so the hash datastore cannot
+  produce an empty one — only a host storing the key itself could.
+- `pmix_server_locally_resolve_peers()` and `..._node()` in
+  [`pmix_server_resolve.c`](../server/pmix_server_resolve.c) are the
+  *same walk* and had the *same* defects. See the twin rule below.
+
+**And `PMIX_PROC_CREATE(0)` returns the same NULL an allocation failure
+does**, which is the seventh sweep's rule meeting the same empty list.
+Asking for a namespace by name on a node it placed nothing on counted
+zero peers, handed the count to `PMIX_PROC_CREATE`, and reported
+`PMIX_ERR_NOMEM` — where `PMIx_Resolve_peers(3)` documents an empty result
+as `PMIX_SUCCESS` with a NULL array and a zero count. Both the client and
+the server had it. Regression: `test/unit/resolve_api.c`.
+
+### `pmix_client_resolve.c` and `pmix_server_resolve.c` are twins
+
+`resolve_peers()`/`resolve_nodes()` here and
+`pmix_server_locally_resolve_peers()`/`..._node()` there are the same
+computation over the same datastore, written twice. **Every defect found
+in one of them was present in the other**, in both directions: the empty-
+list crash and the `PMIX_PROC_CREATE(0)` report went client → server this
+sweep, and the per-namespace rank reset went server → client (the server
+had already fixed it, with a comment saying why, while the client had
+not). When you change one, read the other before you stop.
+
+The rank reset is worth understanding rather than copying. `try_fetch()`
+mutates `cb->proc->rank` to `PMIX_RANK_WILDCARD` for its retry and does
+not put it back, and it *declines outright* for a rank that is not
+`PMIX_RANK_UNDEF` — so a single aggregate walk gave its first namespace a
+different lookup from all the rest, and the answer depended on the order
+the namespaces happened to sit in `pmix_globals.nspaces`. It was benign
+against today's `hash` module, and it is worth knowing exactly why before
+anyone decides the reset is unnecessary: for a `PMIX_NODE_INFO`-qualified
+fetch, `pmix_gds_hash_fetch()` sends both `UNDEF` and `WILDCARD` down the
+`!PMIX_RANK_IS_VALID` branch to `fetch_nodeinfo()`, and only `WILDCARD`
+additionally gets the `doover` retry against the job-level table. So
+`WILDCARD` is a superset there, and nothing was lost — by accident, and
+only for one module.
+
+### The caddy outlives the reply, and both halves must agree about it
+
+Both `PMIx_Resolve_peers` and `PMIx_Resolve_nodes` **reuse their
+`pmix_resolve_caddy_t`** when the server round-trip fails: they reset the
+lock and re-shift the *same* object into the local computation, because a
+server that does not recognize the command is the expected reason to fall
+back. Two rules follow, and neither is visible from the recv callback
+alone:
+
+- **The recv callback must leave `procs` and `nprocs` agreeing with each
+  other on every failure path.** `wait_peers_cbfunc()` freed the array on
+  a failed unpack and left the count standing; the local fallback then
+  found nothing, reported `PMIX_SUCCESS`, and the caller was handed a
+  NULL array with a non-zero count to index. `PMIX_PROC_FREE` nulls the
+  pointer it is given, so the caddy destructor was safe — this is a
+  wrong-answer bug, not a double free, which is why it would not show up
+  under valgrind.
+- **Report what actually arrived, not what the peer said it was
+  sending.** `pmix_bfrops_base_unpack()` reports `PMIX_SUCCESS` having
+  filled *fewer* entries when the wire count exceeds the payload, writing
+  the real number back through `num_vals`. Same defect and same fix as
+  `_lookup_cbfunc()` in `pmix_client_pub.c`; and the wire-sized
+  `PMIX_PROC_CREATE` needs its NULL check for the same reason that one
+  does.
+
+*Correctness, lesser:*
+
+- `resolve_nodes()` `PMIX_ERROR_LOG`ged `PMIX_ERR_INVALID_VAL` for a
+  `PMIX_NODE_LIST` that was not a string and then fell through to a
+  `done:` where `rc` was still `PMIX_SUCCESS` — so the caller was told the
+  call succeeded and handed a NULL `nodelist` it is entitled to parse. Its
+  sibling `resolve_peers()` set the status in the same spot. Note the two
+  halves of that test are *not* the same thing and are now split: a wrong
+  **type** is a datastore that has garbage under a reserved key and is an
+  error; a **NULL string** is "no nodes", which is the documented empty
+  answer.
+- Both host-query branches called `pmix_host_server.query` with a query
+  they had failed to build — the `PMIX_ARGV_APPEND` status was unchecked
+  and `PMIX_INFO_CREATE(iptr, 2)` was dereferenced unchecked. They now
+  skip the up-call and work the answer out locally, which is what the
+  branch already does for a host that cannot answer.
+- `respeer()`/`resnode()` dereferenced an unchecked `PMIX_INFO_CREATE`.
+- Two `strdup()` results were handed back as the answer without being
+  checked, so a failed allocation was reported as `PMIX_SUCCESS` with a
+  NULL string.
+- `resolve_peers()` recorded the *counted* peer total rather than the
+  number it actually transferred, so a failed `PMIx_Argv_append_nosize`
+  would have handed the caller phantom entries.
+
+*Noted, not changed — do not re-open these without new evidence:*
+
+- **`PMIX_NEW` is not NULL-checked anywhere in this directory**, for
+  buffers or for caddies, and that is the convention rather than an
+  oversight in this file. The earlier sweeps flagged unchecked
+  `PMIX_INFO_CREATE` and `PMIX_PROC_CREATE` repeatedly and never flagged
+  `PMIX_NEW`. Adding checks here alone would be the inconsistency.
+- **`pa[np].rank = strtoul(p[m], NULL, 10)` validates nothing** — a
+  non-numeric token yields rank 0 and a value past `UINT32_MAX` truncates
+  silently. There are fourteen such sites in the tree, including the exact
+  mirror of this line in `pmix_server_resolve.c`. If this is ever worth
+  closing it wants a shared helper, not a screen here.
+- **`kv->value` is dereferenced without a NULL check** at all four
+  datastore reads. `pmix_kval_t.value` is legitimately NULL-able off the
+  wire (see [`src/mca/bfrops/AGENTS.md`](../mca/bfrops/AGENTS.md)), but
+  these are local GDS fetches — the same reasoning the seventh sweep
+  recorded for `get_data()`.
+- **A lost connection between the `connected` check and the send hangs
+  these two APIs forever.** `pmix_ptl_base_send_recv()` drops the message
+  without invoking the recv callback when the peer has `sd < 0`, after
+  `PMIX_PTL_SEND_RECV` has already reported success — so the
+  `PMIX_WAIT_THREAD` below it waits on a lock nothing will wake. This is
+  the tree-wide condition described under [Invariants](#invariants-and-gotchas);
+  `PMIx_Finalize` is the only entry point that arms a timer against it.
+  Fixing it in this one file would be an inconsistency, not a fix.
+- **The `singleton` half of the "gate every round-trip" pattern is
+  genuinely redundant here.** `pmix_globals.connected` is set in exactly
+  one place — `ptl_base_fns.c` after a successful connect — so a
+  singleton never has it, and every sibling in this directory gates on
+  `!connected` alone.
+- `PMIX_INFO_LOAD(&iptr[0], PMIX_NSPACE, str, PMIX_STRING)` with a NULL
+  `str` is safe: `pmix_bfrops_base_value_load()` zeroes the union for a
+  NULL source rather than reaching `strdup`. A NULL nspace is the
+  documented "all namespaces" request and reaches both host queries.
+- The dead `PMIX_ERR_DATA_VALUE_NOT_FOUND` arm in both functions, and the
+  dead `proc.rank = PMIX_RANK_WILDCARD` store in the pre-v3.2 branch, are
+  unchanged and still carry their explaining comments. `try_fetch()`
+  returns only `PMIX_SUCCESS`, `PMIX_ERR_INVALID_NAMESPACE` and
+  `PMIX_ERR_NOT_FOUND`.
 
 ## Coding conventions specific to this directory
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1103,12 +1103,21 @@ empty array and returns `PMIX_ERR_NOT_A_MEMBER`.
   so a caller who chose the non-blocking form precisely to stay off a
   blocking path gets a blocking call, and one that deadlocks outright if
   it was issued from an event handler on the progress thread. Note the
-  directory has **three** different meanings for a NULL `cbfunc` and this
-  is the third: `PMIx_Get_nb`, `PMIx_Compute_distances_nb` and
-  `PMIx_Group_construct_nb` reject it with `PMIX_ERR_BAD_PARAM`, the two
+  directory has **four** different meanings for a NULL `cbfunc` and this
+  is the last: `PMIx_Get_nb`, `PMIx_Compute_distances_nb` and
+  `PMIx_Group_invite_nb` reject it with `PMIX_ERR_BAD_PARAM`, the two
   fabric `_nb` entry points read it as "the caddy is in `cbdata`" (see
-  the invariant above), and fence blocks. Check which one you are looking
-  at before copying a NULL test between them.
+  the invariant above), the remaining group `_nb` entry points
+  (`PMIx_Group_construct_nb`, `PMIx_Group_join_nb`, `PMIx_Group_leave_nb`,
+  `PMIx_Group_destruct_nb`) accept it as fire-and-forget — their reply
+  handlers all test `NULL != cb->cbfunc` before completing, and the
+  operation still takes effect — and fence blocks. Check which one you are
+  looking at before copying a NULL test between them.
+
+  This entry used to name `PMIx_Group_construct_nb` among the rejecters.
+  It does not reject: it has never tested `cbfunc` at all, and
+  `construct_cbfunc` is written for the NULL case. Do not "restore" a
+  check that was never there.
 
   Left alone because every way of resolving it is a behavior change to a
   released public API rather than a fix: rejecting NULL breaks any caller
@@ -1279,6 +1288,151 @@ without new evidence.
   convention rather than a divergence here, and the in-tree host
   (`test/simple/simptest.c`) ignores `cbfunc` entirely, so nothing
   available demonstrates the failure.
+
+## The eighth sweep — `pmix_client_group.c` and the setup/progress-thread seam
+
+A second pass devoted to this one file, five lenses over it. The theme is
+not the type-tag hazard the fourth and fifth sweeps established — that
+ground held — but a different seam: **the moment a group tracker becomes
+the progress thread's, and what is still being written to it afterwards.**
+
+**Registering the invitation observer publishes the tracker, and the
+invitation can resolve inside that call.** `pmix_event_register_observer`
+runs `check_cached_events()` (see
+[`pmix_event_registration.c`](../event/pmix_event_registration.c)) before
+it acknowledges the registration, and that replays every matching cached
+notification through `pmix_invoke_local_event_hdlr` →
+`sweep_observers()` — synchronously, on the progress thread, with the
+brand-new observer already on the list. So a leader inviting procs that
+have *already* terminated, whose `PMIX_PROC_TERMINATED` events were cached
+because nothing was watching for them, has `invite_observer()` count every
+answer and call `invite_wake()` from inside the registration call itself.
+
+`invite_setup()` then went on to do three things to a tracker that the
+announcement chain already owned:
+
+- it set `cb->optional` from `PMIX_GROUP_OPTIONAL` *after* `announce_step()`
+  had read it, so an invitation the caller marked optional was aborted
+  under the default all-or-nothing policy;
+- it armed the timeout timer on a tracker the chain might already have
+  retired, leaving a live `pmix_event_t` on freed memory;
+- and in the `_nb` form it kept reading `cb->info` to notify the invitees
+  after `invite_finish()` had released the tracker — a use-after-free.
+
+The directive scan, the range info and the timer are now all established
+**before** the registration, and `invite_setup()` holds a reference of its
+own (`PMIX_RETAIN`/`PMIX_RELEASE`) across the registration and the
+notification so nothing can free the tracker underneath it. It also
+reports success when `cb->completed` is set on the way out, because the
+caller has been completed and the tracker retired by then — returning an
+error there had `PMIx_Group_invite_nb` run `invite_teardown()` on a
+tracker that was already torn down.
+
+**The rule worth carrying:** in this file, *registering an observer is a
+publication*. Everything the resolution path reads must be on the tracker
+before it, nothing may be armed on the tracker after it, and any use of
+the tracker below it needs a reference. The same reasoning applies to
+`setup_leader_watch()`, which is why that one hands the registry ownership
+via `watch_relcb` and touches nothing afterwards.
+
+*Wire format:*
+
+- **`PMIx_Group_destruct_nb` packed a field the server never unpacks.**
+  Both group commands are unpacked by the same routine,
+  `pmix_server_group()` in
+  [`pmix_server_group.c`](../server/pmix_server_group.c), which reads the
+  proc array only under `if (0 < nprocs)`. `construct_msg()` guards its
+  pack to match; destruct packed unconditionally — and
+  `pmix_bfrops_base_pack()` writes an element count even for a zero-length
+  array, so destructing a group whose membership had drained put bytes on
+  the wire that the server never consumed. Its next unpack read that stray
+  count as the directive count and *succeeded* having unpacked nothing
+  (`pmix_bfrops_base_unpack` reports `PMIX_SUCCESS` with `*num_vals = 0`
+  when the stored count is zero), leaving the server's `ninf` uninitialized
+  to size an allocation and then index it. Both halves are closed: the
+  client guards the pack, and `ninf` is initialized.
+
+  The general point: **a guarded unpack demands a guarded pack.** When two
+  commands share an unpack routine, they have to agree with it
+  field-for-field, and "pack it anyway, the count is zero" is not a no-op
+  on this wire.
+
+*Crashes on wire- or caller-supplied input:*
+
+- `pmix_server_process_grpinfo()` read `pinfo[0]` and dereferenced
+  `pinfo[0].value.data.proc` on nothing more than the key matching
+  `PMIX_PROCID`. All three of its callers — this file's
+  `construct_cbfunc()`, `pmix_server_setup.c` and `pmix_server_group.c` —
+  hand it an array that came off the wire, so neither the length nor the
+  union member was theirs to assume. The guard went into the helper, where
+  it covers all three; `construct_cbfunc()` additionally now requires a
+  non-empty array, which it was already checking for non-NULL.
+- `invite_setup()` fetched each wildcard's job size **twice** — once to
+  size `cb->members` and once to fill it — and wrote the second pass's
+  count into the first pass's allocation. An elastic job that grew between
+  the two overran the array. The writes are bounded now and a disagreement
+  is an error rather than a short membership.
+- `construct_cbfunc()` unpacked the returned membership into an unchecked
+  `PMIX_PROC_CREATE` result, and `construct_msg()` filled an unchecked
+  `PMIX_INFO_CREATE` one.
+- `PMIx_Group_construct[_nb]` accepted `procs == NULL` with `nprocs > 0`
+  and walked the array. A NULL `procs` is legal for an add-members or
+  bootstrap participant, but only when it is declared empty.
+
+*Leaks:*
+
+- `get_endpts()` was the one exit of that function that returned without
+  `PMIX_DESTRUCT`ing its `pmix_cb_t`, dropping the kvals the GDS fetch had
+  just handed it.
+- `invite_finish()` took `pmix_event_deregister_observer()` on trust. That
+  call fails once the library is shutting down, and when it does no
+  callback comes, so the tracker was never released. `invite_teardown()`
+  checks the same return for the same reason.
+
+*Correctness, lesser:*
+
+- `PMIx_Group_leave_nb()` treated the NULL from `PMIX_PROC_CREATE(0)` as an
+  allocation failure, so leaving a group whose membership had drained
+  returned `PMIX_ERR_NOMEM` — and returned *before* dropping the group, so
+  the caller could never leave it. An empty membership means there is
+  nobody to notify, which is not an error. (See the seventh sweep for why
+  `nmbrs == 0` is a reachable state.)
+
+*Noted, not changed:*
+
+- **`PMIx_Group_invite_nb` deadlocks if called from an event handler.**
+  `invite_setup()` runs on the caller's thread and takes two
+  `PMIX_WAIT_THREAD`s on operations that thread-shift — the observer
+  registration and the `PMIX_GROUP_INVITED` notification — so driving it
+  from a handler waits on the progress thread from the progress thread.
+  For the blocking `PMIx_Group_invite` that is merely the documented
+  property of this file; for the `_nb` form it is a contract defect, since
+  being callable from a handler is the whole point of the non-blocking
+  variant. Closing it means making the setup itself a chain of
+  non-blocking steps, the way `announce_step()` already is — a
+  restructure, not a review fix.
+- `cb->completed` and `cb->timer_active` are plain `bool`s read from the
+  caller's thread and written from the progress thread. Every read is
+  downstream of a mutex operation today, so the ordering is incidental
+  rather than declared. Left as-is because it matches the rest of the
+  file; if one more cross-thread flag appears here, the tracker wants a
+  lock rather than a fourth ad-hoc barrier.
+- `info_cbfunc()` calls `add_group()` with its own tracker's `notterm`,
+  which is always false — the flag lives on the tracker
+  `construct_cbfunc()` reads. That is harmless only because
+  `add_group()` ignores a repeat request and `construct_cbfunc()` gets
+  there first with the right value. On the *join* path there is no first
+  call, so a joiner never records `PMIX_GROUP_NOTIFY_TERMINATION` — which
+  is correct, since a joiner supplied no construct directives.
+
+*No regression coverage was added, and none is possible in `make check`.*
+Every finding above sits behind either a server round-trip or a cached-event
+replay, and the group entry points check `connected` before their
+arguments (see [Testing](#testing)), so a singleton cannot reach any of
+them. The thirteen `run_grp*.pl` tests do cover the reordered
+`invite_setup` end-to-end through `simptest` — construct, invite,
+invite-nb, join, decline, leave, destruct, both timeout cases, both abort
+cases, and the suppression case — and all pass.
 
 ## Coding conventions specific to this directory
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1083,7 +1083,39 @@ zeroes its length — so the `pmix_buffer_t` it fills is what frees them.
 Use `PMIX_LOAD_BUFFER_NON_DESTRUCT` if you ever need the byte object to
 survive.
 
+**`pmix_client_fence.c` also came through all five with nothing to fix.**
+The one shape to understand before touching it is that
+`pmix_client_convert_group_procs()` always hands back a **fresh**
+`PMIX_PROC_CREATE`d array on success — never the caller's `procs` — so
+`PMIx_Fence_nb`'s `created` flag guarding `PMIX_PROC_FREE(rgs, nrg)` is
+freeing library memory, not the application's `const pmix_proc_t
+procs[]`. All four exits below the conversion honor it. The other thing
+worth knowing is that `nrg` is `>= 1` by the time `pack_fence()` runs:
+the zero-length expansion is caught one step earlier by
+`pmix_client_proc_is_included()`, which cannot find the caller in an
+empty array and returns `PMIX_ERR_NOT_A_MEMBER`.
 
+*Noted, not changed:*
+
+- **`PMIx_Fence_nb` blocks when handed a NULL `cbfunc`**, and it is the
+  only `_nb` entry point in this directory that does. It allocates its
+  caddy, sends, and then takes a `PMIX_WAIT_THREAD` branch of its own —
+  so a caller who chose the non-blocking form precisely to stay off a
+  blocking path gets a blocking call, and one that deadlocks outright if
+  it was issued from an event handler on the progress thread. Note the
+  directory has **three** different meanings for a NULL `cbfunc` and this
+  is the third: `PMIx_Get_nb`, `PMIx_Compute_distances_nb` and
+  `PMIx_Group_construct_nb` reject it with `PMIX_ERR_BAD_PARAM`, the two
+  fabric `_nb` entry points read it as "the caddy is in `cbdata`" (see
+  the invariant above), and fence blocks. Check which one you are looking
+  at before copying a NULL test between them.
+
+  Left alone because every way of resolving it is a behavior change to a
+  released public API rather than a fix: rejecting NULL breaks any caller
+  relying on the block, and returning without waiting silently converts
+  their synchronization into a fire-and-forget. `PMIx_Fence` does not go
+  through this branch — it passes `op_cbfunc` — so nothing in the library
+  depends on the answer.
 
 The sweep found two leaks, both on error paths that only a failing
 server can reach, and both fixed: `job_data()` dropped the `nspace`

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -213,6 +213,26 @@ gone — see [openpmix#4059][i4059].)
   send site owns the message on the failure path and must `PMIX_RELEASE`
   it — but must *not* release it on success, where the transport frees it.
   Several sites in this directory leaked the message here.
+
+  **Which role makes those failure paths reachable is worth knowing
+  before you decide one is dead code.** The peer these sites send to is
+  `pmix_client_globals.myserver`, and *nothing in the client role ever
+  sets `myserver->finalized`* — only `mypeer->finalized` is set, by
+  `PMIx_Finalize`. The paths become live because the **server and tool
+  roles alias the two**: `src/server/pmix_server.c` and two paths in
+  `src/tool/pmix_tool.c` assign `pmix_client_globals.myserver =
+  pmix_globals.mypeer`, so once `PMIx_server_finalize` /
+  `PMIx_tool_finalize` marks that object finalized, every send from this
+  directory fails. Keep the cleanup on those branches: it is not
+  defensive padding, it is the self-served case.
+
+  Note also the *other* way a send never completes, which the failure
+  return does **not** cover: `pmix_ptl_base_send_recv()` drops the
+  message and returns without ever invoking the recv callback when the
+  peer has `sd < 0` or a NULL `info`/`nptr`. `PMIX_PTL_SEND_RECV` has
+  already reported `PMIX_SUCCESS` by then, so a blocking caller waits on
+  a lock nothing will wake. That is why `PMIx_Finalize` arms a timer
+  around its wait rather than trusting the reply.
 - **A `PMIX_WAIT_THREAD` after a call that might not have fired its
   callback is a hang.** `PMIx_Notify_event` and
   `PMIx_Register_event_handler` invoke the completion callback only when
@@ -1012,6 +1032,75 @@ grep -n "PMIX_PTL_SEND_RECV" -A 7 src/client/*.c \
   the tracker. That is the documented contract for the callback signature,
   not a defect here, but it is the one place in this directory where a
   caller's mistake leaks library memory.
+
+## The seventh sweep — `pmix_client.c`, and five things it deliberately left alone
+
+The sweep found two leaks, both on error paths that only a failing
+server can reach, and both fixed: `job_data()` dropped the `nspace`
+string the unpack had just allocated when the identity did not match
+our own (the only exit of that function that did not free it), and
+`PMIx_Init` walked away from the `suri` the connect handed back — and,
+on the first of the three server-ID stores, from its `kval` too — on
+three of the error returns between `connect_to_peer` and the point
+where the URI is finally stored. The three stores now release and free
+identically; they used to disagree.
+
+Far more useful is what was examined and **rejected**, because each one
+looks like a defect until you chase it down. Do not re-open these
+without new evidence.
+
+- **`PMIx_Finalize` throws the server's reply away, and that is not the
+  `_commitfn`/`PMIx_Abort` defect.** The server *does* ack
+  `PMIX_FINALIZE_CMD` with a status — `op_cbfunc2()` in
+  [`pmix_server_switchyard.c`](../server/pmix_server_switchyard.c) packs
+  whatever the host's `client_finalized` returned — and `finwait_cbfunc`
+  discards the buffer, exactly the shape flagged for commit and abort
+  above. It stays that way on purpose: the caller cannot act on it (the
+  process is leaving), and `PMIx_Finalize` returning anything but
+  `PMIX_SUCCESS` would newly fail applications that check it. Changing
+  it is a behavior decision about a universally-called API, not a fix.
+- **`PMIx_Init`'s debugger-wait handler is left registered, holding a
+  pointer into a stack frame that is about to die, if the
+  `PMIX_READY_FOR_DEBUG` notification fails.** `PMIX_EVENT_RETURN_OBJECT`
+  is stored as a bare `cbobject` pointer (see the parser in
+  [`pmix_event_registration.c`](../event/pmix_event_registration.c)), and
+  it points at `releaselock` on `PMIx_Init`'s stack. On the success path
+  the handler is `PMIX_EVENT_ONESHOT` and removes itself when it fires,
+  so only the notify-failure return leaves it behind. It is not fixed
+  because the obvious fix does not work: `PMIx_Deregister_event_handler`
+  gates on `pmix_globals.initialized`, which `PMIx_Init` does not set
+  until forty lines later, so the public API is a no-op from there and
+  removing the handler means open-coding the threadshift the public
+  entry point performs. Weigh that against the reachability — the
+  process must ignore a failed `PMIx_Init`, keep running, and then be
+  sent a `PMIX_DEBUGGER_RELEASE` it never asked for.
+- **`pmix_globals.init_called` is set with `__atomic_test_and_set` and
+  cleared with a plain `= false`.** It is a bare `bool`, not an
+  `atomic_bool` like `initialized` beside it, so the clear is a
+  non-atomic store racing an atomic RMW. Left alone because it is not a
+  `src/client` decision: `pmix_client.c`, `pmix_server.c` and
+  `pmix_tool.c` all do exactly this, and the only interleaving that
+  reaches it is a concurrent `PMIx_Init`/`PMIx_Finalize`, which the
+  comment at the top of `PMIx_Init` already declines to support.
+- **The re-entrant `PMIx_Init` returns `PMIX_SUCCESS` where the first
+  call returned `PMIX_ERR_UNREACH`.** A second library in the same
+  process therefore reads "connected" from a singleton that is not, and
+  discovers otherwise only when a server round-trip fails. Recorded
+  rather than changed: the multi-init refcount path exists precisely for
+  those second callers, so altering what it returns is a contract change
+  affecting all of them.
+- **`PMIx_Abort`'s server-role branch calls `pmix_host_server.abort()`
+  with `NULL` for both `cbfunc` and `cbdata` and returns the host's
+  status verbatim.** The typedef documents the host as completing
+  through that callback, so a host honoring the contract either
+  dereferences NULL or never completes, and a host answering
+  `PMIX_OPERATION_SUCCEEDED` (-157) has that handed to the application
+  as a failure. Not changed because the library's own abort up-call in
+  [`pmix_server_ops.c`](../server/pmix_server_ops.c) treats
+  `PMIX_OPERATION_SUCCEEDED` as an error too, so this is a tree-wide
+  convention rather than a divergence here, and the in-tree host
+  (`test/simple/simptest.c`) ignores `cbfunc` entirely, so nothing
+  available demonstrates the failure.
 
 ## Coding conventions specific to this directory
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1724,6 +1724,108 @@ other.
   deliberately NULLs those two members on). Worth knowing before adding a
   reader.
 
+## Defects found in the August 2026 review (eleventh sweep — `pmix_client_topology.c`)
+
+Five lenses over the topology entry points. Four of the five are thin
+hwloc pass-throughs with nothing in them; everything below is in the
+`PMIx_Compute_distances` pair, and all of it is one rule — **a count and
+the array it describes have to agree on every path**, which is the ninth
+sweep's rule about `procs`/`nprocs` meeting a different payload type.
+
+- **`distcb()` set `cb->nvals` before it had an array**, then indexed an
+  unchecked `PMIX_DEVICE_DIST_CREATE`. The count is what `cbdes()` frees
+  against and what the blocking wrapper reads, so it now moves inside the
+  branch that allocated.
+- **`direcv()` sized a `PMIX_DEVICE_DIST_CREATE` from the wire and did not
+  check it**, then unpacked into it. This is the same site class the ninth
+  sweep closed for the wire-sized `PMIX_PROC_CREATE` in
+  `wait_peers_cbfunc()`: the peer's word decides the allocation, so the
+  NULL is as much "more than we can hold" as it is a short heap.
+- **`direcv()` reported the count the peer promised, not the one that
+  arrived.** `pmix_bfrops_base_unpack()` writes the number it actually
+  filled back through `num_vals` and returns `PMIX_SUCCESS` when the
+  payload is shorter than the declared element count, so the application
+  was handed `ndist` entries of which only some were written — the rest
+  zeroed, so a caller printing `uuid` gets a NULL into `%s`. Third
+  occurrence of this exact defect in this directory, after
+  `_lookup_cbfunc()` (`pmix_client_pub.c`) and `wait_peers_cbfunc()`
+  (`pmix_client_resolve.c`). **Assume any `PMIX_BFROPS_UNPACK` of an
+  array in this directory has it until you have checked.**
+  Its failure arm now frees against the *allocated* count before zeroing
+  the pair, because a failed element unpack may already have `strdup`'d
+  into some entries.
+
+*The reason one of these five entry points thread-shifts and four do not
+— read this before "making them consistent":*
+
+`PMIx_Load_topology` builds a stack caddy and `PMIX_THREADSHIFT`s to run
+`pmix_hwloc_load_topology()` on the progress thread. That is not
+ceremony: the function reads and writes **`pmix_globals.topology`**, the
+process-wide cached topology, on the "if we already have a suitable
+version, just return it" path. The stack caddy is safe for the usual
+reason — `PMIX_WAIT_THREAD` holds the frame until the handler wakes it.
+
+Its four siblings call straight into hwloc on the caller's thread, and
+two of them touch that same global: `pmix_hwloc_get_cpuset()` reads
+`pmix_globals.topology.topology`, and `PMIx_Compute_distances_nb` calls
+`pmix_hwloc_load_topology(&pmix_globals.topology)` and
+`pmix_hwloc_get_cpuset(&pmix_globals.cpuset, …)` outright — doing on the
+caller's thread precisely the write the sibling goes to the trouble of
+shifting for. Two application threads, one in `PMIx_Load_topology` and
+one in `PMIx_Compute_distances`, can therefore have the progress thread
+comparing `pmix_globals.topology.source` with `strncasecmp` while the
+caller's thread is assigning it.
+
+**Recorded, not changed.** Closing it means either shifting the other
+four — which `PMIx_Compute_distances_nb` cannot do, being the
+non-blocking form — or putting a lock around `pmix_globals.topology`,
+which is a `pmix_globals` decision rather than a `src/client` one. It is
+also the case the directory already warns about generally ("treat
+concurrent multithreaded use of these APIs with suspicion"). What is
+worth keeping is *why* the asymmetry exists, because from the code alone
+the shift looks removable.
+
+*Verified and clean, so a later sweep need not redo it:*
+
+- **The wire agrees.** This command packs cmd → topology → cpuset →
+  `ninfo` → info-under-`0 < ninfo`, and `pmix_server_device_dists`
+  ([`pmix_server_fabric.c`](../server/pmix_server_fabric.c)) unpacks the
+  same five in the same order with the same guard on the last. No
+  guarded-unpack/unguarded-pack mismatch of the kind the eighth sweep
+  found in the group commands.
+- **The `cnt = cb->nvals` narrowing (`size_t` → `int32_t`) is
+  unreachable.** A wire count above `INT32_MAX` would go negative in
+  `cnt`, but it has to survive `PMIX_DEVICE_DIST_CREATE` first — over a
+  hundred gigabytes — and the NULL check added above turns that into an
+  error return. Do not add a redundant bound; do keep the check.
+- **`notopo`/`nocpuset` are stack objects that never escape.** They are
+  packed synchronously, before the function returns.
+
+*Noted, not changed:*
+
+- `dcbfunc()` hands the caller `icbrelfn` and returns, so a user
+  `pmix_device_dist_cbfunc_t` that never calls it leaks the caddy. That
+  is the documented contract for the callback signature, exactly as the
+  sixth sweep recorded for `construct_cbfunc()` — the second of the two
+  places in this directory where a caller's mistake leaks library memory.
+- **No `make check` coverage is possible for any of the three.** Two are
+  allocation failures and the third needs a server reply whose declared
+  count exceeds its payload. Reaching `direcv` at all requires a client
+  whose *local* hwloc computation failed, which the third sweep already
+  recorded as something the test environments cannot arrange. The
+  argument checks on both entry points are covered in
+  `test/unit/client_api.c`; the reply handling is not covered anywhere.
+
+*The one that was not in this directory:*
+
+- **`pmix_hwloc_compute_distances()` indexed an unchecked
+  `PMIX_DEVICE_DIST_CREATE` too**, and set its `*ndist` out-parameter
+  *above* the `*dist` assignment, so a failure there would have handed
+  the caller a nonzero count with a NULL array — the same disagreement
+  the `direcv` fix closes, in the function that produces the answer when
+  the client can compute it itself. Fixed in
+  [`src/hwloc/pmix_hwloc.c`](../hwloc/pmix_hwloc.c).
+
 ## Coding conventions specific to this directory
 
 - **Mark the exceptional branch.** Error checks, parameter validation,

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -449,6 +449,20 @@ Note the second namespace must be registered with a node-info array and
 host-supplied `PMIX_LOCAL_PEERS`, so a proc map would overwrite the value
 under test.
 
+**Tier 1c — `test/unit/spawn_api.c` (in `make check`).** The same
+stub-host-server trick, applied to `PMIx_Spawn`. It exists because a
+singleton *client* cannot reach spawn's argument handling at all —
+`PMIx_Spawn_nb` gates on `connected` before it looks at `job_info`, and
+the apps copy sits below that gate too, so the only argument check a
+singleton reaches is the `apps`/`napps` one that deliberately precedes it
+(covered in `client_api.c`). A **server** is let through that gate so it
+can hand the request to its own host, so the directive scan and the apps
+copy both run and the call then stops at the absent
+`pmix_host_server.spawn`. `PMIX_ERR_NOT_SUPPORTED` is therefore the "got
+all the way through the argument handling" marker, and every case in the
+file asserts it. Use the same shape for anything else in this file whose
+input handling sits below a `connected` gate.
+
 **Tier 1a — `test/unit/run_grpinviteothers.pl` (in `make check`).**
 Drives `examples/group_invite_others` through `test/simple/simptest`:
 four clients, with rank 0 inviting ranks 1..3 and *not* joining. That
@@ -1122,10 +1136,12 @@ empty array and returns `PMIX_ERR_NOT_A_MEMBER`.
   fabric `_nb` entry points read it as "the caddy is in `cbdata`" (see
   the invariant above), the remaining group `_nb` entry points
   (`PMIx_Group_construct_nb`, `PMIx_Group_join_nb`, `PMIx_Group_leave_nb`,
-  `PMIx_Group_destruct_nb`) accept it as fire-and-forget — their reply
-  handlers all test `NULL != cb->cbfunc` before completing, and the
-  operation still takes effect — and fence blocks. Check which one you are
-  looking at before copying a NULL test between them.
+  `PMIx_Group_destruct_nb`) **and `PMIx_Spawn_nb`** accept it as
+  fire-and-forget — their reply handlers all test `NULL != cb->cbfunc`
+  (`NULL != fcd->spcbfunc` for spawn, in both `wait_cbfunc` and
+  `_lclcbfunc`) before completing, and the operation still takes effect —
+  and fence blocks. Check which one you are looking at before copying a
+  NULL test between them.
 
   This entry used to name `PMIx_Group_construct_nb` among the rejecters.
   It does not reject: it has never tested `cbfunc` at all, and
@@ -1596,6 +1612,117 @@ alone:
   unchanged and still carry their explaining comments. `try_fetch()`
   returns only `PMIX_SUCCESS`, `PMIX_ERR_INVALID_NAMESPACE` and
   `PMIX_ERR_NOT_FOUND`.
+
+## Defects found in the August 2026 review (tenth sweep — `pmix_client_spawn.c`)
+
+Five lenses over the spawn pair. The theme is **the boundary between the
+caller's arrays and ours**, which the third sweep opened when it moved the
+envar harvest below the apps copy. Everything above that copy is running on
+the application's memory and reading counts the application owns, and three
+of the findings are that boundary being crossed in one direction or the
+other.
+
+*The caller's arrays are the caller's:*
+
+- **`PMIx_Spawn_nb` wrote the computed directive count back into the
+  caller's `const pmix_app_t apps[]`.** An app may declare its directives by
+  terminating them with an end-marked info instead of setting `ninfo`; the
+  scan that counts them stored the result into `aptr->ninfo`, and `aptr` is
+  a cast-away-`const` alias for `&apps[n]`. The value written happens to be
+  the right one, which is why nothing ever misbehaved — but a caller whose
+  apps sit in read-only storage takes a SIGSEGV on the store. The count is a
+  local now. **This is the same defect the third sweep fixed for
+  `PMIx_Setenv()`, in the one other place above the copy that writes
+  through `aptr`** — if you add a third, put it below the copy or give it a
+  local.
+- **`(info, ninfo)` is a pair, and a zero count means "no directives"
+  whatever the pointer is.** The directive scan entered on `NULL !=
+  job_info` alone, built an info list from zero entries, and handed it to
+  `PMIx_Info_list_convert()` — which reports `PMIX_ERR_EMPTY` for an empty
+  list. `PMIx_Spawn(job_info, 0, …)` therefore failed the whole spawn with
+  a status that names nothing the caller did wrong. Every sibling that
+  builds an info list here already guards it: `pmix_client_connect.c` and
+  `pmix_client_group.c` both gate the `convert` on a `found` flag rather
+  than on the pointer. Regression: `test/unit/spawn_api.c`.
+
+*Correctness:*
+
+- **An app-level `PMIX_SETUP_APP_ENVARS` harvest served only the first app
+  that asked for one.** The per-app branch set the same `jobenvars` flag
+  that says "the job-level directive already covered every app", so after
+  app 0 harvested, app 1's own directive was never looked at. The two are
+  not the same thing — a job-level harvest is applied to *all* apps' `env`
+  (see the loop below `joblevel_envars`), an app-level one only to that
+  app's — so an MPMD spawn whose second app asked for its own programming
+  model's envars silently got none. The redundant flag is gone; the scan
+  gates on `joblevel_envars` alone. Note this only ever bit the roles that
+  *have* a `pmdl` open — tool, launcher, server — for the reason the third
+  sweep's entry gives.
+
+*Unchecked allocations that are then indexed:*
+
+- `PMIX_APP_CREATE(fcd->apps, …)`, the per-app `PMIX_INFO_CREATE`, and the
+  bare `malloc(2 * sizeof(char *))` for a synthesized `argv` were all
+  dereferenced on the next line. The server's own unpack of this very
+  message (`pmix_server_spawn`, `pmix_server_ops.c`) checks both of the
+  same two macros, so this was a divergence between the two halves of one
+  wire operation rather than a house style. `fcd->copied` is now set at
+  construction rather than after the arrays are filled, so the new error
+  returns between the two actually free what the caddy already holds.
+
+  This is the class the earlier sweeps have consistently closed
+  (`respeer()`, `construct_msg()`, `construct_cbfunc()`). It is **not** an
+  invitation to check `PMIX_NEW`, and the unchecked `strdup()` /
+  `PMIx_Argv_copy()` / `PMIx_Argv_prepend_nosize()` results in the same
+  loop are deliberately left: hardening this function against allocation
+  failure end-to-end is a separate piece of work, and doing half of it is
+  worse than none.
+
+*Noted, not changed — do not re-open these without new evidence:*
+
+- **A host `spawn` that returns `PMIX_OPERATION_SUCCEEDED` is dropped on
+  the floor.** The tree-wide host up-call convention (see
+  [`src/server/AGENTS.md`](../server/AGENTS.md)) is that
+  `PMIX_OPERATION_SUCCEEDED` means "done now, I will not call back — you
+  invoke the completion yourself", and this site treats it as an error:
+  it releases the caddy, never fires `fcd->spcbfunc`, and the blocking
+  `PMIx_Spawn` wrapper then maps the status to `PMIX_SUCCESS` and hands
+  the caller an **empty nspace**. Left alone because the spawn contract has
+  no synchronous channel for the namespace in the first place — a host
+  completing atomically has no way to tell us what it launched — so the
+  return is not really usable here; because `pmix_server_spawn` in
+  `src/server` has the identical shape, making this a convention rather
+  than a divergence; and because nothing in the tree returns it (`pfexec`
+  does not, and the in-tree host modules do not). Closing it properly means
+  extending the `pmix_server_spawn_fn_t` contract, not editing this branch.
+- **The `spawn_iof_flags` stand-in is process-wide and is written from the
+  caller's thread** (`stash_spawn_iof_flags`) while `spawn_or_global_flags()`
+  in [`pmix_iof.c`](../common/pmix_iof.c) reads it on the progress thread.
+  It is safe for the case it was built for: the store happens before
+  `PMIX_PTL_SEND_RECV`, and forwarded output cannot arrive before the
+  request goes out, so the send path's peer lock publishes it. What it does
+  **not** survive is two spawns in flight at once from one process — the
+  second overwrites the first's flags. That is inherent to a single
+  process-wide slot, not a bug in this file; if a tool ever needs
+  concurrent spawns formatted differently, the stand-in has to become a
+  per-request one.
+- **The server branch reads `pmix_server_globals.clients` from the
+  caller's thread.** `pmix_get_peer_object()` walks that pointer array
+  unlocked to resolve a `PMIX_PARENT_ID`, and `PMIx_Spawn_nb` in a server
+  role runs on whatever thread the host called it on, while the progress
+  thread adds and removes clients. Recorded rather than fixed because the
+  cure is to thread-shift the whole entry point — the sibling call in
+  `pmix_monitor.c` has exactly the same exposure — and because a host
+  spawning on behalf of a client it is concurrently losing is not a state
+  anything demonstrates.
+- **`req->flags = cd->flags` in `pmix_server_process_iof()` aliases the
+  caddy's `file`/`directory` strings**, which `scaddes` frees when
+  `_lclcbfunc` releases the caddy — so the IOF request is left holding two
+  dangling pointers. It is harmless today only because **nothing reads
+  `req->flags.file` or `req->flags.directory`**: the output path formats
+  from `nptr->iof_flags` (the namespace's copy, which `wait_cbfunc`
+  deliberately NULLs those two members on). Worth knowing before adding a
+  reader.
 
 ## Coding conventions specific to this directory
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1040,6 +1040,35 @@ pass — memory and lifetime, threading and the PMIx boundary, error paths
 and control flow, portability and representation, and caller contracts —
 rather than re-read the same way five times.
 
+**A group can outlive its membership, and expanding it yields nothing.**
+The `PMIX_GROUP_LEFT` handler in
+[`pmix_event_notification.c`](../event/pmix_event_notification.c)
+decrements `grp->nmbrs` as each member departs and does *not* drop the
+group when the count reaches zero — so a `pmix_group_t` with
+`nmbrs == 0` is a reachable state on `pmix_client_globals.groups`.
+`pmix_client_convert_group_procs()` expanded a `PMIX_RANK_WILDCARD`
+reference to such a group into no participants at all and called that
+success, handing back `*outsize == 0` and the **NULL** that
+`PMIx_Proc_create(0)` returns for a zero count. `PMIx_Get`'s caller then
+`memcpy`'d out of `procs[0]`: a SIGSEGV on a documented-legal call.
+Expansion to nothing is now the same `PMIX_ERR_NOT_FOUND` the function
+already returns for a group rank past the end of the membership, and
+`pmix_client_get.c` additionally requires exactly one proc back rather
+than merely not-more-than-one. **Those two are redundant, not two halves
+of one fix** — either alone closes the crash — so if you rework one,
+check what the other is still doing rather than assuming it is
+load-bearing. Regression: `test_get_empty_group()` in
+`test/unit/client_api.c`.
+
+Two general points fall out of it. `PMIx_Proc_create(0)` returning NULL
+means **any `PMIX_PROC_CREATE` whose count is computed rather than
+literal needs the count checked before the array is indexed.** And this
+function is the directory's one exception to the "define every OUT
+parameter before the first thing that can fail" rule — it sets
+`*outprocs`/`*outsize` only on success. All five callers return
+immediately on a failure status, so that is safe today; it is the kind
+of thing to preserve deliberately rather than discover.
+
 **`pmix_client_connect.c` came through all five with nothing to fix**,
 which is worth recording because two of its shapes look alarming and are
 not. `PMIx_Connect_nb` hands the same `darray` to `PMIX_INFO_LOAD` and

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1033,7 +1033,7 @@ grep -n "PMIX_PTL_SEND_RECV" -A 7 src/client/*.c \
   not a defect here, but it is the one place in this directory where a
   caller's mistake leaks library memory.
 
-## The seventh sweep, and five things it deliberately left alone
+## The seventh sweep, and the things it deliberately left alone
 
 Each file in this pass was audited five times over, through one lens per
 pass — memory and lifetime, threading and the PMIx boundary, error paths
@@ -1095,9 +1095,55 @@ three of the error returns between `connect_to_peer` and the point
 where the URI is finally stored. The three stores now release and free
 identically; they used to disagree.
 
+**A blocking wrapper that reads `cb.status` needs a recv callback that
+writes it.** `PMIx_Fabric_update` reported `PMIX_SUCCESS` for a fabric
+refresh that never happened. It is the one blocking wrapper here that
+passes `cbfunc == NULL` — so the caddy `frecv` completes *is* its stack
+`pmix_cb_t`, and the wakeup branch runs rather than the callback branch.
+But `frecv` wrote `cb->status` in exactly one place: the unpack of the
+server's own status. Every other exit — the lost-connection empty
+buffer, a failed status unpack, a failed `ninfo`/`PMIX_INFO` unpack —
+carried its outcome only in the local `rc` that the *callback* branch
+passes along, leaving `cb->status` at the `PMIX_SUCCESS` `cbcon()` gave
+it. The wrapper then returned success with the caller's `pmix_fabric_t`
+untouched and stale. `frecv` now assigns `cb->status = rc` at
+`complete:`, where `rc` is authoritative on every path.
+
+Note the sibling did not have this: `PMIx_Fabric_register` passes
+`mycbfunc`, which records the status it is handed, so only the
+`cbfunc == NULL` shape is exposed. **When you add a blocking wrapper,
+check which of the two it is** — the "caddy is in `cbdata`" convention
+means the recv callback is writing the *caller's* status field directly,
+and every early exit has to set it. No automated coverage: a singleton
+returns `PMIX_ERR_UNREACH` at the `connected` gate long before the PTL
+round-trip, and no in-tree host implements `pmix_server_module_t.fabric`.
+
 Far more useful is what was examined and **rejected**, because each one
 looks like a defect until you chase it down. Do not re-open these
 without new evidence.
+
+- **A client's `PMIx_Fabric_deregister` never tells the server, and
+  cannot.** There is no `PMIX_FABRIC_DEREGISTER_CMD` — the command enum
+  in [`pmix_globals.h`](../include/pmix_globals.h) has only
+  `PMIX_FABRIC_REGISTER_CMD` (30) and `PMIX_FABRIC_UPDATE_CMD` (31). So
+  the client frees `fabric->info` locally and stops, while the
+  registration `pmix_server_fabric_register` made on its behalf stays on
+  `pmix_pnet_globals.fabrics` for the life of the server. Closing it
+  means a new wire command and a server handler, which is a protocol
+  addition rather than a review fix; recorded so the local-only
+  deregister is not mistaken for an oversight in this file.
+- **`pmix_pnet.register_fabric` returning `PMIX_OPERATION_IN_PROGRESS`
+  would break `PMIx_Fabric_register`'s blocking wrapper**, which treats
+  anything that is neither `PMIX_SUCCESS` nor `PMIX_OPERATION_SUCCEEDED`
+  as an error and destructs its stack caddy before the module's callback
+  can fire. [`pnet.h`](../mca/pnet/pnet.h) does document that return, but
+  the gap is not in this directory: `pmix_pnet_base_register_fabric`
+  records the fabric on `pmix_pnet_globals.fabrics` only for
+  `PMIX_OPERATION_SUCCEEDED`, so an async component's fabric could never
+  be resolved by a later update or deregister either. No shipped
+  component takes that path (see
+  [`src/mca/pnet/AGENTS.md`](../mca/pnet/AGENTS.md)). Fix the base first
+  if one ever does; patching the wrapper alone would hide half of it.
 
 - **`PMIx_Finalize` throws the server's reply away, and that is not the
   `_commitfn`/`PMIx_Abort` defect.** The server *does* ack

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1033,7 +1033,28 @@ grep -n "PMIX_PTL_SEND_RECV" -A 7 src/client/*.c \
   not a defect here, but it is the one place in this directory where a
   caller's mistake leaks library memory.
 
-## The seventh sweep — `pmix_client.c`, and five things it deliberately left alone
+## The seventh sweep, and five things it deliberately left alone
+
+Each file in this pass was audited five times over, through one lens per
+pass — memory and lifetime, threading and the PMIx boundary, error paths
+and control flow, portability and representation, and caller contracts —
+rather than re-read the same way five times.
+
+**`pmix_client_connect.c` came through all five with nothing to fix**,
+which is worth recording because two of its shapes look alarming and are
+not. `PMIx_Connect_nb` hands the same `darray` to `PMIX_INFO_LOAD` and
+then destructs both it and the resulting `pmix_info_t` — that is correct,
+not a double free: `PMIx_Info_load` routes `PMIX_DATA_ARRAY` through
+`pmix_bfrops_base_copy_darray()`, so the info owns a deep copy. (The two
+call sites destruct the source in a different order relative to
+`append_optional()`; both are fine for the same reason.) And
+`wait_cbfunc`'s per-namespace blob loop never leaks `bo`, because
+`PMIX_LOAD_BUFFER` *takes* the bytes — it NULLs the source pointer and
+zeroes its length — so the `pmix_buffer_t` it fills is what frees them.
+Use `PMIX_LOAD_BUFFER_NON_DESTRUCT` if you ever need the byte object to
+survive.
+
+
 
 The sweep found two leaks, both on error paths that only a failing
 server can reach, and both fixed: `job_data()` dropped the `nspace`

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -330,6 +330,9 @@ static void job_data(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &nspace, &cnt, PMIX_STRING);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc || !PMIX_CHECK_NSPACE(nspace, pmix_globals.myid.nspace))) {
         if (PMIX_SUCCESS == rc) {
+            /* the unpack succeeded, so it allocated the string - it is only
+             * the identity that is wrong, and this path owns it */
+            free(nspace);
             rc = PMIX_ERR_INVALID_VAL;
         }
         PMIX_ERROR_LOG(rc);
@@ -970,6 +973,9 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
             rc = fallback_to_next_gds();
         }
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+            /* the URI the connect handed us is ours until it is stored
+             * below - every other exit from this branch frees it */
+            free(suri);
             return rc;
         }
     }
@@ -984,11 +990,12 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         kptr->value->type = PMIX_STRING;
         kptr->value->data.string = strdup(pmix_client_globals.myserver->info->pname.nspace);
         PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
+        PMIX_RELEASE(kptr); // maintain accounting
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
+            free(suri);
             return rc;
         }
-        PMIX_RELEASE(kptr); // maintain accounting
         kptr = PMIX_NEW(pmix_kval_t);
         kptr->key = strdup(PMIX_SERVER_RANK);
         PMIX_VALUE_CREATE(kptr->value, 1);
@@ -998,6 +1005,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
         PMIX_RELEASE(kptr); // maintain accounting
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
+            free(suri);
             return rc;
         }
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -523,7 +523,6 @@ static void _check_for_notify(pmix_info_t info[], size_t ninfo)
             return;
         }
         scd->infocopy = true;
-        scd->ninfo = m + 1;
         n = 0;
         if (NULL != model) {
             PMIX_INFO_XFER(&scd->info[n], model);
@@ -543,6 +542,10 @@ static void _check_for_notify(pmix_info_t info[], size_t ninfo)
         }
         /* mark that it is not to go to any default handlers */
         PMIX_INFO_LOAD(&scd->info[n], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+        /* count what we actually filled, not what we sized for: m counts
+         * every matching key, so a caller that passed one of them twice
+         * left the tail of the array as zeroed entries with an empty key */
+        scd->ninfo = n + 1;
         scd->status = PMIX_MODEL_DECLARED;
         scd->proc = &pmix_globals.myid;
         scd->range = PMIX_RANGE_PROC_LOCAL;

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -155,7 +155,6 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     pmix_cmd_t cmd = PMIX_CONNECTNB_CMD;
     pmix_status_t rc;
     pmix_cb_t *cb, cb2;
-    pmix_byte_object_t bo;
     pmix_info_t xfer;
     pmix_kval_t *kv;
     void *ilist;
@@ -251,7 +250,6 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
      * "remote" scope as all local procs have access
      * to info posted by all other local procs, regardless
      * of their namespace */
-    PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
     PMIX_CONSTRUCT(&cb2, pmix_cb_t);
     cb2.proc = &pmix_globals.myid;
     cb2.scope = PMIX_REMOTE;
@@ -363,7 +361,6 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
                 // now add the kvals
                 PMIX_LIST_FOREACH (kv, &cb2.kvs, pmix_kval_t) {
                     PMIx_Info_list_add_value_unique(ilist, kv->key, kv->value, true);
-                    found = true;
                 }
                 // convert to array
                 rc = PMIx_Info_list_convert(ilist, &darray);
@@ -631,9 +628,12 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
         cnt = 1;
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, &bkt, &nspace, &cnt, PMIX_STRING);
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-            PMIX_ERROR_LOG(rc);
+            /* give up on the remaining blobs - the check below this loop
+             * reports rc to the caller. This used to "continue", which
+             * reads as "skip this blob and take the next one" but does
+             * the same thing, the loop condition being on rc */
             PMIX_DESTRUCT(&bkt);
-            continue;
+            break;
         }
         /* extract and process any proc-related info for this nspace */
         PMIX_GDS_STORE_JOB_INFO(rc, pmix_globals.mypeer, nspace, &bkt);

--- a/src/client/pmix_client_convert.c
+++ b/src/client/pmix_client_convert.c
@@ -83,11 +83,18 @@ pmix_status_t pmix_client_convert_group_procs(const pmix_proc_t *inprocs, size_t
                 /* the nspace matches this group ID */
 
                 if (PMIX_RANK_WILDCARD == inprocs[n].rank) {
-                    /* we need to replace this proc with the grp members */
+                    /* we need to replace this proc with the grp members.
+                     * A group can be sitting on the list with no members
+                     * left - the PMIX_GROUP_LEFT handler decrements nmbrs
+                     * as each one departs and does not drop the group when
+                     * it reaches zero - and that expands to nothing at all.
+                     * Report it the same way as a group rank past the end
+                     * of the membership below, rather than contributing
+                     * no participant and calling that success. */
                     for (i=0; i < grp->nmbrs; i++) {
                         append_unique(&cache, &grp->members[i]);
+                        found = true;
                     }
-                    found = true;
                     break;
                 }
 

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -169,6 +169,14 @@ static void frecv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t *
 
 complete:
     pmix_output_verbose(2, pmix_globals.debug_output, "pmix:fabric recv from server releasing");
+    /* rc is the authoritative outcome by this point - it carries the
+     * server's own status when that was the failure, and our local one
+     * (lost connection, bad reply) otherwise. Record it, because a
+     * blocking caller reached us with its stack caddy as cbdata and no
+     * callback, and reads cb->status rather than anything we pass along:
+     * leaving it at the constructor's PMIX_SUCCESS reported a fabric
+     * update that never happened as having succeeded. */
+    cb->status = rc;
     /* release the caller */
     if (NULL != cb->cbfunc.opfn) {
         cb->cbfunc.opfn(rc, cb->cbdata);

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -203,9 +203,6 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register(pmix_fabric_t *fabric,
     pmix_cb_t cb;
     pmix_status_t rc;
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:fabric register");
-
     if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
@@ -213,6 +210,9 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register(pmix_fabric_t *fabric,
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:fabric register");
 
     /* create a callback object so we can be notified when
      * the non-blocking operation is complete */

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -321,8 +321,10 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             return rc;
         }
-        if (1 < nprocs) {
-            /* we can't support multi-proc gets */
+        if (1 != nprocs) {
+            /* we can't support multi-proc gets - and the memcpy below
+             * needs exactly one, so a count of zero is equally unusable:
+             * PMIx_Proc_create() answers a zero size with NULL */
             PMIX_PROC_FREE(procs, nprocs);
             return PMIX_ERR_BAD_PARAM;
         }

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -402,7 +402,21 @@ static bool try_local_fetch(pmix_cb_t *cb, pmix_get_logic_t *lg)
         return false;
     }
     cb->status = process_values(cb);
-    return (PMIX_SUCCESS == cb->status && NULL != cb->value);
+    if (PMIX_SUCCESS == cb->status && NULL != cb->value) {
+        return true;
+    }
+    /* process_values() can decline - a malformed qualified value in the
+     * store, or a failed allocation - and it does not drain what the
+     * fetch put on the list. Leaving those entries is not a leak, the
+     * caddy destructor takes them, but the ordinary path below is about
+     * to fetch into that same list and process_values() decides between
+     * "the value" and "an aggregate of everything" by counting it. A
+     * stale entry therefore turns a scalar answer into a data array.
+     * Hand the slow path a clean caddy, exactly as the failed-fetch
+     * return above does - this is a short-circuit, never a partial one. */
+    PMIX_LIST_DESTRUCT(&cb->kvs);
+    PMIX_CONSTRUCT(&cb->kvs, pmix_list_t);
+    return false;
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
@@ -1189,7 +1203,10 @@ static void get_data(int sd, short args, void *cbdata)
                             goto done;
                         }
                     } else {
-                        /* couldn't find this proc's appnum - nothing we can do */
+                        /* couldn't find this proc's appnum - nothing we can do.
+                         * Tear the caddy down first: see the hostname fetch
+                         * above, whose failure path had the same hole */
+                        PMIX_DESTRUCT(&cb2);
                         cb->status = PMIX_ERR_NOT_FOUND;
                         goto done;
                     }
@@ -1267,6 +1284,13 @@ static void get_data(int sd, short args, void *cbdata)
                             cb->status = rc;
                             goto done;
                         }
+                    } else {
+                        /* the fetch failed, so the caddy still has to come
+                         * down - the hostname and nodeid fetches above lost
+                         * theirs the same way. Unlike its siblings this one
+                         * carries on with sessionid left at UINT32_MAX, which
+                         * simply resolves to "no such session" below */
+                        PMIX_DESTRUCT(&cb2);
                     }
                 }
             } else {

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -658,8 +658,8 @@ static void _value_cbfunc(pmix_status_t status, pmix_value_t *kv, void *cbdata)
     pmix_cb_t *cb;
     pmix_status_t rc;
 
-    PMIX_ACQUIRE_OBJECT(cb);
     cb = (pmix_cb_t *) cbdata;
+    PMIX_ACQUIRE_OBJECT(cb);
     cb->status = status;
     /* the local get_data path invokes us with the value it already
      * stashed in cb->value - in that case it is ours to keep, so copying
@@ -1005,8 +1005,8 @@ static void get_data(int sd, short args, void *cbdata)
     pmix_kval_t *kv;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    PMIX_ACQUIRE_OBJECT(cb);
     cb = (pmix_cb_t*)cbdata;
+    PMIX_ACQUIRE_OBJECT(cb);
     lg = cb->lg;
     iptr = cb->info;
     nfo = cb->ninfo;

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -237,6 +237,9 @@ static pmix_status_t get_endpts(pmix_info_t *xfer,
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIx_Info_list_release(ilist);
+                /* cb2 still holds the kvals the fetch handed us - this was
+                 * the one exit of this function that walked away from them */
+                PMIX_DESTRUCT(&cb2);
                 return rc;
             }
             // insert into a pmix_info_t for packing
@@ -304,6 +307,12 @@ static pmix_status_t construct_msg(pmix_buffer_t *msg,
         sz = sz + 1;
     }
     PMIX_INFO_CREATE(icopy, sz);
+    if (PMIX_UNLIKELY(0 < sz && NULL == icopy)) {
+        if (lclendpts) {
+            PMIX_INFO_DESTRUCT(&local_endpts);
+        }
+        return PMIX_ERR_NOMEM;
+    }
 
     // check for group info
     for (n=0; n < ninfo; n++) {
@@ -458,8 +467,11 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[], const pmix_p
     }
 
     /* check for bozo input - the group ID names the collective and is
-     * strdup'd onto the tracker below */
-    if (PMIX_UNLIKELY(NULL == grp)) {
+     * strdup'd onto the tracker below. A NULL procs array is legal (an
+     * "add members" or bootstrap participant supplies the membership
+     * separately), but only when it is declared empty: construct_msg()
+     * walks it for any positive count. */
+    if (PMIX_UNLIKELY(NULL == grp || (NULL == procs && 0 < nprocs))) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -705,10 +717,20 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
         PMIX_ERROR_LOG(rc);
         goto done;
     }
-    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, mbrs, nmbrs, PMIX_PROC);
-    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-        PMIX_ERROR_LOG(rc);
-        goto done;
+    /* Only pack the array when there is one, exactly as construct_msg() does.
+     * Both commands are unpacked by the same server routine
+     * (pmix_server_group), and it reads this field only under "0 < nprocs" -
+     * but PMIX_BFROPS_PACK writes an element count even for a zero-length
+     * array, so packing unconditionally put bytes on the wire that the server
+     * never consumes. Its next unpack then read that stray count as the
+     * directive count, succeeded having unpacked nothing, and left the
+     * server's ninf uninitialized. */
+    if (0 < nmbrs) {
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, mbrs, nmbrs, PMIX_PROC);
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+            PMIX_ERROR_LOG(rc);
+            goto done;
+        }
     }
 
     /* pack the info structs */
@@ -965,14 +987,19 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
     if (PMIX_UNLIKELY(NULL == cb->answered)) {
         return PMIX_ERR_NOMEM;
     }
+    /* Fill it in. Note that the wildcard job sizes are fetched a *second*
+     * time here: an elastic job that grew between the two passes would make
+     * this loop write past the array the first pass sized, so every write is
+     * bounded by what was actually allocated and a disagreement between the
+     * two counts is an error rather than a silently wrong membership. */
     m = 0;
-    for (n = 0; n < nprocs; n++) {
+    for (n = 0; n < nprocs && m < cb->nmembers; n++) {
         if (PMIX_RANK_WILDCARD == procs[n].rank) {
             rc = invite_job_size(&procs[n], &jsize);
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 return rc;
             }
-            for (j = 0; j < jsize; j++) {
+            for (j = 0; j < jsize && m < cb->nmembers; j++) {
                 PMIX_LOAD_PROCID(&cb->members[m], procs[n].nspace, j);
                 m++;
             }
@@ -980,6 +1007,9 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
             PMIX_LOAD_PROCID(&cb->members[m], procs[n].nspace, procs[n].rank);
             m++;
         }
+    }
+    if (PMIX_UNLIKELY(m != cb->nmembers)) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
     }
     /* If we (the leader) named ourselves among the invitees, we have
      * obviously already answered by accepting - count that answer here, and
@@ -997,42 +1027,23 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
         }
     }
 
-    /* Watch for the invitees' answers. This is registered as an internal
-     * observer rather than an event handler: invite_observer() is the only
-     * thing that counts answers and calls invite_wake(), and as a handler it
-     * could be silently pre-empted by an application handler that ended the
-     * chain - a PMIX_GROUP_INVITE_ACCEPTED handler that logs who joined, say -
-     * leaving this invitation to block forever unless the caller supplied a
-     * PMIX_TIMEOUT. See openpmix#4059. Observers run ahead of the chain, so
-     * the answers now always reach us.
+    /* Everything the resolution path reads has to be on the tracker before
+     * the observer goes live, and nothing may be *armed* on the tracker
+     * afterwards. Registering the observer publishes it to the progress
+     * thread, and the invitation can resolve from there immediately: the
+     * registration replays matching cached notifications (see
+     * check_cached_events() in src/event/pmix_event_registration.c) into the
+     * observer sweep before it acknowledges the registration, so a leader
+     * whose every invitee has already terminated - and whose terminations
+     * were cached because nothing was watching for them - resolves the
+     * invitation inside the registration call itself.
      *
-     * We run on the caller's thread here, so waiting for the registration to
-     * complete before notifying the invitees is safe (and keeps an early
-     * acceptance from depending on the cached-event replay). The tracker is
-     * NOT handed to the registry to own - the invite path releases it in
-     * invite_teardown - so no release function is given. */
-    ncodes = sizeof(codes) / sizeof(pmix_status_t);
-    PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
-    rc = pmix_event_register_observer("pmix-group-invite", codes, ncodes,
-                                      invite_observer, cb, NULL,
-                                      regcbfunc, &lock);
-    /* only wait if the registration was actually accepted - regcbfunc is the
-     * only thing that ever wakes this lock, and it does not fire when the
-     * call itself failed */
-    if (PMIX_SUCCESS == rc) {
-        PMIX_WAIT_THREAD(&lock.lock);
-        rc = lock.status;
-        cb->ref = lock.ref;
-    }
-    PMIX_DESTRUCT(&lock);
-    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-        return rc;
-    }
-
-    /* check for directives - a timeout bounds how long we wait for the
-     * invitees to respond, and PMIX_GROUP_OPTIONAL selects reduced membership
-     * (form the group on whoever accepts) over the default all-or-nothing
-     * construct (abort if any invitee fails to join) */
+     * The directive scan, the range info and the timer therefore all happen
+     * here rather than below the registration, as they used to. That
+     * ordering had announce_step() read cb->optional before this scan set
+     * it, so a PMIX_GROUP_OPTIONAL invitation was aborted under the default
+     * all-or-nothing policy; and it armed the timeout timer on a tracker the
+     * announcement chain might already have retired. */
     if (NULL != info) {
         for (n = 0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
@@ -1067,6 +1078,60 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
     /* provide the group ID */
     PMIX_INFO_LOAD(&cb->info[n], PMIX_GROUP_ID, grp, PMIX_STRING);
 
+    /* If a timeout was requested, arm a timer so a non-responding invitee
+     * cannot hang the leader indefinitely. The handler runs on the progress
+     * thread; it is cancelled by invite_wake() once every invitee answers,
+     * and by invite_teardown() if we fail below. It is armed before the
+     * observer is registered so that every path that can resolve the
+     * invitation is downstream of it and therefore cancels it. */
+    if (0 < timeout) {
+        pmix_event_assign(&cb->ev, pmix_globals.evbase, -1, 0, invite_timeout, (void *) cb);
+        cb->timer_active = true;
+        tv.tv_sec = timeout;
+        tv.tv_usec = 0;
+        PMIX_POST_OBJECT(cb);
+        pmix_event_add(&cb->ev, &tv);
+    }
+
+    /* Hold a reference of our own for the rest of the setup. From the
+     * registration below onward the tracker belongs to the progress thread
+     * too, and the non-blocking form's completion (invite_finish) releases
+     * it - so without this the announcement could free the tracker while we
+     * are still reading cb->info to notify the invitees. */
+    PMIX_RETAIN(cb);
+
+    /* Watch for the invitees' answers. This is registered as an internal
+     * observer rather than an event handler: invite_observer() is the only
+     * thing that counts answers and calls invite_wake(), and as a handler it
+     * could be silently pre-empted by an application handler that ended the
+     * chain - a PMIX_GROUP_INVITE_ACCEPTED handler that logs who joined, say -
+     * leaving this invitation to block forever unless the caller supplied a
+     * PMIX_TIMEOUT. See openpmix#4059. Observers run ahead of the chain, so
+     * the answers now always reach us.
+     *
+     * We run on the caller's thread here, so waiting for the registration to
+     * complete before notifying the invitees is safe (and keeps an early
+     * acceptance from depending on the cached-event replay). The tracker is
+     * NOT handed to the registry to own - the invite path releases it in
+     * invite_teardown - so no release function is given. */
+    ncodes = sizeof(codes) / sizeof(pmix_status_t);
+    PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
+    rc = pmix_event_register_observer("pmix-group-invite", codes, ncodes,
+                                      invite_observer, cb, NULL,
+                                      regcbfunc, &lock);
+    /* only wait if the registration was actually accepted - regcbfunc is the
+     * only thing that ever wakes this lock, and it does not fire when the
+     * call itself failed */
+    if (PMIX_SUCCESS == rc) {
+        PMIX_WAIT_THREAD(&lock.lock);
+        rc = lock.status;
+        cb->ref = lock.ref;
+    }
+    PMIX_DESTRUCT(&lock);
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+        goto release;
+    }
+
     /* notify everyone of the invitation */
     PMIX_CONSTRUCT(&lock, pmix_group_tracker_t);
     rc = PMIx_Notify_event(PMIX_GROUP_INVITED, &pmix_globals.myid, PMIX_RANGE_CUSTOM,
@@ -1079,23 +1144,18 @@ static pmix_status_t invite_setup(pmix_group_tracker_t *cb, const char *grp,
         rc = lock.status;
     }
     PMIX_DESTRUCT(&lock);
-    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-        return rc;
-    }
 
-    /* if a timeout was requested, arm a timer so a non-responding invitee
-     * cannot hang the leader indefinitely. The handler runs on the progress
-     * thread; it is cancelled by invite_wake() once every invitee answers. */
-    if (0 < timeout) {
-        pmix_event_assign(&cb->ev, pmix_globals.evbase, -1, 0, invite_timeout, (void *) cb);
-        cb->timer_active = true;
-        tv.tv_sec = timeout;
-        tv.tv_usec = 0;
-        PMIX_POST_OBJECT(cb);
-        pmix_event_add(&cb->ev, &tv);
+release:
+    /* If the invitation resolved while we were setting it up, the caller has
+     * already been completed and the tracker retired - our reference is all
+     * that is keeping it alive. Report success in that case: an error return
+     * from here has our caller run invite_teardown() on a tracker that has
+     * already been torn down and completed. */
+    if (cb->completed) {
+        rc = PMIX_SUCCESS;
     }
-
-    return PMIX_SUCCESS;
+    PMIX_RELEASE(cb);
+    return rc;
 }
 
 /* ---- announcing the outcome of an invitation ----------------------------
@@ -1158,10 +1218,16 @@ static void invite_finish(pmix_group_tracker_t *cb)
         pmix_event_del(&cb->ev);
         cb->timer_active = false;
     }
-    if (SIZE_MAX != cb->ref) {
-        pmix_event_deregister_observer(cb->ref, invite_relcb, cb);
+    if (SIZE_MAX != cb->ref &&
+        PMIX_SUCCESS == pmix_event_deregister_observer(cb->ref, invite_relcb, cb)) {
+        /* invite_relcb has the tracker now */
         cb->ref = SIZE_MAX;
     } else {
+        /* either there is nothing registered, or the deregistration was
+         * refused (the library is shutting down) - in which case no callback
+         * is coming and the tracker is still ours to free. Taking the
+         * deregistration on trust leaked it; invite_teardown checks the same
+         * return for the same reason. */
         PMIX_RELEASE(cb);
     }
 }
@@ -2074,13 +2140,22 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
         return PMIX_ERR_NOT_FOUND;
     }
 
-    /* the custom range is the membership, excluding ourselves */
+    /* The custom range is the membership, excluding ourselves. A group whose
+     * membership has drained is a reachable state - the PMIX_GROUP_LEFT
+     * handler decrements the count as members depart and does not drop the
+     * group when it hits zero - and PMIX_PROC_CREATE(0) returns NULL, so
+     * treating that NULL as an allocation failure reported PMIX_ERR_NOMEM for
+     * a group that is simply empty, and returned without dropping it: the
+     * caller could then never leave it. There is nobody to notify in that
+     * case, which is not an error. */
     nmbrs = grpobj->nmbrs;
-    PMIX_PROC_CREATE(range, nmbrs);
-    if (PMIX_UNLIKELY(NULL == range)) {
-        pmix_mutex_unlock(&pmix_client_globals.grouplock);
-        PMIX_RELEASE(cb);
-        return PMIX_ERR_NOMEM;
+    if (0 < nmbrs) {
+        PMIX_PROC_CREATE(range, nmbrs);
+        if (PMIX_UNLIKELY(NULL == range)) {
+            pmix_mutex_unlock(&pmix_client_globals.grouplock);
+            PMIX_RELEASE(cb);
+            return PMIX_ERR_NOMEM;
+        }
     }
     nrange = 0;
     for (m = 0; m < nmbrs; m++) {
@@ -2226,6 +2301,10 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
     }
     if (0 < nmembers) {
         PMIX_PROC_CREATE(members, nmembers);
+        if (PMIX_UNLIKELY(NULL == members)) {
+            ret = PMIX_ERR_NOMEM;
+            goto report;
+        }
         cnt = nmembers;
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, members, &cnt, PMIX_PROC);
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
@@ -2279,10 +2358,14 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
             /* store the info locally. This came off the wire, so the type is
              * the sending server's word rather than ours - a peer that sends
              * anything but a data array here (an older one, or a broken one)
-             * used to have us dereference whatever shared the union */
+             * used to have us dereference whatever shared the union. The
+             * length is that peer's word too: pmix_server_process_grpinfo()
+             * reads element [0] as the contributor's procID, so an empty
+             * array reaches it as a read past the end of the allocation */
             if (PMIX_DATA_ARRAY != grpinfo.value.type ||
                 NULL == grpinfo.value.data.darray ||
-                NULL == grpinfo.value.data.darray->array) {
+                NULL == grpinfo.value.data.darray->array ||
+                0 == grpinfo.value.data.darray->size) {
                 PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
                 ret = PMIX_ERR_INVALID_VAL;
                 PMIX_INFO_DESTRUCT(&grpinfo);
@@ -2308,7 +2391,8 @@ static void construct_cbfunc(struct pmix_peer_t *pr,
                      * per entry */
                     if (PMIX_DATA_ARRAY != iptr[m].value.type ||
                         NULL == iptr[m].value.data.darray ||
-                        NULL == iptr[m].value.data.darray->array) {
+                        NULL == iptr[m].value.data.darray->array ||
+                        0 == iptr[m].value.data.darray->size) {
                         PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
                         ret = PMIX_ERR_INVALID_VAL;
                         PMIX_INFO_DESTRUCT(&grpinfo);

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -415,6 +415,9 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
      * recv routine so we know which callback to use when
      * the return message is recvd */
     cb = PMIX_NEW(pmix_group_tracker_t);
+    if (PMIX_UNLIKELY(NULL == cb)) {
+        return PMIX_ERR_NOMEM;
+    }
 
     /* push the message into our event base to send to the server */
     rc = PMIx_Group_construct_nb(grp, procs, nprocs, info, ninfo, info_cbfunc, cb);
@@ -737,14 +740,12 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grpid[], const pmix_
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &ndinfo, 1, PMIX_SIZE);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(msg);
         goto done;
     }
     if (0 < ndinfo) {
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, dinfo, ndinfo, PMIX_INFO);
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
             goto done;
         }
     }
@@ -1865,6 +1866,9 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
      * recv routine so we know which lock to release when
      * the return message is recvd */
     cb = PMIX_NEW(pmix_group_tracker_t);
+    if (PMIX_UNLIKELY(NULL == cb)) {
+        return PMIX_ERR_NOMEM;
+    }
 
     rc = PMIx_Group_join_nb(grp, leader, opt, info, ninfo, info_cbfunc, cb);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
@@ -2491,7 +2495,6 @@ static void destruct_cbfunc(struct pmix_peer_t *pr,
      * the reply turns out to be: we asked to destruct, so we are done with
      * the group either way, and leaving it registered on one failure path
      * but not the other left the two disagreeing. */
-    grp = NULL;
     pmix_mutex_lock(&pmix_client_globals.grouplock);
     PMIX_LIST_FOREACH(grp, &pmix_client_globals.groups, pmix_group_t) {
         if (0 == strcmp(cb->grpid, grp->grpid)) {

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -482,7 +482,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
 {
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
     pmix_status_t rc;
-    int ret;
+    pmix_status_t ret;
     int32_t cnt;
 
     PMIX_ACQUIRE_OBJECT(cb);
@@ -621,12 +621,12 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
     }
 
 report:
-    if (NULL != cb->cbfunc.lookupfn) {
-        /* hand back the status the SERVER returned, not the status of our
-         * last unpack - they are both PMIX_SUCCESS on the path that used to
-         * reach here, which is why reporting the wrong one went unnoticed */
-        cb->cbfunc.lookupfn(ret, pdata, ndata, cb->cbdata);
-    }
+    /* the callback is known to be non-NULL - a NULL one returned above,
+     * before anything was unpacked. Hand it the status the SERVER returned,
+     * not the status of our last unpack: they are both PMIX_SUCCESS on the
+     * path that used to reach here, which is why reporting the wrong one
+     * went unnoticed */
+    cb->cbfunc.lookupfn(ret, pdata, ndata, cb->cbdata);
 
     /* cleanup - every exit now runs the callback first and falls through
      * here, so there is nothing left to jump to */

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -591,8 +591,16 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
         goto report;
     }
     if (0 < ndata) {
-        /* create the array storage */
+        /* create the array storage. The count came off the wire, so the
+         * allocation can genuinely fail - and reporting ndata with a NULL
+         * pdata would hand a pmix_lookup_cbfunc_t a count it is entitled to
+         * index */
         PMIX_PDATA_CREATE(pdata, ndata);
+        if (PMIX_UNLIKELY(NULL == pdata)) {
+            ret = PMIX_ERR_NOMEM;
+            ndata = 0;
+            goto report;
+        }
         cnt = ndata;
         /* unpack the returned values into the pdata array */
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, pdata, &cnt, PMIX_PDATA);
@@ -605,6 +613,11 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix
             ret = rc;
             goto report;
         }
+        /* report what was actually unpacked, not what the peer said it was
+         * sending: the unpack succeeds having filled fewer entries when the
+         * two disagree, and the remainder are empty pdata the caller would
+         * otherwise be told to read */
+        ndata = cnt;
     }
 
 report:

--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -167,6 +167,8 @@ static void resolve_peers(int sd, short args, void *cbdata)
     pmix_kval_t *kv;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
+    PMIX_ACQUIRE_OBJECT(cd);
+
     // restrict our search to already available info - do
     // not allow the search to call up to the server. This
     // avoids a threadlock situation
@@ -1063,7 +1065,7 @@ static void wait_node_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     int32_t cnt;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:client resolve_peers callback activated with %d bytes",
+                        "pmix:client resolve_nodes callback activated with %d bytes",
                         (NULL == buf) ? -1 : (int) buf->bytes_used);
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 

--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -161,6 +161,7 @@ static void resolve_peers(int sd, short args, void *cbdata)
     char **p, **tmp = NULL, *prs;
     pmix_proc_t *pa;
     size_t m, n, np, ninfo;
+    int npeers;
     pmix_namespace_t *ns;
     char *key;
     pmix_kval_t *kv;
@@ -207,6 +208,15 @@ static void resolve_peers(int sd, short args, void *cbdata)
         /* cycle across all known nspaces and aggregate the results */
         PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
             PMIX_LOAD_NSPACE(proc.nspace, ns->nspace);
+            /* restart each namespace from UNDEF: try_fetch() mutates the
+             * rank to WILDCARD for its retry and does not put it back, and
+             * it declines outright for a rank that is not UNDEF - so
+             * leaving it mutated denied every subsequent namespace its own
+             * first-choice lookup, making the answer depend on the order
+             * the namespaces happen to sit in the list. The server's
+             * pmix_server_locally_resolve_peers() resets it for the same
+             * reason */
+            proc.rank = PMIX_RANK_UNDEF;
             rc = try_fetch(&cb);
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 continue;
@@ -230,6 +240,22 @@ static void resolve_peers(int sd, short args, void *cbdata)
                 PMIX_CONSTRUCT(&cb.kvs, pmix_list_t);
                 continue;
             }
+            /* count the peers BEFORE recording the entry. An nspace can have
+             * this node in its map with no procs of its own on it, and the
+             * host reports that as an empty peer list. The transfer pass
+             * below splits every recorded entry back apart, and
+             * PMIx_Argv_split() of a string with no tokens returns NULL -
+             * so recording an empty one dereferences that NULL the moment
+             * any other nspace contributes a proc and the pass runs. */
+            p = PMIx_Argv_split(val->data.string, ',');
+            npeers = PMIx_Argv_count(p);
+            PMIx_Argv_free(p);
+            if (0 == npeers) {
+                /* no local peers on this node for this nspace */
+                PMIX_LIST_DESTRUCT(&cb.kvs);
+                PMIX_CONSTRUCT(&cb.kvs, pmix_list_t);
+                continue;
+            }
             /* prepend the nspace */
             if (PMIX_UNLIKELY(0 > pmix_asprintf(&prs, "%s:%s", ns->nspace, val->data.string))) {
                 PMIX_LIST_DESTRUCT(&cb.kvs);
@@ -238,11 +264,8 @@ static void resolve_peers(int sd, short args, void *cbdata)
             }
             /* add to our list of results */
             PMIx_Argv_append_nosize(&tmp, prs);
-            /* split to count the npeers */
-            p = PMIx_Argv_split(val->data.string, ',');
-            np += PMIx_Argv_count(p);
+            np += npeers;
             /* done with this entry */
-            PMIx_Argv_free(p);
             free(prs);
             // clean up and cycle around to next namespace
             PMIX_LIST_DESTRUCT(&cb.kvs);
@@ -257,8 +280,10 @@ static void resolve_peers(int sd, short args, void *cbdata)
                 goto done;
             }
             cd->procs = pa;
-            cd->nprocs = np;
-            /* transfer the results */
+            /* transfer the results. Note that nprocs is recorded from the
+             * transfer below, not from the count above: the two disagree
+             * if an append into tmp failed, and the difference would be
+             * handed to the caller as procs it may index */
             np = 0;
             for (n = 0; NULL != tmp[n]; n++) {
                 /* find the nspace delimiter */
@@ -283,10 +308,12 @@ static void resolve_peers(int sd, short args, void *cbdata)
                 PMIx_Argv_free(p);
             }
             PMIx_Argv_free(tmp);
+            cd->nprocs = np;
             rc = PMIX_SUCCESS;
         } else {
-            /* nothing resolved, but the walk above may still have collected
-             * entries (an nspace whose peer list was an empty string) */
+            /* nothing resolved - an entry is recorded only when it carried
+             * at least one peer, so tmp is empty here, but free it rather
+             * than depend on that */
             PMIx_Argv_free(tmp);
         }
         goto done;
@@ -332,6 +359,15 @@ process:
     /* split the procs to get a list */
     p = PMIx_Argv_split(val->data.string, ',');
     np = PMIx_Argv_count(p);
+    if (0 == np) {
+        /* the node is in this nspace's map but hosts none of its procs -
+         * the documented empty answer, not an error. It has to be caught
+         * here because PMIX_PROC_CREATE(0) hands back exactly the NULL an
+         * allocation failure does, and the check below would report the
+         * empty result as PMIX_ERR_NOMEM */
+        PMIx_Argv_free(p);
+        goto done;
+    }
 
     /* allocate the proc array */
     PMIX_PROC_CREATE(pa, np);
@@ -368,14 +404,18 @@ static void respeer(pmix_status_t status, pmix_info_t info[], size_t ninfo, void
     PMIX_ACQUIRE_OBJECT(cb);
 
     cb->status = status;
-    if (PMIX_SUCCESS == status) {
-        cb->ninfo = ninfo;
+    if (PMIX_SUCCESS == status && 0 < ninfo) {
         PMIX_INFO_CREATE(cb->info, ninfo);
-        /* this is our copy, so mark it as such - otherwise the caddy
-         * destructor leaves the whole array behind */
-        cb->infocopy = true;
-        for (n=0; n < ninfo; n++) {
-            PMIX_INFO_XFER(&cb->info[n], &info[n]);
+        if (PMIX_UNLIKELY(NULL == cb->info)) {
+            cb->status = PMIX_ERR_NOMEM;
+        } else {
+            cb->ninfo = ninfo;
+            /* this is our copy, so mark it as such - otherwise the caddy
+             * destructor leaves the whole array behind */
+            cb->infocopy = true;
+            for (n=0; n < ninfo; n++) {
+                PMIX_INFO_XFER(&cb->info[n], &info[n]);
+            }
         }
     }
     if (NULL != release_fn) {
@@ -431,6 +471,15 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
             PMIX_QUERY_CONSTRUCT(&query);
             PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_RESOLVE_PEERS);
             PMIX_INFO_CREATE(iptr, 2);
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc || NULL == iptr)) {
+                /* we cannot describe the request, so there is no point in
+                 * making it - fall through and work it out for ourselves */
+                if (NULL != iptr) {
+                    PMIX_INFO_FREE(iptr, 2);
+                }
+                PMIX_QUERY_DESTRUCT(&query);
+                goto local;
+            }
             str = (char*)nspace;
             PMIX_INFO_LOAD(&iptr[0], PMIX_NSPACE, str, PMIX_STRING);
             PMIX_INFO_SET_QUALIFIER(&iptr[0]);
@@ -474,6 +523,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
             }
             PMIX_DESTRUCT(&cb);
         }
+    local:
         // if we get here, then the host wasn't able to
         // provide us with what we need, so let's do it ourselves
         cd = PMIX_NEW(pmix_resolve_caddy_t);
@@ -559,7 +609,10 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
     } else {
         // if the server couldn't process it, that's likely because it
         // is an older version that doesn't recognize the cmd. So
-        // process it ourselves
+        // process it ourselves. Note that we reuse the caddy here, so
+        // wait_peers_cbfunc() has to leave procs/nprocs agreeing with
+        // each other on every failure path - a count left standing over
+        // a released array would be handed straight to the caller
         cd->nodename = nd;
         PMIX_LOAD_NSPACE(cd->nspace, nspace);
         // reset the lock
@@ -638,12 +691,17 @@ static void resolve_nodes(int sd, short args, void *cbdata)
                 PMIX_CONSTRUCT(&cb.kvs, pmix_list_t);
                 continue;
             }
-            /* add to our list of results, ensuring uniqueness */
+            /* add to our list of results, ensuring uniqueness. An empty
+             * node list is the same "no nodes" answer as the NULL one
+             * caught above, and it has to be caught too: PMIx_Argv_split()
+             * of a string with no tokens returns NULL, not an empty array */
             p = PMIx_Argv_split(val->data.string, ',');
-            for (n = 0; NULL != p[n]; n++) {
-                PMIx_Argv_append_unique_nosize(&tmp, p[n]);
+            if (NULL != p) {
+                for (n = 0; NULL != p[n]; n++) {
+                    PMIx_Argv_append_unique_nosize(&tmp, p[n]);
+                }
+                PMIx_Argv_free(p);
             }
-            PMIx_Argv_free(p);
             PMIX_LIST_DESTRUCT(&cb.kvs);
             PMIX_CONSTRUCT(&cb.kvs, pmix_list_t);
         }
@@ -685,11 +743,23 @@ process:
     }
     kv = (pmix_kval_t*)pmix_list_get_first(&cb.kvs);
     val = kv->value;
-    if (PMIX_STRING != val->type || NULL == val->data.string) {
+    if (PMIX_STRING != val->type) {
+        /* report it as well as log it - rc is PMIX_SUCCESS on the way in
+         * here, so falling through left the caller being told the call
+         * succeeded with a NULL nodelist it is entitled to parse */
         PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
+        rc = PMIX_ERR_INVALID_VAL;
+        goto done;
+    }
+    if (NULL == val->data.string) {
+        /* no nodes recorded for this nspace - the default (empty) response
+         * is the correct answer, exactly as in the aggregate walk above */
         goto done;
     }
     cd->nodelist = strdup(val->data.string);
+    if (PMIX_UNLIKELY(NULL == cd->nodelist)) {
+        rc = PMIX_ERR_NOMEM;
+    }
 
 done:
     /* pass back the result */
@@ -711,13 +781,17 @@ static void resnode(pmix_status_t status, pmix_info_t info[], size_t ninfo, void
     PMIX_ACQUIRE_OBJECT(cb);
 
     cb->status = status;
-    if (PMIX_SUCCESS == status) {
-        cb->ninfo = ninfo;
+    if (PMIX_SUCCESS == status && 0 < ninfo) {
         PMIX_INFO_CREATE(cb->info, ninfo);
-        /* our copy - see respeer() above */
-        cb->infocopy = true;
-        for (n=0; n < ninfo; n++) {
-            PMIX_INFO_XFER(&cb->info[n], &info[n]);
+        if (PMIX_UNLIKELY(NULL == cb->info)) {
+            cb->status = PMIX_ERR_NOMEM;
+        } else {
+            cb->ninfo = ninfo;
+            /* our copy - see respeer() above */
+            cb->infocopy = true;
+            for (n=0; n < ninfo; n++) {
+                PMIX_INFO_XFER(&cb->info[n], &info[n]);
+            }
         }
     }
     if (NULL != release_fn) {
@@ -762,6 +836,12 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
         if (NULL != pmix_host_server.query) {
             PMIX_QUERY_CONSTRUCT(&query);
             PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_RESOLVE_NODE);
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+                /* we cannot name what we are asking for, so there is no
+                 * point in asking - work it out for ourselves instead */
+                PMIX_QUERY_DESTRUCT(&query);
+                goto local;
+            }
             str = (char*)nspace;
             PMIX_INFO_LOAD(&info, PMIX_NSPACE, str, PMIX_STRING);
             PMIX_INFO_SET_QUALIFIER(&info);
@@ -791,6 +871,9 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
                         PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
                     } else {
                         *nodelist = strdup(val->data.string);
+                        if (PMIX_UNLIKELY(NULL == *nodelist)) {
+                            rc = PMIX_ERR_NOMEM;
+                        }
                         PMIX_DESTRUCT(&cb);
                         return rc;
                     }
@@ -798,6 +881,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
             }
             PMIX_DESTRUCT(&cb);
         }
+    local:
         // if we get here, then the host wasn't able to
         // provide us with what we need, so let's do it ourselves
         cd = PMIX_NEW(pmix_resolve_caddy_t);
@@ -927,18 +1011,39 @@ static void wait_peers_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &cd->nprocs, &cnt, PMIX_SIZE);
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
+            cd->nprocs = 0;
             ret = rc;
             goto done;
         }
         if (0 < cd->nprocs) {
+            /* the count came off the wire, so this allocation can genuinely
+             * fail */
             PMIX_PROC_CREATE(cd->procs, cd->nprocs);
+            if (PMIX_UNLIKELY(NULL == cd->procs)) {
+                cd->nprocs = 0;
+                ret = PMIX_ERR_NOMEM;
+                goto done;
+            }
             cnt = cd->nprocs;
             PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, cd->procs, &cnt, PMIX_PROC);
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_PROC_FREE(cd->procs, cd->nprocs);
+                cd->nprocs = 0;
                 ret = rc;
                 goto done;
+            }
+            if (0 == cnt) {
+                /* the peer's count and its payload disagreed and nothing was
+                 * filled in. PMIX_PROC_FREE is a no-op for a zero count, so
+                 * release the block before recording that count */
+                PMIX_PROC_FREE(cd->procs, cd->nprocs);
+                cd->nprocs = 0;
+            } else {
+                /* report what actually arrived, not what the server said it
+                 * was sending: the unpack succeeds having filled fewer
+                 * entries when the two disagree */
+                cd->nprocs = cnt;
             }
         }
     }

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -108,6 +108,12 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
                         "%s pmix: spawn called",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
+    /* ensure the nspace is initialized - note that nspace
+     * is a pmix_nspace_t object, and therefore it cannot
+     * be NULL. Do it above the state checks so it is defined
+     * on every return, not just the ones that get this far */
+    memset(nspace, 0, PMIX_MAX_NSLEN + 1);
+
     if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.initialized))) {
         return PMIX_ERR_INIT;
     }
@@ -115,11 +121,6 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
-
-    /* ensure the nspace is initialized - note that nspace
-     * is a pmix_nspace_t object, and therefore it cannot
-     * be NULL */
-    memset(nspace, 0, PMIX_MAX_NSLEN + 1);
 
     /* create a callback object */
     cb = PMIX_NEW(pmix_cb_t);
@@ -522,6 +523,10 @@ envars_done:
          * of job termination so we can setup the event registration */
         pmix_server_spawn_parser(fcd->peer, &fcd->channels, &fcd->flags,
                                  fcd->info, fcd->ninfo);
+        /* a no-op on this branch - the stash is for tools, and this branch
+         * has already excluded them. Kept so the two dispatch paths read
+         * the same way, and so relaxing the condition above does not
+         * silently drop the stash */
         stash_spawn_iof_flags(&fcd->flags);
 
         /* call the local host */

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -194,10 +194,9 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_SPAWNNB_CMD;
     pmix_status_t rc;
-    size_t n, m;
+    size_t n, m, nappinfo;
     pmix_setup_caddy_t *fcd = NULL;
     pmix_app_t *aptr;
-    bool jobenvars = false;
     bool forkexec = false;
     pmix_kval_t *kv;
     pmix_list_t ilist;
@@ -248,15 +247,22 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     fcd = PMIX_NEW(pmix_setup_caddy_t);
     fcd->spcbfunc = cbfunc;
     fcd->cbdata = cbdata;
+    /* everything we are about to put in the caddy's info and apps fields is
+     * built here and owned by us, so mark it copied now rather than after
+     * the arrays are filled - this is what tells the destructor (scaddes)
+     * to free them, and every error return below goes through it */
+    fcd->copied = true;
 
-    /* check job info for directives */
-    if (NULL != job_info) {
+    /* check job info for directives - a non-NULL pointer with a zero count
+     * is a legal way of saying "no directives", and it must not be treated
+     * as an empty list: PMIx_Info_list_convert() reports PMIX_ERR_EMPTY for
+     * one, which used to come back to the caller as the spawn's failure */
+    if (NULL != job_info && 0 < ninfo) {
         xlist = PMIx_Info_list_start();
         for (n = 0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&job_info[n], PMIX_SETUP_APP_ENVARS)) {
                 /* harvested and applied to our copy of the apps, below */
                 joblevel_envars = true;
-                jobenvars = true;
             } else if (PMIX_CHECK_KEY(&job_info[n], PMIX_PARENT_ID)) {
                 /* the directive comes straight from the caller, so verify it
                  * really carries a proc before dereferencing the union - a
@@ -295,10 +301,10 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
      * going to modify the individual app structs */
     fcd->napps = napps;
     PMIX_APP_CREATE(fcd->apps, fcd->napps);
-    /* we now own the info and apps arrays we filled into the caddy, so
-     * mark it copied - this is what tells the destructor (scaddes) to
-     * free them, on both the completion path and every error path below */
-    fcd->copied = true;
+    if (PMIX_UNLIKELY(NULL == fcd->apps)) {
+        PMIX_RELEASE(fcd);
+        return PMIX_ERR_NOMEM;
+    }
     for (n = 0; n < napps; n++) {
         aptr = (pmix_app_t *) &apps[n];
         /* protect against bozo case - an argv whose first element is NULL
@@ -335,6 +341,13 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         if (NULL == aptr->argv) {
             tmp = pmix_basename(aptr->cmd);
             fcd->apps[n].argv = (char **) malloc(2 * sizeof(char *));
+            if (PMIX_UNLIKELY(NULL == fcd->apps[n].argv)) {
+                if (NULL != tmp) {
+                    free(tmp);
+                }
+                PMIX_RELEASE(fcd);
+                return PMIX_ERR_NOMEM;
+            }
             fcd->apps[n].argv[0] = tmp;
             fcd->apps[n].argv[1] = NULL;
         } else {
@@ -365,7 +378,14 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         /* do a quick check of the apps directive array to ensure
          * the ninfo field has been set */
         if (NULL != aptr->info) {
-            if (0 == aptr->ninfo) {
+            /* count the directives into a local of our own. "apps" is the
+             * caller's const array, so the count we work out is not ours to
+             * write back into it - a caller whose apps sit in read-only
+             * storage would take a SIGSEGV on the store. Same boundary the
+             * envar harvest below respects: above the copy we are running
+             * on the caller's memory. */
+            nappinfo = aptr->ninfo;
+            if (0 == nappinfo) {
                 /* look for the info marked as "end" - test the bound
                  * before the dereference, or the guard below can never
                  * be reached (we would have walked off the array first) */
@@ -378,20 +398,31 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
                     PMIX_RELEASE(fcd);
                     return PMIX_ERR_BAD_PARAM;
                 }
-                aptr->ninfo = m;
+                nappinfo = m;
             }
 
             // copy the info array
-            if (0 < aptr->ninfo) {
-                fcd->apps[n].ninfo = aptr->ninfo;
-                PMIX_INFO_CREATE(fcd->apps[n].info, fcd->apps[n].ninfo);
-                for (m=0; m < aptr->ninfo; m++) {
+            if (0 < nappinfo) {
+                PMIX_INFO_CREATE(fcd->apps[n].info, nappinfo);
+                if (PMIX_UNLIKELY(NULL == fcd->apps[n].info)) {
+                    PMIX_RELEASE(fcd);
+                    return PMIX_ERR_NOMEM;
+                }
+                /* only now that the array exists, so a failure above does
+                 * not leave the app claiming directives it does not have */
+                fcd->apps[n].ninfo = nappinfo;
+                for (m = 0; m < nappinfo; m++) {
                     PMIX_INFO_XFER(&fcd->apps[n].info[m], &aptr->info[m]);
                 }
             }
         }
 
-        if (!jobenvars) {
+        /* an app-level harvest applies to *this* app's environment only, so
+         * it must not be recorded as having covered the job - doing so meant
+         * the first app carrying the directive was the only one served, and
+         * an MPMD spawn whose second app asked for its own programming
+         * model's envars silently got none */
+        if (!joblevel_envars) {
             for (m = 0; m < fcd->apps[n].ninfo; m++) {
                 if (PMIX_CHECK_KEY(&fcd->apps[n].info[m], PMIX_SETUP_APP_ENVARS)) {
                     PMIX_CONSTRUCT(&ilist, pmix_list_t);
@@ -412,7 +443,6 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
                         PMIx_Setenv(kv->value->data.envar.envar, kv->value->data.envar.value, true,
                                     &fcd->apps[n].env);
                     }
-                    jobenvars = true;
                     PMIX_LIST_DESTRUCT(&ilist);
                     break;
                 }

--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -210,7 +210,7 @@ static void direcv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t 
 {
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
     pmix_status_t rc;
-    int cnt;
+    int32_t cnt;
 
     PMIX_HIDE_UNUSED_PARAMS(hdr);
 

--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -110,20 +110,28 @@ static void distcb(pmix_status_t status, pmix_device_distance_t *dist, size_t nd
     size_t n;
 
     cb->status = status;
-    cb->nvals = ndist;
 
     if (PMIX_SUCCESS == status && 0 < ndist) {
-        PMIX_DEVICE_DIST_CREATE(cb->dist, cb->nvals);
-        for (n = 0; n < cb->nvals; n++) {
-            if (NULL != dist[n].uuid) {
-                cb->dist[n].uuid = strdup(dist[n].uuid);
+        PMIX_DEVICE_DIST_CREATE(cb->dist, ndist);
+        if (PMIX_UNLIKELY(NULL == cb->dist)) {
+            cb->status = PMIX_ERR_NOMEM;
+        } else {
+            /* claim the entries only once they exist - cb->nvals is what
+             * the caddy destructor frees against and what the blocking
+             * wrapper hands the caller, so it must never describe an
+             * array that is not there */
+            cb->nvals = ndist;
+            for (n = 0; n < ndist; n++) {
+                if (NULL != dist[n].uuid) {
+                    cb->dist[n].uuid = strdup(dist[n].uuid);
+                }
+                if (NULL != dist[n].osname) {
+                    cb->dist[n].osname = strdup(dist[n].osname);
+                }
+                cb->dist[n].type = dist[n].type;
+                cb->dist[n].mindist = dist[n].mindist;
+                cb->dist[n].maxdist = dist[n].maxdist;
             }
-            if (NULL != dist[n].osname) {
-                cb->dist[n].osname = strdup(dist[n].osname);
-            }
-            cb->dist[n].type = dist[n].type;
-            cb->dist[n].mindist = dist[n].mindist;
-            cb->dist[n].maxdist = dist[n].maxdist;
         }
     }
     if (NULL != release_fn) {
@@ -244,13 +252,34 @@ static void direcv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr, pmix_buffer_t 
         goto complete;
     }
     if (0 < cb->nvals) {
+        /* this count came off the wire, so the allocation is sized by the
+         * peer's word and can fail for that reason as much as for a short
+         * heap - either way there is nowhere to put the answer */
         PMIX_DEVICE_DIST_CREATE(cb->dist, cb->nvals);
+        if (PMIX_UNLIKELY(NULL == cb->dist)) {
+            cb->nvals = 0;
+            rc = PMIX_ERR_NOMEM;
+            goto complete;
+        }
         cnt = cb->nvals;
         PMIX_BFROPS_UNPACK(rc, peer, buf, cb->dist, &cnt, PMIX_DEVICE_DIST);
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
+            /* the unpack may have filled - and strdup'd into - some of the
+             * entries before it gave up, so free against the count we
+             * allocated, then leave the pair agreeing at empty. The caller
+             * is handed both, and an array and a count that disagree is a
+             * wrong answer rather than a leak */
+            PMIX_DEVICE_DIST_FREE(cb->dist, cb->nvals);
+            cb->nvals = 0;
             goto complete;
         }
+        /* the unpack writes back what it actually filled, which is fewer
+         * than the peer's count promised when the payload was short of it.
+         * Report that, not the promise: the count travels to the caller
+         * with the array, and the entries past the real end were never
+         * written. */
+        cb->nvals = cnt;
     }
 
 complete:

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -1469,6 +1469,13 @@ pmix_status_t pmix_hwloc_compute_distances(pmix_topology_t *topo, pmix_cpuset_t 
         goto cleanup;
     }
     PMIX_DEVICE_DIST_CREATE(array, n);
+    if (PMIX_UNLIKELY(NULL == array)) {
+        rc = PMIX_ERR_NOMEM;
+        goto cleanup;
+    }
+    /* claim the entries only once they exist - the count is set ahead of
+     * the array below, so a failure here has to leave it at the zero the
+     * default returns established, not at a size nothing backs */
     *ndist = n;
     n = 0;
     PMIX_LIST_FOREACH (d, &dists, pmix_devdist_item_t) {

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -411,6 +411,39 @@ fence tracker applies: releasing a block destructs its `grp_trk_t`s and
 their `local_cbs`, so remove the current `cd` from `local_cbs` before
 releasing on a host-error return, or the switchyard double-frees it.
 
+## `pmix_server_resolve.c` is a twin of `src/client/pmix_client_resolve.c`
+
+`pmix_server_locally_resolve_peers()` / `..._node()` here and
+`resolve_peers()` / `resolve_nodes()` in
+[`src/client/pmix_client_resolve.c`](../client/AGENTS.md) are the same
+computation over the same datastore, written twice — the server answers
+for a client that round-tripped, the client answers for itself when it
+cannot reach a server. **Every defect found in one has so far been
+present in the other, in both directions.** Read the twin before you stop
+changing either.
+
+The recurring one is that `PMIx_Argv_split()` returns **NULL** for a
+string with no tokens rather than an empty array, and every list these
+functions read out of the datastore can legitimately be the empty string:
+a namespace's map can name a node it placed nothing on, and `store_map()`
+records that node's `PMIX_LOCAL_PEERS` as `strdup("")`. The `NULL ==
+string` guards throughout both files do not cover that state. Related,
+and reachable from the same input: `PMIX_PROC_CREATE(0)` hands back the
+same NULL an allocation failure does, so a zero peer count reported as
+`PMIX_ERR_NOMEM` where the empty answer was correct.
+
+The one that went the other way is worth keeping: the aggregate walk here
+resets `proc.rank` to `PMIX_RANK_UNDEF` per namespace, with a comment
+saying why, and the client's `try_fetch()` did not — so its answer
+depended on the order the namespaces sat in the list. See the ninth-sweep
+entry in the client's `AGENTS.md` for why that was benign against today's
+`hash` module, before deciding the reset is unnecessary.
+
+Regression coverage for the shared defects lives on the client side, in
+`test/unit/resolve_api.c`; it drives the public APIs in a server process
+whose stub host module has no `query`, which is exactly the configuration
+that reaches these local computations.
+
 ## Peer lifecycle, tombstones, and event purging
 
 `pmix_server_peer_finalized` (`pmix_server_registration.c:460`) and its helper

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -403,9 +403,17 @@ pmix_status_t pmix_server_process_grpinfo(size_t ctxid,
     pmix_status_t rc;
     pmix_proc_t procid;
 
-    // the first element in the array must be the procID
-    // of the process that contributed this info
-    if (!PMIX_CHECK_KEY(&pinfo[0], PMIX_PROCID)) {
+    /* The first element in the array must be the procID of the process that
+     * contributed this info. Every caller of this function hands it an array
+     * that arrived over the wire - from a peer's group contribution or from
+     * the host's setup blob - so neither the length nor the union member is
+     * ours to assume: an empty array made this read past the end of the
+     * allocation, and a PMIX_PROCID carrying anything but a pmix_proc_t made
+     * the memcpy read from whatever shared the union. */
+    if (0 == npinfo || NULL == pinfo ||
+        !PMIX_CHECK_KEY(&pinfo[0], PMIX_PROCID) ||
+        PMIX_PROC != pinfo[0].value.type ||
+        NULL == pinfo[0].value.data.proc) {
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return PMIX_ERR_BAD_PARAM;
     }
@@ -1029,7 +1037,10 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     char *grpid = NULL;
     pmix_proc_t *procs = NULL;
     pmix_info_t *info = NULL;
-    size_t n, ninfo = 0, ninf, nprocs = 0;
+    /* ninf is initialized because a peer whose message is short or malformed
+     * can have the unpack below report success without writing it - the count
+     * it found was zero - and ninf then sizes an allocation and indexes it */
+    size_t n, ninfo = 0, ninf = 0, nprocs = 0;
     grp_block_t *blk;
     grp_trk_t *trk;
     bool need_cxtid = false;

--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -166,6 +166,7 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
     char *nspace, *nd;
     pmix_proc_t *pa = NULL;
     size_t m, n, np = 0, ninfo = 3;
+    int npeers;
     pmix_namespace_t *ns;
     pmix_buffer_t *reply;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
@@ -243,6 +244,24 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
                 PMIX_CONSTRUCT(&cb.kvs, pmix_list_t);
                 continue;
             }
+            /* count the peers BEFORE recording the entry. A namespace can
+             * have this node in its map with no procs of its own on it,
+             * and the host reports that as an empty peer list. The
+             * transfer pass below splits every recorded entry back apart,
+             * and PMIx_Argv_split() of a string with no tokens returns
+             * NULL - so recording an empty one dereferences that NULL the
+             * moment any other namespace contributes a proc and the pass
+             * runs at all. The client half of this walk, resolve_peers()
+             * in src/client/pmix_client_resolve.c, is the same code and
+             * had the same defect */
+            p = PMIx_Argv_split(kv->value->data.string, ',');
+            npeers = PMIx_Argv_count(p);
+            PMIx_Argv_free(p);
+            if (0 == npeers) {
+                PMIX_LIST_DESTRUCT(&cb.kvs);
+                PMIX_CONSTRUCT(&cb.kvs, pmix_list_t);
+                continue;
+            }
             /* prepend the nspace */
             if (0 > pmix_asprintf(&prs, "%s:%s", ns->nspace, kv->value->data.string)) {
                 PMIX_LIST_DESTRUCT(&cb.kvs);
@@ -251,11 +270,8 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
             }
             /* add to our list of results */
             PMIx_Argv_append_nosize(&tmp, prs);
-            /* split to count the npeers */
-            p = PMIx_Argv_split(kv->value->data.string, ',');
-            np += PMIx_Argv_count(p);
+            np += npeers;
             /* done with this entry */
-            PMIx_Argv_free(p);
             free(prs);
             // clean up and cycle around to next namespace
             PMIX_LIST_DESTRUCT(&cb.kvs);
@@ -366,11 +382,23 @@ process:
     /* split the procs to get a list */
     p = PMIx_Argv_split(kv->value->data.string, ',');
     np = PMIx_Argv_count(p);
+    if (0 == np) {
+        /* the node is in this namespace's map but hosts none of its
+         * procs - the documented empty answer, not an error. It has to be
+         * caught here because PMIX_PROC_CREATE(0) hands back exactly the
+         * NULL an allocation failure does, and the check below would
+         * report the empty result as PMIX_ERR_NOMEM */
+        PMIx_Argv_free(p);
+        ret = PMIX_SUCCESS;
+        PMIX_DESTRUCT(&cb);
+        goto done;
+    }
 
     /* allocate the proc array */
     PMIX_PROC_CREATE(pa, np);
     if (NULL == pa) {
         ret = PMIX_ERR_NOMEM;
+        np = 0;
         PMIx_Argv_free(p);
         PMIX_DESTRUCT(&cb);
         goto done;
@@ -538,12 +566,17 @@ void pmix_server_locally_resolve_node(int sd, short args, void *cbdata)
                 PMIX_CONSTRUCT(&cb.kvs, pmix_list_t);
                 continue;
             }
-            /* add to our list of results, ensuring uniqueness */
+            /* add to our list of results, ensuring uniqueness. An empty
+             * node list is the same "no nodes" answer as the NULL one
+             * caught above, and it has to be caught too: PMIx_Argv_split()
+             * of a string with no tokens returns NULL, not an empty array */
             p = PMIx_Argv_split(val->data.string, ',');
-            for (n = 0; NULL != p[n]; n++) {
-                PMIx_Argv_append_unique_nosize(&tmp, p[n]);
+            if (NULL != p) {
+                for (n = 0; NULL != p[n]; n++) {
+                    PMIx_Argv_append_unique_nosize(&tmp, p[n]);
+                }
+                PMIx_Argv_free(p);
             }
-            PMIx_Argv_free(p);
             PMIX_LIST_DESTRUCT(&cb.kvs);
             PMIX_CONSTRUCT(&cb.kvs, pmix_list_t);
         }

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -122,6 +122,24 @@ The August 2026 second sweep of that directory added:
   init, because the defect was a missing `initialized` gate in front of a
   `pmix_globals.mypeer` dereference. Keep it there.
 
+The seventh sweep added `test_get_empty_group()`, which plants a
+`pmix_group_t` with no members on `pmix_client_globals.groups` and then
+does a wildcard `PMIx_Get` against its group id. Expanding that used to
+hand the caller the NULL `PMIx_Proc_create(0)` returns, with a count of
+zero, which `PMIx_Get` then `memcpy`'d out of — so this one **segfaults**
+against the unfixed library rather than failing.
+
+Two things about its shape are deliberate. The group is planted directly
+instead of being constructed and then emptied, because a singleton has no
+server to construct one with, and the subject is what the expansion does
+with an empty membership rather than how it got that way. And it covers
+`PMIx_Get` **only**: the other callers of the expansion — fence,
+connect/disconnect, group construct — answer their singleton or
+`connected` check well before they reach the group list, so a case for any
+of them would pass against the unfixed library and assert nothing. That
+is the same unreachability described at the end of this section; resist
+adding the "obvious" sibling cases.
+
 The third sweep added `test_topology_bad_params()`. The topology entry
 points are the one part of `src/client` that answers entirely out of
 hwloc, so they gate on `initialized` alone and a singleton reaches their

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -72,7 +72,7 @@ These run anywhere and are the bulk of the suite: `compress`, `preg`,
 `bfrops_helpers`, `info_support`, `iof_pattern`,
 `hwloc_datatype`, `tracker_match`, `trk_complete`, `collective_status`,
 `collect_job_info`, `progress_threads`, `runtime_init`, `pmix_log`,
-`server_get`.
+`server_get`, `resolve_api`.
 
 **Singleton client tests** — call the real public API in a process that
 comes up with no server. `client_cycle` (init/finalize cycling),
@@ -346,6 +346,48 @@ Two things about the setup are easy to get wrong and were:
 
 The multi-node half of this file — the actual remote fetch — is
 [`contrib/dockerswarm/run-server-tests.sh`](../../contrib/dockerswarm/AGENTS.md).
+
+### `resolve_api` — the local half of `PMIx_Resolve_peers`/`_nodes`
+
+[`resolve_api.c`](resolve_api.c) is the only program in this suite that
+reaches the *local computation* behind `PMIx_Resolve_peers` and
+`PMIx_Resolve_nodes` rather than just their argument checks (those are in
+`client_api.c`). It comes up as a PMIx server with a stub host module,
+and that is what routes it there: both APIs consult
+`pmix_host_server.query` first, and a stub module has none, so each falls
+through to the thread-shifted local path. No client, no socket, no DVM.
+
+The subject is a node that hosts **none** of a namespace's processes —
+an ordinary state, since a namespace's map can name a node it placed
+nothing on, and the datastore records that as a `PMIX_LOCAL_PEERS` value
+that is the *empty string* rather than a NULL one. `PMIx_Argv_split()`
+returns NULL for a string with no tokens, so the aggregate walk recorded
+such a namespace and then indexed that NULL, and the single-namespace
+path handed a zero count to `PMIX_PROC_CREATE` and reported the NULL it
+gets back as `PMIX_ERR_NOMEM`.
+
+Both halves were verified by reverting each fix independently: the
+aggregate case **segfaults** against the unfixed library (exit 139, with
+the buffered output lost, which is the signature described under
+`bfrops_malformed` above), and the single-namespace case fails its
+assertion.
+
+Two things about the setup are load-bearing:
+
+- The empty namespace is registered with a `PMIX_NODE_INFO_ARRAY` and
+  **no proc map**. `store_map()` derives its own `PMIX_LOCAL_PEERS` from
+  the proc map and *replaces* a host-supplied one, so adding a proc map
+  would quietly overwrite the value under test.
+- The namespace arguments are `pmix_nspace_t` variables, not string
+  literals. These APIs take a fixed-size array, and gcc rejects a shorter
+  literal outright under `-Werror=stringop-overread`.
+
+What it cannot reach is the matching empty-list guard in
+`resolve_nodes()`: `PMIX_NODE_LIST` is derived by joining the node map,
+so the hash datastore cannot produce an empty one through
+`PMIx_server_register_nspace`. That guard is hardening against a host
+that stores the key itself. The node cases here only pin the ordinary
+answers.
 
 ### `runtime_init` — the `src/runtime` bring-up regression test
 

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -72,7 +72,7 @@ These run anywhere and are the bulk of the suite: `compress`, `preg`,
 `bfrops_helpers`, `info_support`, `iof_pattern`,
 `hwloc_datatype`, `tracker_match`, `trk_complete`, `collective_status`,
 `collect_job_info`, `progress_threads`, `runtime_init`, `pmix_log`,
-`server_get`, `resolve_api`.
+`server_get`, `resolve_api`, `spawn_api`.
 
 **Singleton client tests** — call the real public API in a process that
 comes up with no server. `client_cycle` (init/finalize cycling),
@@ -388,6 +388,36 @@ so the hash datastore cannot produce an empty one through
 `PMIx_server_register_nspace`. That guard is hardening against a host
 that stores the key itself. The node cases here only pin the ordinary
 answers.
+
+### `spawn_api` — `PMIx_Spawn`'s argument handling
+
+[`spawn_api.c`](spawn_api.c) borrows `resolve_api`'s stub-host-server
+trick for a different reason. `PMIx_Spawn_nb` gates on `connected`
+*before* it looks at `job_info` or copies the apps array, so a singleton
+client is turned away with `PMIX_ERR_UNREACH` and none of that code is
+reachable from `client_api.c` — which is why the only spawn checks there
+are the `apps`/`napps` ones that deliberately precede the gate. A
+**server** is let through the gate so it can hand the request to its own
+host, so with a stub module the directive scan and the apps copy both run
+and the call stops at the absent `pmix_host_server.spawn`.
+`PMIX_ERR_NOT_SUPPORTED` is therefore this file's "reached the end of the
+argument handling" marker, and every case asserts it.
+
+Two defects are pinned, both verified by reverting each fix
+independently (each case fails on its own, and only its own):
+
+- `PMIx_Spawn(job_info, 0, …)` — a non-NULL pointer with a zero count is
+  "no directives", but the scan entered on the pointer alone and the
+  resulting empty info list came back from `PMIx_Info_list_convert()` as
+  `PMIX_ERR_EMPTY`, which failed the spawn.
+- an app whose directives are **end-marked rather than counted**: the
+  scan wrote the count it worked out back into the caller's `const
+  pmix_app_t apps[]`. The sentinel has to sit past index 0 for the case
+  to mean anything — a sentinel at index 0 counts zero, and writing zero
+  over a zero proves nothing.
+
+The apps here carry `cmd = "true"` and are never launched; nothing in
+this file gets past the host up-call, by design.
 
 ### `runtime_init` — the `src/runtime` bring-up regression test
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api
 
 client_api_SOURCES = \
         client_api.c
@@ -315,4 +315,10 @@ server_get_SOURCES = \
         server_get.c
 server_get_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 server_get_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+resolve_api_SOURCES = \
+        resolve_api.c
+resolve_api_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+resolve_api_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api
 
 client_api_SOURCES = \
         client_api.c
@@ -321,4 +321,10 @@ resolve_api_SOURCES = \
         resolve_api.c
 resolve_api_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 resolve_api_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+spawn_api_SOURCES = \
+        spawn_api.c
+spawn_api_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+spawn_api_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/unit/client_api.c
+++ b/test/unit/client_api.c
@@ -54,6 +54,11 @@
 
 #include "include/pmix.h"
 
+#include "src/class/pmix_list.h"
+#include "src/client/pmix_client_ops.h"
+#include "src/include/pmix_globals.h"
+#include "src/threads/pmix_threads.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -330,6 +335,61 @@ static void test_group_lock_concurrency(void)
         pthread_join(tid[n], NULL);
     }
     check(1, "8 threads x 400 gets through the group-list lock completed");
+}
+
+/* A group can sit on pmix_client_globals.groups with no members left: the
+ * PMIX_GROUP_LEFT handler decrements nmbrs as each member departs and does
+ * not drop the group when it reaches zero. Expanding a wildcard reference
+ * to such a group yields no participants at all, and
+ * pmix_client_convert_group_procs() used to report that as success - it
+ * handed back the NULL that PMIx_Proc_create(0) returns along with a count
+ * of zero, and PMIx_Get's caller then memcpy'd out of procs[0]. That is a
+ * SIGSEGV on a call the API documents as legal, so this case asserts
+ * survival first and the error return second.
+ *
+ * The group is planted directly rather than driven through a real
+ * construct-then-leave, because a singleton has no server to construct one
+ * with. That is fair here: the subject is what the expansion does with an
+ * empty membership, not how the membership became empty. */
+static void test_get_empty_group(void)
+{
+    pmix_group_t *grp;
+    pmix_proc_t proc;
+    pmix_value_t *val = NULL;
+    pmix_status_t rc;
+
+    fprintf(stdout, "\n-- PMIx_Get against a group with no members --\n");
+
+    grp = PMIX_NEW(pmix_group_t);
+    if (NULL == grp) {
+        check(0, "allocate the empty group");
+        return;
+    }
+    grp->grpid = strdup("client.api.emptygroup");
+    /* the constructor already leaves members NULL and nmbrs 0 */
+
+    pmix_mutex_lock(&pmix_client_globals.grouplock);
+    pmix_list_append(&pmix_client_globals.groups, &grp->super);
+    pmix_mutex_unlock(&pmix_client_globals.grouplock);
+
+    PMIX_LOAD_PROCID(&proc, "client.api.emptygroup", PMIX_RANK_WILDCARD);
+    rc = PMIx_Get(&proc, "client.api.absent.key", NULL, 0, &val);
+    check(PMIX_SUCCESS != rc, "PMIx_Get on a memberless group returns rather than crashing");
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    /* PMIx_Get is the only entry point a singleton can drive into the
+     * expansion at all. The collectives that also call it - fence,
+     * connect/disconnect, group construct - answer their singleton or
+     * connected check first and never reach the group list, so a case
+     * for them here would pass against the unfixed library and prove
+     * nothing. Their side lives in the swarm suite. */
+
+    pmix_mutex_lock(&pmix_client_globals.grouplock);
+    pmix_list_remove_item(&pmix_client_globals.groups, &grp->super);
+    pmix_mutex_unlock(&pmix_client_globals.grouplock);
+    PMIX_RELEASE(grp);
 }
 
 static void test_fabric(void)
@@ -642,6 +702,7 @@ int main(int argc, char **argv)
     test_fabric();
     test_group_join_outparams();
     test_group_construct_invite_outparams();
+    test_get_empty_group();
     test_group_lock_concurrency();
 
     rc = PMIx_Finalize(NULL, 0);

--- a/test/unit/resolve_api.c
+++ b/test/unit/resolve_api.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for PMIx_Resolve_peers / PMIx_Resolve_nodes
+ * (src/client/pmix_client_resolve.c) against a node that hosts none of a
+ * namespace's processes.
+ *
+ * That state is ordinary - a namespace's map can name a node on which it
+ * placed nothing - and the datastore reports it as a PMIX_LOCAL_PEERS
+ * value that is an empty string rather than a NULL one. Both of the
+ * defects below follow from the same fact about PMIx_Argv_split(): given a
+ * string with no tokens it returns NULL, not an empty array.
+ *
+ *   the aggregate walk
+ *      PMIx_Resolve_peers() with a NULL namespace visits every namespace
+ *      the library knows, records "nspace:peers" for each, and then splits
+ *      every recorded entry back apart to fill the proc array. An entry
+ *      whose peer list was empty split back to NULL and was indexed
+ *      immediately - a SIGSEGV on the progress thread, taken as soon as
+ *      any *other* namespace contributed a proc and made the transfer
+ *      pass run at all.
+ *
+ *   the single-namespace path
+ *      Asking for that namespace by name counted zero peers and handed
+ *      the count to PMIX_PROC_CREATE, which returns NULL for a zero count
+ *      exactly as it does for an allocation failure. The call therefore
+ *      reported PMIX_ERR_NOMEM where PMIx_Resolve_peers(3) documents an
+ *      empty result as PMIX_SUCCESS with a NULL array and a zero count.
+ *
+ * The process comes up as a PMIx server with a stub host module. That is
+ * what puts these on the local path: PMIx_Resolve_peers consults
+ * pmix_host_server.query first, and a stub module has none, so the call
+ * falls through to the thread-shifted local computation under test. It
+ * also means no client, no socket and no DVM are involved.
+ *
+ * Two namespaces are registered on this one node:
+ *
+ *   RESOLVE_UT_PEERS  a node map and proc map naming this host with ranks
+ *                     0 and 1, so the datastore derives PMIX_LOCAL_PEERS
+ *                     of "0,1" for it.
+ *   RESOLVE_UT_EMPTY  a PMIX_NODE_INFO_ARRAY naming this host with an
+ *                     explicitly empty PMIX_LOCAL_PEERS, and deliberately
+ *                     *no* proc map - the map-driven derivation replaces a
+ *                     host-supplied PMIX_LOCAL_PEERS, so supplying a proc
+ *                     map here would overwrite the value under test.
+ *
+ * What this file does not reach: the matching empty-list guard in
+ * resolve_nodes(). PMIX_NODE_LIST is derived by joining the node map, so
+ * the hash datastore cannot produce an empty one through
+ * PMIx_server_register_nspace; that guard is hardening against a host that
+ * stores the key itself, not a reproduced defect. The node cases below
+ * therefore only pin the ordinary answers.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define RESOLVE_UT_PEERS "resolve-ut-peers"
+#define RESOLVE_UT_EMPTY "resolve-ut-empty"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* Register a namespace whose map places ranks 0 and 1 on this node. The
+ * datastore derives PMIX_LOCAL_PEERS from the proc map, so this is the
+ * namespace that actually has peers here. */
+static pmix_status_t register_with_peers(void)
+{
+    pmix_info_t info[3];
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    char *noderegex = NULL, *ppnregex = NULL;
+    uint32_t nprocs = 2;
+
+    PMIx_generate_regex(pmix_globals.hostname, &noderegex);
+    PMIx_generate_ppn("0,1", &ppnregex);
+
+    PMIX_INFO_LOAD(&info[0], PMIX_NODE_MAP, noderegex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&info[1], PMIX_PROC_MAP, ppnregex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&info[2], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+
+    PMIX_LOAD_NSPACE(ns, RESOLVE_UT_PEERS);
+    rc = PMIx_server_register_nspace(ns, 2, info, 3, NULL, NULL);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_INFO_DESTRUCT(&info[2]);
+    free(noderegex);
+    free(ppnregex);
+    return rc;
+}
+
+/* Register a namespace that names this node but places nothing on it, by
+ * handing the server a node-info array whose PMIX_LOCAL_PEERS is the empty
+ * string. No proc map: store_map() would derive its own PMIX_LOCAL_PEERS
+ * and replace this one. */
+static pmix_status_t register_without_peers(void)
+{
+    pmix_info_t info[2];
+    pmix_data_array_t *darray;
+    pmix_info_t *nd;
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    uint32_t nprocs = 0;
+
+    PMIX_DATA_ARRAY_CREATE(darray, 2, PMIX_INFO);
+    if (NULL == darray) {
+        return PMIX_ERR_NOMEM;
+    }
+    nd = (pmix_info_t *) darray->array;
+    PMIX_INFO_LOAD(&nd[0], PMIX_HOSTNAME, pmix_globals.hostname, PMIX_STRING);
+    PMIX_INFO_LOAD(&nd[1], PMIX_LOCAL_PEERS, "", PMIX_STRING);
+
+    PMIX_INFO_LOAD(&info[0], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_LOAD_KEY(info[1].key, PMIX_NODE_INFO_ARRAY);
+    info[1].flags = 0;
+    info[1].value.type = PMIX_DATA_ARRAY;
+    info[1].value.data.darray = darray;
+
+    PMIX_LOAD_NSPACE(ns, RESOLVE_UT_EMPTY);
+    rc = PMIx_server_register_nspace(ns, 0, info, 2, NULL, NULL);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_status_t rc;
+    pmix_proc_t *procs = NULL;
+    pmix_nspace_t ns_peers, ns_empty;
+    size_t nprocs = 0;
+    char *nodelist = NULL;
+    size_t n;
+    bool allpeers;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "resolve_api: PMIx_Resolve_peers / PMIx_Resolve_nodes unit tests\n");
+
+    /* these APIs take a pmix_nspace_t - a fixed-size array - so they must
+     * be handed one, not a string literal */
+    PMIX_LOAD_NSPACE(ns_peers, RESOLVE_UT_PEERS);
+    PMIX_LOAD_NSPACE(ns_empty, RESOLVE_UT_EMPTY);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    /* the stub module has no query entry point, which is what routes these
+     * calls to the local computation under test - assert it rather than
+     * assume it */
+    if (NULL != pmix_host_server.query) {
+        fprintf(stderr, "test setup error: host module advertises query\n");
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    rc = register_with_peers();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "register_with_peers failed: %s\n", PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+    rc = register_without_peers();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "register_without_peers failed: %s\n", PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    /* --- baseline: the namespace that does have peers here ---------- */
+    rc = PMIx_Resolve_peers(NULL, ns_peers, &procs, &nprocs);
+    report("namespace with peers succeeds", PMIX_SUCCESS == rc);
+    report("namespace with peers returns both ranks", 2 == nprocs && NULL != procs);
+    if (NULL != procs) {
+        PMIX_PROC_FREE(procs, nprocs);
+        procs = NULL;
+    }
+    nprocs = 0;
+
+    /* --- a node this namespace placed nothing on -------------------- */
+    /* PMIX_PROC_CREATE(0) returns the same NULL an allocation failure
+     * does, so this used to be reported as PMIX_ERR_NOMEM */
+    rc = PMIx_Resolve_peers(NULL, ns_empty, &procs, &nprocs);
+    report("namespace with no peers here succeeds", PMIX_SUCCESS == rc);
+    report("namespace with no peers here returns an empty array",
+           0 == nprocs && NULL == procs);
+    if (NULL != procs) {
+        PMIX_PROC_FREE(procs, nprocs);
+        procs = NULL;
+    }
+    nprocs = 0;
+
+    /* --- the aggregate walk across both namespaces ------------------ */
+    /* this is the one that segfaulted: the empty namespace was recorded
+     * on the results list, and the transfer pass split it back to the
+     * NULL that PMIx_Argv_split() returns and indexed it */
+    rc = PMIx_Resolve_peers(NULL, NULL, &procs, &nprocs);
+    report("aggregate walk survives a namespace with no peers here",
+           PMIX_SUCCESS == rc);
+    report("aggregate walk returns only the peers that exist",
+           2 == nprocs && NULL != procs);
+    allpeers = (NULL != procs);
+    for (n = 0; n < nprocs && NULL != procs; n++) {
+        if (!PMIX_CHECK_NSPACE(procs[n].nspace, ns_peers)) {
+            allpeers = false;
+        }
+    }
+    report("aggregate walk attributes every proc to the right namespace", allpeers);
+    if (NULL != procs) {
+        PMIX_PROC_FREE(procs, nprocs);
+        procs = NULL;
+    }
+    nprocs = 0;
+
+    /* --- nodes, by namespace and aggregated ------------------------- */
+    rc = PMIx_Resolve_nodes(ns_peers, &nodelist);
+    report("resolve_nodes for a mapped namespace succeeds", PMIX_SUCCESS == rc);
+    report("resolve_nodes names this host",
+           NULL != nodelist && NULL != strstr(nodelist, pmix_globals.hostname));
+    if (NULL != nodelist) {
+        free(nodelist);
+        nodelist = NULL;
+    }
+
+    rc = PMIx_Resolve_nodes(NULL, &nodelist);
+    report("aggregate resolve_nodes succeeds", PMIX_SUCCESS == rc);
+    report("aggregate resolve_nodes names this host",
+           NULL != nodelist && NULL != strstr(nodelist, pmix_globals.hostname));
+    if (NULL != nodelist) {
+        free(nodelist);
+        nodelist = NULL;
+    }
+
+    PMIx_server_finalize();
+
+    fprintf(stdout, "resolve_api: %d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/spawn_api.c
+++ b/test/unit/spawn_api.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for PMIx_Spawn's handling of its two input arrays
+ * (src/client/pmix_client_spawn.c).
+ *
+ * The process comes up as a PMIx server with a stub host module, and that
+ * is what makes these reachable at all. A singleton *client* is turned
+ * away at PMIx_Spawn_nb's "am I connected" gate with PMIX_ERR_UNREACH
+ * before either array is looked at. A server is not: the gate lets a
+ * server through so it can hand the request to its own host, so the
+ * directive scan and the apps copy both run, and the call then stops at
+ * the missing pmix_host_server.spawn with PMIX_ERR_NOT_SUPPORTED. That
+ * status is therefore the "got all the way through the argument handling"
+ * marker every case below tests for.
+ *
+ *   a non-NULL job_info with a zero count
+ *      (info, ninfo) is a pair and a zero count means "no directives"
+ *      whatever the pointer is. PMIx_Spawn_nb entered its directive scan
+ *      on the pointer alone, built an empty info list from it, and handed
+ *      that to PMIx_Info_list_convert() - which reports PMIX_ERR_EMPTY for
+ *      an empty list. The spawn failed with that status.
+ *
+ *   the caller's apps array is const
+ *      An app may declare its directives by terminating them with an
+ *      end-marked info instead of setting ninfo. PMIx_Spawn_nb counts them
+ *      and used to write the count back into apps[n].ninfo - a store into
+ *      the caller's "const pmix_app_t apps[]", which segfaults outright
+ *      for a caller whose apps sit in read-only storage. The count now
+ *      lives in a local. Note the sentinel has to sit past index 0 for
+ *      this to be visible: a sentinel at index 0 counts zero, and writing
+ *      zero over a zero proves nothing.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_status_t rc;
+    pmix_nspace_t nspace;
+    pmix_app_t app;
+    pmix_info_t jobinfo[2];
+    pmix_info_t *appinfo;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "spawn_api: PMIx_Spawn argument-handling unit tests\n");
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    /* the stub module has no spawn entry point - that is what makes
+     * PMIX_ERR_NOT_SUPPORTED the marker for "reached the end of the
+     * argument handling", so assert it rather than assume it */
+    if (NULL != pmix_host_server.spawn) {
+        fprintf(stderr, "test setup error: host module advertises spawn\n");
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    /* --- control: no directives at all ------------------------------ */
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup("true");
+    app.maxprocs = 1;
+    rc = PMIx_Spawn(NULL, 0, &app, 1, nspace);
+    report("a spawn with no directives reaches the host up-call",
+           PMIX_ERR_NOT_SUPPORTED == rc);
+    PMIX_APP_DESTRUCT(&app);
+
+    /* --- a non-NULL job_info carrying a zero count ------------------- */
+    PMIX_INFO_LOAD(&jobinfo[0], PMIX_PERSONALITY, "ompi", PMIX_STRING);
+    PMIX_INFO_LOAD(&jobinfo[1], PMIX_PERSONALITY, "ompi", PMIX_STRING);
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup("true");
+    app.maxprocs = 1;
+    rc = PMIx_Spawn(jobinfo, 0, &app, 1, nspace);
+    report("a non-NULL job_info with a zero count is not an empty list",
+           PMIX_ERR_NOT_SUPPORTED == rc);
+    PMIX_APP_DESTRUCT(&app);
+
+    /* and the ordinary case still works - the guard above must gate on
+     * the count, not stop reading directives altogether */
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup("true");
+    app.maxprocs = 1;
+    rc = PMIx_Spawn(jobinfo, 2, &app, 1, nspace);
+    report("job-level directives are still carried when the count is set",
+           PMIX_ERR_NOT_SUPPORTED == rc);
+    PMIX_APP_DESTRUCT(&app);
+    PMIX_INFO_DESTRUCT(&jobinfo[0]);
+    PMIX_INFO_DESTRUCT(&jobinfo[1]);
+
+    /* --- an app whose directives are end-marked rather than counted -- */
+    PMIX_INFO_CREATE(appinfo, 2);
+    if (NULL == appinfo) {
+        fprintf(stderr, "test setup error: out of memory\n");
+        PMIx_server_finalize();
+        return 1;
+    }
+    PMIX_INFO_LOAD(&appinfo[0], PMIX_PERSONALITY, "ompi", PMIX_STRING);
+    PMIX_INFO_SET_END(&appinfo[1]);
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup("true");
+    app.maxprocs = 1;
+    app.info = appinfo;
+    app.ninfo = 0;
+    rc = PMIx_Spawn(NULL, 0, &app, 1, nspace);
+    report("an end-marked app info array reaches the host up-call",
+           PMIX_ERR_NOT_SUPPORTED == rc);
+    report("counting an end-marked app info array leaves the caller's app alone",
+           0 == app.ninfo && appinfo == app.info);
+    /* the app owns nothing we did not give it - hand the info array back
+     * to ourselves rather than letting PMIX_APP_DESTRUCT free it twice */
+    app.info = NULL;
+    app.ninfo = 0;
+    PMIX_APP_DESTRUCT(&app);
+    PMIX_INFO_FREE(appinfo, 2);
+
+    PMIx_server_finalize();
+
+    fprintf(stdout, "spawn_api: %d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}


### PR DESCRIPTION
Sweeps 7–11 of the `src/client` deep review, one file at a time, five
lenses per file — memory and lifetime, threading and the PMIx boundary,
error paths and control flow, portability and representation, and caller
contracts — rather than the same read five times.

Twenty-three commits. Substantive fixes and style sweeps are kept separate
so neither obscures the other.

## User-visible fixes

**Spawn** (`pmix_client_spawn.c`)

- `PMIx_Spawn(job_info, 0, …)` failed the whole spawn with
  `PMIX_ERR_EMPTY`. The directive scan entered on a non-NULL pointer alone
  and handed the resulting empty list to `PMIx_Info_list_convert()`.
  `(info, ninfo)` is a pair; a zero count means "no directives".
- `PMIx_Spawn_nb` wrote its computed directive count back into the caller's
  `const pmix_app_t apps[]` — right value, wrong memory, and a SIGSEGV for
  a caller whose apps sit in read-only storage. Same defect the third sweep
  fixed for `PMIx_Setenv()`, in the one other place that writes through
  `aptr`.
- An app-level `PMIX_SETUP_APP_ENVARS` served only the *first* app that
  asked, because the per-app harvest set the flag meaning "the job-level
  directive already covered every app". An MPMD spawn whose second app
  wanted its own programming model's envars silently got none.
- Three allocations dereferenced on the next line. The server's unpack of
  this same message checks the same two macros, so this was a divergence
  between two halves of one wire operation.

**Topology** (`pmix_client_topology.c`, `src/hwloc/pmix_hwloc.c`)

- `PMIx_Compute_distances` reported the count the server *promised* rather
  than the count that arrived. `pmix_bfrops_base_unpack()` writes what it
  actually filled back through `num_vals` and still returns
  `PMIX_SUCCESS` on a short payload, so the application got entries that
  were never written — zeroed, so a caller reading `uuid` finds a NULL.
  **Third occurrence of this exact defect in this directory**, after
  `_lookup_cbfunc()` and `wait_peers_cbfunc()`.
- The same handler sized an allocation from the wire count without
  checking it, and `pmix_hwloc_compute_distances()` had the mirror image —
  an unchecked create plus `*ndist` committed above `*dist`.

Earlier commits on the branch cover the resolve pair on a node hosting no
peers, the lookup reply count, the fabric update status, group reference
expansion, and the group invite observer race. Release notes in
`docs/news/news-v7.x.rst`.

## Tests

New `test/unit/spawn_api.c`, wired into `make check`. It comes up as a
server with a stub host module, because a singleton *client* is turned away
at `PMIx_Spawn_nb`'s `connected` gate before any of the argument handling
runs — a server is let through so it can hand the request to its own host,
then stops at the absent `pmix_host_server.spawn`. Both cases were verified
by reverting each fix independently; each fails on its own and only its own.

`make check` is 122/122. Builds are warning-free under `--enable-devel-check`.

## Not covered

The swarm suite did not run — `contrib/dockerswarm/` is empty in this tree,
so the multi-node tier the client `AGENTS.md` describes was unavailable. The
MPMD envars fix in particular has no test behind it: it only bites roles
with a `pmdl` framework open, and `test/simple/simptest` cannot host a spawn
(item 4 below).

## A note on the review notes themselves

A reconciliation pass re-checked all ~35 "noted, not changed" items this
directory has accumulated, against the code rather than against the previous
sweep's word. Three did not survive:

- the fourth sweep's `invite_setup()` observer-ordering item was **closed by
  the eighth sweep** and sat under "not changed" for four sweeps afterwards;
- the ninth sweep's claim that **`PMIX_NEW` is not NULL-checked anywhere in
  this directory** is false — 14 of 81 sites are checked, including the
  buffer allocation it said nobody checked. The claim had been used to
  justify leaving new allocations unchecked, including in this branch;
- the same sweep's count of unvalidated `strtoul` rank parses (fourteen) is
  ten.

Corrected in `Correct three stale claims in the client review notes`. A wrong
note is worse than no note, because it gets believed.

## Deferred items

Twenty-two items were deliberately not fixed, each re-verified against the
tree during that pass. The full list — with file:line and the shape of each
fix — is below, retained here rather than trimmed, so it can be turned into
issues once triaged. Settled *refutations* are deliberately not in this list;
they stay in `AGENTS.md`, where they stop the next reviewer re-deriving them.

<details>
<summary><b>Investigate / fix (17)</b></summary>

1. `PMIx_Group_invite_nb` deadlocks if called from an event handler — `invite_setup()` takes two `PMIX_WAIT_THREAD`s on the caller's thread. Fix: a non-blocking chain, as `announce_step()` already is.
2. `PMIx_Fabric_deregister` never tells the server — no `PMIX_FABRIC_DEREGISTER_CMD` (`pmix_globals.h:244-245`). Needs a wire command and a server handler.
3. `pmix_pnet.register_fabric` returning `PMIX_OPERATION_IN_PROGRESS` would break the blocking wrapper; the base records a fabric only for `PMIX_OPERATION_SUCCEEDED` (`pnet_base_fns.c:326`). Fix the base first.
4. `test/simple/simptest` cannot host a spawn — `spawn_fn` waits on a thread-shifting API while running on the progress thread (`simptest.c:684`, waits `:454`/`:474`). Blocks spawn coverage in `make check`.
5. `PMIx_Init` leaves the debugger-wait handler registered on the notify-failure return, holding a pointer into a dying stack frame (`pmix_client.c:1158-1163`).
6. `pmix_globals.init_called` is set with an atomic RMW and cleared with a plain store; it is a bare `bool` (`pmix_globals.h:856`, `pmix_client.c:669`/`:1263`). Same in server and tool.
7. `PMIx_Fence_nb` blocks when handed a NULL `cbfunc` — the only `_nb` entry point here that does (`pmix_client_fence.c:92-93`).
8. `PMIx_Group_leave_nb` drops the group before notifying, so a notification failure errors a caller whose group we already forgot (`pmix_client_group.c:117,119,143`).
9. `cb->completed` / `cb->timer_active` are plain `bool`s crossing threads on ordering that is incidental rather than declared (`pmix_client_group.c:97-98`).
10. `rank = strtoul(token, NULL, 10)` validates nothing — ten sites; wants a shared helper.
11. A lost connection between the `connected` check and the send hangs the caller forever (`ptl_base_sendrecv.c:751,799`). Tree-wide; only `PMIx_Finalize` arms a timer.
12. `PMIx_Value_get_number(kv->value, …)` unchecked at three fetches (`pmix_client_get.c:1088,1199,1281`). The screen belongs in the function.
13. A host `spawn` returning `PMIX_OPERATION_SUCCEEDED` is dropped, and the blocking wrapper reports success with an empty nspace. `pmix_server_spawn_fn_t` has no synchronous channel for the namespace — contract extension.
14. `spawn_iof_flags` is process-wide and cannot survive two spawns in flight.
15. `PMIx_Spawn_nb`'s server branch reads `pmix_server_globals.clients` off the progress thread (`pmix_client_spawn.c:509`); `pmix_monitor.c:263` has the same exposure.
16. `pmix_globals.topology` is written from two threads — `PMIx_Load_topology` shifts for it, `PMIx_Get_cpuset` and `PMIx_Compute_distances_nb` do not.
17. **New.** Decide the `PMIX_NEW` NULL-check convention here and make it consistent — 14 of 81 checked. Either direction is defensible; the inconsistency is not.

</details>

<details>
<summary><b>Decide — behavior questions about released APIs (5)</b></summary>

18. `PMIx_Finalize` discards the server's reply. Kept deliberately: the caller cannot act on it, and returning anything but `PMIX_SUCCESS` would newly fail applications that check it.
19. The re-entrant `PMIx_Init` returns `PMIX_SUCCESS` where the first call returned `PMIX_ERR_UNREACH`, so a second library reads "connected" from a singleton that is not.
20. `refcb()` swallows the `PMIX_GDS_STORE_KV` status. Reporting it would change what `PMIx_Get` returns for a partially-successful refresh.
21. `process_request()` reads `PMIX_DATA_SCOPE` with no type check — cannot crash, but a mistyped directive yields a wrong scope and a wrong answer. "Reject" and "ignore" are both defensible.
22. `PMIx_Abort`'s server-role branch passes NULL/NULL to `pmix_host_server.abort()` and returns its status verbatim (`pmix_client.c:1409-1416`). Tree-wide convention rather than a divergence here.

</details>
