### PR TITLE
Deep review of src/server: all twenty files, five lenses each

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,6 +293,7 @@ test/unit/server_fence
 test/unit/server_connect
 test/unit/server_dmodex
 test/unit/server_fabric
+test/unit/server_resolve
 test/unit/info_support
 test/unit/rndz_stale
 test/unit/singleton_register

--- a/.gitignore
+++ b/.gitignore
@@ -290,6 +290,7 @@ test/unit/spawn_api
 test/unit/server_get
 test/unit/server_control
 test/unit/server_fence
+test/unit/server_connect
 test/unit/server_dmodex
 test/unit/server_fabric
 test/unit/info_support

--- a/.gitignore
+++ b/.gitignore
@@ -288,6 +288,7 @@ test/unit/runtime_init
 test/unit/resolve_api
 test/unit/spawn_api
 test/unit/server_get
+test/unit/server_control
 test/unit/info_support
 test/unit/rndz_stale
 test/unit/singleton_register

--- a/.gitignore
+++ b/.gitignore
@@ -294,6 +294,7 @@ test/unit/server_connect
 test/unit/server_dmodex
 test/unit/server_fabric
 test/unit/server_resolve
+test/unit/server_setup
 test/unit/info_support
 test/unit/rndz_stale
 test/unit/singleton_register

--- a/.gitignore
+++ b/.gitignore
@@ -290,6 +290,7 @@ test/unit/spawn_api
 test/unit/server_get
 test/unit/server_control
 test/unit/server_dmodex
+test/unit/server_fabric
 test/unit/info_support
 test/unit/rndz_stale
 test/unit/singleton_register

--- a/.gitignore
+++ b/.gitignore
@@ -289,6 +289,7 @@ test/unit/resolve_api
 test/unit/spawn_api
 test/unit/server_get
 test/unit/server_control
+test/unit/server_fence
 test/unit/server_dmodex
 test/unit/server_fabric
 test/unit/info_support

--- a/.gitignore
+++ b/.gitignore
@@ -289,6 +289,7 @@ test/unit/resolve_api
 test/unit/spawn_api
 test/unit/server_get
 test/unit/server_control
+test/unit/server_dmodex
 test/unit/info_support
 test/unit/rndz_stale
 test/unit/singleton_register

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -7,6 +7,15 @@ series, in reverse chronological order.
 7.0.0 -- TBD
 ------------
 Detailed changes since v6.1.0:
+ - PMIx_Disconnect now honors PMIX_TIMEOUT while the server is still
+   collecting local contributions, as PMIx_Fence and PMIx_Connect
+   already did. Until every local participant has called, the request
+   has not been passed to the host environment, so nothing the host
+   might do about the timeout can reach it - which is precisely the
+   case the attribute is documented for, a participant that never
+   arrives. Such a disconnect previously blocked its callers
+   indefinitely and stranded the collective's tracker; it now completes
+   every waiting participant with PMIX_ERR_TIMEOUT
  - PMIx_Spawn and PMIx_Spawn_nb no longer treat a non-NULL job_info
    pointer carrying a zero ninfo as an empty directive list. Such a call
    failed the whole spawn with PMIX_ERR_EMPTY, a status naming nothing

--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -160,7 +160,7 @@ static void resolve_peers(int sd, short args, void *cbdata)
     pmix_value_t *val;
     char **p, **tmp = NULL, *prs;
     pmix_proc_t *pa;
-    size_t m, n, np, ninfo;
+    size_t m, n, np, nalloc = 0, ninfo;
     int npeers;
     pmix_namespace_t *ns;
     char *key;
@@ -286,15 +286,24 @@ static void resolve_peers(int sd, short args, void *cbdata)
              * transfer below, not from the count above: the two disagree
              * if an append into tmp failed, and the difference would be
              * handed to the caller as procs it may index */
+            nalloc = np;
             np = 0;
             for (n = 0; NULL != tmp[n]; n++) {
-                /* find the nspace delimiter */
-                prs = strchr(tmp[n], ':');
+                /* Find the nspace delimiter, searching from the right. A
+                 * namespace is an arbitrary string assigned by the host and
+                 * may itself contain a colon, while the peer list appended
+                 * above is a comma-delimited list of ranks and cannot. So
+                 * the last colon is the one we inserted; taking the first
+                 * would split a namespace such as "job:a,b" in the middle,
+                 * and this pass would then find more comma-separated fields
+                 * in it than the counting pass above did - writing past the
+                 * end of the array that count sized. */
+                prs = strrchr(tmp[n], ':');
                 if (PMIX_UNLIKELY(NULL == prs)) {
                     /* should never happen, but silence a Coverity warning */
                     rc = PMIX_ERR_BAD_PARAM;
                     PMIx_Argv_free(tmp);
-                    PMIX_PROC_FREE(pa, np);
+                    PMIX_PROC_FREE(pa, nalloc);
                     cd->procs = NULL;
                     cd->nprocs = 0;
                     goto done;
@@ -302,15 +311,20 @@ static void resolve_peers(int sd, short args, void *cbdata)
                 *prs = '\0';
                 ++prs;
                 p = PMIx_Argv_split(prs, ',');
-                for (m = 0; NULL != p[m]; m++) {
+                /* never write more entries than were allocated, whatever
+                 * the two passes make of a malformed peer list */
+                for (m = 0; NULL != p[m] && np < nalloc; m++) {
                     PMIX_LOAD_NSPACE(pa[np].nspace, tmp[n]);
                     pa[np].rank = strtoul(p[m], NULL, 10);
                     ++np;
                 }
                 PMIx_Argv_free(p);
             }
-            PMIx_Argv_free(tmp);
+            /* report what was filled, not what was sized - they differ
+             * only if a malformed peer list left the fill short, and the
+             * tail would then be zeroed procs rather than real ones */
             cd->nprocs = np;
+            PMIx_Argv_free(tmp);
             rc = PMIX_SUCCESS;
         } else {
             /* nothing resolved - an entry is recorded only when it carried

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -379,6 +379,16 @@ add or edit an entry point:
    an ordinary application mistake. For a data array, confirm
    `PMIX_DATA_ARRAY == value.type` **and** the array's own element type
    before walking it; `target_array()` in `pmix_monitor.c` is the pattern.
+
+   **Screen at the reader, not at the entry point.** That sweep put the
+   query check in `PMIx_Query_info_nb` and missed `pmix_parse_localquery`,
+   which reads the same three qualifiers — and which is *also* reached
+   from `pmix_server_query`, i.e. from qualifiers a client packed and this
+   process unpacked off the wire. A check that runs in the requestor's
+   process buys the server nothing: it is the peer's own honesty being
+   verified by the peer. Mistyping `PMIX_NSPACE` there segfaulted the
+   server outright. When you harden one of these, find every reader of the
+   value and put the check at the one they share.
 9. **A completion must happen exactly once, on every path.** The two
    failure modes are symmetric and both appear here. *Never* — a request
    that returns without invoking the callback hangs the blocking wrapper

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -298,14 +298,35 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
     for (n = 0; n < nqueries; n++) {
         rank_given = false;
         PMIX_LOAD_PROCID(&proc, NULL, PMIX_RANK_INVALID);
+        /* Screen each qualifier's type before reading its union. The
+         * identical check in PMIx_Query_info_nb below is not enough: it
+         * runs in the *requestor's* process, and this function is also
+         * reached from pmix_server_query, which unpacks these qualifiers
+         * straight off the wire. A peer that tags PMIX_PROCID as, say, a
+         * string then has us read a char* as a pmix_proc_t* - so the
+         * screen has to sit here, where both callers pass through. */
         for (p = 0; p < queries[n].nqual; p++) {
             if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_PROCID)) {
+                if (PMIX_PROC != queries[n].qualifiers[p].value.type ||
+                    NULL == queries[n].qualifiers[p].value.data.proc) {
+                    rc = PMIX_ERR_BAD_PARAM;
+                    goto badparam;
+                }
                 PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.proc->nspace);
                 proc.rank = queries[n].qualifiers[p].value.data.proc->rank;
                 rank_given = true;
             } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_NSPACE)) {
+                if (PMIX_STRING != queries[n].qualifiers[p].value.type ||
+                    NULL == queries[n].qualifiers[p].value.data.string) {
+                    rc = PMIX_ERR_BAD_PARAM;
+                    goto badparam;
+                }
                 PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.string);
             } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_RANK)) {
+                if (PMIX_PROC_RANK != queries[n].qualifiers[p].value.type) {
+                    rc = PMIX_ERR_BAD_PARAM;
+                    goto badparam;
+                }
                 proc.rank = queries[n].qualifiers[p].value.data.rank;
                 rank_given = true;
             }
@@ -490,6 +511,19 @@ void pmix_parse_localquery(int sd, short args, void *cbdata)
     /* get here if the request returned PMIX_SUCCESS, which means
      * that the query is being processed and will call the cbfunc
      * when complete */
+
+badparam:
+    /* a qualifier we cannot read means we cannot run the query at all -
+     * drop the scratch state and report it. cb is not live here: this
+     * iteration has not constructed it yet, and the previous one
+     * destructed its own before looping */
+    PMIX_LIST_DESTRUCT(&unresolved);
+    if (NULL != cd->cbfunc) {
+        cd->cbfunc(rc, NULL, 0, cd->cbdata, _local_relcb, cd);
+    } else {
+        _local_relcb(cd);
+    }
+    return;
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Query_info(pmix_query_t queries[], size_t nqueries,

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -483,6 +483,7 @@ static void cbcon(pmix_cb_t *p)
     p->dist = NULL;
     p->bo = NULL;
     p->infocopy = false;
+    p->dircopy = false;
     p->nvals = 0;
     PMIX_CONSTRUCT(&p->kvs, pmix_list_t);
     p->copy = false;
@@ -510,8 +511,12 @@ static void cbdes(pmix_cb_t *p)
     if (p->infocopy) {
         PMIX_INFO_FREE(p->info, p->ninfo);
     }
-    if (NULL != p->dist) {
-        PMIX_DEVICE_DIST_FREE(p->dist, p->nvals);
+    /* the directives are borrowed from the caller in every path that
+     * simply passes an API's argument down, so only an owner that says
+     * so gets them freed - see pmix_server_monitor, which unpacks them
+     * off the wire and therefore owns them */
+    if (p->dircopy) {
+        PMIX_INFO_FREE(p->directives, p->ndirs);
     }
     PMIX_LIST_DESTRUCT(&p->kvs);
 }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -735,6 +735,7 @@ typedef struct {
     pmix_device_distance_t *dist;
     pmix_byte_object_t *bo;
     bool infocopy;
+    bool dircopy;
     size_t nvals;
     pmix_list_t kvs;
     bool copy;

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -614,10 +614,46 @@ every participant caddy, optionally synthesizes `PMIX_GROUP_MEMBER_FAILED`
 events for departed members, then unlinks and releases the block. The
 fault paths `pmix_server_grp_peer_lost` (connection dropped) and
 `pmix_server_grp_member_left` (voluntary `PMIx_Group_leave`) both funnel
-to `account_departed`. The same release-before-detach discipline as the
-fence tracker applies: releasing a block destructs its `grp_trk_t`s and
-their `local_cbs`, so remove the current `cd` from `local_cbs` before
-releasing on a host-error return, or the switchyard double-frees it.
+to `account_departed`.
+
+Releasing a block destructs its `grp_trk_t`s and their `local_cbs`,
+which is why the fence-family instinct — detach the current `cd`, then
+release — reads as correct here. **It is not, once the local phase is
+complete.** By the time the block is handed to the host, every local
+participant has contributed and its caddy is on the block; detaching
+only the caller's and releasing answers that one client and silently
+frees the other N-1 replies, hanging those clients. Every such path —
+the host refusing the up-call, `aggregate_info` failing, and the two
+mirrors of both inside `account_departed` — instead hands the whole
+block to `grpcbfunc` with the error, which replies to every participant
+and then tears the block down. The caller then returns `PMIX_SUCCESS`,
+because `grpcbfunc` has taken ownership of its caddy too. The one place
+the detach-and-release shape is still right is the follower/bootstrap
+arm, whose block is created for a single caller and holds exactly one
+caddy.
+
+For the same reason `_grpcbfunc` must never return early. Its block has
+`host_called` set, so nothing else in the tree will ever complete it —
+returning on a missing context ID or a `pmix_server_process_grpinfo`
+failure left the block on `grp_collectives` for the life of the server
+with its participants waiting forever. Record the failure in
+`scd->status` and fall through to the reply loop.
+
+Read that reply loop's `break`s carefully: each one abandons the reply
+for the participant being served, and they are all directly inside the
+`local_cbs` loop except the group-info pack, which sits one level
+deeper. A bare `break` there escaped only the info loop and fell through
+to `PMIX_SERVER_QUEUE_REPLY` on the buffer it had just released.
+
+Two things here are safe and look as though they should not be. A block
+handed to the host survives the call without any reference of its own —
+unlike the dmodex tracker above — because `host_called` is set before
+the up-call and `account_departed` skips any block carrying it, so
+`_grpcbfunc` is the only code that frees a block. And
+`notify_local_members_of_loss` hands a stack `pmix_info_t[2]` to
+`pmix_server_notify_client_of_event` and destructs it on the next line:
+that entry point deep-copies the array into its own caddy *before*
+thread-shifting, so nothing is borrowed across the shift.
 
 ## `pmix_server_resolve.c` is a twin of `src/client/pmix_client_resolve.c`
 
@@ -986,9 +1022,12 @@ misbehave by design).
   `test/unit/server_fence.c` and `test/unit/server_connect.c`, whose
   info-count cases kill an unfixed library rather than failing it. **Any
   new collective handler that seeds slots past the unpacked ones owes the
-  same screen** — the group handler builds its info array differently
-  (`ninfo = ninf + 1`, `pmix_server_group.c`) and should be read with
-  this in mind.
+  same screen**. The group handler was the fourth: it builds its array as
+  `ninfo = ninf + 1` and seeds `PMIX_LOCAL_COLLECTIVE_STATUS` at
+  `info[ninf]` before the unpack, so a count near `SIZE_MAX` wrapped that
+  to a zero-element array — `PMIx_Info_create` answers NULL, which
+  nothing checked — and wrote the seed at `info[SIZE_MAX]`. Its proc
+  count had the mirror problem. Both now carry the round-trip screen.
 
   While you are there, note the layout those two seeds establish, because
   the completion arms depend on it: for the fence and disconnect families

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -814,6 +814,44 @@ the client-driven pull/registration commands. Note `pmix_server_process_iof`
 drains the cache into a newly registered request so a late subscriber
 still sees recently produced output.
 
+**The three client-driven commands own the arrays they unpack, and the
+`pmix_setup_caddy_t` will not believe it without being told.** They are
+the mirror image of the two public push APIs, which park the *caller's*
+proc array and byte object on the same members and must detach them
+before releasing (see the caddy-zoo section). Here the arrays are ours,
+so the caddy needs `copied` set for `info` and a non-zero `nbo` for the
+byte object — and both were missing. Note the two halves fail
+differently: `pmix_server_iofreg` and `iofstdin` leaked only on their
+error returns, because their completions (`_iofreg`, `stdcbfunc`) free
+the array explicitly, while `pmix_server_iofdereg` leaked on *every*
+deregistration, since `_iofdereg` has no such free. And `nbo` left at
+zero frees the byte object's container while leaking its payload —
+`PMIx_Byte_object_free` runs its destruct loop `n` times and then frees
+the array, so zero means "free the box, keep the contents."
+
+**A registration the host refuses has to come back out of
+`pmix_globals.iof_requests`.** `pmix_server_iofreg` adds the
+`pmix_iof_req_t` — which takes a `PMIX_RETAIN` on the requestor — before
+the up-call, because the refid has to be in hand to report. `_iofreg`
+removes it again when the host fails the request *asynchronously*; the
+synchronous refusal did not, leaving an entry that pinned the peer for
+the life of the server and went on matching output for a pull that was
+never granted. Deregistration is deliberately not symmetric: it drops
+the local entry *before* the up-call and does not restore it if the host
+refuses, because the client asked to stop and the refid it would be
+handed back could not be the same one.
+
+**Every count these handlers read off the wire needs the round-trip
+screen**, for the reasons set out under "What *does* need screening"
+below. `pmix_server_iofdereg` is the `+ 1` shape: it sizes its array as
+`ninfo + 1` so it can seed `PMIX_IOF_STOP` in the last slot itself, so a
+count near `SIZE_MAX` wraps that sum to zero and writes the seed at
+`info[SIZE_MAX]`. `pmix_server_iof_handler`, `iofreg` and `iofstdin`
+are the plainer shape, but `iofreg` also copies its proc array again
+afterwards walking the `size_t` rather than the `int32_t` the unpack
+consumed. Covered by `test/unit/iof_output.c`, whose wrap case kills an
+unfixed library rather than failing it.
+
 ## Inventory collection
 
 `pmix_server_inventory.c` is short and reads as though several things in

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -344,6 +344,17 @@ The completion status is recorded into the tracker's info array by
 connect appends per-participant endpoint info and job-level info *after*
 that slot, so a positional write would clobber it.
 
+**Every collective owes `PMIX_TIMEOUT` a local timer, because the host
+cannot supply one.** The attribute is documented as bounding the whole
+operation, and the directives do reach the host in `trk->info` - but only
+once the collective is complete enough to be handed up. Until the last
+local participant contributes, the host has never heard of the request,
+so the case the attribute exists for (a participant that never arrives)
+is exactly the case only we can bound. Fence and connect always armed
+one; disconnect did not, and hung its callers forever on a missing
+participant. `test/simple/simptimeout.c` covers all three, driven under
+`simptest`.
+
 Timers are armed with `PMIX_THREADSHIFT_DELAY(trk, ..._timeout, secs)`
 guarded by `!trk->event_active`, and the fence family does **not** add a
 retain when arming (the collectives-list reference is the sole

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -273,6 +273,25 @@ written and never read, which is why the dangling pointers were harmless
 rather than a use-after-free. A reader added later would need its own
 copy of the strings, not the caddy's.
 
+### `pmix_cb_t` borrows its directives, and never owns its `proc`
+
+`pmix_cb_t` carries two info arrays with two different ownership rules,
+and one member the destructor deliberately ignores:
+
+- `info`/`ninfo` are freed by `cbdes` only when `infocopy` is set.
+- `directives`/`ndirs` are freed only when `dircopy` is set. **Every
+  other site in the tree that fills this member borrows it** — it is the
+  caller's array, handed down through `PMIx_Process_monitor_nb` or the
+  IOF calls — so the flag exists for the one owner: `pmix_server_monitor`,
+  which unpacks the directives off the wire. Without it the array leaked
+  on every monitor command.
+- `proc` is **never** freed by the destructor, because it is as often a
+  pointer to a stack `pmix_proc_t` (`pmix_server_refresh_cache` does
+  exactly that) as it is an allocation. A handler that
+  `PMIX_PROC_CREATE`s one owes it a free on every path that does not
+  reach the completion — `pmix_monitor_processing`'s `relcbfunc` is what
+  frees it on the paths that do.
+
 Any struct handed to `PMIX_THREADSHIFT` **must** carry a `pmix_event_t ev`
 as its thread-shift member (the caddy contract from the top-level guide).
 Do not stack-allocate a caddy that outlives its creating function — the
@@ -611,6 +630,13 @@ Two suites cover the halves:
   exceeds its local size, and asserts the classification and that nothing
   is left parked on `local_reqs`. Read its header for what it pins down
   and what it deliberately cannot reproduce.
+- [`test/unit/server_control.c`](../../test/unit/server_control.c) drives
+  `pmix_server_log` and `pmix_server_job_ctrl` from hand-packed wire
+  buffers — the malformed-count screens, the appended `PMIX_LOG_SOURCE` /
+  `PMIX_LOG_TIMESTAMP` directives, and the RFC precedence rule that a
+  repeated cleanup directory upgrades the entry already on the epilog.
+  The bad-directive-count case aborts rather than fails against an
+  unfixed library, the same bargain `test/unit/iof_output.c` makes.
 - [`contrib/dockerswarm/run-server-tests.sh`](../../contrib/dockerswarm/run-server-tests.sh)
   is the multi-node half: direct modex, spawn-plus-connect across
   namespaces, group blocks spanning nodes, IOF pull/dereg against a
@@ -690,6 +716,32 @@ misbehave by design).
   that lookup, creates and appends the namespace itself. Verified by
   instrumenting both sites. Do not "fix" the dead branch on the theory
   that the lookup can fail.
+- **An unchecked `PMIX_*_CREATE` followed straight by an unpack is not a
+  bug.** `pmix_bfrops_base_unpack` screens `NULL == dst` and returns
+  `PMIX_ERR_BAD_PARAM`, so the near-universal shape here — `if (0 < n)
+  { PMIX_INFO_CREATE(array, n); cnt = n; unpack into array; }` — fails
+  cleanly when the allocation fails, whether from real memory pressure or
+  from an absurd count off the wire. Do not sprinkle NULL checks through
+  these handlers; it was audited and refuted.
+- **What *does* need screening is a wire count used before, or without,
+  the unpack.** Every count arrives as a `size_t` and is then consumed
+  through the `int32_t` that `PMIX_BFROPS_UNPACK` takes, so a peer can
+  send one that truncates to zero or to a negative number. That is
+  harmless wherever the only use is sizing an array the unpack
+  immediately guards — which is every handler here except
+  `pmix_server_log`, which indexes the directive array to append
+  `PMIX_LOG_SOURCE` *before* anything is unpacked into it (a negative
+  index off a NULL array) and hands `(info, ninfo)` to `plog` even when
+  the unpack was skipped. It now rejects a count that does not survive
+  the round trip. Apply the same test to any new handler that reads a
+  count before it reads the array.
+- **`PMIX_LIST_DESTRUCT` is not idempotent.** It drains the list and then
+  calls `PMIX_DESTRUCT`, which under `--enable-debug` zeroes the object's
+  magic id and asserts on it — so a second destruct of the same list
+  aborts the server, and nothing restores the id in between.
+  `pmix_server_job_ctrl` destructed its four cleanup lists mid-function
+  *and* again at its exit label, under a comment asserting the practice
+  was harmless. Destruct each local list exactly once, on the way out.
 - **Screen the shape of anything the host hands you before indexing it.**
   A `pmix_info_t` carrying a `PMIX_DATA_ARRAY` is a host-supplied
   structure, and several sites here read `array[0]` and `array[1]`
@@ -708,6 +760,21 @@ misbehave by design).
   session-directory cleanup and that guard becomes an `rmdir` of a
   system-defined directory. It sits below `pmix_rte_finalize()` for that
   reason and there is a comment at the site saying so.
+- **The status `pmix_server_refresh_cache` packs is discarded by the
+  client, on purpose.** `refcb` in `pmix_client_get.c` unpacks that
+  status, then drains kvals until the buffer runs out and overwrites the
+  status with `PMIX_SUCCESS`. That is not an oversight to repair from
+  this side: `refresh_cache()` is called for its side effect, and its
+  return value aborts the whole `PMIx_Get` — so propagating a
+  "nothing to refresh" `PMIX_ERR_NOT_FOUND` would fail gets that
+  currently succeed. Pack the honest status (it is the right thing on the
+  wire), but do not build anything here on the client acting on it.
+- **`pmix_server_job_ctrl` creating a namespace for an unknown target is
+  deliberate.** A job-control request may name a job this server has not
+  been told about yet, and the epilog directives need somewhere to hang;
+  `_register_nspace` looks the namespace up by name and reuses the entry
+  when registration eventually arrives. It is not a leak and not a
+  phantom.
 - **A public API's non-blocking form still has to clean up when the
   caller passes no callback.** `PMIx_server_setup_application` and
   `PMIx_server_collect_inventory` take a callback and have no blocking

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -513,6 +513,38 @@ caller twice. If you ever discard an lcd that could have *other*
 requesters, they do need their callbacks — follow
 `pmix_pending_nspace_requests`, which drains with callbacks.
 
+**A tracker handed to the host carries a reference of its own.** Both
+sites that call `pmix_host_server.direct_modex` pass the `lcd` as
+`cbdata`, and the host holds that pointer until it calls `dmdx_cbfunc` -
+which may be long after we have decided the tracker is finished with. A
+namespace deregistration for the target retires *every* tracker naming
+it (see below), so the bare pointer the host was holding was a dangling
+one. Each up-call therefore takes a `PMIX_RETAIN` on the lcd and gives
+it back on exactly one of three arms: the host declines the call,
+`dmdx_cbfunc` finds the progress thread stopped, or `_process_dmdx_reply`
+finishes. The reply handler then has to ask `tracker_is_pending` whether
+the tracker is still on `local_reqs` before touching it - our reference
+keeps the object alive, it does not put it back on the list, and
+resolving an unlinked tracker would `pmix_list_remove_item` it a second
+time.
+
+The same reasoning governs the *directives*: the host keeps every input
+valid until it calls back, and the `pmix_server_caddy_t` does not live
+that long, so what goes up is `lcd->info` - the tracker's own copy, which
+`pmix_server_get` augments in place with `PMIX_REQUIRED_KEY` - and never
+`cd->info`. `pmix_pending_nspace_requests` always did it this way.
+
+**`_satisfy_request` reports whether it *answered*, not whether it
+succeeded.** Once it has data to hand back it invokes `cbfunc`, and that
+hands the server caddy to the reply path, which queues the client's
+answer and releases it. So every arm past that point must return
+`PMIX_SUCCESS` even when the status it passed was an error - both callers
+read a non-SUCCESS return as "nobody has answered this requester yet",
+and `pmix_server_get` responds by parking the caddy on a fresh dmodex
+tracker while `check_req` responds by calling the requester's `cbfunc` a
+second time. A failed assemble or a failed pack after the fetch had
+already succeeded therefore produced a double reply on a freed caddy.
+
 **A tracker on `local_reqs` whose target has departed must fail its
 waiters, not just disappear.** `pmix_server_purge_events` runs when a peer
 finalizes or a namespace is deregistered, and any direct-modex tracker
@@ -769,8 +801,11 @@ Two suites cover the halves:
 - [`test/unit/server_get.c`](../../test/unit/server_get.c) drives
   `pmix_server_get` directly against a registered nspace whose job size
   exceeds its local size, and asserts the classification and that nothing
-  is left parked on `local_reqs`. Read its header for what it pins down
-  and what it deliberately cannot reproduce.
+  is left parked on `local_reqs`. It also drives the handler from a
+  hand-packed buffer whose info count is a lie - one that wraps the
+  allocation and one that merely truncates - and those cases kill an
+  unfixed library rather than failing it. Read its header for what it
+  pins down and what it deliberately cannot reproduce.
 - [`test/unit/server_dmodex.c`](../../test/unit/server_dmodex.c) covers
   `PMIx_Store_internal` and the `remote_pnd` deferral above, including
   the departure drain. It orders itself off `PMIx_Store_internal` rather
@@ -923,6 +958,18 @@ misbehave by design).
   reads a count before it reads the array, or that walks the `size_t`
   rather than the `int32_t` afterwards.
 
+  Know *why* an oversized count is dangerous and not merely wasteful:
+  `PMIx_Info_create` computes `n * sizeof(pmix_info_t)` with no overflow
+  guard and then **constructs every one of the `n` elements**. A count
+  large enough to wrap that product therefore yields a short allocation
+  whose constructor loop runs straight off the end - so the crash happens
+  inside the allocation, before any of the "the unpack screens a NULL
+  destination" reasoning gets a chance to apply. `PMIX_PROC_CREATE` and
+  the other `_CREATE` macros are built the same way. That is why the
+  round-trip screen belongs on any count a peer controls, not only on the
+  ones with a visible `+ 2`. `pmix_server_get` needed it for exactly this
+  reason, and its wire count is covered by `test/unit/server_get.c`.
+
   **The collective handlers are the third case, and the worst of them.**
   Fence and connect both size their info array as `ninf + 2` and then
   seed two slots at `info[ninf]` and `info[ninf+1]` — *before* anything
@@ -1005,6 +1052,19 @@ misbehave by design).
   `_register_nspace` looks the namespace up by name and reuses the entry
   when registration eventually arrives. It is not a leak and not a
   phantom.
+- **Two things in `pmix_server_get.c` look like defects and are not.**
+  `get_job_data` returns `PMIX_SUCCESS` with an empty buffer when the
+  fetch finds nothing, and its callers pass that empty payload to the
+  client as a success. That is safe and should be left alone:
+  `_getnb_cbfunc` in `pmix_client_get.c` initializes its reported status
+  to `PMIX_ERR_NOT_FOUND` and only overwrites it if a value actually
+  turns up, so an empty success degrades to not-found at the requester -
+  the same bargain as the `refresh_cache` status above. And the
+  `direct_modex` up-call sites treat `PMIX_OPERATION_SUCCEEDED` as a
+  refusal rather than handling it as the third arm of the usual
+  tri-state. There is no coherent "done now, no callback" for this
+  up-call: its entire product is a data blob delivered through the
+  callback, and the header describes no such arm.
 - **A public API's non-blocking form still has to clean up when the
   caller passes no callback.** `PMIx_server_setup_application` and
   `PMIx_server_collect_inventory` take a callback and have no blocking

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -199,9 +199,39 @@ callback casts.** `_fabric_response` exists to answer a fabric request the
 `pnet` layer satisfied locally, and it called the switchyard's
 `pmix_server_fabric_cbfunc` with `qcd->cbdata` — a `pmix_server_caddy_t` — where that
 function casts to `pmix_query_caddy_t` and dereferences the result. The
-sibling `pmix_server_fabric_update` never set `qcd->cbfunc` at all. Both
-are latent only because no in-tree `pnet` component answers a fabric
-request; a component that did would crash immediately.
+sibling `pmix_server_fabric_update` did not set `qcd->cbfunc` at all.
+Both were latent only because no in-tree `pnet` component answers a
+fabric request — `pmix_pnet.register_fabric` returns
+`PMIX_ERR_NOT_SUPPORTED` when no active component implements it, so every
+arm of `pmix_server_fabric_register` above the host up-call is unreached
+today. Read the rest of that function with the same caution: its
+`PMIX_SUCCESS` arm answers a component that promised a callback by
+`PMIX_WAIT_THREAD`-ing on the switchyard's own thread, so a component
+that completed from the progress thread would deadlock the server rather
+than merely crash it.
+
+**A callback that only thread-shifts has not consumed your data.** The
+`(release_fn, release_cbdata)` pair is not decoration for the host path:
+`pmix_server_dist_cbfunc` and `pmix_server_fabric_cbfunc` both park their
+payload on a `pmix_shift_caddy_t` and pack the reply from it later, on the
+progress thread. `pmix_server_device_dists` computed the distances
+locally, passed `(NULL, NULL)` for the pair, and freed the array on the
+next line — so every locally answered `PMIx_Compute_distances` packed
+freed heap into the reply. A local producer needs a release function
+exactly as much as a remote one does; `dist_relfn` in
+`pmix_server_fabric.c` is the shape.
+
+**The hwloc unpackers hand back a `source` string even when they hand
+back nothing else.** `pmix_hwloc_unpack_topology` and
+`pmix_hwloc_unpack_cpuset` both `strdup("hwloc")` unconditionally, and
+`pmix_hwloc_destruct_{topology,cpuset}` free it only when they are also
+freeing the object it describes. So the two "the client didn't supply
+one, use ours" paths in `pmix_server_device_dists` — the common case for
+both arguments — each leaked that string on every request: the topology
+one because borrowing the global topology skips the destruct, the cpuset
+one because `pmix_hwloc_parse_cpuset_string` overwrites the member with a
+fresh `strdup`. Free it yourself on any path where you replace or borrow
+past one of these.
 
 ## The caddy zoo
 
@@ -719,6 +749,14 @@ Two suites cover the halves:
   `PMIx_Query_info_nb` does in the *requestor's* process; a mistyped
   `PMIX_NSPACE` segfaulted the server until `pmix_parse_localquery`
   grew its own check.
+- [`test/unit/server_fabric.c`](../../test/unit/server_fabric.c) drives
+  `pmix_server_device_dists` from a hand-packed buffer that carries no
+  topology — the "use your own" path — and asserts that a locally
+  computed distance array is handed over with a release function rather
+  than freed on the spot. Note it reports SKIP rather than PASS on a host
+  whose hwloc finds no OS devices (a bare macOS one), because there is
+  then no answer to hold the contract against; the leak half of it only
+  shows under valgrind.
 - [`test/unit/event_chain.c`](../../test/unit/event_chain.c) drives
   `pmix_server_register_events` / `pmix_server_deregister_events` from
   hand-packed wire buffers alongside its client-side event-chain cases —

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -814,6 +814,33 @@ the client-driven pull/registration commands. Note `pmix_server_process_iof`
 drains the cache into a newly registered request so a late subscriber
 still sees recently produced output.
 
+## Inventory collection
+
+`pmix_server_inventory.c` is short and reads as though several things in
+it could be wrong. They are not, and the reasons are worth knowing
+before you "fix" one:
+
+- **An inventory sweep on a server with no `pnet`/`pgpu` components is a
+  success, not a failure.** Both entry points in the `pmix_pnet` /
+  `pmix_pgpu` API tables are always non-NULL (they are the `_base_`
+  functions, wired up statically in each framework's `*_base_frame.c`),
+  and each walks its `actives` list and returns `PMIX_SUCCESS` when that
+  list is empty. So the `goto report` arms mean a component really
+  failed.
+- **`PMIx_Info_list_convert` copies.** It `PMIx_Info_xfer`s every element
+  into a freshly created array, so `clct` owns what it hands back *and*
+  still owes the list a `PMIX_LIST_DESTRUCT`. Doing both is not a double
+  free. `PMIX_ERR_EMPTY` from it means "nothing collected" and is mapped
+  to success with a NULL array.
+- **`cirelease` is handed to the *host*, so it can run on the host's
+  thread.** That is safe only because it touches nothing global — it
+  frees the converted array and releases the caddy. Do not grow it into
+  something that walks `pmix_server_globals`; thread-shift instead.
+- The blocking arm of `PMIx_server_deliver_inventory` returning
+  `PMIX_OPERATION_SUCCEEDED` rather than `PMIX_SUCCESS` is the
+  convention every blocking `PMIx_server_*` form here follows (see
+  `pmix_server_setup.c` and `pmix_server_registration.c`), not a slip.
+
 ## Wire format and interoperability
 
 Everything crossing the socket obeys the top-level Version

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -1032,6 +1032,75 @@ before you "fix" one:
   convention every blocking `PMIx_server_*` form here follows (see
   `pmix_server_setup.c` and `pmix_server_registration.c`), not a slip.
 
+## Resolving peers and nodes
+
+`pmix_server_resolve.c` answers the two "convenience" queries. Both entry
+points have the same shape: unpack the request, build a one-element
+`pmix_query_t` on `cd->query` describing it, offer it to
+`pmix_host_server.query` because the host has the more global view, and
+only if that comes back with anything other than `PMIX_SUCCESS`
+thread-shift to a local handler that answers out of our own GDS. The two
+local handlers are also the fall-back target of the *reply* path: the
+error arms of `pmix_server_respeers_cbfunc` / `_resnodes_cbfunc` shift the
+same caddy to them when the host accepted the query and then failed it.
+So the local handlers may be entered from two places, and both rely on
+`cd->query->qualifiers` still carrying what the entry point put there —
+two elements for peers (nspace, hostname), one for node (nspace).
+
+**`docs/how-things-work/resolve.rst` is the contract, and it is not the
+one you would guess.** Read it before changing any status these handlers
+return; several answers that look like unreported failures are what the
+document requires:
+
+- A namespace that is known but currently has no nodes assigned answers
+  `PMIX_SUCCESS` with a **NULL** node list. That is a successfully
+  executed request, not a miss, and `PMIx_Resolve_nodes` says exactly the
+  same thing when it resolves out of the client's own store — so a server
+  that handed the raw fetch status back made one server answer one
+  question two different ways depending on which side computed it, and
+  cost the caller a documented success. Only `PMIX_ERR_NOT_FOUND` gets
+  this treatment; `PMIX_ERR_INVALID_NAMESPACE` (we have never heard of
+  it) and `PMIX_ERR_DATA_VALUE_NOT_FOUND` (the host never supplied the
+  data) are real answers and go back as they are.
+- The peers side is asymmetric on purpose. A node that is not on the
+  namespace's list is `PMIX_SUCCESS` with zero procs, but a node that
+  *is* on the list with no `PMIX_LOCAL_PEERS` recorded against it is
+  `PMIX_ERR_DATA_VALUE_NOT_FOUND` — the document spells out both. Do not
+  "make these consistent."
+
+**The tri-state does not apply to the `query` up-call here.** Both entry
+points treat anything other than `PMIX_SUCCESS` — including
+`PMIX_OPERATION_SUCCEEDED` — as "the host is not answering this one" and
+fall through to the local handler. That is right rather than a missed
+arm: the whole product of this up-call is an info array delivered through
+the callback, so there is no coherent "done now, no callback" result to
+receive, and the host having declared itself done means it will not call
+back and cannot double-answer the client. Same reasoning as the
+`direct_modex` up-call in `pmix_server_get.c`.
+
+**The aggregate peer walk counts in one pass and fills in another, and
+the two have to agree.** A request naming no namespace walks
+`pmix_globals.nspaces`, builds one `"<nspace>:<peerlist>"` string per
+namespace with `pmix_asprintf`, and accumulates the peer count as it
+goes; it then sizes a `pmix_proc_t` array from that count and walks the
+strings *again*, splitting each back apart to fill it. The split used
+`strchr`, i.e. the **first** colon — but a namespace is an arbitrary
+string the host assigned and nothing forbids a colon in it, so a
+namespace such as `"res:ut,x"` yielded three comma-separated fields on
+the way back where two peers had been counted on the way out, and the
+third was written past the end of the array. Split from the right
+(`strrchr`): the delimiter we inserted is the last colon, because the
+peer list is a comma-delimited list of ranks. And bound the fill by the
+allocated count anyway — a peer list is host-supplied data and the two
+passes agreeing is not something this function can prove. Note also that
+the array must be freed with the count that was *allocated*, not the
+count that was filled, on every path out.
+
+The whole file is covered by
+[`test/unit/server_resolve.c`](../../test/unit/server_resolve.c), which
+registers a colon-bearing namespace precisely to hold the two passes
+against each other.
+
 ## Wire format and interoperability
 
 Everything crossing the socket obeys the top-level Version
@@ -1147,6 +1216,19 @@ Two suites cover the halves:
   whose hwloc finds no OS devices (a bare macOS one), because there is
   then no answer to hold the contract against; the leak half of it only
   shows under valgrind.
+- [`test/unit/server_resolve.c`](../../test/unit/server_resolve.c) drives
+  `pmix_server_resolve_peers` / `pmix_server_resolve_node` from
+  hand-packed wire buffers against a host module with no `query` entry
+  point, so every request takes the local handler. It registers three
+  namespaces — a plain one, one whose *name* carries the `:` delimiter
+  the aggregate walk inserts, and one with no node map at all — and reads
+  the replies back off `send_msg`, per the `test/unit/server_control.c`
+  idiom. The colon-bearing namespace is what holds the aggregate walk's
+  counting pass and its filling pass against each other; against an
+  unfixed library that case reports the wrong peer count and may take the
+  process down on the out-of-bounds write first. The bare namespace pins
+  the "known namespace, no nodes assigned" answer that
+  `docs/how-things-work/resolve.rst` requires to be a success.
 - [`test/unit/event_chain.c`](../../test/unit/event_chain.c) drives
   `pmix_server_register_events` / `pmix_server_deregister_events` from
   hand-packed wire buffers alongside its client-side event-chain cases —

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -255,13 +255,23 @@ and `PMIx_server_setup_local_support` leaked its `strdup` on the
 `PMIX_ERR_WOULD_BLOCK` arm. Do not "fix" this by moving `nspace` into the
 destructor - that turns the leak into a free of a string literal.
 
-A related trap sits one layer out: `pmix_server_process_iof` does
-`req->flags = cd->flags`, a **shallow** copy of a `pmix_iof_flags_t` whose
-`file` and `directory` members are `strdup`ed and owned by the caddy. The
-`pmix_iof_req_t` outlives the caddy, so those two pointers dangle the
-moment the caddy is released. It is latent only because nothing reads
-`pmix_iof_req_t::flags` today (`pmix_iof_process_iof` does not); the day
-something does, it needs its own copy.
+A related rule applies to `pmix_iof_flags_t`, which is copied by
+assignment in three places while two of its members are `strdup`ed:
+**a shallow copy of the flags owns nothing, so NULL `file` and
+`directory` right after it.** The strings belong to whatever parsed
+them - for `pmix_server_process_iof` that is the setup caddy, which is
+released long before the `pmix_iof_req_t` it copied into. Both client-side
+copies (`stash_spawn_iof_flags` and the spawn reply handler in
+`pmix_client_spawn.c`) NULL them explicitly; the server-side one did not,
+and left two dangling pointers in a long-lived request.
+
+Note which flags the output path actually consults, because it is not
+these: `pmix_iof_write_output` takes its formatting flags from
+`nptr->iof_flags`, `stand_in_flags()` or `pmix_globals.iof_flags` - the
+namespace and the process, never the request. `pmix_iof_req_t::flags` is
+written and never read, which is why the dangling pointers were harmless
+rather than a use-after-free. A reader added later would need its own
+copy of the strings, not the caddy's.
 
 Any struct handed to `PMIX_THREADSHIFT` **must** carry a `pmix_event_t ev`
 as its thread-shift member (the caddy contract from the top-level guide).

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -206,7 +206,23 @@ host completion lands, and the host process outlives our finalize - so
 what is dropped there is stranded for good. Exactly one of the two arms
 can fire for a given request (the outer returns before shifting, so the
 inner never runs), which is why calling `relfn` in both is right rather
-than a double release.
+than a double release. The rule is not confined to that file: the two
+relfn-carrying pairs in `pmix_server_op_replies.c` - modex and get - had
+exactly the same four arms, and both now honor it.
+
+**A payload the release function owns must be disowned on every path that
+destructs the buffer holding it.** `PMIX_LOAD_BUFFER` does not copy and
+does not allocate: it points the buffer straight at the payload it is
+handed and NULLs the source pointer. So a `PMIX_DESTRUCT` of that buffer
+frees memory that belongs to whoever gave us the `(relfn, relcbdata)`
+pair, which is then freed a second time when the release function runs.
+`_getcbfunc` NULLed `base_ptr`/`bytes_used` before destructing on its
+success path and *not* on the arm where `PMIX_BFROPS_COPY_PAYLOAD`
+failed, so a failed copy was a double free of the host's blob. Disown the
+buffer immediately after the copy, before branching on its status - that
+way one line covers both arms. The same reasoning is why `_mdxcbfunc`
+uses `PMIX_LOAD_BUFFER_NON_DESTRUCT` and carries a comment saying not to
+destruct `xfer`.
 
 **A callback signature with no release function has to *copy* what it
 parks.** `pmix_credential_cbfunc_t` and `pmix_validation_cbfunc_t` -
@@ -351,6 +367,27 @@ and one member the destructor deliberately ignores:
   reach the completion — `pmix_monitor_processing`'s `relcbfunc` is what
   frees it on the paths that do.
 
+### What `scdes` does *not* free
+
+`pmix_shift_caddy_t` is the generic bounce caddy, and its destructor
+frees only `key`, `peer`, `pname.nspace`, `kv`, and the two info arrays
+under `infocopy`/`dircopy`. Everything else parked on it is the
+handler's to free by hand, on **every** path — `pdata` most of all, since
+`pmix_server_lookup_cbfunc` builds a whole `PMIX_PDATA_CREATE`d array
+there (it must: `pmix_lookup_cbfunc_t` carries no release function, so
+nothing the host passes survives the return). `_lkupcbfunc` freed it only
+on its success arm, so every pack failure and the finalize-race early-out
+leaked the array and every value in it. Free it at the common label, not
+beside the pack that consumed it.
+
+A related trap sits one level down: **a stack `pmix_cb_t` must be
+destructed on every path, not only where the fetch succeeded.** `cbcon`
+constructs a lock unconditionally and `cbdes` is the only thing that
+takes it down, and `pthread_mutex_init`/`pthread_cond_init` are allowed
+to allocate. `_spcb` had the `PMIX_DESTRUCT(&cb)` inside its
+`PMIX_SUCCESS == rc` arm, and a fetch that finds nothing is the ordinary
+case for a job this server has not been told about yet.
+
 Any struct handed to `PMIX_THREADSHIFT` **must** carry a `pmix_event_t ev`
 as its thread-shift member (the caddy contract from the top-level guide).
 Do not stack-allocate a caddy that outlives its creating function — the
@@ -425,6 +462,30 @@ the trickiest bugs):**
   `cd->trk = NULL`, which is a no-op: nothing in the tree ever assigns
   `pmix_server_caddy_t::trk` a non-NULL value, so `cddes`'s release of it
   is unreachable too. Removal from `local_cbs` is what does the work.
+
+**A completion loop owes a reply to *every* caddy on `local_cbs`, and the
+status it packs must survive the loop.** The three fence-family
+completions (`_mdxcbfunc`, `_cnct`, `_discnct`) walk `local_cbs` packing
+one reply per participant, and both halves of that were wrong:
+
+- **Leaving the loop on a per-participant failure hangs the rest.** The
+  timer was cancelled at the top and the tracker release at the foot
+  frees the remaining caddies without a reply, so nothing in the tree
+  will ever answer them. This is the fence-family twin of the group rule
+  below ("detaching only the caller's and releasing answers that one
+  client and silently frees the other N-1"). Serve the next participant
+  instead: `continue` where the reply cannot be built, and — in `_cnct`,
+  where the failure is per-participant job-info assembly rather than the
+  status pack — hand *that* client the error and carry on.
+- **`PMIX_GDS_MARK_MODEX_COMPLETE` assigns the variable it is given.**
+  `_mdxcbfunc` passed it the same local that held the collective's
+  status, one line after packing it, so every participant after the
+  first was told a failed fence had succeeded. `gds/hash`'s entry point
+  is a no-op returning `PMIX_SUCCESS`, so this fired on every ordinary
+  server rather than in some corner. Keep the collective's status in a
+  variable nothing else writes; use the pack-status local for the macro.
+  Covered by `test/unit/server_fence.c`, whose two-participant case
+  reads back what was queued for each.
 
 The completion status is recorded into the tracker's info array by
 `pmix_server_set_collective_status`, which locates the
@@ -829,6 +890,20 @@ zero frees the byte object's container while leaking its payload —
 `PMIx_Byte_object_free` runs its destruct loop `n` times and then frees
 the array, so zero means "free the box, keep the contents."
 
+**A two-caddy handler's completion owes the switchyard caddy its
+release.** `pmix_server_iofreg` and `iofdereg` park the switchyard's
+`pmix_server_caddy_t` on `cd->cbdata` of their own `pmix_setup_caddy_t`
+and then return `PMIX_SUCCESS`, so the switchyard lets go of it — and
+`scaddes` does not reach `cbdata`, so releasing the setup caddy releases
+nothing else. `_iofdreg` gets this right with three explicit releases;
+`_iofreg` released only the setup caddy, so the server caddy and the
+`PMIX_RETAIN` it holds on the requesting peer leaked on **every** IOF
+pull registration — pinning that peer, and everything hanging off it, for
+the life of the server. Both halves of the pair owe it: the outer
+callback's `progress_thread_stopped` arm had the same hole. Whenever a
+handler nests one caddy inside another, write down which one releases
+which; the destructors will not do it for you.
+
 **A registration the host refuses has to come back out of
 `pmix_globals.iof_requests`.** `pmix_server_iofreg` adds the
 `pmix_iof_req_t` — which takes a `PMIX_RETAIN` on the requestor — before
@@ -968,6 +1043,12 @@ Two suites cover the halves:
   library. Its host stub *declines* the fence on purpose — accepting
   would leave the completion to the test, and queueing a reply to a peer
   with no socket is not something a single-process program can do.
+  A separate case drives the *completion*, `pmix_server_modex_cbfunc`,
+  over a hand-built two-participant tracker with a failing status and
+  reads back what was queued for each — the shape that catches both a
+  reply loop that abandons participants and a status the loop clobbers.
+  It reads the replies off `send_msg`/`send_queue`, per the
+  `test/unit/server_control.c` idiom below.
   `test/unit/tracker_match.c` and `test/unit/trk_complete.c` cover the
   tracker-identity and completion-predicate halves of the same file, and
   [`test/unit/collect_job_info.c`](../../test/unit/collect_job_info.c)

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -900,9 +900,10 @@ nothing else. `_iofdreg` gets this right with three explicit releases;
 `PMIX_RETAIN` it holds on the requesting peer leaked on **every** IOF
 pull registration — pinning that peer, and everything hanging off it, for
 the life of the server. Both halves of the pair owe it: the outer
-callback's `progress_thread_stopped` arm had the same hole. Whenever a
-handler nests one caddy inside another, write down which one releases
-which; the destructors will not do it for you.
+callback's `progress_thread_stopped` arm had the same hole, and so did
+`pmix_server_spcbfunc`, the spawn completion, which nests the same way.
+Whenever a handler nests one caddy inside another, write down which one
+releases which; the destructors will not do it for you.
 
 **A registration the host refuses has to come back out of
 `pmix_globals.iof_requests`.** `pmix_server_iofreg` adds the
@@ -1208,6 +1209,28 @@ misbehave by design).
   to a zero-element array — `PMIx_Info_create` answers NULL, which
   nothing checked — and wrote the seed at `info[SIZE_MAX]`. Its proc
   count had the mirror problem. Both now carry the round-trip screen.
+
+  **The classic commands in `pmix_server_ops.c` were the last group
+  without it.** Publish, lookup and unpublish all size their array as
+  `ninfo + 1` so they can seed `PMIX_USERID` in the last slot, and spawn
+  sizes an info array and an app array straight from the wire —
+  `PMIx_App_create` multiplies and constructs exactly as
+  `PMIx_Info_create` does, and `scaddes` then walks the `size_t` when it
+  frees. All five counts now carry the screen. The key counts in lookup
+  and unpublish deliberately do **not**: each key is unpacked one at a
+  time inside the loop, so an absurd `nkeys` simply runs the buffer dry
+  and fails on the first short read — it never reaches an allocator.
+
+  Note also what the unpack itself protects you from, so you screen for
+  the right reason. `pmix_bfrops_base_unpack` reads the count the
+  *packer* wrote and unpacks `min(packed, provided)`, reporting success
+  whenever the storage was big enough. So handing it a `cnt` larger than
+  the array on the wire is harmless — `pmix_server_publish` passed
+  `ninfo + 1` where its two siblings pass `ninfo`, and that over-read
+  never did anything. What it did do was make the guard around the
+  unpack (`0 < cd->ninfo`, always true) fire for a publish carrying no
+  info objects at all, where the buffer is already exhausted; gate on
+  the wire count, not on the array size that carries your extra slot.
 
   While you are there, note the layout those two seeds establish, because
   the completion arms depend on it: for the fence and disconnect families

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -388,6 +388,28 @@ to allocate. `_spcb` had the `PMIX_DESTRUCT(&cb)` inside its
 `PMIX_SUCCESS == rc` arm, and a fetch that finds nothing is the ordinary
 case for a job this server has not been told about yet.
 
+### A blocking entry point that never reads its lock's status
+
+The blocking pattern below is only half done if the handler wakes the
+lock directly. `PMIx_server_define_process_set` and
+`_delete_process_set` both set `cd.opcbfunc = pmix_server_lock_opcbfunc`
+and `cd.cbdata = &cd.lock` — and then their handlers called
+`PMIX_WAKEUP_THREAD(&cd->lock)` themselves and the entry points returned
+a literal `PMIX_SUCCESS`. The waker was dead code and every failure the
+handler could have reported was invisible to the host. Call
+`cd->opcbfunc(rc, cd->cbdata)` on every arm out of the handler, and read
+`cd.lock.status` back **before** `PMIX_DESTRUCT` takes the lock down.
+
+Related: these two are public `PMIx_server_*` entry points, so the host
+can hand them anything, and neither screened its arguments. A NULL pset
+name reaches `strdup`, `strcmp` and `PMIX_INFO_LOAD`; a NULL member
+array reaches `memcpy`; and a **zero** member count is the one that does
+not look like a bug — `PMIx_Data_array_create` answers NULL for a
+zero-element array exactly as it does for a failed allocation, and the
+next line read `darray->array`. All three segfaulted the progress
+thread. `test/unit/progress_threads.c` covers them, and its zero-count
+case kills an unfixed library rather than failing it.
+
 Any struct handed to `PMIX_THREADSHIFT` **must** carry a `pmix_event_t ev`
 as its thread-shift member (the caddy contract from the top-level guide).
 Do not stack-allocate a caddy that outlives its creating function — the

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -56,7 +56,7 @@ module where it cannot, and queue replies back. The file map:
 | `pmix_server_control.c` | The directive and service commands: query, log, allocate, job control, monitor, credential get and validate, session control, resource blocks, and the job-data cache refresh. |
 | `pmix_server_fabric.c` | `fabric_register` / `fabric_update` and the device-distance computation. |
 | `pmix_server_classes.c` | The `PMIX_CLASS_INSTANCE` con/destructors for every type declared in `pmix_server_ops.h` or `pmix_globals.h`, so the ownership rules a destructor encodes can be read in one place. A type private to a single file keeps its class beside it — `grp_block_t`/`grp_trk_t`/`grp_shifter_t` in `pmix_server_group.c`, `rank_blob_t` in `pmix_server_fence.c`, `pmix_dmdx_reply_caddy_t` in `pmix_server_get.c`, `pmix_srvr_epi_caddy_t` in `pmix_server_control.c`. |
-| `pmix_server_fence.c` | The fence collective (barrier + modex data exchange) **and the shared collective-tracker engine** — `pmix_server_get_tracker`, `pmix_server_new_tracker`, `pmix_server_collect_data`, `pmix_server_trk_update`, `pmix_server_commit`, plus the two predicates every family consults: `pmix_server_trk_complete` and `pmix_server_set_collective_status`. |
+| `pmix_server_fence.c` | The fence collective (barrier + modex data exchange) **and the shared collective-tracker engine** — `pmix_server_get_tracker`, `pmix_server_new_tracker`, `pmix_server_collect_data`, `pmix_server_commit`, plus the two predicates every family consults: `pmix_server_trk_complete` and `pmix_server_set_collective_status`. Also `PMIx_server_collect_job_info`, the public API a host uses to pull packed job-level info for a set of procs. |
 | `pmix_server_connect.c` | The connect / disconnect collectives (built on the same tracker engine). |
 | `pmix_server_group.c` | The group collectives (construct/destruct/leave/invite) — a **two-level** block/tracker engine distinct from the fence tracker, plus the peer-lost / member-left fault paths. |
 | `pmix_server_get.c` | Server-side `PMIx_Get` and direct modex (dmodex): the local-satisfy-vs-remote-fetch decision tree, the `local_reqs` / `remote_pnd` deferred-request lists, and the registration-completion re-entry points. |
@@ -424,6 +424,17 @@ that has to tear the tracker down itself (no completion function was ever
 attached) is bound by the same rule as everything else here: **unlink
 from `collectives` first, then release.**
 
+**Cancel the timer before the host up-call, at every site that makes
+one.** `pmix_server_fence` does, and says why at the call site: once the
+tracker is in the host's hands our timeout and the host's completion race,
+and the host can return a tracker we already released. The other two
+places that hand a tracker to `pmix_host_server.fence_nb` —
+`pmix_server_execute_collective` in `pmix_server_registration.c` and the
+lost-connection sweep in `src/mca/ptl/base/ptl_base_sendrecv.c` — do not
+cancel it. Both are reached only after a tracker has been sitting
+incomplete (a late registration, a departed participant), which is
+precisely when a `PMIX_TIMEOUT` timer is most likely to be armed.
+
 **Read `PMIX_TIMEOUT` into a variable of the width you ask for.**
 `PMIx_Value_get_number(value, dest, type)` writes exactly `sizeof(type)`
 bytes through `dest`. Handing it `&tv.tv_sec` while asking for
@@ -432,6 +443,34 @@ a little-endian host, which happens to work, and the high half on a
 big-endian one, which multiplies every timeout by 2^32. Convert through a
 `uint32_t` of its own and assign. The fence, connect and get handlers all
 do this now; `pmix_server_group` always did.
+
+**The modex blob handed *up* to the host belongs to the host, and nothing
+says so in the header.** `pmix_server_fence` unloads the assembled bucket
+into a bare `char *data` and passes it to `pmix_host_server.fence_nb`; so
+does `pmix_server_execute_collective`. Neither frees it, and that is not
+an oversight to "fix": the request direction carries no
+`(release_fn, release_cbdata)` pair the way the reply direction does, and
+the in-tree reference host parks the pointer on a caddy and reads it later
+from another thread (`fencenb_fn` in `test/simple/simptest.c`), so freeing
+it on return would be a use-after-free. Ownership transfers on the call.
+`simptest` then leaks it — that is a defect in the test host, not in the
+library, and it is the reason a naive valgrind run of the simple suite
+shows a per-fence leak here.
+
+**`pmix_cb_t::copy` is advisory and no fetch honors it.** Several sites
+here set `cb.copy = false` with a comment about letting the GDS return a
+pointer into local storage; `gds/hash` marks the parameter unused and
+`pmix_hash_fetch` allocates a fresh `pmix_kval_t` for every value it
+returns. So `PMIX_LIST_DESTRUCT(&cb.kvs)` is always correct and never
+drops a reference the datastore still holds. Do not "optimize" a caller
+on the theory that `copy = false` handed back a borrowed pointer.
+
+**`pmix_pending_resolve` always returns `PMIX_SUCCESS`.** Its callers
+check the status anyway, which is harmless, but do not build error
+handling on it — in particular `pmix_server_commit` returns that status
+to the client as the status of its *commit*, which would report one
+proc's `PMIx_Commit` as failed because some other proc's parked get could
+not be drained.
 
 ### Data collection
 
@@ -749,6 +788,22 @@ Two suites cover the halves:
   `PMIx_Query_info_nb` does in the *requestor's* process; a mistyped
   `PMIX_NSPACE` segfaulted the server until `pmix_parse_localquery`
   grew its own check.
+- [`test/unit/server_fence.c`](../../test/unit/server_fence.c) drives
+  `pmix_server_fence` from hand-packed wire buffers: the two malformed
+  counts above, and a well-formed request whose seeded info slots must
+  reach the host in the order the completion arms read them back. Its
+  helper thread-shifts, because the handler touches
+  `pmix_server_globals.collectives` and must not be called from `main()`.
+  The info-count case aborts rather than fails against an unfixed
+  library. Its host stub *declines* the fence on purpose — accepting
+  would leave the completion to the test, and queueing a reply to a peer
+  with no socket is not something a single-process program can do.
+  `test/unit/tracker_match.c` and `test/unit/trk_complete.c` cover the
+  tracker-identity and completion-predicate halves of the same file, and
+  [`test/unit/collect_job_info.c`](../../test/unit/collect_job_info.c)
+  covers `PMIx_server_collect_job_info`, including the case where one
+  named namespace cannot be answered for and must not discard the job
+  info collected for the others.
 - [`test/unit/server_fabric.c`](../../test/unit/server_fabric.c) drives
   `pmix_server_device_dists` from a hand-packed buffer that carries no
   topology — the "use your own" path — and asserts that a locally
@@ -867,6 +922,33 @@ misbehave by design).
   survive the round trip. Apply the same test to any new handler that
   reads a count before it reads the array, or that walks the `size_t`
   rather than the `int32_t` afterwards.
+
+  **The collective handlers are the third case, and the worst of them.**
+  Fence and connect both size their info array as `ninf + 2` and then
+  seed two slots at `info[ninf]` and `info[ninf+1]` — *before* anything
+  is unpacked into it. A wire count near `SIZE_MAX` wraps that `+ 2` down
+  to a one- or zero-element array (`PMIx_Info_create` answers NULL for
+  zero, which is caught, but not for one), and the seeds are then written
+  at `info[SIZE_MAX]`. That is an out-of-bounds write a local client
+  drives directly, and there is no unpack in front of it to screen
+  anything. The proc count in the same message is the mirror image: it is
+  multiplied by `sizeof(pmix_proc_t)` to size the proc array, and it is
+  the `size_t` — not the `int32_t` the unpack consumed — that the `qsort`
+  and the `PMIX_PROC_FREE` afterwards walk. `pmix_server_fence` now
+  screens both, with the same round-trip test; **`pmix_server_connect`
+  has the identical shape at both of its `ninfo = ninf + 2` sites and
+  still needs it.** Covered by `test/unit/server_fence.c`, whose
+  info-count case segfaults an unfixed library rather than failing it.
+
+  While you are there, note the layout those two seeds establish, because
+  the completion arms depend on it: for the fence and disconnect families
+  `PMIX_LOCAL_COLLECTIVE_STATUS` is the **last** element, and
+  `pmix_server_fence` reads it positionally as `trk->info[trk->ninfo-1]`
+  on both its local-only and its `PMIX_OPERATION_SUCCEEDED` arms. That is
+  correct only because connect is the family that appends past the slot —
+  which is exactly why `pmix_server_set_collective_status` locates it by
+  key instead. Do not copy the positional read into a family that
+  appends.
 - **`PMIX_LIST_DESTRUCT` is not idempotent.** It drains the list and then
   calls `PMIX_DESTRUCT`, which under `--enable-debug` zeroes the object's
   magic id and asserts on it — so a second destruct of the same list

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -515,6 +515,25 @@ The completion status is recorded into the tracker's info array by
 connect appends per-participant endpoint info and job-level info *after*
 that slot, so a positional write would clobber it.
 
+**Finishing a tracker's definition is per-tracker, and adds to the
+count.** `_register_nspace` and `_register_client` walk every incomplete
+tracker when a registration lands, and both halves of that walk were
+shared state when they should not have been. `all_def` - "are all of this
+tracker's namespaces registered" - was initialized above the loop, so one
+tracker naming a namespace we had not been told about left every tracker
+behind it in the list marked incomplete, and whether a collective
+completed depended on its position in `collectives`. And the
+`PMIX_RANK_WILDCARD` arm *assigned* `trk->nlocal` where
+`pmix_server_new_tracker` accumulates it, so a fence naming two wildcard
+namespaces kept only the last-registered one's count: it went up to the
+host as soon as that many local procs had contributed, and the rest
+arrived to find the tracker gone and hung on a fresh one nobody would
+complete. The count is now accumulated, guarded against double-counting by
+the namespace's *previous* `nlocalprocs` - `SIZE_MAX` there is exactly the
+question "could `new_tracker` have counted this one already?", since it
+counts a namespace only when the count is known and every tracker on the
+list predates this call. Both are covered by `test/unit/server_fence.c`.
+
 **Every collective owes `PMIX_TIMEOUT` a local timer, because the host
 cannot supply one.** The attribute is documented as bounding the whole
 operation, and the directives do reach the host in `trk->info` - but only
@@ -539,13 +558,49 @@ from `collectives` first, then release.**
 **Cancel the timer before the host up-call, at every site that makes
 one.** `pmix_server_fence` does, and says why at the call site: once the
 tracker is in the host's hands our timeout and the host's completion race,
-and the host can return a tracker we already released. The other two
-places that hand a tracker to `pmix_host_server.fence_nb` —
-`pmix_server_execute_collective` in `pmix_server_registration.c` and the
-lost-connection sweep in `src/mca/ptl/base/ptl_base_sendrecv.c` — do not
-cancel it. Both are reached only after a tracker has been sitting
-incomplete (a late registration, a departed participant), which is
+and the host can return a tracker we already released. Note the tracker
+destructor does **not** delete the event, so the same cancel is owed by
+any path that tears a tracker down itself. `pmix_server_execute_collective`
+now does both; the lost-connection sweep in
+`src/mca/ptl/base/ptl_base_sendrecv.c` still does not, and it is reached
 precisely when a `PMIX_TIMEOUT` timer is most likely to be armed.
+
+**`pmix_server_execute_collective` is the fourth up-call site, and it owes
+everything the other three do.** It is what fires a collective that a late
+`register_nspace` or `register_client` has just unblocked, and it had none
+of the discipline its siblings carry: it never cancelled the timer, never
+set `host_called`, never checked the host entry point was non-NULL (a
+comment claimed `pmix_server_new_tracker` had done so - it does not), and
+discarded the host's return value entirely, so a refusal left every
+participant blocked forever on a tracker stranded on the `collectives`
+list. Its own pack failures returned the same way. A collective reached
+through this path has no switchyard caddy to hand back - every caddy on
+`local_cbs` is already the tracker's - so the way to fail it is to drive
+the completion function with the error, which replies to each participant
+and tears the tracker down. That is what `fail_collective` is for.
+
+**Never build the modex bucket anywhere but `pmix_server_collect_data`.**
+`pmix_server_execute_collective` used to assemble it inline, and the copy
+had drifted: it shipped the bare collect-type byte plus rank blobs with
+neither the compression flag nor the enclosing byte object that
+`pmix_gds_base_store_modex` unpacks, and it packed with the first
+participant's `bfrops` module rather than `pmix_globals.mypeer`'s. So
+every fence that had to wait on a registration handed the host a blob no
+receiving server could parse - invisible to `make check`, because a
+single-node run never defers a fence. The clone de-duplication that copy
+carried now lives in `pmix_server_collect_data`, where both callers get
+it: a fork/exec'd clone shares its parent's `pmix_rank_info_t`, so
+identity of `&peer->info->pname` is what tells the two apart.
+
+**A tracker handed to `PMIX_EXECUTE_COLLECTIVE` crosses an async hop, so
+the caddy takes a reference.** `pmix_trkr_caddy_t` used to carry a bare
+pointer, and anything that ran between `pmix_event_active` and the
+handler - a departing participant completing the collective, a timeout -
+could release the tracker underneath it. The caddy now retains and its
+destructor releases. As with the dmodex tracker, **the reference keeps the
+object alive but does not put it back on the `collectives` list**, so
+`pmix_server_execute_collective` still asks `collective_is_pending` before
+acting on it, exactly as `_process_dmdx_reply` asks `tracker_is_pending`.
 
 **Read `PMIX_TIMEOUT` into a variable of the width you ask for.**
 `PMIx_Value_get_number(value, dest, type)` writes exactly `sizeof(type)`
@@ -1066,6 +1121,12 @@ Two suites cover the halves:
   library. Its host stub *declines* the fence on purpose — accepting
   would leave the completion to the test, and queueing a reply to a peer
   with no socket is not something a single-process program can do.
+  A further case builds three trackers in a known list order and drives
+  a `PMIx_server_register_nspace` across them, pinning both halves of the
+  tracker-update walk above: that a registration adds to a hybrid
+  tracker's local count rather than replacing it, and that a tracker
+  naming an unregistered namespace does not mark the trackers behind it
+  incomplete.
   A separate case drives the *completion*, `pmix_server_modex_cbfunc`,
   over a hand-built two-participant tracker with a failing status and
   reads back what was queued for each — the shape that catches both a
@@ -1290,6 +1351,27 @@ misbehave by design).
   and, for a data array, its *element* type, or a correctly-tagged array
   of some other type walks past its end. This is the client-side twin of
   the `pmix_parse_localquery` screen.
+- **The registration entry points build global state, so a failed
+  allocation must not be left on a global list.** `_register_nspace` and
+  `_register_client` both `strdup` the namespace name straight into a
+  freshly created `pmix_namespace_t` and appended it unchecked - and every
+  lookup in this directory `strcmp`s that member, so a transient failure
+  became a permanent segfault of the progress thread. `_register_client`
+  also trusted the "called only once per rank" contract in its own
+  comment: the "have we got everyone" test is an exact equality against
+  the length of `nptr->ranks`, so a second entry for a rank pushes that
+  list permanently past `nlocalprocs`, `all_registered` is never set, and
+  every collective involving the namespace hangs with nothing reporting
+  why. It now says so with `PMIX_ERR_DUPLICATE_KEY` instead.
+- **The `nlocalprocs < 0` arm of `_register_nspace` is the *update* path,
+  and it has its own rules.** It stores each directive through the gds
+  module by hand rather than going through `PMIX_GDS_ADD_NSPACE`. Two
+  things there are easy to get wrong: a `PMIX_VALUE_XFER` whose status is
+  discarded hands the datastore a value that was never populated (and the
+  store's own status then overwrites the transfer's), and the
+  `job_info_recvd` guard only works if something sets the flag - only the
+  full-registration path did, so a second update carrying
+  `PMIX_JOB_INFO_ARRAY` re-cached the whole array.
 - **`pmix_server_globals.system_tmpdir` is read by the directory-removal
   guard, so finalize must not free it early.** Only the string is freed
   here; the directory is removed by `pmix_ptl_close()` (inside

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -589,6 +589,35 @@ misbehave by design).
   ownership discipline line for line.
 - **Preserve wire compatibility:** V1/version gating, append-only layouts,
   tolerate-short-buffer unpacks.
+- **A kval built to carry a *borrowed* payload must give it up before
+  release.** The recurring shape here is `PMIX_KVAL_NEW(kptr, KEY)` →
+  point `kptr->value` at something → `PMIX_GDS_STORE_KV` →
+  `PMIX_RELEASE(kptr)`. That release runs `kvdes`, which runs
+  `value_destruct`, which frees the value's payload *outright* — a
+  `PMIX_DATA_ARRAY` through `data_array_free`, a `PMIX_STRING` through
+  `free`. And the store does not take the payload: `pmix_hash_store`
+  deep-copies it. So a value pointed at memory that is not ours hands
+  that memory back to the heap while its real owner still holds it.
+  Most sites are safe because they build a payload they own
+  (`PMIX_PROC_CREATE`, `pmix_asprintf`); `PMIX_ALLOC_MAU` in
+  `PMIx_server_init` borrowed the *host's* `pmix_data_array_t` straight
+  out of the caller's `info[]`, so init freed it and the host's own free
+  of it was a double free. Either copy into the value, or NULL the
+  borrowed member before releasing. Covered by
+  `test/unit/singleton_register`.
+- **The server's own `mypeer->nptr` never reaches `pmix_globals.nspaces`,
+  and nothing depends on it.** The block in `PMIx_server_init` that would
+  prepend it is guarded on `NULL == mypeer->nptr`, which `pmix_rte_init`
+  has already made non-NULL — so it is dead, and the comment above it
+  ("ensure our own nspace is first on the list") describes an intent the
+  code does not carry out. This looks like it should break the
+  `PMIX_LAUNCHER_RNDZ_URI` path, where `job_data` stores our parent's
+  reply under our own nspace and `hash_store_job_info` looks that nspace
+  up on `pmix_globals.nspaces` before storing anything. It does not:
+  `pmix_gds_hash_get_tracker(nspace, true)`, called immediately above
+  that lookup, creates and appends the namespace itself. Verified by
+  instrumenting both sites. Do not "fix" the dead branch on the theory
+  that the lookup can fail.
 - **Screen the shape of anything the host hands you before indexing it.**
   A `pmix_info_t` carrying a `PMIX_DATA_ARRAY` is a host-supplied
   structure, and several sites here read `array[0]` and `array[1]`

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -582,6 +582,62 @@ client, so the `pname` read is safe; `server_object` is simply NULL for a
 peer the host never registered as a client, which hosts already handle
 (and is what lets PRRTE tell the two apart).
 
+## The event registration store
+
+`pmix_server_globals.events` is a list of `pmix_regevents_info_t`, one
+per event code (plus one keyed `PMIX_MAX_ERR_CONSTANT` for default
+handlers), each owning a `peers` list of `pmix_peer_events_info_t` — one
+entry per registration message that named the code. Three invariants are
+easy to get wrong.
+
+**A peer legitimately holds more than one entry for the same code, so a
+deregistration has to clear them all.** The client library packs a
+handler's *whole* code list whenever any code in that list is new to this
+server, so a client that registers one handler for `{A}` and a second for
+`{A, B}` sends both lists and we record `A` twice — deliberately, since
+each entry carries that handler's own `PMIX_EVENT_AFFECTED_PROC` filter.
+It then sends exactly one deregistration for `A`, when its last handler
+for `A` goes away. `pmix_server_deregister_events` stopped at the first
+match and left the rest behind for the life of the connection: the server
+kept forwarding the code to a peer with no handler for it, and `peers`
+never emptied, so `pmix_server_prune_reginfo` never fired and the host was
+never told to stop either.
+
+**`reginfo->active` is a promise to every future registrant, so a host
+that refuses must have it given back — on both arms.** `mark_activations`
+sets it for the codes a request is about to ask the host about, sorting
+them to the front of the array so the host is handed just that subset;
+`undo_activations` is its inverse, and the only thing that reads the flag
+is the next registration deciding whether to ask again. The synchronous
+refusal always called `undo_activations`; the asynchronous one did not, so
+a host that accepted a registration for processing and then failed it left
+the code marked active forever — and every later registrant for it was
+told it succeeded and then never saw the event. `pmix_setup_caddy_t`
+carries `nactive` for exactly this. The undo runs on the progress thread
+(`_failed_registration`), *not* in the host callback, because the store is
+progress-thread state — `regevopcbfunc` may be called on the host's own
+thread and does nothing but thread-shift.
+
+The peer entries a failed registration added are deliberately *not*
+removed. A peer may hold several handlers for one code and nothing in the
+request identifies which entry belongs to it; those entries go when the
+peer deregisters or departs. Note also that
+`pmix_peer_events_info_t::enviro_events` is written and never read
+anywhere in the tree — the same shape as `pmix_iof_req_t::flags`.
+
+**The cached-event replay answers with the registration's status, not its
+own.** `_check_cached_events` runs after a successful registration to hand
+a late registrant anything already in the notification hotel that matches
+its codes, its affected-proc filter and the event's range. It used to
+report whatever the replay ran into, so failing to pack or queue one stale
+event told the client its handler was not registered — while the server
+had in fact registered it, leaving an entry the client would never
+deregister. Note that all three arms have to attach that filter to the
+caddy (`scd->procs`) and the host-completes-asynchronously arm did not, so
+it replayed events the registrant had said it did not want; attach it
+*before* the up-call, since the host may complete on another thread the
+moment it has the caddy.
+
 ## IOF forwarding
 
 Standard-I/O forwarding is buffered through `pmix_server_globals.iof`
@@ -663,6 +719,13 @@ Two suites cover the halves:
   `PMIx_Query_info_nb` does in the *requestor's* process; a mistyped
   `PMIX_NSPACE` segfaulted the server until `pmix_parse_localquery`
   grew its own check.
+- [`test/unit/event_chain.c`](../../test/unit/event_chain.c) drives
+  `pmix_server_register_events` / `pmix_server_deregister_events` from
+  hand-packed wire buffers alongside its client-side event-chain cases —
+  the default-handler entry that registration has to create, and the
+  duplicate `(peer, code)` entries a deregistration has to clear in full.
+  Its `client_evreq()` helper thread-shifts, because both of those touch
+  `pmix_server_globals` and must not be called from `main()`.
 - [`contrib/dockerswarm/run-server-tests.sh`](../../contrib/dockerswarm/run-server-tests.sh)
   is the multi-node half: direct modex, spawn-plus-connect across
   namespaces, group blocks spanning nodes, IOF pull/dereg against a
@@ -754,13 +817,18 @@ misbehave by design).
   through the `int32_t` that `PMIX_BFROPS_UNPACK` takes, so a peer can
   send one that truncates to zero or to a negative number. That is
   harmless wherever the only use is sizing an array the unpack
-  immediately guards — which is every handler here except
-  `pmix_server_log`, which indexes the directive array to append
-  `PMIX_LOG_SOURCE` *before* anything is unpacked into it (a negative
-  index off a NULL array) and hands `(info, ninfo)` to `plog` even when
-  the unpack was skipped. It now rejects a count that does not survive
-  the round trip. Apply the same test to any new handler that reads a
-  count before it reads the array.
+  immediately guards. Two handlers here are not that. `pmix_server_log`
+  indexes the directive array to append `PMIX_LOG_SOURCE` *before*
+  anything is unpacked into it (a negative index off a NULL array) and
+  hands `(info, ninfo)` to `plog` even when the unpack was skipped;
+  `pmix_server_register_events` walks its code array `ncodes` times while
+  only `cnt` entries were unpacked into it, and that array comes from a
+  bare `malloc`, so the tail is uninitialized rather than constructed
+  (an info array is safe here precisely because `PMIX_INFO_CREATE`
+  constructs every element). Both now reject a count that does not
+  survive the round trip. Apply the same test to any new handler that
+  reads a count before it reads the array, or that walks the `size_t`
+  rather than the `int32_t` afterwards.
 - **`PMIX_LIST_DESTRUCT` is not idempotent.** It drains the list and then
   calls `PMIX_DESTRUCT`, which under `--enable-debug` zeroes the object's
   magic id and asserts on it — so a second destruct of the same list
@@ -775,6 +843,19 @@ misbehave by design).
   and long enough first: `_register_nspace` and `_register_resources` both
   did not, and neither is reachable only from trusted code - a host is
   free to get this wrong.
+
+  **The same applies with more force to anything a *client* handed you.**
+  An info array a handler unpacked off the wire carries whatever type tag
+  the peer chose, so reading its union without checking that tag is
+  reading a pointer the peer picked. `pmix_server_register_events` took
+  `PMIX_EVENT_AFFECTED_PROC` and `PMIX_EVENT_AFFECTED_PROCS` straight out
+  of it, so a mistyped one had the server copy a `pmix_proc_t` out of a
+  scalar or dereference that scalar as a `pmix_data_array_t`; the group
+  branch of `pmix_server_event_recvd_from_client` did the same with
+  `PMIX_GROUP_ID` and `strcmp`'d the result. Confirm the value's type -
+  and, for a data array, its *element* type, or a correctly-tagged array
+  of some other type walks past its end. This is the client-side twin of
+  the `pmix_parse_localquery` screen.
 - **`pmix_server_globals.system_tmpdir` is read by the directory-removal
   guard, so finalize must not free it early.** Only the string is freed
   here; the directory is removed by `pmix_ptl_close()` (inside

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -454,6 +454,22 @@ callback with a status before discarding the tracker: those requesters are
 same reference-counting trap as the one below - the difference is only
 whether the waiters deserve to be told.
 
+**`remote_pnd` is the same trap pointing the other way.** It holds the
+*host's* `PMIx_server_dmodex_request` calls (`pmix_server_dmodex.c`),
+parked when the local client they name has not committed its data yet -
+and `pmix_server_commit` unlinking one is the only thing that ever took a
+request back off the list. So a target that departs without ever
+committing (it aborted, it never called `PMIx_Put`, its namespace was
+deregistered) left the host holding a request it would never hear about
+again, and the remote server that asked - along with the client blocked
+in `PMIx_Get` behind it - waited forever. `pmix_server_purge_events` now
+calls `pmix_server_fail_remote_pnd`, the mirror of
+`pmix_server_fail_local_reqs`: answer the host with a status, then
+discard. Note the response function's contract while you are there - the
+public header says **"The PMIx server will free the data blob upon return
+from the response fn"**, which is why `_dmodex_req` frees `data`
+immediately after calling it.
+
 **Do not read a `PMIX_LIST_FOREACH` variable after the loop.** A loop
 that runs to completion leaves it pointing at the list's sentinel, which
 is a bare `pmix_list_item_t`; reading any later field of the element type
@@ -630,6 +646,11 @@ Two suites cover the halves:
   exceeds its local size, and asserts the classification and that nothing
   is left parked on `local_reqs`. Read its header for what it pins down
   and what it deliberately cannot reproduce.
+- [`test/unit/server_dmodex.c`](../../test/unit/server_dmodex.c) covers
+  `PMIx_Store_internal` and the `remote_pnd` deferral above, including
+  the departure drain. It orders itself off `PMIx_Store_internal` rather
+  than a sleep: that call blocks on the progress thread, so anything
+  queued ahead of it has run by the time it returns.
 - [`test/unit/server_control.c`](../../test/unit/server_control.c) drives
   `pmix_server_log` and `pmix_server_job_ctrl` from hand-packed wire
   buffers — the malformed-count screens, the appended `PMIX_LOG_SOURCE` /

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -115,6 +115,49 @@ callback.** Getting this wrong is the dominant bug class in this
 directory (leaks when a success path forgets to release, double-frees
 when an error path releases a caddy the switchyard will also release).
 
+Three things about the switchyard read as defects and are not. Check them
+against this list before "fixing" one:
+
+- **A failed `PMIX_SERVER_QUEUE_REPLY` cannot strand a client.** Several
+  arms release the reply and carry on returning `PMIX_SUCCESS`, which
+  looks like a client left blocked forever. The macro has exactly one
+  failure mode — `peer->finalized`, answered with `PMIX_ERR_UNREACH` —
+  so whenever it fails there is no longer a peer waiting for the answer,
+  and the synthesized reply the message handler would send instead could
+  not be queued either.
+- **`PMIX_DEREGEVENTS_CMD` answers nothing, deliberately.** It is the one
+  arm that returns `PMIX_SUCCESS` without queuing a reply and without an
+  async owner to queue one later. The client sends that command through
+  `PMIX_PTL_SEND_RECV` with a **NULL** callback (`dereg_event_hdlr` in
+  `src/event/pmix_event_registration.c`), so nothing is waiting on a tag.
+- **`PMIX_GDS_CADDY` and `PMIX_SERVER_QUEUE_REPLY` both dereference an
+  unchecked `PMIX_NEW`.** Making the macros NULL-safe does not help: the
+  handler on the next line dereferences the caddy it was given, so the
+  crash moves rather than goes away, and covering it properly would mean
+  a check at all thirty-odd dispatch arms for a condition under which the
+  library cannot service the request anyway. Left as is, on purpose.
+
+**The outer host callbacks own the caddy on *every* arm that does not
+thread-shift.** `op_cbfunc`, `op_cbfunc2` and `resop_cbfunc` each have
+two: the `progress_thread_stopped` early-out and the failure to allocate
+the `pmix_shift_caddy_t`. All three released the caddy on the first and
+dropped it on the second, stranding the `PMIX_RETAIN` it holds on the
+requesting peer — and with it the peer and everything hanging off it —
+for the life of the server.
+
+**And `resop_cbfunc` is not shaped like the other two.** `op_cbfunc`'s
+`cbdata` really is the switchyard's `pmix_server_caddy_t`: the handlers
+that name it (`pmix_server_abort`, `_publish`, `_unpublish`, `_log`,
+`_iofstdin`) park it on `cd->cbdata` of a caddy of their own and drive
+`cd->opcbfunc(status, cd->cbdata)` at the end. `pmix_server_resblk`
+instead hands its **own `pmix_setup_caddy_t`** to the host as the
+up-call's `cbdata`, with the server caddy nested inside it. So that
+callback owns three things — the server caddy, the caddy's `nspace`
+string, and the setup caddy — and neither destructor reaches the other
+two. It was declared as taking the wrong type, and both of its early
+returns released only the outermost object. When you add a callback
+here, read the *producing* handler to see which caddy it actually passes.
+
 ### The host-callback → reply pattern
 
 For any command the local server cannot answer itself, the handler

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -194,6 +194,35 @@ session-control, job-control and monitor - returned without it, stranding
 the host's data for the life of the host process. `pmix_server_modex_cbfunc` and the
 fabric/dist family show the shape to copy.
 
+**That includes the `progress_thread_stopped` arm, which is the one it is
+easiest to read as exempt.** Every callback in
+`pmix_server_info_replies.c` opens with that early-out, in both halves of
+the pair - the outer callback that may run on the host's thread and the
+inner `_*cbfunc` that runs after the shift. All eighteen of those arms
+tore down our own caddies and returned without calling `relfn`. The arm
+is not unreachable and it is not a special case: the flag goes up while
+`PMIx_server_finalize` is running, which is exactly when an in-flight
+host completion lands, and the host process outlives our finalize - so
+what is dropped there is stranded for good. Exactly one of the two arms
+can fire for a given request (the outer returns before shifting, so the
+inner never runs), which is why calling `relfn` in both is right rather
+than a double release.
+
+**A callback signature with no release function has to *copy* what it
+parks.** `pmix_credential_cbfunc_t` and `pmix_validation_cbfunc_t` -
+`pmix_server_cred_cbfunc` and `pmix_server_validate_cbfunc` - carry no
+`(relfn, relcbdata)` pair, so nothing the host passes survives the return
+of the call. Both of them only thread-shift, and pack the reply later on
+the progress thread. Validate always copied its info array and said why;
+cred copied the credential (`PMIX_BFROPS_COPY`) and then parked the info
+array *by pointer* beside it, so a host that answered from a stack frame
+- the natural thing for a one-element reply - had the server pack that
+frame after it was gone. Copy into the caddy and set `infocopy`, rather
+than freeing explicitly at the end: the flag also covers the early
+returns above the completion, which is where validate leaked its copy.
+The regression case is in `test/unit/server_control.c`, whose host stub
+destructs and overwrites its array the instant the callback returns.
+
 **An internal completion path must hand the callback the object that
 callback casts.** `_fabric_response` exists to answer a fabric request the
 `pnet` layer satisfied locally, and it called the switchyard's
@@ -858,7 +887,12 @@ Two suites cover the halves:
   server unpacks those off the wire, so it cannot rely on the screening
   `PMIx_Query_info_nb` does in the *requestor's* process; a mistyped
   `PMIX_NSPACE` segfaulted the server until `pmix_parse_localquery`
-  grew its own check.
+  grew its own check. Its `get_credential` case is the one place in the
+  suite that reads a *reply* back: `PMIX_SERVER_QUEUE_REPLY` never arms
+  the send event for a peer whose `sd` is negative, so the message comes
+  to rest on `peer->send_msg` and a single process can unpack what the
+  server actually packed. Use that idiom rather than a host stub's
+  arguments when what you need to pin down is what crossed the wire.
 - [`test/unit/server_fence.c`](../../test/unit/server_fence.c) drives
   `pmix_server_fence` from hand-packed wire buffers: the two malformed
   counts above, and a well-formed request whose seeded info slots must

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -55,7 +55,7 @@ module where it cannot, and queue replies back. The file map:
 | `pmix_server_events.c` | The event family: `register_events` / `deregister_events`, the registration store and the bookkeeping that decides when our host must start or stop forwarding a code (`pmix_server_activate_events`, `pmix_server_deactivate_events`, `pmix_server_prune_reginfo`), the cached-event replay for a late registrant, and `pmix_server_event_recvd_from_client`. |
 | `pmix_server_control.c` | The directive and service commands: query, log, allocate, job control, monitor, credential get and validate, session control, resource blocks, and the job-data cache refresh. |
 | `pmix_server_fabric.c` | `fabric_register` / `fabric_update` and the device-distance computation. |
-| `pmix_server_classes.c` | **All** the server-side `PMIX_CLASS_INSTANCE` con/destructors, so the ownership rules a destructor encodes can be read in one place. |
+| `pmix_server_classes.c` | The `PMIX_CLASS_INSTANCE` con/destructors for every type declared in `pmix_server_ops.h` or `pmix_globals.h`, so the ownership rules a destructor encodes can be read in one place. A type private to a single file keeps its class beside it — `grp_block_t`/`grp_trk_t`/`grp_shifter_t` in `pmix_server_group.c`, `rank_blob_t` in `pmix_server_fence.c`, `pmix_dmdx_reply_caddy_t` in `pmix_server_get.c`, `pmix_srvr_epi_caddy_t` in `pmix_server_control.c`. |
 | `pmix_server_fence.c` | The fence collective (barrier + modex data exchange) **and the shared collective-tracker engine** — `pmix_server_get_tracker`, `pmix_server_new_tracker`, `pmix_server_collect_data`, `pmix_server_trk_update`, `pmix_server_commit`, plus the two predicates every family consults: `pmix_server_trk_complete` and `pmix_server_set_collective_status`. |
 | `pmix_server_connect.c` | The connect / disconnect collectives (built on the same tracker engine). |
 | `pmix_server_group.c` | The group collectives (construct/destruct/leave/invite) — a **two-level** block/tracker engine distinct from the fence tracker, plus the peer-lost / member-left fault paths. |
@@ -215,6 +215,54 @@ request; a component that did would crash immediately.
 | `pmix_dmdx_local_t` / `pmix_dmdx_request_t` / `pmix_dmdx_remote_t` | `pmix_server_ops.h:113/123/107` | Direct-modex deferral bookkeeping (see get.c). |
 | `pmix_query_caddy_t`, `pmix_cb_t`, `pmix_inventory_rollup_t` | globals / ops.h | Query/fetch and inventory roll-up carriers. |
 
+### `pmix_setup_caddy_t` does not own its members uniformly
+
+This is the single most error-prone thing in the caddy zoo, because
+`scaddes` (`pmix_server_classes.c:182`) frees three groups of member on
+three different rules, and the rule is not visible at the assignment site:
+
+| Member | Freed by the destructor? |
+|--------|--------------------------|
+| `procs`/`nprocs`, `units`/`nunits`, `bo`/`nbo`, `peer`, `flags.file`/`.directory` | **Always** |
+| `info`/`ninfo`, `apps`/`napps` | Only when `copied` is true |
+| `nspace`, `keys` | **Never** |
+
+So a handler that parks the *caller's* proc array or byte object on a
+caddy — `PMIx_server_IOF_deliver` and `PMIx_server_IOF_flow_control` both
+do, and must, per the no-copy rule — has to detach it before the caddy is
+released, or the destructor calls `free()` on memory the host owns, often
+a stack frame. `_iofdeliver` and `_iofflowcontrol` do exactly that in
+their "release the caddy" blocks; both of their `PMIX_ERR_WOULD_BLOCK`
+early returns did not, so the blocking form called from the progress
+thread freed the caller's proc and byte object. `PMIx_server_define_process_set`
+shows the same idiom on a stack caddy ("protect the input"). Covered by
+`test/unit/iof_output.c`, whose case aborts rather than fails against an
+unfixed library.
+
+Note the asymmetry the two free helpers add: `PMIx_Proc_free(p, n)` frees
+`p` only when `0 < n`, but `PMIx_Byte_object_free(b, n)` frees `b`
+whenever it is non-NULL — so leaving `nbo` at zero does *not* protect a
+borrowed `bo`.
+
+The other half of the rule is the "never" row. `nspace` and `keys` are
+borrowed as often as they are owned - `PMIx_Register_attributes` parks the
+host's own `function` string and `attrs` array there, and the pset stack
+caddies park the caller's `pset_name` - so the destructor cannot free
+them and every site that *does* own one owes it a `free()` on every path
+that discards the caddy. Two forgot: `pmix_server_abort` unpacks the
+abort message into `nspace` (an allocation) and leaked it on every abort,
+and `PMIx_server_setup_local_support` leaked its `strdup` on the
+`PMIX_ERR_WOULD_BLOCK` arm. Do not "fix" this by moving `nspace` into the
+destructor - that turns the leak into a free of a string literal.
+
+A related trap sits one layer out: `pmix_server_process_iof` does
+`req->flags = cd->flags`, a **shallow** copy of a `pmix_iof_flags_t` whose
+`file` and `directory` members are `strdup`ed and owned by the caddy. The
+`pmix_iof_req_t` outlives the caddy, so those two pointers dangle the
+moment the caddy is released. It is latent only because nothing reads
+`pmix_iof_req_t::flags` today (`pmix_iof_process_iof` does not); the day
+something does, it needs its own copy.
+
 Any struct handed to `PMIX_THREADSHIFT` **must** carry a `pmix_event_t ev`
 as its thread-shift member (the caddy contract from the top-level guide).
 Do not stack-allocate a caddy that outlives its creating function — the
@@ -283,9 +331,12 @@ the trickiest bugs):**
   (dangling pointer → UAF on the next sweep), and **never release a
   tracker whose `local_cbs` still holds a caddy that the switchyard will
   also release** on a non-SUCCESS return (double free). When a host
-  up-call is rejected, remove the current `cd` from `local_cbs` (and set
-  `cd->trk = NULL`) *before* returning the error, as the connect
-  host-error path at `pmix_server_connect.c:421-434` demonstrates.
+  up-call is rejected, remove the current `cd` from `local_cbs` *before*
+  returning the error, as the connect host-error path at
+  `pmix_server_connect.c:421-434` demonstrates. Those paths also set
+  `cd->trk = NULL`, which is a no-op: nothing in the tree ever assigns
+  `pmix_server_caddy_t::trk` a non-NULL value, so `cddes`'s release of it
+  is unreachable too. Removal from `local_cbs` is what does the work.
 
 The completion status is recorded into the tracker's info array by
 `pmix_server_set_collective_status`, which locates the

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -934,11 +934,14 @@ misbehave by design).
   anything. The proc count in the same message is the mirror image: it is
   multiplied by `sizeof(pmix_proc_t)` to size the proc array, and it is
   the `size_t` — not the `int32_t` the unpack consumed — that the `qsort`
-  and the `PMIX_PROC_FREE` afterwards walk. `pmix_server_fence` now
-  screens both, with the same round-trip test; **`pmix_server_connect`
-  has the identical shape at both of its `ninfo = ninf + 2` sites and
-  still needs it.** Covered by `test/unit/server_fence.c`, whose
-  info-count case segfaults an unfixed library rather than failing it.
+  and the `PMIX_PROC_FREE` afterwards walk. Fence, connect and disconnect
+  now all screen both counts with the same round-trip test. Covered by
+  `test/unit/server_fence.c` and `test/unit/server_connect.c`, whose
+  info-count cases kill an unfixed library rather than failing it. **Any
+  new collective handler that seeds slots past the unpacked ones owes the
+  same screen** — the group handler builds its info array differently
+  (`ninfo = ninf + 1`, `pmix_server_group.c`) and should be read with
+  this in mind.
 
   While you are there, note the layout those two seeds establish, because
   the completion arms depend on it: for the fence and disconnect families

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -657,7 +657,12 @@ Two suites cover the halves:
   `PMIX_LOG_TIMESTAMP` directives, and the RFC precedence rule that a
   repeated cleanup directory upgrades the entry already on the epilog.
   The bad-directive-count case aborts rather than fails against an
-  unfixed library, the same bargain `test/unit/iof_output.c` makes.
+  unfixed library, the same bargain `test/unit/iof_output.c` makes. It
+  also drives `pmix_server_query` with mistyped query qualifiers — the
+  server unpacks those off the wire, so it cannot rely on the screening
+  `PMIx_Query_info_nb` does in the *requestor's* process; a mistyped
+  `PMIX_NSPACE` segfaulted the server until `pmix_parse_localquery`
+  grew its own check.
 - [`contrib/dockerswarm/run-server-tests.sh`](../../contrib/dockerswarm/run-server-tests.sh)
   is the multi-node half: direct modex, spawn-plus-connect across
   namespaces, group blocks spanning nodes, IOF pull/dereg against a

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -433,6 +433,93 @@ Never touch `pmix_server_globals` state before the thread-shift — do it
 inside the `_worker(int sd, short args, void *cbdata)` handler that runs
 on the progress thread.
 
+**`PMIX_RELEASE` NULLs the pointer it is given** when that release drops
+the last reference — both the debug and the optimized spelling end with
+`object = NULL` (`src/class/pmix_object.h:543`). So a handler that
+releases a caddy on an error arm and then falls into a shared exit label
+that tests `NULL == fcd` is correct, not a use-after-free, and an
+`x = NULL` written after a release is redundant rather than load-bearing.
+`_setup_app` reads exactly that way and was audited as a UAF twice before
+this was written down. The one case where it does *not* hold is an object
+someone else still holds a reference to — there the pointer survives the
+call, which is the intended meaning.
+
+## Preparing a job (`pmix_server_setup.c`)
+
+Everything here runs before a job's processes do. Three things in it are
+easy to get wrong and were.
+
+**A payload that lives in the caller's info array must be borrowed, not
+loaded.** `PMIX_LOAD_BUFFER` does not copy: it points the buffer at the
+payload it is handed and then NULLs the source pointer and zeroes the
+size. `_register_resources` used it on the `PMIX_GROUP_JOB_INFO` byte
+object, which sits inside `cd->info` — the host's own array, which the
+host owns and keeps valid until our callback fires. So the handler
+emptied the host's info element (a second registration with the same
+array then silently found no job info) and leaked the blob, because the
+buffer is never destructed — and destructing it would have been worse,
+freeing memory the host still owns. Use
+`PMIX_LOAD_BUFFER_NON_DESTRUCT` and do not destruct, the same bargain
+`_mdxcbfunc` makes with `xfer`.
+
+**An unpack loop that ends on `PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER`
+must not report it.** Running the buffer dry is how the job-info walk
+*finishes*, and that status was still in `rc` when the handler drove the
+completion — so every registration carrying job info told the host it had
+failed, and the blocking form returned the error instead of
+`PMIX_OPERATION_SUCCEEDED`. The handler now keeps the status it reports
+in a variable of its own that records the *first* failure, since the
+transient `rc` of the last sub-operation is not the result of the call
+either: a later success used to erase an earlier error just as readily.
+
+**The global data cache appends, so deregistration has to clear every
+match.** `_register_resources` adds a `pmix_kval_t` to
+`pmix_server_globals.gdata` for any key that is not one of the four group
+keys, without checking whether that key is already there — so a host that
+re-registers a key to update its value leaves two entries, and
+`gds/hash` walks the list in order when it seeds a namespace, which makes
+the *later* one the one in effect. `_deregister_resources` stopped at the
+first match, so it removed the shadowed entry and left the live one: the
+deregistration silently did nothing. It now clears every entry carrying
+the key, which is what the man page ("each matching entry") requires.
+Note what is still missing there: the man page also describes narrowing a
+removal with qualifiers — a `PMIX_NODE_INFO_ARRAY` naming one node's
+fabric device — and nothing implements that, so such a request removes
+every entry carrying that key rather than the one described.
+
+**The helper APIs are pass-throughs, so the public entry point is the
+only place their arguments get screened.** `PMIx_generate_regex` /
+`_ppn` hand `input` and `regexp` straight to a `preg` component, and
+`preg/raw` `strncmp`s the one and writes through the other without
+looking; `PMIx_server_generate_locality_string` / `_cpuset_string` hand
+theirs to hwloc, which reports a bad cpuset *by writing NULL through the
+output pointer* and therefore cannot be the code that screens it. All
+four took the library down on a NULL. The `regex2` pair always screened
+its arguments here; the others now match it. (`PMIx_server_generate_cpuset`
+is the exception that needs nothing: `pmix_hwloc_parse_cpuset_string`
+screens both of its arguments and says so.)
+
+**And the group arrays a host registers need the same shape screen the
+group collective applies to the ones a client sends.** The
+`PMIX_GROUP_INFO` / `PMIX_GROUP_INFO_ARRAY` and `PMIX_GROUP_ENDPT_DATA`
+arms read `value.data.darray` — and, inside an endpoint array,
+`value.data.proc` and `value.data.scope` — on the strength of the key
+alone. `pmix_server_valid_darray` is that screen, shared with
+`pmix_server_group.c` through `pmix_server_ops.h`; positional element
+types still need checking by hand, since the array being of the right
+element type says nothing about what a given element carries.
+
+One thing to know before writing a host against this: `pmix_common.h`
+documents `PMIX_GROUP_ENDPT_DATA` as a `pmix_byte_object_t`, while both
+this code and
+[`PMIx_server_register_resources(3)`](../../docs/man/man3/PMIx_server_register_resources.3.rst)
+treat it as a `pmix_data_array_t` of `pmix_info_t` whose first two
+elements are the proc ID and the scope. Nothing in the tree produces the
+attribute, so neither statement is being exercised. The header comment
+looks like the stale one — `PMIX_GROUP_JOB_INFO` immediately below it
+*is* a byte object and is read as one — but that has not been settled
+against the Standard, so it is flagged here rather than quietly changed.
+
 ## The collective-tracker engine (fence / connect / disconnect)
 
 All three of these collectives share `pmix_server_trkr_t` and the engine
@@ -1216,6 +1303,22 @@ Two suites cover the halves:
   whose hwloc finds no OS devices (a bare macOS one), because there is
   then no answer to hold the contract against; the leak half of it only
   shows under valgrind.
+- [`test/unit/server_setup.c`](../../test/unit/server_setup.c) covers the
+  job-preparation calls above, driving every one of them through its
+  public entry point in the blocking form — which makes the ordering
+  deterministic without a single sleep, since a blocking
+  `PMIx_server_*` call does not return until its handler has run. It
+  builds its `PMIX_GROUP_JOB_INFO` blob with
+  `PMIx_server_collect_job_info`, which is what produces that format in
+  the first place, and then asserts both halves of the borrow rule: that
+  the call reports success rather than end-of-buffer, and that the
+  caller's byte object still has its bytes afterwards. It pairs every
+  mistyped array with a well-formed one, so the screens are held to
+  accepting what they should. Three groups of case there — the argument
+  screens and both mistyped arrays — take an unfixed library down rather
+  than failing it; that was checked by reverting each screen in turn, and
+  a regression therefore looks like an empty log and exit 139, not a FAIL
+  line.
 - [`test/unit/server_resolve.c`](../../test/unit/server_resolve.c) drives
   `pmix_server_resolve_peers` / `pmix_server_resolve_node` from
   hand-packed wire buffers against a host module with no `query` entry

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -120,6 +120,12 @@ pmix_server_globals_t pmix_server_globals = {
 
 // local variables
 static pmix_event_t parentdied;
+/* Records the descriptor PMIX_KEEPALIVE_PIPE named, so finalize can take
+ * that event back down and close it. It is a static rather than a local
+ * because finalize cannot re-derive the answer - the pipe was a directive
+ * to *init*, and init removes it from the environment. Mirrors the same
+ * bookkeeping in PMIx_tool_init/PMIx_tool_finalize. */
+static int keepalive_fd = -1;
 static char *security_mode = NULL;
 static char *bfrops_mode = NULL;
 static char *gds_mode = NULL;
@@ -178,9 +184,13 @@ static void job_data(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
         return;
     }
 
-    /* decode it */
+    /* decode it - leave cb->status set to the store result so PMIx_server_init
+     * sees a storage failure rather than having it masked as success. The
+     * "nothing more to unpack" case is normalized to PMIX_SUCCESS by the
+     * module, so a parent that had no job data for us still succeeds here. */
     PMIX_GDS_STORE_JOB_INFO(cb->status, pmix_client_globals.myserver, nspace, buf);
-    cb->status = PMIX_SUCCESS;
+
+    free(nspace);
     PMIX_POST_OBJECT(cb);
     PMIX_WAKEUP_THREAD(&cb->lock);
 }
@@ -548,6 +558,14 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
                 singleton = info[n].value.data.string;
 
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_MAU)) {
+                /* this comes straight from our host and nothing has
+                 * validated it - the key says what it is, never what is
+                 * in the value */
+                if (PMIX_DATA_ARRAY != info[n].value.type ||
+                    NULL == info[n].value.data.darray) {
+                    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                    return PMIX_ERR_BAD_PARAM;
+                }
                 mau = info[n].value.data.darray;
 
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_TOOL_CONNECT_OPTIONAL)) {
@@ -613,11 +631,12 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     /* if we were given a keepalive pipe, register an
      * event to capture the event */
     if (NULL != (evar = getenv("PMIX_KEEPALIVE_PIPE"))) {
-        rc = strtol(evar, NULL, 10);
-        pmix_event_set(pmix_globals.evbase, &parentdied, rc, PMIX_EV_READ, pdiedfn, NULL);
+        keepalive_fd = strtol(evar, NULL, 10);
+        pmix_event_set(pmix_globals.evbase, &parentdied, keepalive_fd,
+                       PMIX_EV_READ, pdiedfn, NULL);
         pmix_event_add(&parentdied, NULL);
         pmix_unsetenv("PMIX_KEEPALIVE_PIPE", &environ);
-        pmix_fd_set_cloexec(rc); // don't let children inherit this
+        pmix_fd_set_cloexec(keepalive_fd); // don't let children inherit this
     }
 
     /* assign our internal bfrops module */
@@ -840,6 +859,15 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         kptr->value->type = PMIX_DATA_ARRAY;
         kptr->value->data.darray = mau;
         PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, PMIX_INTERNAL, kptr);
+        /* The store deep-copied the array, and this value only *borrowed*
+         * our host's. Detach it before releasing: the kval destructor
+         * runs value_destruct, which frees a PMIX_DATA_ARRAY payload
+         * outright - so leaving it attached hands our caller's array back
+         * to the heap while the caller still holds it in its own info
+         * array and will free it again. Both neighbors below build a
+         * payload they own (PMIX_PROC_CREATE, pmix_asprintf); this one
+         * does not, which is what makes the detach necessary. */
+        kptr->value->data.darray = NULL;
         PMIX_RELEASE(kptr); // maintain accounting
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -1028,6 +1056,16 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "pmix:server finalize called");
+
+    /* Take down the file-scope event init may have registered, while the
+     * base it is on still exists - otherwise it survives into a state
+     * where its base has been destroyed under it, and the descriptor it
+     * watches is never given back. Matches PMIx_tool_finalize. */
+    if (0 <= keepalive_fd) {
+        pmix_event_del(&parentdied);
+        close(keepalive_fd);
+        keepalive_fd = -1;
+    }
 
     /* wait here until all active events have been processed */
     PMIx_Progress_thread_stop(NULL, 0);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -969,7 +969,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
                             "[%s:%d] WAITING IN INIT FOR RELEASE", pmix_globals.myid.nspace,
                             pmix_globals.myid.rank);
         cd = PMIX_NEW(pmix_rshift_caddy_t);
-        cd->codes = malloc(sizeof(int));
+        cd->codes = malloc(sizeof(pmix_status_t));
         cd->codes[0] = PMIX_DEBUGGER_RELEASE;
         cd->ncodes = 1;
         cd->info = evinfo;
@@ -1100,6 +1100,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
         }
     }
     PMIX_DESTRUCT(&pmix_server_globals.clients);
+    PMIX_LIST_DESTRUCT(&pmix_server_globals.nspaces);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.collectives);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.remote_pnd);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.local_reqs);
@@ -1118,16 +1119,22 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     PMIX_LIST_DESTRUCT(&pmix_server_globals.psets);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.grp_collectives);
 
+    /* NULL each of these as it goes: they are file-scope statics that
+     * outlive the library, and pmix_server_initialize() is the only thing
+     * that repopulates them */
     if (NULL != security_mode) {
         free(security_mode);
+        security_mode = NULL;
     }
 
     if (NULL != bfrops_mode) {
         free(bfrops_mode);
+        bfrops_mode = NULL;
     }
 
     if (NULL != gds_mode) {
         free(gds_mode);
+        gds_mode = NULL;
     }
 
     /* close the psensor framework */

--- a/src/server/pmix_server_classes.c
+++ b/src/server/pmix_server_classes.c
@@ -159,6 +159,9 @@ static void scadcon(pmix_setup_caddy_t *p)
     memset(&p->proc, 0, sizeof(pmix_proc_t));
     PMIX_CONSTRUCT_LOCK(&p->lock);
     p->nspace = NULL;
+    p->status = PMIX_SUCCESS;
+    p->uid = 0;
+    p->gid = 0;
     p->codes = NULL;
     p->ncodes = 0;
     p->procs = NULL;
@@ -309,33 +312,6 @@ PMIX_CLASS_INSTANCE(pmix_regevents_info_t,
                     pmix_list_item_t,
                     regcon, regdes);
 
-static void ilcon(pmix_inventory_rollup_t *p)
-{
-    PMIX_CONSTRUCT_LOCK(&p->lock);
-    p->status = PMIX_SUCCESS;
-    p->requests = 0;
-    p->replies = 0;
-    PMIX_CONSTRUCT(&p->payload, pmix_list_t);
-    p->info = NULL;
-    p->ninfo = 0;
-    p->cbfunc = NULL;
-    p->infocbfunc = NULL;
-    p->opcbfunc = NULL;
-    p->cbdata = NULL;
-}
-static void ildes(pmix_inventory_rollup_t *p)
-{
-    PMIX_DESTRUCT_LOCK(&p->lock);
-    PMIX_LIST_DESTRUCT(&p->payload);
-}
-PMIX_CLASS_INSTANCE(pmix_inventory_rollup_t,
-                    pmix_object_t,
-                    ilcon, ildes);
-
-PMIX_CLASS_INSTANCE(pmix_group_caddy_t,
-                    pmix_list_item_t,
-                    NULL, NULL);
-
 static void iocon(pmix_iof_cache_t *p)
 {
     p->bo = NULL;
@@ -345,7 +321,7 @@ static void iocon(pmix_iof_cache_t *p)
 static void iodes(pmix_iof_cache_t *p)
 {
     PMIX_BYTE_OBJECT_FREE(p->bo, 1); // macro protects against NULL
-    if (0 < p->ninfo) {
+    if (NULL != p->info) {
         PMIX_INFO_FREE(p->info, p->ninfo);
     }
 }

--- a/src/server/pmix_server_classes.c
+++ b/src/server/pmix_server_classes.c
@@ -219,7 +219,19 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_setup_caddy_t,
                                 pmix_object_t,
                                 scadcon, scaddes);
 
-PMIX_CLASS_INSTANCE(pmix_trkr_caddy_t, pmix_object_t, NULL, NULL);
+static void tkcon(pmix_trkr_caddy_t *p)
+{
+    p->trk = NULL;
+}
+static void tkdes(pmix_trkr_caddy_t *p)
+{
+    /* PMIX_SETUP_COLLECTIVE retained the tracker so it could not be
+     * released while the caddy was in flight - give that back */
+    if (NULL != p->trk) {
+        PMIX_RELEASE(p->trk);
+    }
+}
+PMIX_CLASS_INSTANCE(pmix_trkr_caddy_t, pmix_object_t, tkcon, tkdes);
 
 static void dmcon(pmix_dmdx_remote_t *p)
 {

--- a/src/server/pmix_server_classes.c
+++ b/src/server/pmix_server_classes.c
@@ -164,6 +164,7 @@ static void scadcon(pmix_setup_caddy_t *p)
     p->gid = 0;
     p->codes = NULL;
     p->ncodes = 0;
+    p->nactive = 0;
     p->procs = NULL;
     p->nprocs = 0;
     p->apps = NULL;

--- a/src/server/pmix_server_classes.c
+++ b/src/server/pmix_server_classes.c
@@ -17,10 +17,16 @@
  * $HEADER$
  */
 
-/* Construction and destruction of the server library's classes. Every
- * PMIX_CLASS_INSTANCE for a type declared in pmix_server_ops.h (or used
- * only by the server role) lives here, so the ownership rules a
- * destructor encodes can be read in one place. */
+/* Construction and destruction of the server library's classes. The
+ * PMIX_CLASS_INSTANCE for every type declared in pmix_server_ops.h, or
+ * declared in pmix_globals.h and used only by the server role, lives
+ * here so the ownership rules a destructor encodes can be read in one
+ * place. A type private to a single .c file keeps its class beside it
+ * instead - see pmix_server_group.c, pmix_server_fence.c,
+ * pmix_server_get.c and pmix_server_control.c.
+ *
+ * Note that PMIX_NEW does not zero the allocation, so a member a
+ * constructor here skips starts out as whatever was on the heap. */
 
 #include "src/include/pmix_config.h"
 

--- a/src/server/pmix_server_connect.c
+++ b/src/server/pmix_server_connect.c
@@ -52,10 +52,6 @@
 #endif
 #include <event.h>
 
-#ifndef MAX
-#    define MAX(a, b) ((a) > (b) ? (a) : (b))
-#endif
-
 #include "src/class/pmix_hotel.h"
 #include "src/class/pmix_list.h"
 #include "src/common/pmix_attributes.h"
@@ -172,6 +168,7 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &ninf, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
     ninfo = ninf + 2;

--- a/src/server/pmix_server_connect.c
+++ b/src/server/pmix_server_connect.c
@@ -143,7 +143,15 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
      * with that situation. Instead, the client should at least send
      * us their own namespace for the use-case where the connection
      * spans all procs in that namespace */
-    if (nprocs < 1) {
+    /* Bound it from above as well, by the round trip through the int32_t
+     * the unpack consumes it as: this count is multiplied by
+     * sizeof(pmix_proc_t) to size the allocation below, and a wire value
+     * large enough to wrap that product yields a short allocation whose
+     * element constructors then run off the end. It also keeps "cnt" from
+     * silently naming a different number of procs than the qsort and the
+     * free below walk. */
+    cnt = nprocs;
+    if (nprocs < 1 || 0 > cnt || (size_t) cnt != nprocs) {
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         rc = PMIX_ERR_BAD_PARAM;
         goto cleanup;
@@ -168,6 +176,20 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &ninf, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    /* This count comes off the wire, so screen it before it is used to
+     * size an allocation and then to index that allocation. Two slots are
+     * seeded at info[ninf] and info[ninf+1] *before* anything is unpacked,
+     * so a count near SIZE_MAX wraps "ninf + 2" down to a one-element
+     * array and writes the seeds far outside it; the same wrap can happen
+     * inside the allocator's "ninfo * sizeof(pmix_info_t)". Requiring the
+     * count to survive the round trip through the int32_t that the unpack
+     * below consumes it as bounds it well clear of both. */
+    cnt = ninf;
+    if (0 > cnt || (size_t) cnt != ninf) {
+        rc = PMIX_ERR_BAD_PARAM;
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
@@ -332,7 +354,15 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
      * with that situation. Instead, the client should at least send
      * us their own namespace for the use-case where the connection
      * spans all procs in that namespace */
-    if (nprocs < 1) {
+    /* Bound it from above as well, by the round trip through the int32_t
+     * the unpack consumes it as: this count is multiplied by
+     * sizeof(pmix_proc_t) to size the allocation below, and a wire value
+     * large enough to wrap that product yields a short allocation whose
+     * element constructors then run off the end. It also keeps "cnt" from
+     * silently naming a different number of procs than the qsort and the
+     * free below walk. */
+    cnt = nprocs;
+    if (nprocs < 1 || 0 > cnt || (size_t) cnt != nprocs) {
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         rc = PMIX_ERR_BAD_PARAM;
         goto cleanup;
@@ -357,6 +387,20 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &ninf, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    /* This count comes off the wire, so screen it before it is used to
+     * size an allocation and then to index that allocation. Two slots are
+     * seeded at info[ninf] and info[ninf+1] *before* anything is unpacked,
+     * so a count near SIZE_MAX wraps "ninf + 2" down to a one-element
+     * array and writes the seeds far outside it; the same wrap can happen
+     * inside the allocator's "ninfo * sizeof(pmix_info_t)". Requiring the
+     * count to survive the round trip through the int32_t that the unpack
+     * below consumes it as bounds it well clear of both. */
+    cnt = ninf;
+    if (0 > cnt || (size_t) cnt != ninf) {
+        rc = PMIX_ERR_BAD_PARAM;
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }

--- a/src/server/pmix_server_connect.c
+++ b/src/server/pmix_server_connect.c
@@ -76,6 +76,54 @@
 #include "src/client/pmix_client_ops.h"
 #include "pmix_server_ops.h"
 
+/* Timeout for either collective in this file. The local-collection phase
+ * is ours to bound: until every local participant has contributed we
+ * have not called the host, so nothing the host might do about
+ * PMIX_TIMEOUT can help a participant that never arrives. */
+static void collective_timeout(int sd, short args, void *cbdata)
+{
+    pmix_server_trkr_t *trk = (pmix_server_trkr_t *) cbdata;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    pmix_output_verbose(2, pmix_server_globals.connect_output,
+                        "ALERT: %s timeout fired",
+                        (PMIX_CONNECTNB_CMD == trk->type) ? "connect" : "disconnect");
+
+    /* execute the provided callback function with the error */
+    if (NULL != trk->op_cbfunc) {
+        trk->op_cbfunc(PMIX_ERR_TIMEOUT, trk);
+        return; // the cbfunc will have cleaned up the tracker
+    }
+    /* no completion function was ever attached, so tear the tracker down
+     * ourselves - which means unlinking it from the collectives list first.
+     * Being on that list is not a reference; releasing while still linked
+     * leaves a dangling entry that the next sweep walks into. */
+    trk->event_active = false;
+    pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+    PMIX_RELEASE(trk);
+}
+
+/* Pull a PMIX_TIMEOUT out of the directives the client sent, if it gave
+ * one. Use the type-tolerant accessor rather than a raw union read so any
+ * integer type is accepted, and convert through a uint32_t of its own:
+ * the accessor writes exactly the width of the requested type, so handing
+ * it the address of a wider time_t would fill only half the field - the
+ * wrong half on a big-endian host. */
+static void check_timeout(pmix_info_t *info, size_t ninfo, struct timeval *tv)
+{
+    size_t n;
+    uint32_t tmo;
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+            if (PMIX_SUCCESS == PMIx_Value_get_number(&info[n].value, &tmo, PMIX_UINT32)) {
+                tv->tv_sec = tmo;
+            }
+            return;
+        }
+    }
+}
+
 pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
                                      pmix_op_cbfunc_t cbfunc)
 {
@@ -85,6 +133,7 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
     size_t nprocs, ninfo, ninf;
     pmix_server_trkr_t *trk;
     pmix_proc_t *procs = NULL;
+    struct timeval tv = {0, 0};
 
     /* unpack the number of procs */
     cnt = 1;
@@ -142,6 +191,8 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
         if (PMIX_SUCCESS != rc) {
             goto cleanup;
         }
+        /* check for a timeout */
+        check_timeout(info, ninf, &tv);
     }
 
     /* find/create the local tracker for this operation */
@@ -168,11 +219,29 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
     /* add this contributor to the tracker so they get
      * notified when we are done */
     pmix_list_append(&trk->local_cbs, &cd->super);
+
+    /* if a timeout was specified, arm it once - guard against re-arming for
+     * each contributor. Do not retain the tracker: its collectives-list
+     * reference persists until completion, and completion deletes the timer
+     * before releasing (mirroring the fence family). */
+    if (0 < tv.tv_sec && !trk->event_active) {
+        PMIX_THREADSHIFT_DELAY(trk, collective_timeout, tv.tv_sec);
+        trk->event_active = true;
+    }
+
     /* if all local contributions have been received,
      * let the local host's server know that we are at the
      * "fence" point - they will callback once the [dis]connect
      * across all participants has been completed */
     if (pmix_server_trk_complete(trk)) {
+        /* delete the local-phase timer before handing the tracker to the
+         * host, so a late internal timeout cannot race the host completion
+         * (which could return the tracker after we released it). Once handed
+         * up, the host owns any further timeout. */
+        if (trk->event_active) {
+            pmix_event_del(&trk->ev);
+            trk->event_active = false;
+        }
         if (trk->local) {
             /* the operation is being atomically completed and the host will
              * not be calling us back - ensure we notify all participants.
@@ -238,27 +307,6 @@ cleanup:
     return rc;
 }
 
-static void connect_timeout(int sd, short args, void *cbdata)
-{
-    pmix_server_trkr_t *trk = (pmix_server_trkr_t *) cbdata;
-    PMIX_HIDE_UNUSED_PARAMS(sd, args);
-
-    pmix_output_verbose(2, pmix_server_globals.connect_output, "ALERT: connect timeout fired");
-
-    /* execute the provided callback function with the error */
-    if (NULL != trk->op_cbfunc) {
-        trk->op_cbfunc(PMIX_ERR_TIMEOUT, trk);
-        return; // the cbfunc will have cleaned up the tracker
-    }
-    /* no completion function was ever attached, so tear the tracker down
-     * ourselves - which means unlinking it from the collectives list first.
-     * Being on that list is not a reference; releasing while still linked
-     * leaves a dangling entry that the next sweep walks into. */
-    trk->event_active = false;
-    pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
-    PMIX_RELEASE(trk);
-}
-
 pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
                                   pmix_buffer_t *buf,
                                   pmix_op_cbfunc_t cbfunc)
@@ -269,7 +317,6 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
     pmix_info_t *info = NULL, *iptr, endpt;
     size_t nprocs, ninfo, n, ninf;
     pmix_server_trkr_t *trk;
-    uint32_t tmo;
     struct timeval tv = {0, 0};
 
     pmix_output_verbose(2, pmix_server_globals.connect_output,
@@ -335,21 +382,7 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
             goto cleanup;
         }
         /* check for a timeout */
-        for (n = 0; n < ninf; n++) {
-            if (0 == strncmp(info[n].key, PMIX_TIMEOUT, PMIX_MAX_KEYLEN)) {
-                /* use the type-tolerant accessor rather than a raw union
-                 * read so any integer type for the timeout is accepted,
-                 * matching the fence family. Convert through a uint32_t of
-                 * its own: the accessor writes exactly the width of the
-                 * requested type, so handing it the address of a wider
-                 * time_t would fill only half the field - the wrong half
-                 * on a big-endian host. */
-                if (PMIX_SUCCESS == PMIx_Value_get_number(&info[n].value, &tmo, PMIX_UINT32)) {
-                    tv.tv_sec = tmo;
-                }
-                break;
-            }
-        }
+        check_timeout(info, ninf, &tv);
     }
 
     /* find/create the local tracker for this operation */
@@ -390,6 +423,11 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
         // add the endpt to the end
         ninf = trk->ninfo + 1;
         PMIX_INFO_CREATE(iptr, ninf);
+        if (NULL == iptr) {
+            PMIX_INFO_DESTRUCT(&endpt);
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
         for (n=0; n < trk->ninfo; n++) {
             PMIX_INFO_XFER(&iptr[n], &trk->info[n]);
         }
@@ -411,6 +449,11 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
         // add the info to the end
         ninf = trk->ninfo + 1;
         PMIX_INFO_CREATE(iptr, ninf);
+        if (NULL == iptr) {
+            PMIX_INFO_DESTRUCT(&endpt);
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
         for (n=0; n < trk->ninfo; n++) {
             PMIX_INFO_XFER(&iptr[n], &trk->info[n]);
         }
@@ -430,7 +473,7 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
      * reference persists until completion, and completion deletes the timer
      * before releasing (mirroring the fence family). */
     if (0 < tv.tv_sec && !trk->event_active) {
-        PMIX_THREADSHIFT_DELAY(trk, connect_timeout, tv.tv_sec);
+        PMIX_THREADSHIFT_DELAY(trk, collective_timeout, tv.tv_sec);
         trk->event_active = true;
     }
 

--- a/src/server/pmix_server_control.c
+++ b/src/server/pmix_server_control.c
@@ -899,7 +899,7 @@ pmix_status_t pmix_server_session_ctrl(pmix_server_caddy_t *cd,
         PMIX_INFO_CREATE(scd->info, scd->ninfo);
         /* we unpacked this array, so the caddy owns it - without the
          * flag the destructor leaves it behind on every path that does
-         * not reach _sessctrlcbfunc's explicit free */
+         * not reach _sctrl_cbfunc's explicit free */
         scd->infocopy = true;
         cnt = scd->ninfo;
         PMIX_BFROPS_UNPACK(rc, cd->peer, buf, scd->info, &cnt, PMIX_INFO);

--- a/src/server/pmix_server_control.c
+++ b/src/server/pmix_server_control.c
@@ -65,11 +65,11 @@ pmix_status_t pmix_server_query(pmix_peer_t *peer, pmix_buffer_t *buf,
     pmix_status_t rc;
     pmix_query_caddy_t *cd;
 
-     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
-   pmix_output_verbose(2, pmix_server_globals.base_output,
+    pmix_output_verbose(2, pmix_server_globals.base_output,
                         "recvd query from client");
 
     cd = PMIX_NEW(pmix_query_caddy_t);
@@ -125,7 +125,6 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
     pmix_shift_caddy_t *cd;
     pmix_proc_t proc;
     time_t timestamp;
-    PMIX_HIDE_UNUSED_PARAMS(cbfunc, cbdata);
 
     pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
                         "pmix:server recvd log from client");
@@ -670,7 +669,7 @@ pmix_status_t pmix_server_monitor(pmix_peer_t *peer, pmix_buffer_t *buf,
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
-   pmix_output_verbose(2, pmix_server_globals.base_output,
+    pmix_output_verbose(2, pmix_server_globals.base_output,
                         "recvd monitor request from client %s",
                         PMIX_PEER_PRINT(peer));
 

--- a/src/server/pmix_server_control.c
+++ b/src/server/pmix_server_control.c
@@ -139,7 +139,12 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
         return PMIX_ERR_NOMEM;
     }
     if (PMIX_PEER_IS_EARLIER(peer, 3, 0, 0)) {
-        timestamp = -1;
+        /* zero is the sender's own "no timestamp" value, and the only
+         * test applied below is "0 < timestamp" - a -1 sentinel would
+         * read as a very large positive time on a platform whose
+         * time_t is unsigned, and manufacture a garbage timestamp
+         * directive for exactly the peers too old to have sent one */
+        timestamp = 0;
     } else {
         /* unpack the timestamp */
         cnt = 1;
@@ -157,7 +162,19 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         goto exit;
     }
+    /* the count arrives off the wire and is carried in a size_t while
+     * every use of it goes through the int32_t unpack count, so screen
+     * the truncation here. Unlike its siblings, this handler acts on
+     * cd->ninfo even when the unpack below is skipped - it hands the
+     * pair straight to plog - so a count that survives as zero would
+     * walk a NULL array. The directive count below is worse still: it
+     * indexes the array before anything is unpacked into it */
     cnt = cd->ninfo;
+    if (0 > cnt || (size_t) cnt != cd->ninfo) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
     PMIX_INFO_CREATE(cd->info, cd->ninfo);
     /* the caddy owns this array and must release it when done */
     cd->infocopy = true;
@@ -177,22 +194,32 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer, pmix_buffer_t *buf,
         goto exit;
     }
     cnt = cd->ndirs;
+    if (0 > cnt || (size_t) cnt != cd->ndirs) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
     /* always add the source to the directives so we
      * can tell downstream if this gets "upcalled" to
      * our host for relay */
-    cd->ndirs = cnt + 1;
+    cd->ndirs = (size_t) cnt + 1;
     /* if a timestamp was sent, then we add it to the directives */
     if (0 < timestamp) {
         cd->ndirs++;
-        PMIX_INFO_CREATE(cd->directives, cd->ndirs);
-        PMIX_INFO_LOAD(&cd->directives[cnt], PMIX_LOG_SOURCE, &proc, PMIX_PROC);
-        PMIX_INFO_LOAD(&cd->directives[cnt + 1], PMIX_LOG_TIMESTAMP, &timestamp, PMIX_TIME);
-    } else {
-        PMIX_INFO_CREATE(cd->directives, cd->ndirs);
-        PMIX_INFO_LOAD(&cd->directives[cnt], PMIX_LOG_SOURCE, &proc, PMIX_PROC);
     }
-    /* the caddy owns this array and must release it when done */
+    PMIX_INFO_CREATE(cd->directives, cd->ndirs);
+    if (NULL == cd->directives) {
+        rc = PMIX_ERR_NOMEM;
+        goto exit;
+    }
+    /* the caddy owns this array and must release it when done - set
+     * before the loads below so an early return cannot strand it */
     cd->dircopy = true;
+    PMIX_INFO_LOAD(&cd->directives[(size_t) cnt], PMIX_LOG_SOURCE, &proc, PMIX_PROC);
+    if (0 < timestamp) {
+        PMIX_INFO_LOAD(&cd->directives[(size_t) cnt + 1], PMIX_LOG_TIMESTAMP,
+                       &timestamp, PMIX_TIME);
+    }
 
     /* unpack the directives */
     if (0 < cnt) {
@@ -356,9 +383,11 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
     /* construct every local list up front so that a single cleanup at the
      * exit label covers all of them - the bad-param and no-memory paths in
      * the directive scan below used to jump past their destructors and
-     * leak whatever cleanup entries had already been cached. Draining a
-     * list twice is harmless (PMIX_LIST_DESTRUCT leaves it re-initialized),
-     * so the mid-function destructs can stay where they are. */
+     * leak whatever cleanup entries had already been cached. Every list is
+     * destructed exactly once, on the way out: PMIX_LIST_DESTRUCT ends in
+     * PMIX_DESTRUCT, which zeroes the object's magic id, so a second one
+     * on the same list trips the magic-id assertion in a --enable-debug
+     * build. Do not re-add the mid-function destructs. */
     PMIX_CONSTRUCT(&epicache, pmix_list_t);
     PMIX_CONSTRUCT(&cachedirs, pmix_list_t);
     PMIX_CONSTRUCT(&cachefiles, pmix_list_t);
@@ -530,7 +559,6 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 }
             }
         }
-        PMIX_LIST_DESTRUCT(&ignorefiles);
         /* now look at the directories */
         PMIX_LIST_FOREACH (cdir, &cachedirs, pmix_cleanup_dir_t) {
             PMIX_LIST_FOREACH (epicd, &epicache, pmix_srvr_epi_caddy_t) {
@@ -539,12 +567,16 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 PMIX_LIST_FOREACH (cdir2, &epicd->epi->cleanup_dirs, pmix_cleanup_dir_t) {
                     if (0 == strcmp(cdir2->path, cdir->path)) {
                         /* duplicate - check for difference in flags per RFC
-                         * precedence rules */
-                        if (!cdir->recurse && recurse) {
-                            cdir->recurse = recurse;
+                         * precedence rules. The entry that has to absorb the
+                         * more permissive flag is the one already registered
+                         * on the epilog (cdir2); cdir is the request-local
+                         * copy we are about to discard, and its flags are
+                         * never read, so upgrading it did nothing at all */
+                        if (!cdir2->recurse && recurse) {
+                            cdir2->recurse = recurse;
                         }
-                        if (!cdir->leave_topdir && leave_topdir) {
-                            cdir->leave_topdir = leave_topdir;
+                        if (!cdir2->leave_topdir && leave_topdir) {
+                            cdir2->leave_topdir = leave_topdir;
                         }
                         duplicate = true;
                         break;
@@ -556,8 +588,6 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                         if (0 == strcmp(cf->path, cdir->path)) {
                             /* return an error */
                             rc = PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES;
-                            PMIX_LIST_DESTRUCT(&cachedirs);
-                            PMIX_LIST_DESTRUCT(&cachefiles);
                             goto exit;
                         }
                     }
@@ -570,7 +600,6 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 }
             }
         }
-        PMIX_LIST_DESTRUCT(&cachedirs);
         PMIX_LIST_FOREACH (cf, &cachefiles, pmix_cleanup_file_t) {
             PMIX_LIST_FOREACH (epicd, &epicache, pmix_srvr_epi_caddy_t) {
                 /* scan the existing list of files for any duplicate */
@@ -585,10 +614,8 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                     /* check for conflict with ignore */
                     PMIX_LIST_FOREACH (cf2, &epicd->epi->ignores, pmix_cleanup_file_t) {
                         if (0 == strcmp(cf->path, cf2->path)) {
-                            /* return an error - cachedirs was already
-                             * destructed above, so only cachefiles remains */
+                            /* return an error */
                             rc = PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES;
-                            PMIX_LIST_DESTRUCT(&cachefiles);
                             goto exit;
                         }
                     }
@@ -599,7 +626,6 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 }
             }
         }
-        PMIX_LIST_DESTRUCT(&cachefiles);
         if (cnt == (int) cd->ninfo) {
             /* nothing more to do */
             rc = PMIX_OPERATION_SUCCEEDED;
@@ -686,6 +712,10 @@ pmix_status_t pmix_server_monitor(pmix_peer_t *peer, pmix_buffer_t *buf,
     /* unpack the directives */
     if (0 < cb->ndirs) {
         PMIX_INFO_CREATE(cb->directives, cb->ndirs);
+        /* we unpacked these ourselves, so the caddy owns them - the
+         * common monitor code borrows its directives from the caller
+         * and so cannot free them on our behalf */
+        cb->dircopy = true;
         cnt = cb->ndirs;
         PMIX_BFROPS_UNPACK(rc, peer, buf, cb->directives, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
@@ -699,6 +729,10 @@ pmix_status_t pmix_server_monitor(pmix_peer_t *peer, pmix_buffer_t *buf,
     return PMIX_SUCCESS;
 
 exit:
+    /* the pmix_cb_t destructor does not free the proc array - only the
+     * completion path through pmix_monitor_processing does, and we are
+     * not going to reach it */
+    PMIX_PROC_FREE(cb->proc, 1);
     PMIX_RELEASE(cb);
     return rc;
 }
@@ -864,6 +898,10 @@ pmix_status_t pmix_server_session_ctrl(pmix_server_caddy_t *cd,
     /* unpack the info */
     if (0 < scd->ninfo) {
         PMIX_INFO_CREATE(scd->info, scd->ninfo);
+        /* we unpacked this array, so the caddy owns it - without the
+         * flag the destructor leaves it behind on every path that does
+         * not reach _sessctrlcbfunc's explicit free */
+        scd->infocopy = true;
         cnt = scd->ninfo;
         PMIX_BFROPS_UNPACK(rc, cd->peer, buf, scd->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
@@ -958,6 +996,10 @@ pmix_status_t pmix_server_resblk(pmix_server_caddy_t *cd,
     /* unpack the info */
     if (0 < scd->ninfo) {
         PMIX_INFO_CREATE(scd->info, scd->ninfo);
+        /* the setup caddy frees info only when it is told it owns it,
+         * and _resopcbfunc frees only the block name - so without this
+         * the array leaked on every resource block request */
+        scd->copied = true;
         cnt = scd->ninfo;
         PMIX_BFROPS_UNPACK(rc, cd->peer, buf, scd->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
@@ -981,6 +1023,13 @@ pmix_status_t pmix_server_resblk(pmix_server_caddy_t *cd,
     return PMIX_SUCCESS;
 
 exit:
+    /* the setup caddy destructor never frees nspace - it is borrowed as
+     * often as it is owned - so the block name we unpacked is ours to
+     * release here, exactly as _resopcbfunc does on the reply path */
+    if (NULL != scd->nspace) {
+        free(scd->nspace);
+        scd->nspace = NULL;
+    }
     PMIX_RELEASE(scd);
     return rc;
 }

--- a/src/server/pmix_server_dmodex.c
+++ b/src/server/pmix_server_dmodex.c
@@ -136,6 +136,10 @@ static void _dmodex_req(int sd, short args, void *cbdata)
         /* rank isn't known yet - defer
          * the request until we do */
         dcd = PMIX_NEW(pmix_dmdx_remote_t);
+        if (NULL == dcd) {
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
         dcd->cd = cd;
         pmix_list_append(&pmix_server_globals.remote_pnd, &dcd->super);
         return;
@@ -147,6 +151,10 @@ static void _dmodex_req(int sd, short args, void *cbdata)
         /* track the request so we can fulfill it once
          * data is recvd */
         dcd = PMIX_NEW(pmix_dmdx_remote_t);
+        if (NULL == dcd) {
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
         dcd->cd = cd;
         pmix_list_append(&pmix_server_globals.remote_pnd, &dcd->super);
         return;
@@ -183,6 +191,30 @@ cleanup:
     PMIX_RELEASE(cd);
 }
 
+void pmix_server_fail_remote_pnd(pmix_peer_t *peer, pmix_proc_t *proc,
+                                 pmix_status_t status)
+{
+    pmix_dmdx_remote_t *dcd, *dnxt;
+
+    PMIX_LIST_FOREACH_SAFE (dcd, dnxt, &pmix_server_globals.remote_pnd, pmix_dmdx_remote_t) {
+        if ((NULL != peer && NULL != peer->info
+             && PMIX_CHECK_NAMES(&peer->info->pname, &dcd->cd->proc))
+            || (NULL != proc && PMIX_CHECK_PROCID(proc, &dcd->cd->proc))) {
+            pmix_list_remove_item(&pmix_server_globals.remote_pnd, &dcd->super);
+            /* the only thing that ever takes a request off this list is
+             * the target committing its data, and the target has just
+             * gone away - so answer the host rather than dropping its
+             * request. A dropped one leaves the remote server that asked
+             * for the data, and the client behind it, waiting on a reply
+             * nobody is going to send */
+            if (NULL != dcd->cd->cbfunc) {
+                dcd->cd->cbfunc(status, NULL, 0, dcd->cd->cbdata);
+            }
+            PMIX_RELEASE(dcd);
+        }
+    }
+}
+
 PMIX_EXPORT pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
                                                      pmix_dmodex_response_fn_t cbfunc, void *cbdata)
 {
@@ -206,6 +238,9 @@ PMIX_EXPORT pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
                         PMIX_NAME_PRINT(&pmix_globals.myid), PMIX_NAME_PRINT(proc));
 
     cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
     pmix_strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
     cd->proc.rank = proc->rank;
     cd->cbfunc = cbfunc;
@@ -245,7 +280,9 @@ PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc, const cha
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
-    if (NULL == key || PMIX_MAX_KEYLEN < pmix_keylen(key)) {
+    /* the value is dereferenced by the transfer below, so screen it here
+     * alongside the key rather than faulting inside bfrops */
+    if (NULL == key || PMIX_MAX_KEYLEN < pmix_keylen(key) || NULL == val) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -274,7 +311,16 @@ PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc, const cha
         return PMIX_ERR_NOMEM;
     }
     cd->kv->key = strdup(key);
-    cd->kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+    /* construct the destination rather than handing the transfer raw
+     * heap: the transfer assigns the type before it copies the payload,
+     * so a copy that fails part way leaves a pointer-backed type sitting
+     * over an uninitialized union - and the kval destructor below then
+     * frees whatever was in it. A constructed value fails safe */
+    PMIX_VALUE_CREATE(cd->kv->value, 1);
+    if (NULL == cd->kv->value) {
+        PMIX_RELEASE(cd);
+        return PMIX_ERR_NOMEM;
+    }
     PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, cd->kv->value, val);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);

--- a/src/server/pmix_server_events.c
+++ b/src/server/pmix_server_events.c
@@ -50,6 +50,8 @@
 #include "pmix_server_ops.h"
 #include "src/client/pmix_client_ops.h"
 
+static void undo_activations(pmix_status_t *codes, size_t nactive);
+
 static void _check_cached_events(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *scd = (pmix_setup_caddy_t *) cbdata;
@@ -189,32 +191,39 @@ static void _check_cached_events(int sd, short args, void *cbdata)
     if (NULL != scd->info) {
         PMIX_INFO_FREE(scd->info, scd->ninfo);
     }
+    /* Answer the requestor with the status of its _registration_, not
+     * with whatever the replay above ran into. The only caller that
+     * leaves an opcbfunc on the caddy is the host-completed registration
+     * path, and the host said that succeeded - failing to hand a client a
+     * stale cached event does not undo it. Reporting the replay status
+     * would tell the client its handler was not registered while the
+     * server had in fact registered it, leaving a store entry the client
+     * would never deregister. The replay failure is logged above. */
     if (NULL != scd->opcbfunc) {
-        scd->opcbfunc(ret, scd->cbdata);
+        scd->opcbfunc(scd->status, scd->cbdata);
     }
     PMIX_RELEASE(scd);
 }
 
-/* provide a callback function for the host when it finishes
- * processing the registration */
-static void regevopcbfunc(pmix_status_t status, void *cbdata)
+/* our host refused a registration it had accepted for processing, so it
+ * is not forwarding those codes after all - give back the interest we
+ * recorded on its behalf when we made the request, or the next
+ * registrant for one of them will be told it succeeded and then never
+ * see the event. This mirrors what the server's registration of its
+ * _own_ handlers does when the host refuses asynchronously (see
+ * _reg_hdlr_complete in src/event/pmix_event_registration.c). The peer
+ * entries the request added to the store are deliberately left alone: a
+ * peer may hold several handlers for the same code, so there is no way
+ * to tell from here which entry belongs to the failed request. */
+static void _failed_registration(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
 
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
-        PMIX_RELEASE(cd);
-        return;
-    }
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    /* if the registration succeeded, then check local cache */
-    if (PMIX_SUCCESS == status) {
-        cd->status = status;
-        PMIX_THREADSHIFT(cd, _check_cached_events);
-        return;
-    }
+    undo_activations(cd->codes, cd->nactive);
 
-    /* it didn't succeed, so cleanup and execute the callback
-     * so we don't hang */
+    /* cleanup and execute the callback so we don't hang */
     if (NULL != cd->codes) {
         free(cd->codes);
     }
@@ -222,9 +231,41 @@ static void regevopcbfunc(pmix_status_t status, void *cbdata)
         PMIX_INFO_FREE(cd->info, cd->ninfo);
     }
     if (NULL != cd->opcbfunc) {
-        cd->opcbfunc(status, cd->cbdata);
+        cd->opcbfunc(cd->status, cd->cbdata);
     }
     PMIX_RELEASE(cd);
+}
+
+/* provide a callback function for the host when it finishes
+ * processing the registration. This may be called on the host's own
+ * thread, so it does nothing here but thread-shift - the registration
+ * store it has to correct on failure is progress-thread state */
+static void regevopcbfunc(pmix_status_t status, void *cbdata)
+{
+    pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
+
+    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the caddy carries the codes and info arrays, but its destructor
+         * does not free them - so release them here */
+        if (NULL != cd->codes) {
+            free(cd->codes);
+        }
+        if (NULL != cd->info) {
+            PMIX_INFO_FREE(cd->info, cd->ninfo);
+        }
+        PMIX_RELEASE(cd);
+        return;
+    }
+
+    cd->status = status;
+
+    /* if the registration succeeded, then check local cache */
+    if (PMIX_SUCCESS == status) {
+        PMIX_THREADSHIFT(cd, _check_cached_events);
+        return;
+    }
+
+    PMIX_THREADSHIFT(cd, _failed_registration);
 }
 
 /* the host is done processing our request to stop forwarding a code -
@@ -271,7 +312,12 @@ bool pmix_server_prune_reginfo(pmix_regevents_info_t *reginfo)
     pmix_list_remove_item(&pmix_server_globals.events, &reginfo->super);
     if (reginfo->active) {
         codes = (pmix_status_t *) malloc(sizeof(pmix_status_t));
-        if (NULL != codes) {
+        if (NULL == codes) {
+            /* we cannot ask our host to stop, so it will keep forwarding
+             * a code nobody here wants - note it and carry on, as the
+             * registration itself is still correctly gone */
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        } else {
             codes[0] = reginfo->code;
             stop_forwarding(codes, 1);
         }
@@ -427,6 +473,18 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
+    /* The count arrives off the wire in a size_t while the unpack below
+     * consumes it through an int32_t, so screen the truncation here.
+     * Every loop in this function walks the array for "ncodes" entries
+     * while only "cnt" of them were ever unpacked into it - and unlike an
+     * info array, this one comes from a bare malloc, so the entries past
+     * the unpack are uninitialized rather than constructed */
+    cnt = ncodes;
+    if (0 > cnt || (size_t) cnt != ncodes) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
     /* unpack the array of codes */
     if (0 < ncodes) {
         codes = (pmix_status_t *) malloc(ncodes * sizeof(pmix_status_t));
@@ -464,25 +522,50 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
         }
     }
 
-    /* check the directives */
+    /* Check the directives. These came off the wire, so the type tag on
+     * each value is whatever the peer said it was - screen it before
+     * reading the union. A mistyped PMIX_EVENT_AFFECTED_PROC has us copy
+     * a pmix_proc_t out of whatever a scalar or a string pointer happens
+     * to be, and a mistyped PMIX_EVENT_AFFECTED_PROCS dereferences the
+     * same garbage as a pmix_data_array_t; even a correctly-typed array
+     * of some other element type would have us read past its end. The
+     * equivalent checks the client library makes run in the requestor's
+     * process, so they buy us nothing here. */
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
-            if (NULL != affected) {
+            if (NULL != affected ||
+                PMIX_PROC != info[n].value.type ||
+                NULL == info[n].value.data.proc) {
                 PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
                 rc = PMIX_ERR_BAD_PARAM;
                 goto cleanup;
             }
             naffected = 1;
             PMIX_PROC_CREATE(affected, naffected);
+            if (NULL == affected) {
+                naffected = 0;
+                rc = PMIX_ERR_NOMEM;
+                goto cleanup;
+            }
             memcpy(affected, info[n].value.data.proc, sizeof(pmix_proc_t));
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROCS)) {
-            if (NULL != affected) {
+            if (NULL != affected ||
+                PMIX_DATA_ARRAY != info[n].value.type ||
+                NULL == info[n].value.data.darray ||
+                PMIX_PROC != info[n].value.data.darray->type ||
+                NULL == info[n].value.data.darray->array ||
+                0 == info[n].value.data.darray->size) {
                 PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
                 rc = PMIX_ERR_BAD_PARAM;
                 goto cleanup;
             }
             naffected = info[n].value.data.darray->size;
             PMIX_PROC_CREATE(affected, naffected);
+            if (NULL == affected) {
+                naffected = 0;
+                rc = PMIX_ERR_NOMEM;
+                goto cleanup;
+            }
             memcpy(affected, info[n].value.data.darray->array, naffected * sizeof(pmix_proc_t));
         }
     }
@@ -546,6 +629,11 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
         prev->peer = peer;
         if (NULL != affected) {
             PMIX_PROC_CREATE(prev->affected, naffected);
+            if (NULL == prev->affected) {
+                PMIX_RELEASE(prev);
+                rc = PMIX_ERR_NOMEM;
+                goto cleanup;
+            }
             prev->naffected = naffected;
             memcpy(prev->affected, affected, naffected * sizeof(pmix_proc_t));
         }
@@ -583,6 +671,11 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
             prev->peer = peer;
             if (NULL != affected) {
                 PMIX_PROC_CREATE(prev->affected, naffected);
+                if (NULL == prev->affected) {
+                    PMIX_RELEASE(prev);
+                    rc = PMIX_ERR_NOMEM;
+                    goto cleanup;
+                }
                 prev->naffected = naffected;
                 memcpy(prev->affected, affected, naffected * sizeof(pmix_proc_t));
             }
@@ -606,6 +699,11 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
             prev->peer = peer;
             if (NULL != affected) {
                 PMIX_PROC_CREATE(prev->affected, naffected);
+                if (NULL == prev->affected) {
+                    PMIX_RELEASE(prev);
+                    rc = PMIX_ERR_NOMEM;
+                    goto cleanup;
+                }
                 prev->naffected = naffected;
                 memcpy(prev->affected, affected, naffected * sizeof(pmix_proc_t));
             }
@@ -641,10 +739,20 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
         scd->peer = peer;
         scd->codes = codes;
         scd->ncodes = ncodes;
+        scd->nactive = nactive;
         scd->info = info;
         scd->ninfo = ninfo;
         scd->opcbfunc = cbfunc;
         scd->cbdata = cbdata;
+        /* hand the caddy the procs this registrant restricted its interest
+         * to, so the cached-event replay filters on them exactly as the
+         * two completed-locally paths below do. This has to happen before
+         * the up-call: the host is free to complete on another thread the
+         * moment it has the caddy, and the replay reads these */
+        scd->procs = affected;
+        scd->nprocs = naffected;
+        affected = NULL;
+        naffected = 0;
         /* only the codes needing activation were sorted to the front of
          * the array, so that is all we hand the host - the caddy still
          * carries the full array as the cached-event check needs it */
@@ -655,9 +763,6 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
             pmix_output_verbose(
                 2, pmix_server_globals.event_output,
                 "server register events: host server processing event registration");
-            if (NULL != affected) {
-                PMIX_PROC_FREE(affected, naffected);
-            }
             return rc;
         } else if (PMIX_OPERATION_SUCCEEDED == rc) {
             /* we need to check cached notifications, but we want to ensure
@@ -669,8 +774,8 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
              * callback prior to delivery of an event notification */
             if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
                 /* the caddy carries the codes and info arrays, but its
-                 * destructor does not free them - so release them here,
-                 * along with the affected array that was never attached */
+                 * destructor does not free them - so release them here.
+                 * The affected array it now owns goes with the caddy */
                 if (NULL != scd->codes) {
                     free(scd->codes);
                 }
@@ -678,17 +783,12 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
                     PMIX_INFO_FREE(scd->info, scd->ninfo);
                 }
                 PMIX_RELEASE(scd);
-                if (NULL != affected) {
-                    PMIX_PROC_FREE(affected, naffected);
-                }
                 return PMIX_ERR_NOT_AVAILABLE;
             }
 
-            /* scd->peer was already set (with its retain) above - taking a
-             * second reference here leaked one on every registration the
-             * host completed atomically */
-            scd->procs = affected;
-            scd->nprocs = naffected;
+            /* scd->peer and scd->procs were already set (with the peer's
+             * retain) above - taking a second reference here leaked one on
+             * every registration the host completed atomically */
             scd->opcbfunc = NULL;
             scd->cbdata = NULL;
             PMIX_THREADSHIFT(scd, _check_cached_events);
@@ -717,6 +817,10 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
         }
 
         scd = PMIX_NEW(pmix_setup_caddy_t);
+        if (NULL == scd) {
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
         PMIX_RETAIN(peer);
         scd->peer = peer;
         scd->codes = codes;
@@ -734,7 +838,8 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
 
 cleanup:
     pmix_output_verbose(2, pmix_server_globals.event_output,
-                        "server register events: ninfo =%lu rc =%d", ninfo, rc);
+                        "server register events: ninfo =%lu rc =%d",
+                        (unsigned long) ninfo, rc);
     if (NULL != info) {
         PMIX_INFO_FREE(info, ninfo);
     }
@@ -753,7 +858,7 @@ void pmix_server_deregister_events(pmix_peer_t *peer, pmix_buffer_t *buf)
     pmix_status_t rc, code;
     pmix_regevents_info_t *reginfo = NULL;
     pmix_regevents_info_t *reginfo_next;
-    pmix_peer_events_info_t *prev;
+    pmix_peer_events_info_t *prev, *prev_next;
 
     pmix_output_verbose(2, pmix_server_globals.event_output,
                         "%s recvd deregister events from %s",
@@ -767,13 +872,22 @@ void pmix_server_deregister_events(pmix_peer_t *peer, pmix_buffer_t *buf)
         PMIX_LIST_FOREACH_SAFE (reginfo, reginfo_next, &pmix_server_globals.events,
                                 pmix_regevents_info_t) {
             if (code == reginfo->code) {
-                /* found it - remove this peer from the list */
-                PMIX_LIST_FOREACH (prev, &reginfo->peers, pmix_peer_events_info_t) {
+                /* Found it - remove _every_ registration this peer holds
+                 * for the code, not just the first. A peer can hold more
+                 * than one: its library packs the whole code list of a
+                 * handler whenever any code in that list is new to us, so
+                 * a second handler naming an already-registered code adds
+                 * a second entry here. It sends the deregistration only
+                 * when its last handler for the code is gone, so anything
+                 * of this peer's still sitting on the list is stale -
+                 * stopping at the first left one behind, which kept us
+                 * forwarding the code to a peer that had no handler for it
+                 * and kept the reginfo from ever being pruned. */
+                PMIX_LIST_FOREACH_SAFE (prev, prev_next, &reginfo->peers,
+                                        pmix_peer_events_info_t) {
                     if (prev->peer == peer) {
-                        /* found it */
                         pmix_list_remove_item(&reginfo->peers, &prev->super);
                         PMIX_RELEASE(prev);
-                        break;
                     }
                 }
                 /* if nobody is left registered for this code - not the
@@ -918,10 +1032,24 @@ pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer, pmix_buffer
     if (PMIX_GROUP_LEFT == cd->status) {
         char *grpid = NULL;
         pmix_proc_t *affected = NULL;
+        /* both of these are read out of the union, so confirm the type
+         * the peer tagged each with - a mistyped PMIX_GROUP_ID would be
+         * strcmp'd as a pointer built from a scalar, and a mistyped
+         * affected proc dereferenced the same way */
         for (n = 0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GROUP_ID)) {
+                if (PMIX_STRING != cd->info[n].value.type) {
+                    rc = PMIX_ERR_BAD_PARAM;
+                    PMIX_ERROR_LOG(rc);
+                    goto exit;
+                }
                 grpid = cd->info[n].value.data.string;
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_EVENT_AFFECTED_PROC)) {
+                if (PMIX_PROC != cd->info[n].value.type) {
+                    rc = PMIX_ERR_BAD_PARAM;
+                    PMIX_ERROR_LOG(rc);
+                    goto exit;
+                }
                 affected = cd->info[n].value.data.proc;
             }
         }

--- a/src/server/pmix_server_events.c
+++ b/src/server/pmix_server_events.c
@@ -581,7 +581,6 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer, pmix_buffer_t *buf,
     /* if they asked for enviro events, and our host doesn't support
      * register_events, then we cannot meet the request */
     if (enviro_events && NULL == pmix_host_server.register_events) {
-        enviro_events = false;
         rc = PMIX_ERR_NOT_SUPPORTED;
         goto cleanup;
     }

--- a/src/server/pmix_server_fabric.c
+++ b/src/server/pmix_server_fabric.c
@@ -47,6 +47,25 @@
 
 #include "pmix_server_ops.h"
 
+/* Carrier for a locally computed distance array. The callback that
+ * receives one only thread-shifts; the reply is packed from it later, on
+ * the progress thread, so the array has to outlive the function that
+ * built it. That is what the (release_fn, release_cbdata) pair in the
+ * callback signature is for - the host path uses it to hold its own data
+ * alive, and the local path needs it for exactly the same reason. */
+typedef struct {
+    pmix_device_distance_t *dist;
+    size_t ndist;
+} pmix_dist_relcaddy_t;
+
+static void dist_relfn(void *cbdata)
+{
+    pmix_dist_relcaddy_t *rel = (pmix_dist_relcaddy_t *) cbdata;
+
+    PMIX_DEVICE_DIST_FREE(rel->dist, rel->ndist);
+    free(rel);
+}
+
 static void _fabric_response(int sd, short args, void *cbdata)
 {
     pmix_query_caddy_t *qcd = (pmix_query_caddy_t *) cbdata;
@@ -230,9 +249,15 @@ pmix_status_t pmix_server_fabric_update(pmix_server_caddy_t *cd, pmix_buffer_t *
     /* setup the requesting peer name */
     pmix_strncpy(proc.nspace, cd->peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = cd->peer->info->pname.rank;
-    /* add the index */
+    /* add the index. Nothing screens this allocation the way an unpack
+     * would - the load below writes straight through it */
     qcd->ninfo = 1;
     PMIX_INFO_CREATE(qcd->info, qcd->ninfo);
+    if (NULL == qcd->info) {
+        qcd->ninfo = 0;
+        rc = PMIX_ERR_NOMEM;
+        goto exit;
+    }
     PMIX_INFO_LOAD(&qcd->info[0], PMIX_FABRIC_INDEX, &index, PMIX_SIZE);
 
     /* ask the host to execute the request */
@@ -261,8 +286,9 @@ pmix_status_t pmix_server_device_dists(pmix_server_caddy_t *cd,
     pmix_cpuset_t cpuset = {NULL, NULL};
     pmix_status_t rc;
     pmix_device_distance_t *distances;
+    pmix_dist_relcaddy_t *rel;
     size_t ndist;
-    int cnt;
+    int32_t cnt;
     pmix_cb_t cb;
     pmix_kval_t *kv;
     pmix_proc_t proc;
@@ -315,6 +341,14 @@ pmix_status_t pmix_server_device_dists(pmix_server_caddy_t *cd,
 
     /* if the cpuset is NULL, see if we know the binding of the requesting process */
     if (NULL == cpuset.bitmap) {
+        /* the unpack hands back a "hwloc" source string even when it
+         * carried no bitmap, and pmix_hwloc_parse_cpuset_string below
+         * overwrites that member with a fresh one - so give the first
+         * back now, while we still have the pointer to it */
+        if (NULL != cpuset.source) {
+            free(cpuset.source);
+            cpuset.source = NULL;
+        }
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
         /* the cb destructor does not own cb.key, so point it at the
          * string constant rather than a strdup that nothing would free */
@@ -352,15 +386,33 @@ pmix_status_t pmix_server_device_dists(pmix_server_caddy_t *cd,
     /* compute the distances */
     rc = pmix_hwloc_compute_distances(&topo, &cpuset, cd->info, cd->ninfo, &distances, &ndist);
     if (PMIX_SUCCESS == rc) {
-        /* send the reply */
-        cbfunc(rc, distances, ndist, cd, NULL, NULL);
-        PMIX_DEVICE_DIST_FREE(distances, ndist);
+        /* Send the reply. The callback only thread-shifts, and the reply
+         * is packed from the array on the progress thread after we have
+         * returned - so freeing it here handed the packer freed memory.
+         * Give the callback a release function instead, and let the
+         * chain free the array once it is done with it. */
+        rel = (pmix_dist_relcaddy_t *) malloc(sizeof(pmix_dist_relcaddy_t));
+        if (NULL == rel) {
+            PMIX_DEVICE_DIST_FREE(distances, ndist);
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
+        rel->dist = distances;
+        rel->ndist = ndist;
+        cbfunc(rc, distances, ndist, cd, dist_relfn, rel);
     }
 
 cleanup:
     if (NULL != topo.topology &&
         topo.topology != pmix_globals.topology.topology) {
         pmix_hwloc_destruct_topology(&topo);
+    }
+    /* the unpack strdup's a source string even for the NULL topology that
+     * says "use your own" - and on that path we borrow the global
+     * topology, so the destruct above is skipped and nothing else would
+     * ever free it. It NULLs the member when it does run */
+    if (NULL != topo.source) {
+        free(topo.source);
     }
     if (NULL != cpuset.bitmap) {
         pmix_hwloc_destruct_cpuset(&cpuset);

--- a/src/server/pmix_server_fabric.c
+++ b/src/server/pmix_server_fabric.c
@@ -71,6 +71,8 @@ static void _fabric_response(int sd, short args, void *cbdata)
     pmix_query_caddy_t *qcd = (pmix_query_caddy_t *) cbdata;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
+    PMIX_ACQUIRE_OBJECT(qcd);
+
     /* qcd->cbfunc is the switchyard's fabric_cbfunc, which expects the
      * query caddy - not the server caddy hanging off qcd->cbdata. Handing
      * it qcd->cbdata made it read a pmix_server_caddy_t as a
@@ -247,8 +249,7 @@ pmix_status_t pmix_server_fabric_update(pmix_server_caddy_t *cd, pmix_buffer_t *
     }
 
     /* setup the requesting peer name */
-    pmix_strncpy(proc.nspace, cd->peer->info->pname.nspace, PMIX_MAX_NSLEN);
-    proc.rank = cd->peer->info->pname.rank;
+    PMIX_LOAD_PROCID(&proc, cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
     /* add the index. Nothing screens this allocation the way an unpack
      * would - the load below writes straight through it */
     qcd->ninfo = 1;

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -311,6 +311,18 @@ pmix_server_trkr_t *pmix_server_get_tracker(char *id, pmix_proc_t *procs,
                 if (0 < i) {
                     sz = trk->npcs + i;
                     PMIX_PROC_CREATE(ptr, sz);
+                    if (NULL == ptr) {
+                        /* nothing screens this allocation downstream - the
+                         * next statement copies into it. Hand back the
+                         * tracker we found without the new participants
+                         * rather than dereferencing NULL; returning NULL
+                         * would be worse still, as the caller would then
+                         * create a second tracker for an id that already
+                         * has one */
+                        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                        PMIX_LIST_DESTRUCT(&cache);
+                        return trk;
+                    }
                     memcpy(ptr, trk->pcs, trk->npcs * sizeof(pmix_proc_t));
                     j = trk->npcs;
                     PMIX_LIST_FOREACH(p, &cache, pmix_proclist_t) {
@@ -593,6 +605,7 @@ static void _collect_job_info(int sd, short args, void *cbdata)
     pmix_proc_t proc;
     pmix_cb_t cb;
     pmix_status_t ret = PMIX_SUCCESS;
+    pmix_status_t rc;
     pmix_buffer_t pbkt;
     pmix_kval_t *kptr;
     pmix_byte_object_t pbo;
@@ -651,7 +664,14 @@ static void _collect_job_info(int sd, short args, void *cbdata)
         cb.scope = PMIX_SCOPE_UNDEF;
         cb.copy = false;
 
-        ret = PMIX_ERR_NOT_FOUND;
+        /* the fetch status is per-nspace and must not become the status of
+         * the whole request: a namespace we cannot answer for is skipped
+         * exactly like one we have never heard of, a few lines above. Left
+         * in 'ret', it made the outcome depend on which nspace happened to
+         * be last - and PMIx_server_collect_job_info only hands the buffer
+         * back on success, so one unanswerable nspace discarded the job
+         * info already collected for all the others */
+        rc = PMIX_ERR_NOT_FOUND;
         // have any local clients registered?
         if (0 < pmix_list_get_size(&nptr->ranks)) {
             // get one of the local clients so we will
@@ -660,16 +680,16 @@ static void _collect_job_info(int sd, short args, void *cbdata)
             if (NULL != rinfo) {
                 peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, rinfo->peerid);
                 if (NULL != peer) {
-                    PMIX_GDS_FETCH_KV(ret, peer, &cb);
+                    PMIX_GDS_FETCH_KV(rc, peer, &cb);
                 }
             }
         }
         // if we didn't find it there, try getting it
         // from our storage
-        if (PMIX_SUCCESS != ret) {
-            PMIX_GDS_FETCH_KV(ret, pmix_globals.mypeer, &cb);
-            if (PMIX_SUCCESS != ret) {
-                PMIX_ERROR_LOG(ret);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
                 PMIX_DESTRUCT(&cb);
                 continue;
             }
@@ -784,6 +804,14 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
              * may not be a contribution */
             PMIX_LOAD_PROCID(&pcs, scd->peer->info->pname.nspace, scd->peer->info->pname.rank);
             pbkt = PMIX_NEW(pmix_buffer_t);
+            if (NULL == pbkt) {
+                /* the pack below screens a NULL buffer, but its error arm
+                 * then releases it - so catch this here */
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                rc = PMIX_ERR_NOMEM;
+                PMIX_LIST_DESTRUCT(&rank_blobs);
+                goto cleanup;
+            }
             /* pack the rank */
             PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, pbkt, &pcs, 1, PMIX_PROC);
             if (PMIX_SUCCESS != rc) {
@@ -827,8 +855,15 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
          * node and this information (and the flag) will be ignored,
          * meaning that no error is generated! */
         blob_info_byte= PMIX_COLLECT_YES;
-        /* pack the modex blob info byte */
+        /* pack the modex blob info byte - check it, as the blob packs
+         * below would otherwise overwrite the failure and ship a bucket
+         * whose first byte is a rank blob rather than the collect type */
         PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &bucket, &blob_info_byte, 1, PMIX_BYTE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_LIST_DESTRUCT(&rank_blobs);
+            goto cleanup;
+        }
 
         /* pack the collected blobs of processes */
         PMIX_LIST_FOREACH (blob, &rank_blobs, rank_blob_t) {
@@ -862,6 +897,10 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
         blob_info_byte= PMIX_COLLECT_NO;
         /* pack the modex blob info byte */
         PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &bucket, &blob_info_byte, 1, PMIX_BYTE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
     }
 
     if (!PMIX_BUFFER_IS_EMPTY(&bucket)) {
@@ -939,8 +978,15 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
                         "recvd fence from %s with %d procs",
                         PMIX_PEER_PRINT(cd->peer), (int) nprocs);
     /* there must be at least one as the client has to at least provide
-     * their own namespace */
-    if (nprocs < 1) {
+     * their own namespace. Bound it from above as well, by the same
+     * round trip through the int32_t the unpack consumes it as: this
+     * count is multiplied by sizeof(pmix_proc_t) to size the allocation
+     * below, and a wire value large enough to wrap that product yields a
+     * short allocation whose element constructors then run off the end.
+     * It also keeps "cnt" from silently naming a different number of
+     * procs than the qsort and the free below walk. */
+    cnt = nprocs;
+    if (nprocs < 1 || 0 > cnt || (size_t) cnt != nprocs) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -962,6 +1008,21 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &ninf, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
+        goto cleanup;
+    }
+    /* This count comes off the wire, so screen it before it is used to
+     * size an allocation and then to index that allocation. Two slots are
+     * seeded at info[ninf] and info[ninf+1] *before* anything is unpacked,
+     * so a count near SIZE_MAX wraps "ninf + 2" down to a one-element
+     * array and writes the seeds far outside it; the same wrap can happen
+     * inside the allocator's "ninfo * sizeof(pmix_info_t)". Requiring the
+     * count to survive the round trip through the int32_t that the unpack
+     * below consumes it as - the screen pmix_server_register_events
+     * uses - bounds it well clear of both. */
+    cnt = ninf;
+    if (0 > cnt || (size_t) cnt != ninf) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
     ninfo = ninf + 2;

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -52,10 +52,6 @@
 #endif
 #include <event.h>
 
-#ifndef MAX
-#    define MAX(a, b) ((a) > (b) ? (a) : (b))
-#endif
-
 #include "src/class/pmix_hotel.h"
 #include "src/class/pmix_list.h"
 #include "src/common/pmix_attributes.h"
@@ -939,8 +935,11 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
         PMIX_BYTE_OBJECT_DESTRUCT(&bo); // releases the data
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_DESTRUCT(&bkt);
         }
+        /* the unload above emptied it, so this only balances the
+         * construct - but destruct it on every path, not just the
+         * failing one */
+        PMIX_DESTRUCT(&bkt);
     }
 
 cleanup:

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -787,6 +787,9 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
     rank_blob_t *blob;
     uint8_t blob_info_byte;
     bool compressed;
+    pmix_list_t pnames;
+    pmix_namelist_t *pn;
+    bool found;
 
     PMIX_CONSTRUCT(&bucket, pmix_buffer_t);
 
@@ -795,7 +798,34 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
                            "fence - assembling data");
 
         PMIX_CONSTRUCT(&rank_blobs, pmix_list_t);
+        PMIX_CONSTRUCT(&pnames, pmix_list_t);
         PMIX_LIST_FOREACH (scd, &trk->local_cbs, pmix_server_caddy_t) {
+            /* Contribute each participating rank once. A fork/exec'd clone
+             * shares its parent's pmix_rank_info_t, so both caddies name
+             * the same rank and would otherwise have that rank's remote
+             * data fetched and packed into the bucket twice. Identity of
+             * the rank_info's pname is the test, exactly as the clone
+             * accounting in the tracker engine uses it. */
+            found = false;
+            PMIX_LIST_FOREACH (pn, &pnames, pmix_namelist_t) {
+                if (pn->pname == &scd->peer->info->pname) {
+                    found = true;
+                    break;
+                }
+            }
+            if (found) {
+                continue;
+            }
+            pn = PMIX_NEW(pmix_namelist_t);
+            if (NULL == pn) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                rc = PMIX_ERR_NOMEM;
+                PMIX_LIST_DESTRUCT(&pnames);
+                PMIX_LIST_DESTRUCT(&rank_blobs);
+                goto cleanup;
+            }
+            pn->pname = &scd->peer->info->pname;
+            pmix_list_append(&pnames, &pn->super);
             /* get any remote contribution - note that there
              * may not be a contribution */
             PMIX_LOAD_PROCID(&pcs, scd->peer->info->pname.nspace, scd->peer->info->pname.rank);
@@ -805,6 +835,7 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
                  * then releases it - so catch this here */
                 PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
                 rc = PMIX_ERR_NOMEM;
+                PMIX_LIST_DESTRUCT(&pnames);
                 PMIX_LIST_DESTRUCT(&rank_blobs);
                 goto cleanup;
             }
@@ -812,6 +843,7 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
             PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, pbkt, &pcs, 1, PMIX_PROC);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
+                PMIX_LIST_DESTRUCT(&pnames);
                 PMIX_LIST_DESTRUCT(&rank_blobs);
                 PMIX_RELEASE(pbkt);
                 goto cleanup;
@@ -828,6 +860,7 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DESTRUCT(&cb);
+                        PMIX_LIST_DESTRUCT(&pnames);
                         PMIX_LIST_DESTRUCT(&rank_blobs);
                         PMIX_RELEASE(pbkt);
                         goto cleanup;
@@ -844,6 +877,7 @@ pmix_status_t pmix_server_collect_data(pmix_server_trkr_t *trk,
                 PMIX_RELEASE(pbkt);
             }
         }
+        PMIX_LIST_DESTRUCT(&pnames);
         /* mark the collection type so we can check on the
          * receiving end that all participants did the same. Note
          * that if the receiving end thinks that the collect flag
@@ -1279,4 +1313,25 @@ void pmix_server_set_collective_status(pmix_info_t *info, size_t ninfo,
             return;
         }
     }
+}
+
+/* The reader half of the above. Locate the slot by key for the same
+ * reason the setter does: connect appends per-participant endpoint and
+ * job-level info past it, so the positional read the fence handler uses
+ * on its own arms is only correct for the families that append nothing.
+ * A tracker carrying no status slot has not been degraded by anything,
+ * so report success. */
+pmix_status_t pmix_server_get_collective_status(pmix_info_t *info, size_t ninfo)
+{
+    size_t n;
+
+    if (NULL == info) {
+        return PMIX_SUCCESS;
+    }
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_LOCAL_COLLECTIVE_STATUS)) {
+            return info[n].value.data.status;
+        }
+    }
+    return PMIX_SUCCESS;
 }

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -106,6 +106,21 @@ static void relfn(void *cbdata)
     }
 }
 
+/* Is this tracker still on the pending list? A tracker handed to the host
+ * for a direct modex carries a reference of its own, so it outlives being
+ * retired - but a retired tracker must not be resolved or removed again. */
+static bool tracker_is_pending(pmix_dmdx_local_t *lcd)
+{
+    pmix_dmdx_local_t *cd;
+
+    PMIX_LIST_FOREACH (cd, &pmix_server_globals.local_reqs, pmix_dmdx_local_t) {
+        if (cd == lcd) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /* Discard a local dmodex tracker that we created for a request we then
  * failed to launch. Each parked requester on loc_reqs holds its own
  * reference on the tracker, so simply releasing the tracker's creation
@@ -248,10 +263,28 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
         PMIX_ERROR_LOG(rc);
         return rc;
     }
+    /* This count comes off the wire under the client's control, and the
+     * usual "the unpack screens a NULL destination" argument does not
+     * cover it: PMIx_Info_create multiplies it by sizeof(pmix_info_t)
+     * without an overflow guard and then *constructs* that many elements,
+     * so a value large enough to wrap the product yields a short
+     * allocation the constructor loop immediately runs off the end of.
+     * The directive scan below walks the size_t as well, rather than the
+     * int32_t the unpack consumed. Require the count to survive the round
+     * trip through that int32_t - the same screen fence, connect and
+     * register_events apply - which bounds it well clear of the wrap. */
+    cnt = cd->ninfo;
+    if (0 > cnt || (size_t) cnt != cd->ninfo) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        cd->ninfo = 0;
+        return rc;
+    }
     if (0 < cd->ninfo) {
         PMIX_INFO_CREATE(cd->info, cd->ninfo);
         if (NULL == cd->info) {
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            cd->ninfo = 0;
             return PMIX_ERR_NOMEM;
         }
         cnt = cd->ninfo;
@@ -349,7 +382,10 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
                     PMIX_ERROR_LOG(rc);
                     PMIX_DESTRUCT(&pbkt);
                     PMIX_DESTRUCT(&xfer);
-                    PMIX_DESTRUCT(&cb);
+                    /* cb was already destructed above - destructing it a
+                     * second time takes down its lock and its kvs list
+                     * twice, which aborts a debug build on the list's
+                     * magic id and is undefined on the mutex */
                     return rc;
                 }
                 PMIX_UNLOAD_BUFFER(&xfer, bo.bytes, bo.size);
@@ -696,6 +732,12 @@ request:
     } else if (PMIX_ERR_NOT_AVAILABLE == rc) {
         /* means they requested "immediate" */
         return PMIX_ERR_NOT_FOUND;
+    } else if (NULL == lcd) {
+        /* we failed to create a tracker at all (out of memory), so there
+         * is nothing parked and nothing that will ever answer this
+         * requester - hand the error back so the switchyard replies. Note
+         * that every arm below dereferences lcd */
+        return rc;
     }
 
     /* Getting here means that we didn't already have a request for
@@ -711,22 +753,46 @@ request:
      * resource manager server to please get the info for us from
      * whomever is hosting the target process */
     if (NULL != pmix_host_server.direct_modex) {
+        /* augment the tracker's own copy of the directives, not the
+         * caddy's. The host keeps every input valid until it calls us
+         * back, and the server caddy does not live that long - failing
+         * this tracker (its target departed) answers the requester and
+         * frees the caddy while the host still holds its info array.
+         * The tracker does live that long: we retain it below.
+         * pmix_pending_nspace_requests hands up the same array */
         if (NULL != key) {
-            sz = cd->ninfo;
+            sz = lcd->ninfo;
             PMIX_INFO_CREATE(info, sz + 1);
+            if (NULL == info) {
+                /* nothing screens this one - we index the array ourselves
+                 * instead of handing it to an unpack that would reject a
+                 * NULL destination. The tracker we just created carries
+                 * only this requester, so discarding it without callbacks
+                 * leaves the switchyard to answer them */
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                discard_local_tracker(lcd);
+                return PMIX_ERR_NOMEM;
+            }
             for (n = 0; n < sz; n++) {
-                PMIX_INFO_XFER(&info[n], &cd->info[n]);
+                PMIX_INFO_XFER(&info[n], &lcd->info[n]);
             }
             PMIX_INFO_LOAD(&info[sz], PMIX_REQUIRED_KEY, key, PMIX_STRING);
-            if (NULL != cd->info) {
-                PMIX_INFO_FREE(cd->info, cd->ninfo);
+            if (NULL != lcd->info) {
+                PMIX_INFO_FREE(lcd->info, lcd->ninfo);
             }
-            cd->info = info;
-            cd->ninfo = sz + 1;
+            lcd->info = info;
+            lcd->ninfo = sz + 1;
         }
-        rc = pmix_host_server.direct_modex(&lcd->proc, cd->info, cd->ninfo, dmdx_cbfunc, lcd);
+        /* the host holds this pointer until it calls dmdx_cbfunc, and the
+         * tracker can be retired out from under it in the meantime - a
+         * namespace deregistration for the target retires every tracker
+         * naming it - so take a reference for the host to hold */
+        PMIX_RETAIN(lcd);
+        rc = pmix_host_server.direct_modex(&lcd->proc, lcd->info, lcd->ninfo, dmdx_cbfunc, lcd);
         if (PMIX_SUCCESS != rc) {
-            /* may have a function entry but not support the request */
+            /* may have a function entry but not support the request - it
+             * will not call us back, so give the reference back */
+            PMIX_RELEASE(lcd);
             discard_local_tracker(lcd);
         }
     } else {
@@ -793,7 +859,15 @@ complete:
      * data to them */
     req = PMIX_NEW(pmix_dmdx_request_t);
     if (NULL == req) {
-        *ld = lcd;
+        if (PMIX_ERR_NOT_FOUND == rc) {
+            /* we created this tracker a few lines above for a requester we
+             * can no longer park on it - take it back off the list rather
+             * than leaving an empty tracker there for the life of the
+             * server. Leave *ld NULL: nothing is parked, so no caller may
+             * hand this tracker to the host */
+            pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
+            PMIX_RELEASE(lcd);
+        }
         return PMIX_ERR_NOMEM;
     }
     if (NULL != key) {
@@ -846,7 +920,13 @@ void pmix_pending_nspace_requests(pmix_namespace_t *nptr)
         if (!found) {
             rc = PMIX_ERR_NOT_SUPPORTED;
             if (NULL != pmix_host_server.direct_modex) {
+                /* hand the host a reference of its own - see the matching
+                 * comment in pmix_server_get */
+                PMIX_RETAIN(cd);
                 rc = pmix_host_server.direct_modex(&cd->proc, cd->info, cd->ninfo, dmdx_cbfunc, cd);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_RELEASE(cd);
+                }
             }
             if (PMIX_SUCCESS != rc) {
                 pmix_dmdx_request_t *req, *req_next;
@@ -1094,9 +1174,16 @@ complete:
     PMIX_DESTRUCT(&pbkt);
 
     if (found) {
-        /* pass it back */
+        /* pass it back. Report SUCCESS to our caller even when rc carries
+         * an error: invoking cbfunc hands the server caddy to the reply
+         * path, which queues the client's answer and releases it. Both
+         * callers treat a non-SUCCESS return as "nobody has answered this
+         * requester yet" - pmix_server_get parks the caddy on a new dmodex
+         * tracker, and check_req calls the requester's cbfunc a second
+         * time - so returning rc here turned a failed assemble or pack
+         * into a double reply on a caddy that was already freed. */
         cbfunc(rc, data, sz, cbdata, relfn, data);
-        return rc;
+        return PMIX_SUCCESS;
     }
 
     /* nothing is being passed back, so nothing will call relfn for us -
@@ -1219,6 +1306,7 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
     bool found;
     pmix_buffer_t pbkt;
     pmix_cb_t cb;
+    pmix_proc_t wildcard;
 
     PMIX_ACQUIRE_OBJECT(caddy);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
@@ -1227,6 +1315,18 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
                         "[%s:%d] process dmdx reply from %s:%u",
                         __FILE__, __LINE__,
                         caddy->lcd->proc.nspace, caddy->lcd->proc.rank);
+
+    /* the tracker is alive because we retained it for the host, but it may
+     * have been retired while the host was working - a departing target or
+     * a deregistered namespace fails and discards every tracker naming it,
+     * and those waiters have already been told. There is then nothing to
+     * resolve, and nothing to store the data for */
+    if (!tracker_is_pending(caddy->lcd)) {
+        pmix_output_verbose(2, pmix_server_globals.get_output,
+                            "[%s:%d] dmdx reply for a retired tracker - discarding",
+                            __FILE__, __LINE__);
+        goto release;
+    }
 
     /* find the nspace object for the proc whose data is being received */
     nptr = NULL;
@@ -1242,6 +1342,12 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
          * processes from it running on this host - so just record it
          * so we know we have the data for any future requests */
         nptr = PMIX_NEW(pmix_namespace_t);
+        if (NULL == nptr) {
+            /* everything below dereferences this, and pmix_pending_resolve
+             * takes it as its first argument */
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            goto release;
+        }
         nptr->nspace = strdup(caddy->lcd->proc.nspace);
         /* add to the list */
         pmix_list_append(&pmix_globals.nspaces, &nptr->super);
@@ -1320,13 +1426,11 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
                      * transfer it across to the individual nspace storage
                      * components */
                     PMIX_CONSTRUCT(&cb, pmix_cb_t);
-                    PMIX_PROC_CREATE(cb.proc, 1);
-                    if (NULL == cb.proc) {
-                        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-                        PMIX_DESTRUCT(&cb);
-                        goto complete;
-                    }
-                    PMIX_LOAD_PROCID(cb.proc, nm->ns->nspace, PMIX_RANK_WILDCARD);
+                    /* point at a stack proc - cbdes deliberately never
+                     * frees this member, so a PMIX_PROC_CREATE here
+                     * leaked one proc on every reply that took this arm */
+                    PMIX_LOAD_PROCID(&wildcard, nm->ns->nspace, PMIX_RANK_WILDCARD);
+                    cb.proc = &wildcard;
                     cb.scope = PMIX_INTERNAL;
                     cb.copy = false;
                     PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
@@ -1338,8 +1442,13 @@ static void _process_dmdx_reply(int sd, short args, void *cbdata)
                     PMIX_LIST_FOREACH (kv, &cb.kvs, pmix_kval_t) {
                         PMIX_GDS_STORE_KV(rc, peer, &caddy->lcd->proc, PMIX_INTERNAL, kv);
                         if (PMIX_SUCCESS != rc) {
+                            /* report it the same way the sibling arm below
+                             * does - a requester told SUCCESS here goes on
+                             * to fetch data that was never stored */
                             PMIX_ERROR_LOG(rc);
-                            break;
+                            caddy->status = rc;
+                            PMIX_DESTRUCT(&cb);
+                            goto complete;
                         }
                     }
                     PMIX_DESTRUCT(&cb);
@@ -1387,11 +1496,14 @@ complete:
     pmix_pending_resolve(nptr, caddy->lcd->proc.rank,
                          caddy->status, PMIX_REMOTE, caddy->lcd);
 
+release:
     /* now call the release function so the host server
      * knows it can release the data */
     if (NULL != caddy->relcbfunc) {
         caddy->relcbfunc(caddy->cbdata);
     }
+    /* give back the reference we took on the tracker for the host */
+    PMIX_RELEASE(caddy->lcd);
     PMIX_RELEASE(caddy);
 }
 
@@ -1407,6 +1519,8 @@ static void dmdx_cbfunc(pmix_status_t status, const char *data, size_t ndata, vo
         if (NULL != release_fn) {
             release_fn(release_cbdata);
         }
+        /* give back the reference the up-call took on our behalf -
+         * _process_dmdx_reply is the only other place that drops it */
         PMIX_RELEASE(lcd);
         return;
     }
@@ -1415,6 +1529,16 @@ static void dmdx_cbfunc(pmix_status_t status, const char *data, size_t ndata, vo
      * need to thread-shift into our local progress thread before
      * accessing any global info */
     caddy = PMIX_NEW(pmix_dmdx_reply_caddy_t);
+    if (NULL == caddy) {
+        /* nothing we can do beyond honoring the release contract with the
+         * host's own data and giving back the tracker reference the
+         * up-call took for it */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
+        PMIX_RELEASE(lcd);
+        return;
+    }
     caddy->status = status;
     /* point to the callers cbfunc */
     caddy->relcbfunc = release_fn;

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -64,7 +64,6 @@ extern pmix_server_module_t pmix_host_server;
 typedef struct {
     pmix_object_t super;
     pmix_event_t ev;
-    volatile bool active;
     pmix_status_t status;
     const char *data;
     size_t ndata;
@@ -95,9 +94,9 @@ static pmix_status_t get_job_data(char *nspace, pmix_server_caddy_t *cd,
                                   char *key, pmix_buffer_t *pbkt);
 static void get_timeout(int sd, short args, void *cbdata);
 
-/* declare a function whose sole purpose is to
- * free data that we provided to our host server
- * when servicing dmodex requests */
+/* The release function we hand to the reply path along with a payload we
+ * unloaded from a buffer: the reply copies the bytes, then calls this to
+ * give the unload allocation back. */
 static void relfn(void *cbdata)
 {
     char *data = (char *) cbdata;
@@ -196,8 +195,9 @@ static pmix_status_t defer_response(char *nspace, pmix_rank_t rank, char *key,
         pmix_event_evtimer_add(&req->ev, tv);
         req->event_active = true;
     }
-    /* the peer object has been added to the new lcd tracker,
-     * so return success here */
+    /* hand the tracker back, along with the status that says whether we
+     * created it (PMIX_ERR_NOT_FOUND) or joined one already waiting on
+     * this same target (PMIX_SUCCESS) */
     *locald = lcd;
     return rc;
 }
@@ -899,7 +899,7 @@ void pmix_pending_nspace_requests(pmix_namespace_t *nptr)
         pmix_rank_info_t *info;
         bool found = false;
 
-        if (0 != strncmp(nptr->nspace, cd->proc.nspace, PMIX_MAX_NSLEN)) {
+        if (!PMIX_CHECK_NSPACE(nptr->nspace, cd->proc.nspace)) {
             continue;
         }
 
@@ -931,7 +931,9 @@ void pmix_pending_nspace_requests(pmix_namespace_t *nptr)
             if (PMIX_SUCCESS != rc) {
                 pmix_dmdx_request_t *req, *req_next;
                 PMIX_LIST_FOREACH_SAFE (req, req_next, &cd->loc_reqs, pmix_dmdx_request_t) {
-                    req->cbfunc(PMIX_ERR_NOT_FOUND, NULL, 0, req->cbdata, NULL, NULL);
+                    if (NULL != req->cbfunc) {
+                        req->cbfunc(PMIX_ERR_NOT_FOUND, NULL, 0, req->cbdata, NULL, NULL);
+                    }
                     pmix_list_remove_item(&cd->loc_reqs, &req->super);
                     PMIX_RELEASE(req);
                 }
@@ -1218,7 +1220,9 @@ static void check_req(pmix_namespace_t *nptr,
     if (PMIX_SUCCESS != status) {
         /* if we've got an error for this request - just forward it*/
         PMIX_LIST_FOREACH_SAFE(req, rnext, &ptr->loc_reqs, pmix_dmdx_request_t) {
-            req->cbfunc(status, NULL, 0, req->cbdata, NULL, NULL);
+            if (NULL != req->cbfunc) {
+                req->cbfunc(status, NULL, 0, req->cbdata, NULL, NULL);
+            }
             pmix_list_remove_item(&ptr->loc_reqs, &req->super);
             PMIX_RELEASE(req);
         }
@@ -1241,7 +1245,7 @@ static void check_req(pmix_namespace_t *nptr,
             } else {
                 key = NULL;
             }
-           rc = _satisfy_request(nptr, rank, key, &scd, diffnspace, scope,
+            rc = _satisfy_request(nptr, rank, key, &scd, diffnspace, scope,
                                   req->cbfunc, req->cbdata);
             if (PMIX_SUCCESS != rc) {
                 /* if we can't satisfy this particular request (missing key?) */

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -405,16 +405,12 @@ newblock:
     return PMIX_SUCCESS;
 }
 
-/* An info that is supposed to carry an array of some element type carries
- * whatever the sender actually put there. Everything screened with this
- * arrives either off the wire from a local client or back down from the
- * host, so reading the union on the strength of the key alone means
- * dereferencing a pointer the sender chose - or walking past the end of a
- * correctly-tagged array of some other type. Confirm the value is a data
- * array, of the element type we are about to cast it to, and long enough
- * to index. */
-static bool valid_darray(const pmix_info_t *info, pmix_data_type_t type,
-                         size_t minsz)
+/* Confirm an info really carries a data array of the element type we are
+ * about to cast it to - see the header for why every array from a client
+ * or from the host needs this. Shared with pmix_server_setup.c, which
+ * screens the same group arrays when the host registers them directly. */
+bool pmix_server_valid_darray(const pmix_info_t *info, pmix_data_type_t type,
+                              size_t minsz)
 {
     if (PMIX_DATA_ARRAY != info->value.type ||
         NULL == info->value.data.darray ||
@@ -558,7 +554,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
             }
 
         } else if (PMIX_CHECK_KEY(&scd->info[n], PMIX_GROUP_MEMBERSHIP)) {
-            if (!valid_darray(&scd->info[n], PMIX_PROC, 1)) {
+            if (!pmix_server_valid_darray(&scd->info[n], PMIX_PROC, 1)) {
                 PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
                 continue;
             }
@@ -567,7 +563,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
 
         } else if (PMIX_CHECK_KEY(&scd->info[n], PMIX_GROUP_INFO_ARRAY) ||
                    PMIX_CHECK_KEY(&scd->info[n], PMIX_GROUP_INFO)) {
-            if (!valid_darray(&scd->info[n], PMIX_INFO, 1)) {
+            if (!pmix_server_valid_darray(&scd->info[n], PMIX_INFO, 1)) {
                 PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
                 continue;
             }
@@ -616,7 +612,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
             } else {
                 // contains an array of group info arrays
                 for (n=0; n < ninfo; n++) {
-                    if (!valid_darray(&iptr[n], PMIX_INFO, 1)) {
+                    if (!pmix_server_valid_darray(&iptr[n], PMIX_INFO, 1)) {
                         PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
                         scd->status = PMIX_ERR_TYPE_MISMATCH;
                         goto reply;
@@ -962,8 +958,8 @@ static pmix_status_t aggregate_info(grp_block_t *blk)
                     if (PMIX_CHECK_KEY(&blk->info[m], PMIX_GROUP_ADD_MEMBERS)) {
                         /* both of these were unpacked off the wire, so the
                          * key having matched says nothing about the union */
-                        if (!valid_darray(&blk->info[m], PMIX_PROC, 1) ||
-                            !valid_darray(&trk->info[n], PMIX_PROC, 1)) {
+                        if (!pmix_server_valid_darray(&blk->info[m], PMIX_PROC, 1) ||
+                            !pmix_server_valid_darray(&trk->info[n], PMIX_PROC, 1)) {
                             rc = PMIX_ERR_TYPE_MISMATCH;
                             PMIX_ERROR_LOG(rc);
                             goto bailout;

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -347,17 +347,26 @@ static pmix_status_t get_tracker(char *grpid, bool bootstrap, bool follower,
     PMIX_LIST_FOREACH(blk, &pmix_server_globals.grp_collectives, grp_block_t) {
         if (0 == strcmp(grpid, blk->id)) {
             // we do - pass it back
-            *block = blk;
             // new signature, so create a tracker for it
             trk = PMIX_NEW(grp_trk_t);
+            if (NULL == trk) {
+                return PMIX_ERR_NOMEM;
+            }
+            if (0 < nprocs) {
+                PMIX_PROC_CREATE(trk->pcs, nprocs);
+                if (NULL == trk->pcs) {
+                    PMIX_RELEASE(trk);
+                    return PMIX_ERR_NOMEM;
+                }
+                trk->npcs = nprocs;
+                memcpy(trk->pcs, procs, nprocs * sizeof(pmix_proc_t));
+            }
             // non-owning back-reference - see gtdes
             trk->blk = blk;
-            trk->npcs = nprocs;
-            PMIX_PROC_CREATE(trk->pcs, trk->npcs);
-            memcpy(trk->pcs, procs, nprocs * sizeof(pmix_proc_t));
             trk->info = info;
             trk->ninfo = ninfo;
             pmix_list_append(&blk->mbrs, &trk->super);
+            *block = blk;
             *tracker = trk;
             check_definition_complete(blk);
             return PMIX_SUCCESS;
@@ -367,17 +376,33 @@ static pmix_status_t get_tracker(char *grpid, bool bootstrap, bool follower,
 newblock:
     // new block
     blk = PMIX_NEW(grp_block_t);
+    if (NULL == blk) {
+        return PMIX_ERR_NOMEM;
+    }
     blk->id = strdup(grpid);
-    pmix_list_append(&pmix_server_globals.grp_collectives, &blk->super);
-    *block = blk;
+    if (NULL == blk->id) {
+        PMIX_RELEASE(blk);
+        return PMIX_ERR_NOMEM;
+    }
     // setup a tracker for it
     trk = PMIX_NEW(grp_trk_t);
-    // non-owning back-reference - see gtdes
-    trk->npcs = nprocs;
-    if (NULL != procs) {
-        PMIX_PROC_CREATE(trk->pcs, trk->npcs);
+    if (NULL == trk) {
+        PMIX_RELEASE(blk);
+        return PMIX_ERR_NOMEM;
+    }
+    if (NULL != procs && 0 < nprocs) {
+        PMIX_PROC_CREATE(trk->pcs, nprocs);
+        if (NULL == trk->pcs) {
+            PMIX_RELEASE(trk);
+            PMIX_RELEASE(blk);
+            return PMIX_ERR_NOMEM;
+        }
+        trk->npcs = nprocs;
         memcpy(trk->pcs, procs, nprocs * sizeof(pmix_proc_t));
     }
+    /* nothing below here can fail, so it is safe to publish the block and
+     * to take ownership of the caller's info array */
+    pmix_list_append(&pmix_server_globals.grp_collectives, &blk->super);
     trk->blk = blk;
     trk->info = info;
     trk->ninfo = ninfo;
@@ -387,8 +412,30 @@ newblock:
     } else {
         check_definition_complete(blk);
     }
+    *block = blk;
     *tracker = trk;
     return PMIX_SUCCESS;
+}
+
+/* An info that is supposed to carry an array of some element type carries
+ * whatever the sender actually put there. Everything screened with this
+ * arrives either off the wire from a local client or back down from the
+ * host, so reading the union on the strength of the key alone means
+ * dereferencing a pointer the sender chose - or walking past the end of a
+ * correctly-tagged array of some other type. Confirm the value is a data
+ * array, of the element type we are about to cast it to, and long enough
+ * to index. */
+static bool valid_darray(const pmix_info_t *info, pmix_data_type_t type,
+                         size_t minsz)
+{
+    if (PMIX_DATA_ARRAY != info->value.type ||
+        NULL == info->value.data.darray ||
+        type != info->value.data.darray->type ||
+        NULL == info->value.data.darray->array ||
+        minsz > info->value.data.darray->size) {
+        return false;
+    }
+    return true;
 }
 
 pmix_status_t pmix_server_process_grpinfo(size_t ctxid,
@@ -492,6 +539,7 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
     size_t n, ctxid = SIZE_MAX, nmembers = 0;
     pmix_proc_t *members = NULL;
     bool ctxid_given = false;
+    bool packed;
     pmix_info_t *iptr, *pinfo;
     size_t ninfo, npinfo;
     pmix_list_t grpinfo;
@@ -522,12 +570,23 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
             }
 
         } else if (PMIX_CHECK_KEY(&scd->info[n], PMIX_GROUP_MEMBERSHIP)) {
+            if (!valid_darray(&scd->info[n], PMIX_PROC, 1)) {
+                PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+                continue;
+            }
             members = (pmix_proc_t*)scd->info[n].value.data.darray->array;
             nmembers = scd->info[n].value.data.darray->size;
 
         } else if (PMIX_CHECK_KEY(&scd->info[n], PMIX_GROUP_INFO_ARRAY) ||
                    PMIX_CHECK_KEY(&scd->info[n], PMIX_GROUP_INFO)) {
+            if (!valid_darray(&scd->info[n], PMIX_INFO, 1)) {
+                PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+                continue;
+            }
             g = PMIX_NEW(pmix_info_caddy_t);
+            if (NULL == g) {
+                continue;
+            }
             g->info = &scd->info[n];
             pmix_list_append(&grpinfo, &g->super);
 
@@ -540,16 +599,17 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
 
     // if group info was provided, then we need to store it
     // in our hash table too
+    /* Every failure below reports itself through the reply loop rather
+     * than returning here. Returning left the block on grp_collectives
+     * with host_called already set, so nothing would ever complete it:
+     * its participants waited forever and the block, its trackers and
+     * their caddies leaked for the life of the server. */
     if (0 < pmix_list_get_size(&grpinfo)) {
         // must have been given a context ID
         if (!ctxid_given) {
-            if (NULL != scd->relfn) {
-                scd->relfn(scd->cbdata);
-            }
-            PMIX_RELEASE(scd);
-            PMIX_LIST_DESTRUCT(&grpinfo);
-            free(id);
-            return;
+            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+            scd->status = PMIX_ERR_BAD_PARAM;
+            goto reply;
         }
         /* Each list member points to a pmix_info_t that contains
          * a data array of info from a given proc */
@@ -562,35 +622,31 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                 rc = pmix_server_process_grpinfo(ctxid, iptr, ninfo);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
-                    if (NULL != scd->relfn) {
-                        scd->relfn(scd->cbdata);
-                    }
-                    PMIX_RELEASE(scd);
-                    PMIX_LIST_DESTRUCT(&grpinfo);
-                    free(id);
-                    return;
+                    scd->status = rc;
+                    goto reply;
                 }
             } else {
                 // contains an array of group info arrays
                 for (n=0; n < ninfo; n++) {
+                    if (!valid_darray(&iptr[n], PMIX_INFO, 1)) {
+                        PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+                        scd->status = PMIX_ERR_TYPE_MISMATCH;
+                        goto reply;
+                    }
                     pinfo = (pmix_info_t*)iptr[n].value.data.darray->array;
                     npinfo = iptr[n].value.data.darray->size;
                     rc = pmix_server_process_grpinfo(ctxid, pinfo, npinfo);
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
-                        if (NULL != scd->relfn) {
-                            scd->relfn(scd->cbdata);
-                        }
-                        PMIX_RELEASE(scd);
-                        PMIX_LIST_DESTRUCT(&grpinfo);
-                        free(id);
-                        return;
+                        scd->status = rc;
+                        goto reply;
                     }
                 }
             }
         }
     }
 
+reply:
     // because bootstrap will have added multiple blocks to the collectives
     // for each bootstrap operation, cycle across the list to find them all.
     // Use the SAFE variant: matching blocks are removed and released below,
@@ -609,14 +665,19 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
             PMIX_LIST_FOREACH (cd, &trk->local_cbs, pmix_server_caddy_t) {
                 reply = PMIX_NEW(pmix_buffer_t);
                 if (NULL == reply) {
-                    break;
+                    continue;
                 }
+                /* Every pack failure below abandons the reply for THIS
+                 * participant and moves on to the next one. It must not
+                 * break out of the loop: the participants behind this one
+                 * are waiting on a reply nobody else will send, and their
+                 * caddies are freed a few lines below with the block. */
                 /* setup the reply, starting with the returned status */
                 PMIX_BFROPS_PACK(ret, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_RELEASE(reply);
-                    break;
+                    continue;
                 }
                 if (PMIX_SUCCESS == scd->status && PMIX_GROUP_CONSTRUCT == op) {
                     /* add the final membership */
@@ -624,14 +685,14 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS != ret) {
                         PMIX_ERROR_LOG(ret);
                         PMIX_RELEASE(reply);
-                        break;
+                        continue;
                     }
                     if (0 < nmembers) {
                         PMIX_BFROPS_PACK(ret, cd->peer, reply, members, nmembers, PMIX_PROC);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
                             PMIX_RELEASE(reply);
-                            break;
+                            continue;
                         }
                     }
                     /* if a ctxid was provided, pass it along */
@@ -639,14 +700,14 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS != ret) {
                         PMIX_ERROR_LOG(ret);
                         PMIX_RELEASE(reply);
-                        break;
+                        continue;
                     }
                     if (ctxid_given) {
                         PMIX_BFROPS_PACK(ret, cd->peer, reply, &ctxid, 1, PMIX_SIZE);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
                             PMIX_RELEASE(reply);
-                            break;
+                            continue;
                         }
                     }
                     /* add any group info */
@@ -655,17 +716,25 @@ static void _grpcbfunc(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS != ret) {
                         PMIX_ERROR_LOG(ret);
                         PMIX_RELEASE(reply);
-                        break;
+                        continue;
                     }
+                    /* this one is nested a level deeper than its siblings,
+                     * so a bare break escaped only the info loop and fell
+                     * through to queue the reply it had just released */
+                    packed = true;
                     if (0 < ninfo) {
                         PMIX_LIST_FOREACH(g, &grpinfo, pmix_info_caddy_t) {
                             PMIX_BFROPS_PACK(ret, cd->peer, reply, g->info, 1, PMIX_INFO);
                             if (PMIX_SUCCESS != ret) {
                                 PMIX_ERROR_LOG(ret);
                                 PMIX_RELEASE(reply);
+                                packed = false;
                                 break;
                             }
                         }
+                    }
+                    if (!packed) {
+                        continue;
                     }
                 }
 
@@ -903,6 +972,14 @@ static pmix_status_t aggregate_info(grp_block_t *blk)
                 if (PMIX_CHECK_KEY(&trk->info[n], blk->info[m].key)) {
                     // check a few critical keys
                     if (PMIX_CHECK_KEY(&blk->info[m], PMIX_GROUP_ADD_MEMBERS)) {
+                        /* both of these were unpacked off the wire, so the
+                         * key having matched says nothing about the union */
+                        if (!valid_darray(&blk->info[m], PMIX_PROC, 1) ||
+                            !valid_darray(&trk->info[n], PMIX_PROC, 1)) {
+                            rc = PMIX_ERR_TYPE_MISMATCH;
+                            PMIX_ERROR_LOG(rc);
+                            goto bailout;
+                        }
                         // aggregate the members
                         nmarray = (pmix_proc_t*)blk->info[m].value.data.darray->array;
                         nmsize = blk->info[m].value.data.darray->size;
@@ -1073,6 +1150,22 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         goto error;
     }
+    /* Screen the count before it sizes an allocation. PMIx_Proc_create
+     * multiplies it by sizeof(pmix_proc_t) with no overflow guard and then
+     * constructs that many elements, so a wire value large enough to wrap
+     * the product yields a short allocation the constructor loop runs off
+     * the end of. It is also the size_t - not the int32_t the unpack
+     * consumes - that the memcpy in get_tracker and the PMIX_PROC_FREE
+     * below walk. Requiring the count to survive the round trip through
+     * that int32_t bounds it well clear of both, and is the same screen
+     * the fence, connect and disconnect handlers apply. */
+    cnt = nprocs;
+    if (0 > cnt || (size_t) cnt != nprocs) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        nprocs = 0;
+        goto error;
+    }
     if (0 < nprocs) {
         PMIX_PROC_CREATE(procs, nprocs);
         if (NULL == procs) {
@@ -1097,8 +1190,27 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         goto error;
     }
+    /* Same screen, and this handler needs it more than most: the status
+     * slot is seeded at info[ninf] *before* anything is unpacked into the
+     * array, so a count near SIZE_MAX wraps "ninf + 1" to zero - for which
+     * PMIx_Info_create answers NULL - and the seed is then written at
+     * info[SIZE_MAX]. There is no unpack in front of it to screen
+     * anything, and a local client drives it directly. The directive scan
+     * below walks the size_t as well. */
+    cnt = ninf;
+    if (0 > cnt || (size_t) cnt != ninf) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
     ninfo = ninf + 1;
     PMIX_INFO_CREATE(info, ninfo);
+    if (NULL == info) {
+        rc = PMIX_ERR_NOMEM;
+        PMIX_ERROR_LOG(rc);
+        ninfo = 0;
+        goto error;
+    }
     /* store default response */
     rc = PMIX_SUCCESS;
     PMIX_INFO_LOAD(&info[ninf], PMIX_LOCAL_COLLECTIVE_STATUS, &rc, PMIX_STATUS);
@@ -1129,14 +1241,20 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
     /* find/create the local tracker for this operation */
     rc = get_tracker(grpid, bootstrap, follower, procs, nprocs,
                      info, ninfo, &blk, &trk);
-    if (PMIX_EXISTS == rc) {
-        // we extended the trk's info array
-        PMIX_INFO_FREE(info, ninfo);
-        info = NULL;
-        ninfo = 0;
+    if (PMIX_SUCCESS != rc) {
+        /* it takes our arrays only on success, so everything we unpacked
+         * is still ours to free at the error label */
+        PMIX_ERROR_LOG(rc);
+        goto error;
     }
+    /* the tracker owns the info array now - the old PMIX_EXISTS arm here
+     * freed it instead, which get_tracker has never returned and which
+     * would have been a double free if it ever did */
+    info = NULL;
+    ninfo = 0;
     // grpid has been copied into the tracker
     free(grpid);
+    grpid = NULL;
     // get_tracker copied the participant array into the tracker, so
     // release our unpacked copy - the tracker's trk->pcs is used from
     // here on
@@ -1198,11 +1316,13 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
 
     rc = aggregate_info(blk);
     if (PMIX_SUCCESS != rc) {
-        pmix_list_remove_item(&trk->local_cbs, &cd->super);
-        // the trk will be released when we release the blk
-        pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
-        PMIX_RELEASE(blk);
-        return rc;
+        /* we only get here once every local participant has contributed, so
+         * the block holds all of their caddies - releasing it would free
+         * them without a reply and hang every one of them. Complete them
+         * all with the error instead, and report success: grpcbfunc has
+         * taken ownership of the caddies, this one included. */
+        grpcbfunc(rc, NULL, 0, blk, NULL, NULL);
+        return PMIX_SUCCESS;
     }
     /* if an expected member was lost before contributing, how we proceed
      * depends on the operation and its directives. For a construct without
@@ -1244,15 +1364,16 @@ pmix_status_t pmix_server_group(pmix_server_caddy_t *cd, pmix_buffer_t *buf,
             grpcbfunc(PMIX_SUCCESS, NULL, 0, blk, NULL, NULL);
             return PMIX_SUCCESS;
         }
-        /* detach this caddy from the tracker before releasing the block:
-         * releasing the block destructs trk->local_cbs, which would release
-         * this caddy, and the switchyard also releases it on our non-SUCCESS
-         * return -- a double free. The sibling error paths above do the same. */
-        pmix_list_remove_item(&trk->local_cbs, &cd->super);
-        /* remove the tracker from the list */
-        pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
-        PMIX_RELEASE(blk);
-        return rc;
+        /* the host refused after every local participant had contributed,
+         * so the block holds all of their caddies. Detaching just this one
+         * and releasing the block answers the caller and hangs everybody
+         * else; hand the refusal to all of them through the same path the
+         * PMIX_OPERATION_SUCCEEDED arm above uses. That also settles the
+         * double-free this used to guard against: grpcbfunc owns the
+         * caddies, so we must report success rather than let the
+         * switchyard release this one a second time. */
+        grpcbfunc(rc, NULL, 0, blk, NULL, NULL);
+        return PMIX_SUCCESS;
     }
 
     return PMIX_SUCCESS;
@@ -1347,8 +1468,8 @@ static void account_departed(grp_block_t *blk, const pmix_proc_t *proc)
         trk = (grp_trk_t *) pmix_list_get_first(&blk->mbrs);
         rc = aggregate_info(blk);
         if (PMIX_SUCCESS != rc) {
-            pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
-            PMIX_RELEASE(blk);
+            /* every contributor's caddy is on this block - tell them */
+            grpcbfunc(rc, NULL, 0, blk, NULL, NULL);
             return;
         }
         /* a member departed before contributing (that is why we are here).
@@ -1381,8 +1502,9 @@ static void account_departed(grp_block_t *blk, const pmix_proc_t *proc)
             /* the host will not call back - drive completion ourselves */
             grpcbfunc(PMIX_SUCCESS, NULL, 0, blk, NULL, NULL);
         } else if (PMIX_SUCCESS != rc) {
-            pmix_list_remove_item(&pmix_server_globals.grp_collectives, &blk->super);
-            PMIX_RELEASE(blk);
+            /* nothing else will answer these participants - we are here
+             * because no further participant call is coming */
+            grpcbfunc(rc, NULL, 0, blk, NULL, NULL);
         }
     }
 }

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -52,10 +52,6 @@
 #endif
 #include <event.h>
 
-#ifndef MAX
-#    define MAX(a, b) ((a) > (b) ? (a) : (b))
-#endif
-
 #include "src/class/pmix_hotel.h"
 #include "src/class/pmix_list.h"
 #include "src/common/pmix_attributes.h"
@@ -142,15 +138,13 @@ static PMIX_CLASS_INSTANCE(grp_block_t,
                            pmix_list_item_t,
                            gbcon, gbdes);
 
+/* One per participating pmix_server_group() call. The timer, lock, id and
+ * status flags a tracker used to carry were never read: the local phase is
+ * timed, frozen and named by the BLOCK, which is the level the host and the
+ * fault paths work at. */
 typedef struct {
     pmix_list_item_t super;
-    pmix_event_t ev;
-    bool event_active;
-    pmix_lock_t lock;
-    char *id;
     grp_block_t *blk;
-    bool host_called;
-    bool hybrid;
     pmix_proc_t *pcs;
     size_t npcs;
     pmix_info_t *info;
@@ -159,12 +153,7 @@ typedef struct {
 } grp_trk_t;
 static void gtcon(grp_trk_t *t)
 {
-    t->event_active = false;
-    PMIX_CONSTRUCT_LOCK(&t->lock);
-    t->id = NULL;
     t->blk = NULL;
-    t->host_called = false;
-    t->hybrid = false;
     t->pcs = NULL;
     t->npcs = 0;
     t->info = NULL;
@@ -173,7 +162,6 @@ static void gtcon(grp_trk_t *t)
 }
 static void gtdes(grp_trk_t *t)
 {
-    PMIX_DESTRUCT_LOCK(&t->lock);
     /* t->blk is a non-owning back-reference: the block owns its trackers
      * (they live on blk->mbrs and are freed by this destructor when the
      * block is released), so the tracker must NOT hold a reference on the

--- a/src/server/pmix_server_info_replies.c
+++ b/src/server/pmix_server_info_replies.c
@@ -67,6 +67,10 @@ static void _alloccbfunc(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != scd->cbfunc.relfn) {
+            scd->cbfunc.relfn(scd->relcbdata);
+        }
         if (NULL != qcd->queries) {
             PMIX_QUERY_FREE(qcd->queries, qcd->nqueries);
         }
@@ -139,6 +143,10 @@ void pmix_server_alloc_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ni
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *) qcd->cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         if (NULL != qcd->queries) {
             PMIX_QUERY_FREE(qcd->queries, qcd->nqueries);
         }
@@ -183,6 +191,10 @@ static void _qrycbfunc(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != scdwrapper->cbfunc.relfn) {
+            scdwrapper->cbfunc.relfn(scdwrapper->relcbdata);
+        }
         PMIX_RELEASE(scd);
         PMIX_RELEASE(scdwrapper);
         return;
@@ -240,6 +252,10 @@ void pmix_server_query_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ni
     pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         PMIX_RELEASE(cd);
         return;
     }
@@ -278,6 +294,10 @@ static void _sctrl_cbfunc(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != scdwrapper->cbfunc.relfn) {
+            scdwrapper->cbfunc.relfn(scdwrapper->relcbdata);
+        }
         PMIX_RELEASE(cd);
         PMIX_RELEASE(scd);
         PMIX_RELEASE(scdwrapper);
@@ -339,6 +359,10 @@ void pmix_server_sessctrl_cbfunc(pmix_status_t status, pmix_info_t *info, size_t
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *)scd->cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         PMIX_RELEASE(cd);
         PMIX_RELEASE(scd);
         return;
@@ -378,6 +402,10 @@ static void _jctrl_cbfunc(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != scd->cbfunc.relfn) {
+            scd->cbfunc.relfn(scd->relcbdata);
+        }
         PMIX_RELEASE(cd);
         PMIX_RELEASE(qcd);
         PMIX_RELEASE(scd);
@@ -442,6 +470,10 @@ void pmix_server_jctrl_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ni
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *) qcd->cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         PMIX_RELEASE(cd);
         PMIX_RELEASE(qcd);
         return;
@@ -480,6 +512,10 @@ static void _mon_cbfunc(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != scd->cbfunc.relfn) {
+            scd->cbfunc.relfn(scd->relcbdata);
+        }
         PMIX_RELEASE(cd);
         PMIX_RELEASE(scd);
         return;
@@ -534,6 +570,10 @@ void pmix_server_monitor_cbfunc(pmix_status_t status, pmix_info_t *info, size_t 
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *) cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         PMIX_RELEASE(cd);
         return;
     }
@@ -643,6 +683,7 @@ void pmix_server_cred_cbfunc(pmix_status_t status, pmix_byte_object_t *credentia
     pmix_query_caddy_t *qcd = (pmix_query_caddy_t *) cbdata;
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *) qcd->cbdata;
     pmix_status_t rc;
+    size_t n;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         PMIX_RELEASE(cd);
@@ -660,9 +701,33 @@ void pmix_server_cred_cbfunc(pmix_status_t status, pmix_byte_object_t *credentia
         return;
     }
     scd->status = status;
-    scd->info = info;
-    scd->ninfo = ninfo;
-    // need to copy this as they may not hold it for us
+    /* this signature carries no release function, so nothing here is
+     * ours past the return - both the credential and the info array
+     * have to be copied before we hand them to another thread */
+    if (NULL != info && 0 < ninfo) {
+        PMIX_INFO_CREATE(scd->info, ninfo);
+        if (NULL == scd->info) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            PMIX_RELEASE(cd);
+            PMIX_RELEASE(qcd);
+            PMIX_RELEASE(scd);
+            return;
+        }
+        scd->ninfo = ninfo;
+        /* the caddy owns the copy - flagging it here covers the early
+         * returns that never reach _cred_cbfunc's cleanup */
+        scd->infocopy = true;
+        for (n=0; n < scd->ninfo; n++) {
+            rc = PMIx_Info_xfer(&scd->info[n], &info[n]);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(cd);
+                PMIX_RELEASE(qcd);
+                PMIX_RELEASE(scd);
+                return;
+            }
+        }
+    }
     PMIX_BFROPS_COPY(rc, cd->peer, (void**)&scd->bo, credential, PMIX_BYTE_OBJECT);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
@@ -729,9 +794,6 @@ cleanup:
     if (NULL != qcd->info) {
         PMIX_INFO_FREE(qcd->info, qcd->ninfo);
     }
-    if (NULL != scd->info) {
-        PMIX_INFO_FREE(scd->info, scd->ninfo);
-    }
     PMIX_RELEASE(qcd);
     PMIX_RELEASE(cd);
     PMIX_RELEASE(scd);
@@ -763,14 +825,25 @@ void pmix_server_validate_cbfunc(pmix_status_t status, pmix_info_t info[], size_
     }
     scd->status = status;
     // need to copy the info as they may not hold it for us
-    if (NULL != info) {
+    if (NULL != info && 0 < ninfo) {
+        PMIX_INFO_CREATE(scd->info, ninfo);
+        if (NULL == scd->info) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            PMIX_RELEASE(cd);
+            PMIX_RELEASE(qcd);
+            PMIX_RELEASE(scd);
+            return;
+        }
         scd->ninfo = ninfo;
-        PMIX_INFO_CREATE(scd->info, scd->ninfo);
+        /* the caddy owns the copy - flagging it here covers the early
+         * returns that never reach _valcbfunc's cleanup */
+        scd->infocopy = true;
         for (n=0; n < scd->ninfo; n++) {
             rc = PMIx_Info_xfer(&scd->info[n], &info[n]);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
-                PMIX_INFO_FREE(scd->info, scd->ninfo);
+                PMIX_RELEASE(cd);
+                PMIX_RELEASE(qcd);
                 PMIX_RELEASE(scd);
                 return;
             }
@@ -790,6 +863,10 @@ static void _fabcbfunc(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != scd->cbfunc.relfn) {
+            scd->cbfunc.relfn(scd->relcbdata);
+        }
         PMIX_RELEASE(scd);
         PMIX_RELEASE(qcd);
         PMIX_RELEASE(cd);
@@ -853,6 +930,10 @@ void pmix_server_fabric_cbfunc(pmix_status_t status, pmix_info_t *info, size_t n
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *) qcd->cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         PMIX_RELEASE(cd);
         PMIX_RELEASE(qcd);
         return;
@@ -889,6 +970,10 @@ static void _distcbfunc(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != scd->cbfunc.relfn) {
+            scd->cbfunc.relfn(scd->relcbdata);
+        }
         PMIX_RELEASE(scd);
         PMIX_RELEASE(cd);
         return;
@@ -943,6 +1028,10 @@ void pmix_server_dist_cbfunc(pmix_status_t status, pmix_device_distance_t *dist,
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *)cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         PMIX_RELEASE(cd);
         return;
     }
@@ -983,6 +1072,10 @@ static void _respeerscbfunc(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cd);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != scd->cbfunc.relfn) {
+            scd->cbfunc.relfn(scd->relcbdata);
+        }
         PMIX_RELEASE(cd);
         PMIX_RELEASE(scd);
         return;
@@ -997,7 +1090,11 @@ static void _respeerscbfunc(int sd, short args, void *cbdata)
             goto done;
         }
         val = &scd->info[0].value;
+        /* this is a host-supplied structure, so check its shape before
+         * indexing it - the array pointer is as much the host's to get
+         * wrong as the type tag is */
         if (PMIX_DATA_ARRAY != val->type ||
+            NULL == val->data.darray ||
             PMIX_PROC != val->data.darray->type) {
             PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
             ret = PMIX_ERR_INVALID_VAL;
@@ -1005,6 +1102,9 @@ static void _respeerscbfunc(int sd, short args, void *cbdata)
         }
         pa = (pmix_proc_t*)val->data.darray->array;
         np = val->data.darray->size;
+        if (NULL == pa) {
+            np = 0;
+        }
     } else {
         /* attempt to locally resolve the request */
         PMIX_THREADSHIFT(cd, pmix_server_locally_resolve_peers);
@@ -1066,6 +1166,10 @@ void pmix_server_respeers_cbfunc(pmix_status_t status, pmix_info_t info[], size_
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *)cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         PMIX_RELEASE(cd);
         return;
     }
@@ -1105,6 +1209,10 @@ static void _resnodescbfunc(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cd);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != scd->cbfunc.relfn) {
+            scd->cbfunc.relfn(scd->relcbdata);
+        }
         PMIX_RELEASE(scd);
         PMIX_RELEASE(cd);
         return;
@@ -1181,6 +1289,10 @@ void pmix_server_resnodes_cbfunc(pmix_status_t status, pmix_info_t info[], size_
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *)cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is still the host's to reclaim, even here */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
         PMIX_RELEASE(cd);
         return;
     }

--- a/src/server/pmix_server_info_replies.c
+++ b/src/server/pmix_server_info_replies.c
@@ -25,7 +25,7 @@
  * the caller - so they are near-identical to each other by design: when
  * adding one, diff it against its neighbor here.
  *
-These are callbacks the host server invokes, so they can run in either
+ * These are callbacks the host server invokes, so they can run in either
  * the host's thread context or our own if the host answers immediately.
  * Anything touching a global entity is therefore pushed into an event
  * before it is used. The switchyard in pmix_server_switchyard.c is the
@@ -184,44 +184,44 @@ void pmix_server_alloc_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ni
 
 static void _qrycbfunc(int sd, short args, void *cbdata)
 {
-    pmix_shift_caddy_t *scdwrapper = (pmix_shift_caddy_t*)cbdata;
-    pmix_server_caddy_t *scd = (pmix_server_caddy_t*)scdwrapper->cbdata;
+    pmix_shift_caddy_t *scd = (pmix_shift_caddy_t*)cbdata;
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t*)scd->cbdata;
     pmix_buffer_t *reply;
     pmix_status_t rc;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         /* the host's data is still the host's to reclaim, even here */
-        if (NULL != scdwrapper->cbfunc.relfn) {
-            scdwrapper->cbfunc.relfn(scdwrapper->relcbdata);
+        if (NULL != scd->cbfunc.relfn) {
+            scd->cbfunc.relfn(scd->relcbdata);
         }
+        PMIX_RELEASE(cd);
         PMIX_RELEASE(scd);
-        PMIX_RELEASE(scdwrapper);
         return;
     }
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "pmix:query callback with status %s",
-                        PMIx_Error_string(scdwrapper->status));
+                        PMIx_Error_string(scd->status));
 
     reply = PMIX_NEW(pmix_buffer_t);
     if (NULL == reply) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         goto cleanup;
     }
-    PMIX_BFROPS_PACK(rc, scd->peer, reply, &scdwrapper->status, 1, PMIX_STATUS);
+    PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto complete;
     }
     /* pack the returned data */
-    PMIX_BFROPS_PACK(rc, scd->peer, reply, &scdwrapper->ninfo, 1, PMIX_SIZE);
+    PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->ninfo, 1, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto complete;
     }
-    if (0 < scdwrapper->ninfo) {
-        PMIX_BFROPS_PACK(rc, scd->peer, reply, scdwrapper->info, scdwrapper->ninfo, PMIX_INFO);
+    if (0 < scd->ninfo) {
+        PMIX_BFROPS_PACK(rc, cd->peer, reply, scd->info, scd->ninfo, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
         }
@@ -231,18 +231,18 @@ static void _qrycbfunc(int sd, short args, void *cbdata)
 
 complete:
     // send reply
-    PMIX_SERVER_QUEUE_REPLY(rc, scd->peer, scd->hdr.tag, reply);
+    PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(reply);
     }
 
 cleanup:
     // cleanup
-    if (NULL != scdwrapper->cbfunc.relfn) {
-        scdwrapper->cbfunc.relfn(scdwrapper->relcbdata);
+    if (NULL != scd->cbfunc.relfn) {
+        scd->cbfunc.relfn(scd->relcbdata);
     }
+    PMIX_RELEASE(cd);
     PMIX_RELEASE(scd);
-    PMIX_RELEASE(scdwrapper);
 }
 
 void pmix_server_query_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
@@ -618,7 +618,7 @@ static void _cred_cbfunc(int sd, short args, void *cbdata)
         return;
     }
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_server_globals.base_output,
                         "pmix:get credential callback with status %s",
                         PMIx_Error_string(scd->status));
 
@@ -756,7 +756,7 @@ static void _valcbfunc(int sd, short args, void *cbdata)
         return;
     }
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_server_globals.base_output,
                         "pmix:validate credential callback with status %s",
                         PMIx_Error_string(scd->status));
 
@@ -1069,7 +1069,7 @@ static void _respeerscbfunc(int sd, short args, void *cbdata)
     size_t np = 0;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    PMIX_ACQUIRE_OBJECT(cd);
+    PMIX_ACQUIRE_OBJECT(scd);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         /* the host's data is still the host's to reclaim, even here */
@@ -1206,7 +1206,7 @@ static void _resnodescbfunc(int sd, short args, void *cbdata)
     char *nodelist = NULL;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    PMIX_ACQUIRE_OBJECT(cd);
+    PMIX_ACQUIRE_OBJECT(scd);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         /* the host's data is still the host's to reclaim, even here */

--- a/src/server/pmix_server_iof.c
+++ b/src/server/pmix_server_iof.c
@@ -99,6 +99,18 @@ void pmix_server_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
         PMIX_ERROR_LOG(rc);
         return;
     }
+    /* this count came off the wire and is about to be multiplied by
+     * sizeof(pmix_info_t) to size an allocation whose element
+     * constructors then walk it, so a value large enough to wrap that
+     * product runs off the end of a short block before any NULL check
+     * gets a say. Require it to survive the round trip through the
+     * int32_t the unpack consumes it as - the screen the fence and
+     * event handlers use */
+    cnt = ninfo;
+    if (0 > cnt || (size_t) cnt != ninfo) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return;
+    }
     if (0 < ninfo) {
         PMIX_INFO_CREATE(info, ninfo);
         cnt = ninfo;
@@ -424,6 +436,13 @@ pmix_status_t pmix_server_process_iof(pmix_setup_caddy_t *cd,
     req->requestor = cd->peer;
     req->nprocs = 1;
     PMIX_PROC_CREATE(req->procs, req->nprocs);
+    if (NULL == req->procs) {
+        /* what follows is a load, not an unpack, so nothing downstream
+         * would screen a NULL here - the same reason pmix_server_iofreg
+         * checks its own proc allocation */
+        PMIX_RELEASE(req);
+        return PMIX_ERR_NOMEM;
+    }
     PMIX_LOAD_PROCID(&req->procs[0], nspace, PMIX_RANK_WILDCARD);
     req->channels = cd->channels;
     /* a shallow copy of the flags owns nothing: file and directory are
@@ -476,6 +495,15 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         goto exit;
     }
+    /* screen the count before it sizes an allocation - see the note in
+     * pmix_server_iof_handler. This one is copied again below, walking
+     * the size_t rather than the int32_t the unpack consumed */
+    cnt = cd->nprocs;
+    if (0 > cnt || (size_t) cnt != cd->nprocs) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
     /* unpack the procs */
     if (0 < cd->nprocs) {
         PMIX_PROC_CREATE(cd->procs, cd->nprocs);
@@ -494,9 +522,20 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         goto exit;
     }
+    cnt = cd->ninfo;
+    if (0 > cnt || (size_t) cnt != cd->ninfo) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
     /* unpack the directives */
     if (0 < cd->ninfo) {
         PMIX_INFO_CREATE(cd->info, cd->ninfo);
+        /* we unpacked this array, so the caddy owns it - without the flag
+         * the destructor leaves it behind on every path that does not
+         * reach _iofreg's explicit free, which includes every error
+         * return below and _iofreg's own finalize-race early-out */
+        cd->copied = true;
         cnt = cd->ninfo;
         PMIX_BFROPS_UNPACK(rc, peer, buf, cd->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
@@ -532,6 +571,14 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer, pmix_buffer_t *buf,
     req->nprocs = cd->nprocs;
     if (0 < req->nprocs) {
         PMIX_PROC_CREATE(req->procs, cd->nprocs);
+        if (NULL == req->procs) {
+            /* nothing screens this one: what follows is a memcpy, not an
+             * unpack, so a failed allocation is a NULL destination that
+             * nobody would catch */
+            PMIX_RELEASE(req);
+            rc = PMIX_ERR_NOMEM;
+            goto exit;
+        }
         memcpy(req->procs, cd->procs, req->nprocs * sizeof(pmix_proc_t));
     }
     req->channels = cd->channels;
@@ -561,6 +608,15 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer, pmix_buffer_t *buf,
          * leave the callback operating on freed memory. */
         return PMIX_SUCCESS;
     }
+
+    /* the host refused, so take the registration back out of the array.
+     * _iofreg does exactly this when the host fails the request
+     * asynchronously; the synchronous refusal left the entry behind,
+     * where it pinned the requestor's peer with its retain for the life
+     * of the server and went on matching output for a pull that was
+     * never granted */
+    pmix_pointer_array_set_item(&pmix_globals.iof_requests, req->local_id, NULL);
+    PMIX_RELEASE(req);
 
 exit:
     PMIX_RELEASE(cd);
@@ -597,10 +653,31 @@ pmix_status_t pmix_server_iofdereg(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         goto exit;
     }
+    /* screen the count before the "+ 1" below: a wire value near
+     * SIZE_MAX wraps that sum down to zero, PMIx_Info_create answers
+     * NULL for a zero-element array, and the stop directive would then
+     * be seeded at info[SIZE_MAX]. The same wrap can happen inside the
+     * allocator's "ninfo * sizeof(pmix_info_t)". This is the screen the
+     * group and collective handlers carry for the same shape */
+    cnt = ninfo;
+    if (0 > cnt || (size_t) cnt != ninfo) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
     /* unpack the directives - note that we have to add one
      * to tell the server to stop forwarding to this channel */
     cd->ninfo = ninfo + 1;
     PMIX_INFO_CREATE(cd->info, cd->ninfo);
+    if (NULL == cd->info) {
+        rc = PMIX_ERR_NOMEM;
+        goto exit;
+    }
+    /* we built this array, so the caddy owns it. Nothing else frees it:
+     * unlike _iofreg, the deregistration completion has no explicit
+     * free, so without the flag every deregistration leaked its
+     * directives - and so did every error return below */
+    cd->copied = true;
     if (0 < ninfo) {
         cnt = ninfo;
         PMIX_BFROPS_UNPACK(rc, peer, buf, cd->info, &cnt, PMIX_INFO);
@@ -713,6 +790,14 @@ pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
         PMIX_ERROR_LOG(rc);
         goto error;
     }
+    /* screen the count before it sizes an allocation - see the note in
+     * pmix_server_iof_handler */
+    cnt = cd->nprocs;
+    if (0 > cnt || (size_t) cnt != cd->nprocs) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
     if (0 < cd->nprocs) {
         PMIX_PROC_CREATE(cd->procs, cd->nprocs);
         if (NULL == cd->procs) {
@@ -734,12 +819,22 @@ pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
         PMIX_ERROR_LOG(rc);
         goto error;
     }
+    cnt = cd->ninfo;
+    if (0 > cnt || (size_t) cnt != cd->ninfo) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
     if (0 < cd->ninfo) {
         PMIX_INFO_CREATE(cd->info, cd->ninfo);
         if (NULL == cd->info) {
             rc = PMIX_ERR_NOMEM;
             goto error;
         }
+        /* we unpacked this array, so the caddy owns it - without the
+         * flag the destructor leaves it behind on every error return
+         * below, which is the only thing that frees it there */
+        cd->copied = true;
         cnt = cd->ninfo;
         PMIX_BFROPS_UNPACK(rc, peer, buf, cd->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
@@ -754,6 +849,12 @@ pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
         rc = PMIX_ERR_NOMEM;
         goto error;
     }
+    /* the destructor frees the *bytes* only for the nbo objects it is
+     * told about, so leaving this at zero would free the container and
+     * leak the payload on every error return below. Note this is safe
+     * only because the object is ours: PMIx_server_IOF_deliver parks a
+     * borrowed one on this same member and detaches it instead */
+    cd->nbo = 1;
 
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, cd->bo, &cnt, PMIX_BYTE_OBJECT);

--- a/src/server/pmix_server_iof.c
+++ b/src/server/pmix_server_iof.c
@@ -282,7 +282,13 @@ pmix_status_t PMIx_server_IOF_deliver(const pmix_proc_t *source, pmix_iof_channe
             /* we are ON the progress thread, so waiting for the event we
              * would post is waiting for ourselves - answer rather than
              * hang. The caller wanted the blocking form; the non-blocking
-             * one works fine from here */
+             * one works fine from here. The caddy is only borrowing the
+             * caller's proc and byte object, and its destructor frees both
+             * unconditionally - detach them as _iofdeliver does before
+             * handing the caddy back */
+            cd->procs = NULL;
+            cd->nprocs = 0;
+            cd->bo = NULL;
             PMIX_RELEASE(cd);
             return PMIX_ERR_WOULD_BLOCK;
         }
@@ -372,7 +378,11 @@ pmix_status_t PMIx_server_IOF_flow_control(const pmix_proc_t *source,
             /* we are ON the progress thread, so waiting for the event we
              * would post is waiting for ourselves - answer rather than
              * hang. The caller wanted the blocking form; the non-blocking
-             * one works fine from here */
+             * one works fine from here. Detach the caller's proc first -
+             * the caddy is only borrowing it, but its destructor frees it
+             * unconditionally */
+            cd->procs = NULL;
+            cd->nprocs = 0;
             PMIX_RELEASE(cd);
             return PMIX_ERR_WOULD_BLOCK;
         }

--- a/src/server/pmix_server_iof.c
+++ b/src/server/pmix_server_iof.c
@@ -426,7 +426,13 @@ pmix_status_t pmix_server_process_iof(pmix_setup_caddy_t *cd,
     PMIX_PROC_CREATE(req->procs, req->nprocs);
     PMIX_LOAD_PROCID(&req->procs[0], nspace, PMIX_RANK_WILDCARD);
     req->channels = cd->channels;
+    /* a shallow copy of the flags owns nothing: file and directory are
+     * strdup'ed by the flag parser and freed with the caddy, which goes
+     * away long before this request does. The client and tool sides of
+     * the same copy say so explicitly - do the same here */
     req->flags = cd->flags;
+    req->flags.file = NULL;
+    req->flags.directory = NULL;
     req->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
     /* process any cached IO */
     PMIX_LIST_FOREACH_SAFE (iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {

--- a/src/server/pmix_server_iof.c
+++ b/src/server/pmix_server_iof.c
@@ -145,8 +145,9 @@ cleanup:
     PMIX_BYTE_OBJECT_DESTRUCT(&bo);
 }
 
-/* callback to receive job info */
-
+/* the progress-thread half of PMIx_server_IOF_deliver: write the output
+ * locally if we are meant to, hand it to every matching registration,
+ * and cache it if nobody has registered for it yet */
 static void _iofdeliver(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;

--- a/src/server/pmix_server_op_replies.c
+++ b/src/server/pmix_server_op_replies.c
@@ -24,7 +24,7 @@
  * and disconnect, spawn, lookup, event registration, and IOF register
  * and deregister.
  *
-These are callbacks the host server invokes, so they can run in either
+ * These are callbacks the host server invokes, so they can run in either
  * the host's thread context or our own if the host answers immediately.
  * Anything touching a global entity is therefore pushed into an event
  * before it is used. The switchyard in pmix_server_switchyard.c is the
@@ -297,6 +297,8 @@ static void _getcbfunc(int sd, short args, void *cbdata)
     pmix_buffer_t *reply, buf;
     pmix_status_t rc;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(scd);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         /* the host is still owed its release - see _mdxcbfunc */
@@ -631,7 +633,10 @@ void pmix_server_cnct_cbfunc(pmix_status_t status, void *cbdata)
     /* need to thread-shift this callback as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        /* nothing we can do - the tracker stays on the collectives list
+         * with its participants waiting, and touching it from here would
+         * be off the progress thread. Say so rather than failing mute */
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return;
     }
     scd->status = status;
@@ -720,7 +725,10 @@ void pmix_server_discnct_cbfunc(pmix_status_t status, void *cbdata)
     /* need to thread-shift this callback as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        /* nothing we can do - the tracker stays on the collectives list
+         * with its participants waiting, and touching it from here would
+         * be off the progress thread. Say so rather than failing mute */
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return;
     }
     scd->status = status;
@@ -942,6 +950,8 @@ static void _evcbfunc(int sd, short args, void *cbdata)
     pmix_status_t rc;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
+    PMIX_ACQUIRE_OBJECT(scd);
+
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         PMIX_RELEASE(cd);
         PMIX_RELEASE(scd);
@@ -1026,7 +1036,6 @@ static void _iofreg(int sd, short args, void *cbdata)
     reply = PMIX_NEW(pmix_buffer_t);
     if (NULL == reply) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        rc = PMIX_ERR_NOMEM;
         goto cleanup;
     }
     /* start with the status */
@@ -1137,7 +1146,9 @@ static void _iofdreg(int sd, short args, void *cbdata)
     pmix_status_t rc;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    PMIX_ACQUIRE_OBJECT(cd);
+    /* the shifter is the object that was posted, so it is the one to
+     * acquire - the setup caddy simply hangs off it */
+    PMIX_ACQUIRE_OBJECT(scdwrapper);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         PMIX_RELEASE(scd);
@@ -1150,7 +1161,6 @@ static void _iofdreg(int sd, short args, void *cbdata)
     reply = PMIX_NEW(pmix_buffer_t);
     if (NULL == reply) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        rc = PMIX_ERR_NOMEM;
         goto cleanup;
     }
     /* its just the status */

--- a/src/server/pmix_server_op_replies.c
+++ b/src/server/pmix_server_op_replies.c
@@ -76,6 +76,12 @@ static void _mdxcbfunc(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(scd);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host's data is owed a release even here: the flag goes up
+         * while PMIx_server_finalize is running, which is exactly when an
+         * in-flight host completion lands, and the host outlives us */
+        if (NULL != scd->cbfunc.relfn) {
+            scd->cbfunc.relfn(scd->relcbdata);
+        }
         PMIX_RELEASE(scd);
         return;
     }
@@ -129,6 +135,11 @@ static void _mdxcbfunc(int sd, short args, void *cbdata)
         if (!found) {
             // add it
             nptr = PMIX_NEW(pmix_nspace_caddy_t);
+            if (NULL == nptr) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                rc = PMIX_ERR_NOMEM;
+                goto finish_collective;
+            }
             PMIX_RETAIN(cd->peer->nptr);
             nptr->ns = cd->peer->nptr;
             pmix_list_append(&nslist, &nptr->super);
@@ -177,26 +188,38 @@ static void _mdxcbfunc(int sd, short args, void *cbdata)
     /* do NOT destruct the xfer buffer as that would release the payload! */
 
 finish_collective:
-    /* loop across all procs in the tracker, sending them the reply */
+    /* Loop across all procs in the tracker, sending them the reply.
+     *
+     * A failure serving one participant must not abandon the others.
+     * Nothing else in the tree will ever answer them - the timer was
+     * cancelled above and the tracker release below frees their caddies
+     * without a reply - so they would sit in PMIx_Fence forever. Skip to
+     * the next participant instead of leaving the loop.
+     *
+     * Note also that the status being packed is rc, the collective's
+     * status, and PMIX_GDS_MARK_MODEX_COMPLETE assigns whatever it is
+     * given: writing it into rc would report a failed fence as a success
+     * to every participant after the first. */
     PMIX_LIST_FOREACH_SAFE (cd, nxt, &tracker->local_cbs, pmix_server_caddy_t) {
         reply = PMIX_NEW(pmix_buffer_t);
         if (NULL == reply) {
-            break;
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            continue;
         }
         /* setup the reply, starting with the returned status */
         PMIX_BFROPS_PACK(ret, cd->peer, reply, &rc, 1, PMIX_STATUS);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             PMIX_RELEASE(reply);
-            goto cleanup;
+            continue;
         }
         /* let the gds have a chance to add any data it needs
          * for providing access to any collected data */
-        PMIX_GDS_MARK_MODEX_COMPLETE(rc, cd->peer, &nslist, reply);
-        if (PMIX_SUCCESS != rc) {
+        PMIX_GDS_MARK_MODEX_COMPLETE(ret, cd->peer, &nslist, reply);
+        if (PMIX_SUCCESS != ret) {
             PMIX_RELEASE(reply);
-            PMIX_ERROR_LOG(rc);
-            goto cleanup;
+            PMIX_ERROR_LOG(ret);
+            continue;
         }
         pmix_output_verbose(2, pmix_server_globals.base_output,
                             "server:modex_cbfunc reply being sent to %s:%u",
@@ -210,7 +233,6 @@ finish_collective:
         PMIX_RELEASE(cd);
     }
 
-cleanup:
     /* Protect data from being free'd because RM pass
      * the pointer that is set to the middle of some
      * buffer (the case with SLURM).
@@ -241,6 +263,10 @@ void pmix_server_modex_cbfunc(pmix_status_t status, const char *data, size_t nda
                         "server:modex_cbfunc called with %d bytes", (int) ndata);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* honor the release contract even here - see _mdxcbfunc */
+        if (NULL != relfn) {
+            relfn(relcbd);
+        }
         return;
     }
 
@@ -273,8 +299,14 @@ static void _getcbfunc(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the host is still owed its release - see _mdxcbfunc */
+        if (NULL != scd->cbfunc.relfn) {
+            scd->cbfunc.relfn(scd->relcbdata);
+        }
+        if (NULL != cd) {
+            PMIX_RELEASE(cd);
+        }
         PMIX_RELEASE(scd);
-        PMIX_RELEASE(cd);
         return;
     }
 
@@ -287,7 +319,7 @@ static void _getcbfunc(int sd, short args, void *cbdata)
     /* setup the reply, starting with the returned status */
     reply = PMIX_NEW(pmix_buffer_t);
     if (NULL == reply) {
-        rc = PMIX_ERR_NOMEM;
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         goto cleanup;
     }
     PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
@@ -296,19 +328,28 @@ static void _getcbfunc(int sd, short args, void *cbdata)
         PMIX_RELEASE(reply);
         goto cleanup;
     }
-    /* if there are data, pack the blob being returned */
+    /* If there are data, pack the blob being returned.
+     *
+     * PMIX_LOAD_BUFFER points the buffer straight at the host's payload -
+     * it neither copies it nor takes ownership of it, and it NULLs the
+     * source it was handed. So the buffer has to be disowned before it is
+     * destructed, on *every* path: the payload belongs to whoever gave us
+     * the release function, and that function is called below. The error
+     * arm destructed the buffer with the pointer still in it, so a failed
+     * copy freed the host's blob and the release function then freed it a
+     * second time. */
     if (NULL != scd->data) {
         PMIX_CONSTRUCT(&buf, pmix_buffer_t);
         PMIX_LOAD_BUFFER(cd->peer, &buf, scd->data, scd->ndata);
         PMIX_BFROPS_COPY_PAYLOAD(rc, cd->peer, reply, &buf);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_RELEASE(reply);
-            PMIX_DESTRUCT(&buf);
-            goto cleanup;
-        }
         buf.base_ptr = NULL;
         buf.bytes_used = 0;
         PMIX_DESTRUCT(&buf);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(reply);
+            goto cleanup;
+        }
     }
 
     /* send the data to the requestor */
@@ -343,17 +384,28 @@ void pmix_server_get_cbfunc(pmix_status_t status, const char *data, size_t ndata
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *) cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
-        PMIX_RELEASE(cd);
+        /* honor the release contract even here - see _mdxcbfunc */
+        if (NULL != relfn) {
+            relfn(relcbd);
+        }
+        if (NULL != cd) {
+            PMIX_RELEASE(cd);
+        }
         return;
     }
 
     /* need to thread-shift this callback as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do beyond honoring the release contract - with
-         * the host's own release data, not the caddy we were handed */
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        /* honor the release contract - with the host's own release data,
+         * not the caddy we were handed - and let go of that caddy, which
+         * nothing else will now release */
         if (NULL != relfn) {
             relfn(relcbd);
+        }
+        if (NULL != cd) {
+            PMIX_RELEASE(cd);
         }
         return;
     }
@@ -372,7 +424,7 @@ static void _cnct(int sd, short args, void *cbdata)
     pmix_server_trkr_t *tracker = scd->tracker;
     pmix_buffer_t *reply, pbkt;
     pmix_byte_object_t bo;
-    pmix_status_t rc;
+    pmix_status_t rc, ret;
     int i;
     pmix_server_caddy_t *cd;
     char **nspaces = NULL;
@@ -421,25 +473,32 @@ static void _cnct(int sd, short args, void *cbdata)
         }
     }
 
-    /* loop across all local procs in the tracker, sending them the reply */
+    /* Loop across all local procs in the tracker, sending them the reply.
+     *
+     * A failure serving one participant must not abandon the others:
+     * nothing else will ever answer them, and the tracker release below
+     * frees their caddies without a reply, so they would sit in
+     * PMIx_Connect forever. Failures that leave this participant's reply
+     * unsendable fall to the participant_error arm at the foot of the
+     * loop, which hands that one client the error and carries on. */
     PMIX_LIST_FOREACH (cd, &tracker->local_cbs, pmix_server_caddy_t) {
         /* setup the reply, starting with the returned status */
         reply = PMIX_NEW(pmix_buffer_t);
         if (NULL == reply) {
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-            rc = PMIX_ERR_NOMEM;
-            goto cleanup;
+            continue;
         }
         /* start with the status */
         PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(reply);
-            goto cleanup;
+            continue;
         }
-        if (PMIX_SUCCESS == scd->status) {
+        if (PMIX_SUCCESS == scd->status && NULL != nspaces) {
             /* loop across all participating nspaces and include their
-             * job-related info */
+             * job-related info. nspaces can be NULL only if every append
+             * above failed to allocate */
             for (i = 0; NULL != nspaces[i]; i++) {
                 /* if this is the local proc's own nspace, then
                  * ignore it - it already has this info */
@@ -467,7 +526,7 @@ static void _cnct(int sd, short args, void *cbdata)
                         PMIX_ERROR_LOG(rc);
                         PMIX_RELEASE(reply);
                         PMIX_DESTRUCT(&cb);
-                        goto error;
+                        goto participant_error;
                     }
                 }
                 PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
@@ -478,7 +537,7 @@ static void _cnct(int sd, short args, void *cbdata)
                     PMIX_RELEASE(reply);
                     PMIX_DESTRUCT(&pbkt);
                     PMIX_DESTRUCT(&cb);
-                    goto error;
+                    goto participant_error;
                 }
                 PMIX_LIST_FOREACH (kptr, &cb.kvs, pmix_kval_t) {
                     PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, kptr, 1, PMIX_KVAL);
@@ -487,7 +546,7 @@ static void _cnct(int sd, short args, void *cbdata)
                         PMIX_RELEASE(reply);
                         PMIX_DESTRUCT(&pbkt);
                         PMIX_DESTRUCT(&cb);
-                        goto error;
+                        goto participant_error;
                     }
                 }
                 PMIX_DESTRUCT(&cb);
@@ -498,7 +557,7 @@ static void _cnct(int sd, short args, void *cbdata)
                         PMIX_ERROR_LOG(rc);
                         PMIX_RELEASE(reply);
                         PMIX_DESTRUCT(&pbkt);
-                        goto error;
+                        goto participant_error;
                     }
                 } else {
                     PMIX_UNLOAD_BUFFER(&pbkt, bo.bytes, bo.size);
@@ -508,7 +567,7 @@ static void _cnct(int sd, short args, void *cbdata)
                         PMIX_ERROR_LOG(rc);
                         PMIX_RELEASE(reply);
                         PMIX_DESTRUCT(&pbkt);
-                        goto error;
+                        goto participant_error;
                     }
                 }
 
@@ -523,30 +582,30 @@ static void _cnct(int sd, short args, void *cbdata)
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(reply);
         }
-    }
-    goto cleanup;
+        continue;
 
-error:
-    reply = PMIX_NEW(pmix_buffer_t);
-    if (NULL == reply) {
-        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        rc = PMIX_ERR_NOMEM;
-        goto cleanup;
-    }
-    /* return an error status so they don't hang */
-    scd->status = rc;
-    PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(reply);
-        goto cleanup;
-    }
-    PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_RELEASE(reply);
+participant_error:
+        /* we could not assemble this participant's job-level info - give
+         * it the error status so it does not hang, and go on to the next
+         * one. Do not record the failure in scd->status: it belongs to
+         * this participant, and the ones behind it may yet be served. */
+        reply = PMIX_NEW(pmix_buffer_t);
+        if (NULL == reply) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            continue;
+        }
+        PMIX_BFROPS_PACK(ret, cd->peer, reply, &rc, 1, PMIX_STATUS);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_RELEASE(reply);
+            continue;
+        }
+        PMIX_SERVER_QUEUE_REPLY(ret, cd->peer, cd->hdr.tag, reply);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_RELEASE(reply);
+        }
     }
 
-cleanup:
     if (NULL != nspaces) {
         PMIx_Argv_free(nspaces);
     }
@@ -610,21 +669,22 @@ static void _discnct(int sd, short args, void *cbdata)
         pmix_event_del(&tracker->ev);
     }
 
-    /* loop across all local procs in the tracker, sending them the reply */
+    /* Loop across all local procs in the tracker, sending them the reply.
+     * A failure serving one participant must not abandon the others - see
+     * the matching note in _cnct. */
     PMIX_LIST_FOREACH (cd, &tracker->local_cbs, pmix_server_caddy_t) {
         /* setup the reply */
         reply = PMIX_NEW(pmix_buffer_t);
         if (NULL == reply) {
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-            rc = PMIX_ERR_NOMEM;
-            goto cleanup;
+            continue;
         }
         /* return the status */
         PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(reply);
-            goto cleanup;
+            continue;
         }
         pmix_output_verbose(2, pmix_server_globals.connect_output,
                             "server:cnct_cbfunc reply being sent to %s:%u",
@@ -635,7 +695,6 @@ static void _discnct(int sd, short args, void *cbdata)
         }
     }
 
-cleanup:
     /* cleanup the tracker -- the host RM is responsible for
      * telling us when to remove the nspace from our data */
     pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
@@ -724,8 +783,11 @@ static void _spcb(int sd, short args, void *cbdata)
                     goto cleanup;
                 }
             }
-            PMIX_DESTRUCT(&cb);
         }
+        /* the destruct belongs outside the success arm: a fetch that finds
+         * nothing is the ordinary case for a job we have not been told
+         * about yet, and cbcon constructs a lock unconditionally */
+        PMIX_DESTRUCT(&cb);
     }
 
     /* the function that created the server_caddy did a
@@ -754,11 +816,18 @@ void pmix_server_spawn_cbfunc(pmix_status_t status, char *nspace, void *cbdata)
 
     /* need to thread-shift this request */
     cd = PMIX_NEW(pmix_shift_caddy_t);
+    if (NULL == cd) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        /* we cannot answer the requestor, but we can at least let go of
+         * the peer this caddy is holding */
+        PMIX_RELEASE(scd);
+        return;
+    }
     cd->status = status;
     if (NULL != nspace) {
         cd->pname.nspace = strdup(nspace);
     }
-    cd->cd = (pmix_server_caddy_t *) cbdata;
+    cd->cd = scd;
 
     PMIX_THREADSHIFT(cd, _spcb);
 }
@@ -802,11 +871,6 @@ static void _lkupcbfunc(int sd, short args, void *cbdata)
             PMIX_RELEASE(reply);
             goto cleanup;
         }
-        /* the array was created with ndata, and npdata is never assigned
-         * anywhere - it is zero from the constructor, and PMIx_Pdata_free()
-         * does nothing at all for a count of zero, so this leaked the whole
-         * array and every value in it on every lookup that returned data */
-        PMIX_PDATA_FREE(scd->pdata, scd->ndata);
     }
 
     /* the function that created the server_caddy did a
@@ -818,7 +882,14 @@ static void _lkupcbfunc(int sd, short args, void *cbdata)
     }
 
 cleanup:
-    /* cleanup */
+    /* The array was created with ndata, and npdata is never assigned
+     * anywhere - it is zero from the constructor, and PMIx_Pdata_free()
+     * does nothing at all for a count of zero, so this leaked the whole
+     * array and every value in it on every lookup that returned data.
+     * scdes does not free pdata either, so the free belongs here rather
+     * than on the success arm alone: the finalize-race early-out and
+     * every pack failure above reach only this label. */
+    PMIX_PDATA_FREE(scd->pdata, scd->ndata);
     PMIX_RELEASE(cd);
     PMIX_RELEASE(scd);
 }
@@ -838,11 +909,18 @@ void pmix_server_lookup_cbfunc(pmix_status_t status, pmix_pdata_t pdata[], size_
 
     /* need to thread-shift this request */
     scd = PMIX_NEW(pmix_shift_caddy_t);
+    if (NULL == scd) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        /* we cannot answer the requestor, but we can at least let go of
+         * the peer this caddy is holding */
+        PMIX_RELEASE(cd);
+        return;
+    }
     scd->status = status;
-    if (NULL != pdata) {
+    if (NULL != pdata && 0 < ndata) {
         scd->ndata = ndata;
         PMIX_PDATA_CREATE(scd->pdata, scd->ndata);
-        for (n=0; n < scd->ndata; n++) {
+        for (n=0; NULL != scd->pdata && n < scd->ndata; n++) {
             memcpy(&scd->pdata[n].proc, &pdata[n].proc, sizeof(pmix_proc_t));
             memcpy(scd->pdata[n].key, pdata[n].key, sizeof(pmix_key_t));
             PMIX_BFROPS_VALUE_XFER(rc, cd->peer, &scd->pdata[n].value, &pdata[n].value);
@@ -881,7 +959,12 @@ static void _evcbfunc(int sd, short args, void *cbdata)
     }
     PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
+        /* the reply carries nothing but this status, so there is no
+         * point queueing an empty buffer - every sibling handler here
+         * abandons the reply when its status will not pack */
         PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(reply);
+        goto cleanup;
     }
     // send reply
     PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
@@ -910,7 +993,10 @@ void pmix_server_events_cbfunc(pmix_status_t status, void *cbdata)
     /* need to thread-shift this callback as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        /* we cannot answer the requestor, but we can at least let go of
+         * the peer this caddy is holding */
+        PMIX_RELEASE(cd);
         return;
     }
     scd->status = status;
@@ -1003,25 +1089,39 @@ cleanup:
         PMIX_PROC_FREE(cd->procs, cd->nprocs);
     }
     PMIX_INFO_FREE(cd->info, cd->ninfo);
-    /* we are done */
+    /* We are done - and the switchyard's caddy is ours to release. The
+     * handler returned PMIX_SUCCESS, so the switchyard did not touch it,
+     * and scaddes does not reach cbdata. Without this the caddy - and the
+     * retain it holds on the requesting peer - leaked on every IOF pull
+     * registration, pinning that peer for the life of the server. See
+     * _iofdreg, which does the same three releases. */
+    PMIX_RELEASE(scd);
     PMIX_RELEASE(cd);
 }
 
 void pmix_server_iofreg_cbfunc(pmix_status_t status, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
+    pmix_server_caddy_t *scd;
+
+    if (NULL == cd) {
+        /* nothing to do */
+        return;
+    }
+    scd = (pmix_server_caddy_t *) cd->cbdata;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* both caddies are ours here - the switchyard let go of the
+         * server caddy when the handler returned PMIX_SUCCESS, and
+         * _iofreg, the arm that would otherwise release it, will never
+         * run. Releasing only the setup caddy stranded the peer retain */
+        PMIX_RELEASE(scd);
         PMIX_RELEASE(cd);
         return;
     }
     pmix_output_verbose(2, pmix_server_globals.iof_output,
                         "server:iof_cbfunc called with status %d", status);
 
-    if (NULL == cd) {
-        /* nothing to do */
-        return;
-    }
     cd->status = status;
 
     /* need to thread-shift this callback as it accesses global data */
@@ -1095,8 +1195,11 @@ void pmix_server_iofdereg_cbfunc(pmix_status_t status, void *cbdata)
     /* need to thread-shift this callback */
     scdwrapper = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scdwrapper) {
-        /* nothing we can do */
+        /* we cannot answer the requestor, but we can at least let go of
+         * the caddies - and the peer retain one of them holds */
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        PMIX_RELEASE(scd);
+        PMIX_RELEASE(cd);
         return;
     }
     scdwrapper->status = status;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -121,6 +121,12 @@ static void abcbfn(pmix_status_t status, void *cbdata)
     if (NULL != cd->opcbfunc) {
         cd->opcbfunc(status, cd->cbdata);
     }
+    /* the abort message was unpacked into the caddy, and the caddy's
+     * destructor does not free that member - it is borrowed as often
+     * as it is owned */
+    if (NULL != cd->nspace) {
+        free(cd->nspace);
+    }
     PMIX_RELEASE(cd);
 }
 
@@ -146,7 +152,8 @@ pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_RELEASE(cd);
         return rc;
     }
-    /* unpack the message */
+    /* unpack the message - this allocates, and from here on every path
+     * that discards the caddy owes it a free */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->nspace, &cnt, PMIX_STRING);
     if (PMIX_SUCCESS != rc) {
@@ -157,8 +164,7 @@ pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->nprocs, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
-        PMIX_RELEASE(cd);
-        return rc;
+        goto error;
     }
 
     /* unpack any provided procs - these are the procs the caller
@@ -166,32 +172,37 @@ pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
     if (0 < cd->nprocs) {
         PMIX_PROC_CREATE(cd->procs, cd->nprocs);
         if (NULL == cd->procs) {
-            PMIX_RELEASE(cd);
-            return PMIX_ERR_NOMEM;
+            rc = PMIX_ERR_NOMEM;
+            goto error;
         }
         cnt = cd->nprocs;
         PMIX_BFROPS_UNPACK(rc, peer, buf, cd->procs, &cnt, PMIX_PROC);
         if (PMIX_SUCCESS != rc) {
-            PMIX_RELEASE(cd);
-            return rc;
+            goto error;
         }
     }
 
     /* let the local host's server execute it */
-    if (NULL != pmix_host_server.abort) {
-        pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
-        proc.rank = peer->info->pname.rank;
-        rc = pmix_host_server.abort(&proc, peer->info->server_object, cd->status,
-                                    cd->nspace, cd->procs, cd->nprocs,
-                                    abcbfn, cd);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_RELEASE(cd);
-        }
-    } else {
-        PMIX_RELEASE(cd);
+    if (NULL == pmix_host_server.abort) {
         rc = PMIX_ERR_NOT_SUPPORTED;
+        goto error;
+    }
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    proc.rank = peer->info->pname.rank;
+    rc = pmix_host_server.abort(&proc, peer->info->server_object, cd->status,
+                                cd->nspace, cd->procs, cd->nprocs,
+                                abcbfn, cd);
+    if (PMIX_SUCCESS != rc) {
+        goto error;
     }
 
+    return rc;
+
+error:
+    if (NULL != cd->nspace) {
+        free(cd->nspace);
+    }
+    PMIX_RELEASE(cd);
     return rc;
 }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -54,10 +54,6 @@
 #endif
 #include <event.h>
 
-#ifndef MAX
-#    define MAX(a, b) ((a) > (b) ? (a) : (b))
-#endif
-
 #include "src/class/pmix_hotel.h"
 #include "src/class/pmix_list.h"
 #include "src/common/pmix_attributes.h"

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -142,6 +142,9 @@ pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
                         "recvd ABORT");
 
     cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
 
@@ -256,6 +259,18 @@ pmix_status_t pmix_server_publish(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
+    /* screen the count before it sizes an allocation: PMIx_Info_create
+     * computes "n * sizeof(pmix_info_t)" with no overflow guard and then
+     * constructs every one of the n elements, so a count large enough to
+     * wrap that product yields a short allocation whose constructor loop
+     * runs straight off the end. This is the round-trip screen the
+     * collective and IOF handlers carry for the same reason. */
+    cnt = ninfo;
+    if (0 > cnt || (size_t) cnt != ninfo) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
     /* we will be adding one for the user id */
     cd = PMIX_NEW(pmix_setup_caddy_t);
     if (NULL == cd) {
@@ -269,9 +284,12 @@ pmix_status_t pmix_server_publish(pmix_peer_t *peer, pmix_buffer_t *buf,
         rc = PMIX_ERR_NOMEM;
         goto cleanup;
     }
-    /* unpack the array of info objects */
-    if (0 < cd->ninfo) {
-        cnt = cd->ninfo;
+    /* unpack the array of info objects - gate on the count that came off
+     * the wire, not on the array size, which carries our own extra slot.
+     * With no info objects there is nothing left in the buffer, so the
+     * unpack the old gate always ran failed the whole publish. */
+    if (0 < ninfo) {
+        cnt = ninfo;
         PMIX_BFROPS_UNPACK(rc, peer, buf, cd->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -364,13 +382,25 @@ pmix_status_t pmix_server_lookup(pmix_peer_t *peer, pmix_buffer_t *buf,
             PMIX_ERROR_LOG(rc);
             goto cleanup;
         }
-        PMIx_Argv_append_nosize(&cd->keys, sptr);
+        rc = PMIx_Argv_append_nosize(&cd->keys, sptr);
         free(sptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
     }
     /* unpack the number of info objects */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    /* screen the count before it sizes an allocation - see the note in
+     * pmix_server_publish */
+    cnt = ninfo;
+    if (0 > cnt || (size_t) cnt != ninfo) {
+        rc = PMIX_ERR_BAD_PARAM;
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
@@ -459,13 +489,25 @@ pmix_status_t pmix_server_unpublish(pmix_peer_t *peer, pmix_buffer_t *buf,
             PMIX_ERROR_LOG(rc);
             goto cleanup;
         }
-        PMIx_Argv_append_nosize(&cd->keys, sptr);
+        rc = PMIx_Argv_append_nosize(&cd->keys, sptr);
         free(sptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
     }
     /* unpack the number of info objects */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    /* screen the count before it sizes an allocation - see the note in
+     * pmix_server_publish */
+    cnt = ninfo;
+    if (0 > cnt || (size_t) cnt != ninfo) {
+        rc = PMIX_ERR_BAD_PARAM;
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
@@ -534,8 +576,17 @@ static void _spcbfunc(int sd, short args, void *cbdata)
 void pmix_server_spcbfunc(pmix_status_t status, char nspace[], void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
+    pmix_server_caddy_t *scd;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
+        /* the switchyard's caddy is parked on cbdata and scaddes does not
+         * reach it, so releasing only this caddy strands it and the
+         * retain it holds on the requesting peer. _spcbfunc, the arm that
+         * would otherwise hand it to the spawn completion, never runs. */
+        scd = (pmix_server_caddy_t *) cd->cbdata;
+        if (NULL != scd) {
+            PMIX_RELEASE(scd);
+        }
         PMIX_RELEASE(cd);
         return;
     }
@@ -657,6 +708,16 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_RELEASE(cd);
         return rc;
     }
+    /* screen the count before it sizes an allocation - see the note in
+     * pmix_server_publish. The parser below also walks this size_t rather
+     * than the int32_t the unpack consumed */
+    cnt = cd->ninfo;
+    if (0 > cnt || (size_t) cnt != cd->ninfo) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
     if (0 < cd->ninfo) {
         PMIX_INFO_CREATE(cd->info, cd->ninfo);
         if (NULL == cd->info) {
@@ -681,6 +742,15 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer, pmix_buffer_t *buf,
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->napps, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    /* the same screen: PMIx_App_create multiplies and constructs exactly
+     * as PMIx_Info_create does, and scaddes walks this size_t when it
+     * frees the array */
+    cnt = cd->napps;
+    if (0 > cnt || (size_t) cnt != cd->napps) {
+        rc = PMIX_ERR_BAD_PARAM;
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -69,11 +69,6 @@ typedef struct {
     bool xoff;      // IOF flow control: suspend (true) or resume (false)
     pmix_byte_object_t *bo;
     size_t nbo;
-    /* timestamp receipt of the notification so we
-     * can evict the oldest one if we get overwhelmed */
-    time_t ts;
-    /* what room of the hotel they are in */
-    int room;
     pmix_op_cbfunc_t opcbfunc;
     pmix_dmodex_response_fn_t cbfunc;
     pmix_setup_application_cbfunc_t setupcbfunc;
@@ -82,27 +77,6 @@ typedef struct {
     void *cbdata;
 } pmix_setup_caddy_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_setup_caddy_t);
-
-/* define a callback function returning inventory */
-typedef void (*pmix_inventory_cbfunc_t)(pmix_status_t status, pmix_list_t *inventory, void *cbdata);
-
-/* define an object for rolling up the inventory*/
-typedef struct {
-    pmix_object_t super;
-    pmix_lock_t lock;
-    pmix_event_t ev;
-    pmix_status_t status;
-    int requests;
-    int replies;
-    pmix_list_t payload; // list of pmix_kval_t containing the replies
-    pmix_info_t *info;
-    size_t ninfo;
-    pmix_inventory_cbfunc_t cbfunc;
-    pmix_info_cbfunc_t infocbfunc;
-    pmix_op_cbfunc_t opcbfunc;
-    void *cbdata;
-} pmix_inventory_rollup_t;
-PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_inventory_rollup_t);
 
 typedef struct {
     pmix_list_item_t super;
@@ -152,14 +126,6 @@ typedef struct {
     bool active;
 } pmix_regevents_info_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_regevents_info_t);
-
-typedef struct {
-    pmix_list_item_t super;
-    pmix_group_t *grp;
-    pmix_rank_t rank;
-    size_t idx;
-} pmix_group_caddy_t;
-PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_group_caddy_t);
 
 typedef struct {
     pmix_list_item_t super;

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -231,6 +231,19 @@ PMIX_EXPORT pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank
 PMIX_EXPORT void pmix_server_fail_local_reqs(pmix_dmdx_local_t *lcd,
                                              pmix_status_t status);
 
+/* The mirror of the above for the other deferral list. remote_pnd holds
+ * the host's own PMIx_server_dmodex_request calls, parked until the
+ * local client they name commits its data - and committing is the only
+ * thing that ever takes one off the list again. When that client departs
+ * instead, answer the host with a status: it is holding a request on
+ * behalf of a remote server whose client is blocked in PMIx_Get, and
+ * nothing else will ever tell it otherwise. Matches on either the
+ * departing peer or a proc (whose rank may be PMIX_RANK_WILDCARD for a
+ * whole namespace), exactly as pmix_server_purge_events does. */
+PMIX_EXPORT void pmix_server_fail_remote_pnd(pmix_peer_t *peer,
+                                             pmix_proc_t *proc,
+                                             pmix_status_t status);
+
 PMIX_EXPORT pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -49,6 +49,10 @@ typedef struct {
     pmix_status_t status;
     pmix_status_t *codes;
     size_t ncodes;
+    /* number of leading entries of "codes" that this request marked as
+     * newly active - the only ones an event registration may give back
+     * if its host up-call is subsequently refused */
+    size_t nactive;
     pmix_proc_t proc;
     pmix_proc_t *procs;
     size_t nprocs;

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -220,8 +220,6 @@ typedef struct {
         pmix_event_active(&((c)->ev), EV_WRITE, 1);                                 \
     } while (0)
 
-PMIX_EXPORT bool pmix_server_trk_update(pmix_server_trkr_t *trk);
-
 PMIX_EXPORT void pmix_pending_nspace_requests(pmix_namespace_t *nptr);
 PMIX_EXPORT pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank,
                                                pmix_status_t status, pmix_scope_t scope,

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -442,6 +442,18 @@ PMIX_EXPORT pmix_status_t pmix_server_process_grpinfo(size_t ctxid,
                                                       pmix_info_t *pinfo,
                                                       size_t npinfo);
 
+/* An info that is supposed to carry an array of some element type carries
+ * whatever the sender actually put there. Everything screened with this
+ * arrives either off the wire from a local client or down from the host,
+ * so reading the union on the strength of the key alone means
+ * dereferencing a pointer the sender chose - or walking past the end of a
+ * correctly-tagged array of some other type. Confirm the value is a data
+ * array, of the element type we are about to cast it to, and long enough
+ * to index. */
+PMIX_EXPORT bool pmix_server_valid_darray(const pmix_info_t *info,
+                                          pmix_data_type_t type,
+                                          size_t minsz);
+
 /* The host-server completion callbacks the switchyard hands to its
  * up-calls. Each one may run in the host's thread context, so each does
  * nothing but thread-shift onto the progress thread, landing in a static

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -207,9 +207,17 @@ typedef struct {
         (c)->peer = (p);                     \
     } while (0)
 
+/* The caddy carries the tracker across an async hop onto the progress
+ * thread, so it takes a reference for the duration - anything else that
+ * runs in between (a departing participant completing the collective, for
+ * one) would otherwise release the tracker out from under the handler.
+ * The caddy's destructor gives the reference back. Note the reference
+ * keeps the object alive; it does NOT keep it on the collectives list, so
+ * a handler must still check that it is there before acting on it. */
 #define PMIX_SETUP_COLLECTIVE(c, t)        \
     do {                                   \
         (c) = PMIX_NEW(pmix_trkr_caddy_t); \
+        PMIX_RETAIN((t));                  \
         (c)->trk = (t);                    \
     } while (0)
 
@@ -524,6 +532,8 @@ PMIX_EXPORT bool pmix_server_trk_complete(pmix_server_trkr_t *trk);
 
 PMIX_EXPORT void pmix_server_set_collective_status(pmix_info_t *info, size_t ninfo,
                                                    pmix_status_t status);
+
+PMIX_EXPORT pmix_status_t pmix_server_get_collective_status(pmix_info_t *info, size_t ninfo);
 
 PMIX_EXPORT void pmix_server_grp_peer_lost(pmix_peer_t *peer);
 

--- a/src/server/pmix_server_pset.c
+++ b/src/server/pmix_server_pset.c
@@ -68,17 +68,58 @@ static void psetdef(int sd, short args, void *cbdata)
     pmix_data_array_t *darray;
     pmix_proc_t *ptr;
     pmix_pset_t *ps;
-    pmix_status_t rc;
+    pmix_status_t rc = PMIX_SUCCESS;
 
     PMIX_ACQUIRE_OBJECT(cd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
+    /* Record the process set before announcing it. Defining it is what
+     * the caller asked for; the event is how local registrants find out.
+     * Announcing first meant an allocation failure here left us having
+     * advertised a set that does not exist. The order is not otherwise
+     * observable: PMIx_Notify_event with a callback thread-shifts, and
+     * we are already on the progress thread, so no handler can run until
+     * this one returns. */
+    ps = PMIX_NEW(pmix_pset_t);
+    if (NULL == ps) {
+        rc = PMIX_ERR_NOMEM;
+        goto done;
+    }
+    ps->name = strdup(cd->nspace);
+    ps->members = (pmix_proc_t *) malloc(cd->nprocs * sizeof(pmix_proc_t));
+    if (NULL == ps->name || NULL == ps->members) {
+        PMIX_RELEASE(ps);
+        rc = PMIX_ERR_NOMEM;
+        goto done;
+    }
+    memcpy(ps->members, cd->procs, cd->nprocs * sizeof(pmix_proc_t));
+    ps->nmembers = cd->nprocs;
+    pmix_list_append(&pmix_server_globals.psets, &ps->super);
+
+    /* now tell any local registrants about it */
     mydat = (mydata_t *) malloc(sizeof(mydata_t));
+    if (NULL == mydat) {
+        goto done;
+    }
     mydat->ninfo = 3;
     PMIX_INFO_CREATE(mydat->info, mydat->ninfo);
+    /* PMIx_Data_array_create answers NULL for a zero-element array as
+     * well as for a failed allocation, so this has to be checked before
+     * its "array" member is read - the caller's member count is screened
+     * up front for the same reason */
+    PMIX_DATA_ARRAY_CREATE(darray, cd->nprocs, PMIX_PROC);
+    if (NULL == mydat->info || NULL == darray) {
+        if (NULL != mydat->info) {
+            PMIX_INFO_FREE(mydat->info, mydat->ninfo);
+        }
+        if (NULL != darray) {
+            PMIX_DATA_ARRAY_FREE(darray);
+        }
+        free(mydat);
+        goto done;
+    }
     PMIX_INFO_LOAD(&mydat->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
     PMIX_INFO_LOAD(&mydat->info[1], PMIX_PSET_NAME, cd->nspace, PMIX_STRING);
-    PMIX_DATA_ARRAY_CREATE(darray, cd->nprocs, PMIX_PROC);
     PMIX_LOAD_KEY(mydat->info[2].key, PMIX_PSET_MEMBERS);
     mydat->info[2].value.type = PMIX_DATA_ARRAY;
     mydat->info[2].value.data.darray = darray;
@@ -86,31 +127,43 @@ static void psetdef(int sd, short args, void *cbdata)
     memcpy(ptr, cd->procs, cd->nprocs * sizeof(pmix_proc_t));
 
     /* a notification that is refused will never reach release_info, so
-     * hand the payload back ourselves in that case */
-    rc = PMIx_Notify_event(PMIX_PROCESS_SET_DEFINE, &pmix_globals.myid, PMIX_RANGE_LOCAL,
-                           mydat->info, mydat->ninfo, release_info, (void *) mydat);
-    if (PMIX_SUCCESS != rc) {
+     * hand the payload back ourselves in that case. It does not fail the
+     * call: the process set is defined either way, and reporting an
+     * undeliverable courtesy event as a failed definition would be a lie
+     * the caller cannot act on */
+    if (PMIX_SUCCESS != (rc = PMIx_Notify_event(PMIX_PROCESS_SET_DEFINE, &pmix_globals.myid,
+                                                PMIX_RANGE_LOCAL, mydat->info, mydat->ninfo,
+                                                release_info, (void *) mydat))) {
+        PMIX_ERROR_LOG(rc);
         release_info(rc, mydat);
     }
+    rc = PMIX_SUCCESS;
 
-    /* now record the process set */
-    ps = PMIX_NEW(pmix_pset_t);
-    ps->name = strdup(cd->nspace);
-    ps->members = (pmix_proc_t *) malloc(cd->nprocs * sizeof(pmix_proc_t));
-    memcpy(ps->members, cd->procs, cd->nprocs * sizeof(pmix_proc_t));
-    ps->nmembers = cd->nprocs;
-    pmix_list_append(&pmix_server_globals.psets, &ps->super);
-
-    PMIX_WAKEUP_THREAD(&cd->lock);
+done:
+    /* report through the waker the public entry point substituted, so
+     * the caller hears about a definition that did not happen */
+    cd->opcbfunc(rc, cd->cbdata);
 }
 
 pmix_status_t PMIx_server_define_process_set(const pmix_proc_t *members, size_t nmembers,
                                              const char *pset_name)
 {
     pmix_setup_caddy_t cd;
+    pmix_status_t rc;
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
+    }
+
+    /* This is a public entry point, so the host can hand us anything.
+     * Every one of these was a segfault on the progress thread: a NULL
+     * name reaches strdup and PMIX_INFO_LOAD, a NULL member array
+     * reaches memcpy, and a zero member count makes
+     * PMIx_Data_array_create answer NULL, which is then dereferenced for
+     * its "array" member. A process set with no members is not a thing
+     * we can describe in the event either. */
+    if (NULL == pset_name || NULL == members || 0 == nmembers) {
+        return PMIX_ERR_BAD_PARAM;
     }
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
@@ -134,11 +187,15 @@ pmix_status_t PMIx_server_define_process_set(const pmix_proc_t *members, size_t 
     cd.cbdata = &cd.lock;
     PMIX_THREADSHIFT(&cd, psetdef);
     PMIX_WAIT_THREAD(&cd.lock);
+    /* read the status back before the lock goes away - this used to
+     * return PMIX_SUCCESS unconditionally, so a definition that failed
+     * looked to the host exactly like one that worked */
+    rc = cd.lock.status;
     /* protect the input */
     cd.procs = NULL;
     cd.nprocs = 0;
     PMIX_DESTRUCT(&cd);
-    return PMIX_SUCCESS;
+    return rc;
 }
 
 static void psetdel(int sd, short args, void *cbdata)
@@ -147,25 +204,12 @@ static void psetdel(int sd, short args, void *cbdata)
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
     mydata_t *mydat;
     pmix_pset_t *ps;
-    pmix_status_t rc;
+    pmix_status_t rc = PMIX_SUCCESS;
 
     PMIX_ACQUIRE_OBJECT(cd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    mydat = (mydata_t *) malloc(sizeof(mydata_t));
-    mydat->ninfo = 2;
-    PMIX_INFO_CREATE(mydat->info, mydat->ninfo);
-    PMIX_INFO_LOAD(&mydat->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-    PMIX_INFO_LOAD(&mydat->info[1], PMIX_PSET_NAME, cd->nspace, PMIX_STRING);
-
-    /* see the matching note in psetdef */
-    rc = PMIx_Notify_event(PMIX_PROCESS_SET_DELETE, &pmix_globals.myid, PMIX_RANGE_LOCAL,
-                           mydat->info, mydat->ninfo, release_info, (void *) mydat);
-    if (PMIX_SUCCESS != rc) {
-        release_info(rc, mydat);
-    }
-
-    /* now find this process set */
+    /* drop the process set first, for the reason given in psetdef */
     PMIX_LIST_FOREACH (ps, &pmix_server_globals.psets, pmix_pset_t) {
         if (0 == strcmp(cd->nspace, ps->name)) {
             pmix_list_remove_item(&pmix_server_globals.psets, &ps->super);
@@ -173,15 +217,51 @@ static void psetdel(int sd, short args, void *cbdata)
             break;
         }
     }
-    PMIX_WAKEUP_THREAD(&cd->lock);
+    /* a name we do not hold is not an error: the host is telling us the
+     * set is gone, and it being gone already is the outcome it wanted */
+
+    /* now tell any local registrants about it */
+    mydat = (mydata_t *) malloc(sizeof(mydata_t));
+    if (NULL == mydat) {
+        rc = PMIX_ERR_NOMEM;
+        goto done;
+    }
+    mydat->ninfo = 2;
+    PMIX_INFO_CREATE(mydat->info, mydat->ninfo);
+    if (NULL == mydat->info) {
+        free(mydat);
+        rc = PMIX_ERR_NOMEM;
+        goto done;
+    }
+    PMIX_INFO_LOAD(&mydat->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&mydat->info[1], PMIX_PSET_NAME, cd->nspace, PMIX_STRING);
+
+    /* see the matching note in psetdef */
+    if (PMIX_SUCCESS != (rc = PMIx_Notify_event(PMIX_PROCESS_SET_DELETE, &pmix_globals.myid,
+                                                PMIX_RANGE_LOCAL, mydat->info, mydat->ninfo,
+                                                release_info, (void *) mydat))) {
+        PMIX_ERROR_LOG(rc);
+        release_info(rc, mydat);
+    }
+    rc = PMIX_SUCCESS;
+
+done:
+    cd->opcbfunc(rc, cd->cbdata);
 }
 
 pmix_status_t PMIx_server_delete_process_set(char *pset_name)
 {
     pmix_setup_caddy_t cd;
+    pmix_status_t rc;
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
+    }
+
+    /* a NULL name reaches strcmp and PMIX_INFO_LOAD on the progress
+     * thread - see the matching screen in the define entry point */
+    if (NULL == pset_name) {
+        return PMIX_ERR_BAD_PARAM;
     }
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
@@ -203,6 +283,9 @@ pmix_status_t PMIx_server_delete_process_set(char *pset_name)
     cd.cbdata = &cd.lock;
     PMIX_THREADSHIFT(&cd, psetdel);
     PMIX_WAIT_THREAD(&cd.lock);
+    /* read the status back before the lock goes away - see the matching
+     * note in the define entry point */
+    rc = cd.lock.status;
     PMIX_DESTRUCT(&cd);
-    return PMIX_SUCCESS;
+    return rc;
 }

--- a/src/server/pmix_server_registration.c
+++ b/src/server/pmix_server_registration.c
@@ -128,7 +128,7 @@ static void _register_nspace(int sd, short args, void *cbdata)
                     ninfo = cd->info[i].value.data.darray->size;
                     /* the first position is the rank */
                     PMIX_LOAD_PROCID(&proc, cd->proc.nspace, iptr[0].value.data.rank);
-                    /* get the peer object for this rank */
+                    /* the remaining entries are that rank's data */
                     for (m=1; m < ninfo; m++) {
                         PMIX_KVAL_NEW(kv, iptr[m].key);
                         if (PMIX_UNLIKELY(NULL == kv)) {
@@ -758,10 +758,6 @@ PMIX_EXPORT void PMIx_server_deregister_nspace(const pmix_nspace_t nspace, pmix_
     pmix_setup_caddy_t *cd;
     pmix_lock_t mylock;
 
-    pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "pmix:server deregister nspace %s",
-                        nspace);
-
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         if (NULL != cbfunc) {
             cbfunc(PMIX_ERR_INIT, cbdata);
@@ -779,6 +775,10 @@ PMIX_EXPORT void PMIx_server_deregister_nspace(const pmix_nspace_t nspace, pmix_
         }
         return;
     }
+
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "pmix:server deregister nspace %s",
+                        nspace);
 
     cd = PMIX_NEW(pmix_setup_caddy_t);
     if (NULL == cd) {

--- a/src/server/pmix_server_registration.c
+++ b/src/server/pmix_server_registration.c
@@ -407,6 +407,9 @@ void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc)
         }
     }
 
+    /* and in any the host asked us for on a remote server's behalf */
+    pmix_server_fail_remote_pnd(peer, proc, PMIX_ERR_LOST_CONNECTION);
+
     /* purge this client from any cached notifications */
     for (i = 0; i < pmix_globals.max_events; i++) {
         pmix_hotel_knock(&pmix_globals.notifications, i, (void **) &ncd);

--- a/src/server/pmix_server_registration.c
+++ b/src/server/pmix_server_registration.c
@@ -64,6 +64,9 @@ static void _register_nspace(int sd, short args, void *cbdata)
     pmix_gds_base_module_t *gds;
     pmix_kval_t *kv;
     pmix_proc_t proc;
+    pmix_nspace_caddy_t *nm;
+    size_t prev_nlocal;
+    bool counted;
 
     PMIX_ACQUIRE_OBJECT(cd);
 
@@ -88,6 +91,15 @@ static void _register_nspace(int sd, short args, void *cbdata)
             goto release;
         }
         nptr->nspace = strdup(cd->proc.nspace);
+        if (NULL == nptr->nspace) {
+            /* do not put a nameless namespace on the global list - every
+             * lookup in this directory strcmp's that member, so it would
+             * turn a transient allocation failure into a permanent
+             * segfault of the progress thread */
+            PMIX_RELEASE(nptr);
+            rc = PMIX_ERR_NOMEM;
+            goto release;
+        }
         pmix_list_append(&pmix_globals.nspaces, &nptr->super);
     }
     if (0 > cd->nlocalprocs) {
@@ -124,7 +136,14 @@ static void _register_nspace(int sd, short args, void *cbdata)
                             goto release;
                         }
                         PMIX_VALUE_XFER(rc, kv->value, &iptr[m].value);
-                        rc = gds->store(&proc, PMIX_REMOTE, kv);
+                        if (PMIX_SUCCESS == rc) {
+                            /* capture the store's own status - and do not
+                             * store at all if the transfer failed, or we
+                             * hand the datastore a value that was never
+                             * populated and then report the store's result
+                             * as though the transfer had succeeded */
+                            rc = gds->store(&proc, PMIX_REMOTE, kv);
+                        }
                         PMIX_RELEASE(kv); // maintain refcount
                         if (PMIX_SUCCESS != rc) {
                             goto release;
@@ -158,12 +177,23 @@ static void _register_nspace(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS != rc) {
                         goto release;
                     }
+                    /* record it, or the guard above never fires on this
+                     * path - only a prior full registration set the flag,
+                     * so a second update carrying job info cached the whole
+                     * array all over again */
+                    nptr->job_info_recvd = true;
                 }
             }
         }
         rc = PMIX_SUCCESS;
         goto release;
     }
+    /* remember whether this namespace's local-process count was already
+     * known, because that is exactly the question "has any live tracker
+     * already counted it?" - pmix_server_new_tracker counts a namespace
+     * only when the count is known, and every tracker in the list was
+     * created before this call */
+    prev_nlocal = nptr->nlocalprocs;
     nptr->nlocalprocs = cd->nlocalprocs;
 
     /* see if we already have everyone */
@@ -208,13 +238,21 @@ static void _register_nspace(int sd, short args, void *cbdata)
      * the host server could have spawned the local client and
      * it called back into the collective -before- our local event
      * would fire the register_client callback. Deal with that here. */
-    all_def = true;
     PMIX_LIST_FOREACH (trk, &pmix_server_globals.collectives, pmix_server_trkr_t) {
         /* if this tracker is already complete, then we
          * don't need to update it */
         if (trk->def_complete) {
             continue;
         }
+        /* "are all this tracker's namespaces registered" is a question
+         * about THIS tracker, so reset it here. Hoisted above the loop it
+         * carried over: one tracker naming a namespace we have not been
+         * told about left the flag false for every tracker after it in
+         * the list, so those were marked incomplete - and stayed that way
+         * until some later registration happened to re-walk them with a
+         * clean flag. Whether a collective completed therefore depended
+         * on its position in the collectives list. */
+        all_def = true;
         /* the fact that the tracker is here means that the tracker was
          * created in response to at least one collective call being received
          * from a participant. However, not all local participants may have
@@ -246,7 +284,40 @@ static void _register_nspace(int sd, short args, void *cbdata)
             /* if this request was for all participants from this nspace, then
              * we handle this case here */
             if (PMIX_RANK_WILDCARD == trk->pcs[i].rank) {
-                trk->nlocal = nptr->nlocalprocs;
+                /* Accumulate - do NOT assign. A hybrid collective names
+                 * several namespaces, and pmix_server_new_tracker already
+                 * added the local count of every one that was registered
+                 * when the tracker was created. Assigning here discarded
+                 * those, so a fence over two wildcard namespaces went up to
+                 * the host as soon as the last-registered one's local procs
+                 * had contributed - the rest then contributed to a tracker
+                 * that no longer existed and hung on a fresh one nobody
+                 * would ever complete.
+                 *
+                 * Guard against counting this namespace twice: only a
+                 * namespace whose count was previously unknown can have
+                 * been skipped by new_tracker. Record it on the tracker's
+                 * nspace list as new_tracker does for the ones it counts. */
+                if (SIZE_MAX == prev_nlocal) {
+                    counted = false;
+                    PMIX_LIST_FOREACH (nm, &trk->nslist, pmix_nspace_caddy_t) {
+                        if (0 == strcmp(nm->ns->nspace, nptr->nspace)) {
+                            counted = true;
+                            break;
+                        }
+                    }
+                    if (!counted) {
+                        nm = PMIX_NEW(pmix_nspace_caddy_t);
+                        if (NULL == nm) {
+                            rc = PMIX_ERR_NOMEM;
+                            goto release;
+                        }
+                        PMIX_RETAIN(nptr);
+                        nm->ns = nptr;
+                        pmix_list_append(&trk->nslist, &nm->super);
+                        trk->nlocal += nptr->nlocalprocs;
+                    }
+                }
                 /* the total number of procs in this nspace was provided
                  * in the data blob delivered to register_nspace, so check
                  * to see if all the procs are local */
@@ -297,6 +368,9 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const pmix_nspace_t nspace
     }
 
     cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
     pmix_strncpy(cd->proc.nspace, nspace, PMIX_MAX_NSLEN);
     cd->nlocalprocs = nlocalprocs;
     cd->opcbfunc = cbfunc;
@@ -434,6 +508,12 @@ void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc)
                     /* we have to remove this target, but leave the rest */
                     ntgs = ncd->ntargets - 1;
                     PMIX_PROC_CREATE(tgs, ntgs);
+                    if (NULL == tgs) {
+                        /* leave the notification's target list alone - it
+                         * names one departed proc, which is harmless,
+                         * where memcpy'ing into NULL is not */
+                        continue;
+                    }
                     p = 0;
                     for (m = 0; m < ncd->ntargets; m++) {
                         if (tgt != &ncd->targets[m]) {
@@ -746,163 +826,183 @@ PMIX_EXPORT void PMIx_server_deregister_nspace(const pmix_nspace_t nspace, pmix_
     PMIX_THREADSHIFT(cd, _deregister_nspace);
 }
 
+/* Cancel a tracker's local-phase timeout.
+ *
+ * This must happen before the tracker is handed to the host, and before
+ * the tracker is released on any path that tears it down here. The
+ * tracker destructor does NOT delete the event, so a release with the
+ * timer still armed leaves libevent holding a pointer into freed memory;
+ * and once the host has the tracker, our timeout and the host's
+ * completion race - a timeout that wins releases a tracker the host is
+ * about to hand back. pmix_server_fence and pmix_server_connect both do
+ * this at their own up-call sites and say why. */
+static void cancel_collective_timer(pmix_server_trkr_t *trk)
+{
+    if (trk->event_active) {
+        pmix_event_del(&trk->ev);
+        trk->event_active = false;
+    }
+}
+
+/* Is this tracker still awaiting execution? The caddy that carried it
+ * onto the progress thread holds a reference, so the object outlives
+ * being retired - but the reference does not put it back on the
+ * collectives list. Anything that completes a collective (a departing
+ * participant, a timeout) unlinks it, and a tracker that has already been
+ * completed must not be handed to the host: its participants have been
+ * answered and its caddies freed. Mirrors tracker_is_pending in
+ * pmix_server_get.c, which guards the same window for direct modex. */
+static bool collective_is_pending(pmix_server_trkr_t *trk)
+{
+    pmix_server_trkr_t *t;
+
+    PMIX_LIST_FOREACH (t, &pmix_server_globals.collectives, pmix_server_trkr_t) {
+        if (t == trk) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Fail a collective we cannot hand to the host.
+ *
+ * Every caddy on local_cbs belongs to a client blocked in the collective,
+ * and by the time we are called the tracker has been declared locally
+ * complete - so no further contribution is coming and nothing else in the
+ * tree will ever answer them. Returning without completing the tracker
+ * therefore hangs every participant and strands the tracker on the
+ * collectives list for the life of the server. Drive the completion
+ * function instead: it replies to each participant and then unlinks and
+ * releases the tracker. If no completion function was ever attached, tear
+ * it down here - unlinking first, since being on the collectives list is
+ * not a reference. */
+static void fail_collective(pmix_server_trkr_t *trk, pmix_status_t status)
+{
+    cancel_collective_timer(trk);
+    trk->host_called = false; // the host will not be calling us back
+    if (PMIX_FENCENB_CMD == trk->type && NULL != trk->modexcbfunc) {
+        trk->modexcbfunc(status, NULL, 0, trk, NULL, NULL);
+        return;
+    }
+    if (NULL != trk->op_cbfunc) {
+        trk->op_cbfunc(status, trk);
+        return;
+    }
+    pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+    PMIX_RELEASE(trk);
+}
+
 void pmix_server_execute_collective(int sd, short args, void *cbdata)
 {
     pmix_trkr_caddy_t *tcd = (pmix_trkr_caddy_t *) cbdata;
     pmix_server_trkr_t *trk = tcd->trk;
-    pmix_server_caddy_t *cd;
-    pmix_peer_t *peer;
     char *data = NULL;
     size_t sz = 0;
-    pmix_byte_object_t bo;
-    pmix_buffer_t bucket, pbkt;
-    pmix_kval_t *kv;
-    pmix_proc_t proc;
-    bool first;
+    pmix_buffer_t bucket;
     pmix_status_t rc;
-    pmix_list_t pnames;
-    pmix_namelist_t *pn;
-    bool found;
-    pmix_cb_t cb;
 
     PMIX_ACQUIRE_OBJECT(tcd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    /* we don't need to check for non-NULL APIs here as
-     * that was already done when the tracker was created */
+    if (!collective_is_pending(trk)) {
+        pmix_output_verbose(2, pmix_server_globals.base_output,
+                            "pmix:server execute_collective on a retired tracker - discarding");
+        PMIX_RELEASE(tcd);
+        return;
+    }
+
+    /* Screen the host entry point we are about to call. The comment that
+     * used to sit here claimed this had already been done when the
+     * tracker was created, but pmix_server_new_tracker makes no such
+     * check - each handler checks its own entry point only on the arm
+     * where the collective completed while it was still holding it, which
+     * is by definition not the arm that lands us here. */
     if (PMIX_FENCENB_CMD == trk->type) {
-        /* if the user asked us to collect data, then we have
-         * to provide any locally collected data to the host
-         * server so they can circulate it - only take data
-         * from the specified procs as not everyone is necessarily
-         * participating! And only take data intended for remote
-         * distribution as local data will be added when we send
-         * the result to our local clients */
-        if (trk->hybrid) {
-            /* if this is a hybrid, then we pack everything using
-             * the daemon-level bfrops module as each daemon is
-             * going to have to unpack it, and then repack it for
-             * each participant. */
-            peer = pmix_globals.mypeer;
-        } else {
-            /* in some error situations, the list of local callbacks can
-             * be empty - if that happens, we just need to call the fence
-             * function to prevent others from hanging */
-            if (0 == pmix_list_get_size(&trk->local_cbs)) {
-                pmix_host_server.fence_nb(trk->pcs, trk->npcs, trk->info, trk->ninfo, data, sz,
-                                          trk->modexcbfunc, trk);
-                PMIX_RELEASE(tcd);
-                return;
-            }
-            /* since all procs are the same, just use the first proc's module */
-            cd = (pmix_server_caddy_t *) pmix_list_get_first(&trk->local_cbs);
-            peer = cd->peer;
+        if (NULL == pmix_host_server.fence_nb) {
+            fail_collective(trk, PMIX_ERR_NOT_SUPPORTED);
+            PMIX_RELEASE(tcd);
+            return;
         }
+        /* Assemble the modex bucket with the shared builder, exactly as
+         * pmix_server_fence does. This was hand-rolled here, and the copy
+         * had drifted from the original in two ways that matter on the
+         * wire: it shipped the raw collect-type-plus-rank-blobs bucket
+         * with neither the compression flag nor the enclosing byte object
+         * that pmix_gds_base_store_modex unpacks, and it packed with the
+         * first participant's bfrops module instead of our own. So a fence
+         * that completed through this path - one that had to wait on a
+         * late register_nspace or register_client - handed the host a blob
+         * no receiving server could parse. Nothing here may build that
+         * payload a second way. */
         PMIX_CONSTRUCT(&bucket, pmix_buffer_t);
-
-        unsigned char tmp = (unsigned char) trk->collect_type;
-        PMIX_BFROPS_PACK(rc, peer, &bucket, &tmp, 1, PMIX_BYTE);
-
-        if (PMIX_COLLECT_YES == trk->collect_type) {
-            pmix_output_verbose(2, pmix_server_globals.base_output, "fence - assembling data");
-            first = true;
-            PMIX_CONSTRUCT(&pnames, pmix_list_t);
-            PMIX_LIST_FOREACH (cd, &trk->local_cbs, pmix_server_caddy_t) {
-                /* see if we have already gotten the contribution from
-                 * this proc */
-                found = false;
-                PMIX_LIST_FOREACH (pn, &pnames, pmix_namelist_t) {
-                    if (pn->pname == &cd->peer->info->pname) {
-                        /* got it */
-                        found = true;
-                        break;
-                    }
-                }
-                if (found) {
-                    continue;
-                } else {
-                    /* record it, or the list stays empty forever: the
-                     * duplicate check above then never matches, a clone
-                     * sharing a rank with its parent has its remote data
-                     * packed into the bucket twice, and every one of these
-                     * objects is leaked because the list destructor below
-                     * has nothing to free */
-                    pn = PMIX_NEW(pmix_namelist_t);
-                    pn->pname = &cd->peer->info->pname;
-                    pmix_list_append(&pnames, &pn->super);
-                }
-                if (trk->hybrid || first) {
-                    /* setup the nspace */
-                    pmix_strncpy(proc.nspace, cd->peer->info->pname.nspace, PMIX_MAX_NSLEN);
-                    first = false;
-                }
-                proc.rank = cd->peer->info->pname.rank;
-                /* get any remote contribution - note that there
-                 * may not be a contribution */
-                PMIX_CONSTRUCT(&cb, pmix_cb_t);
-                cb.proc = &proc;
-                cb.scope = PMIX_REMOTE;
-                cb.copy = true;
-                PMIX_GDS_FETCH_KV(rc, peer, &cb);
-                if (PMIX_SUCCESS == rc) {
-                    /* pack the returned kvals */
-                    PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-                    /* start with the proc id */
-                    PMIX_BFROPS_PACK(rc, peer, &pbkt, &proc, 1, PMIX_PROC);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_DESTRUCT(&cb);
-                        PMIX_DESTRUCT(&pbkt);
-                        PMIX_DESTRUCT(&bucket);
-                        PMIX_LIST_DESTRUCT(&pnames);
-                        PMIX_RELEASE(tcd);
-                        return;
-                    }
-                    PMIX_LIST_FOREACH (kv, &cb.kvs, pmix_kval_t) {
-                        PMIX_BFROPS_PACK(rc, peer, &pbkt, kv, 1, PMIX_KVAL);
-                        if (PMIX_SUCCESS != rc) {
-                            PMIX_ERROR_LOG(rc);
-                            PMIX_DESTRUCT(&cb);
-                            PMIX_DESTRUCT(&pbkt);
-                            PMIX_DESTRUCT(&bucket);
-                            PMIX_LIST_DESTRUCT(&pnames);
-                            PMIX_RELEASE(tcd);
-                            return;
-                        }
-                    }
-                    /* extract the resulting byte object */
-                    PMIX_UNLOAD_BUFFER(&pbkt, bo.bytes, bo.size);
-                    PMIX_DESTRUCT(&pbkt);
-                    /* now pack that into the bucket for return - the pack
-                     * copies, so the unloaded bytes are ours to free */
-                    PMIX_BFROPS_PACK(rc, peer, &bucket, &bo, 1, PMIX_BYTE_OBJECT);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_DESTRUCT(&cb);
-                        PMIX_BYTE_OBJECT_DESTRUCT(&bo);
-                        PMIX_DESTRUCT(&bucket);
-                        PMIX_LIST_DESTRUCT(&pnames);
-                        PMIX_RELEASE(tcd);
-                        return;
-                    }
-                    PMIX_BYTE_OBJECT_DESTRUCT(&bo);
-                }
-                PMIX_DESTRUCT(&cb);
-            }
-            PMIX_LIST_DESTRUCT(&pnames);
+        rc = pmix_server_collect_data(trk, &bucket);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DESTRUCT(&bucket);
+            /* every participant is parked on this tracker and nothing
+             * else will ever answer them */
+            fail_collective(trk, rc);
+            PMIX_RELEASE(tcd);
+            return;
         }
         PMIX_UNLOAD_BUFFER(&bucket, data, sz);
         PMIX_DESTRUCT(&bucket);
-        pmix_host_server.fence_nb(trk->pcs, trk->npcs, trk->info, trk->ninfo, data, sz,
-                                  trk->modexcbfunc, trk);
+        /* the blob transfers to the host on the call - the request
+         * direction carries no release function, and the reference host
+         * reads the pointer later from another thread */
+        cancel_collective_timer(trk);
+        trk->host_called = true;
+        rc = pmix_host_server.fence_nb(trk->pcs, trk->npcs, trk->info, trk->ninfo, data, sz,
+                                       trk->modexcbfunc, trk);
+        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+            fail_collective(trk, rc);
+        } else if (PMIX_OPERATION_SUCCEEDED == rc) {
+            /* the host completed atomically and will not call us back, so
+             * we owe every participant the reply ourselves */
+            trk->host_called = false;
+            rc = pmix_server_get_collective_status(trk->info, trk->ninfo);
+            trk->modexcbfunc(rc, NULL, 0, trk, NULL, NULL);
+        }
     } else if (PMIX_CONNECTNB_CMD == trk->type) {
-        pmix_host_server.connect(trk->pcs, trk->npcs, trk->info, trk->ninfo, trk->op_cbfunc, trk);
+        if (NULL == pmix_host_server.connect) {
+            fail_collective(trk, PMIX_ERR_NOT_SUPPORTED);
+            PMIX_RELEASE(tcd);
+            return;
+        }
+        cancel_collective_timer(trk);
+        trk->host_called = true;
+        rc = pmix_host_server.connect(trk->pcs, trk->npcs, trk->info, trk->ninfo, trk->op_cbfunc,
+                                      trk);
+        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+            fail_collective(trk, rc);
+        } else if (PMIX_OPERATION_SUCCEEDED == rc) {
+            trk->host_called = false;
+            rc = pmix_server_get_collective_status(trk->info, trk->ninfo);
+            trk->op_cbfunc(rc, trk);
+        }
     } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
-        pmix_host_server.disconnect(trk->pcs, trk->npcs, trk->info, trk->ninfo, trk->op_cbfunc,
-                                    trk);
+        if (NULL == pmix_host_server.disconnect) {
+            fail_collective(trk, PMIX_ERR_NOT_SUPPORTED);
+            PMIX_RELEASE(tcd);
+            return;
+        }
+        cancel_collective_timer(trk);
+        trk->host_called = true;
+        rc = pmix_host_server.disconnect(trk->pcs, trk->npcs, trk->info, trk->ninfo, trk->op_cbfunc,
+                                         trk);
+        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+            fail_collective(trk, rc);
+        } else if (PMIX_OPERATION_SUCCEEDED == rc) {
+            trk->host_called = false;
+            rc = pmix_server_get_collective_status(trk->info, trk->ninfo);
+            trk->op_cbfunc(rc, trk);
+        }
     } else {
-        /* unknown type */
+        /* unknown type - nobody is going to complete this one, so tear it
+         * down here: cancel the timer first, since the tracker destructor
+         * does not, then unlink before releasing */
         PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+        cancel_collective_timer(trk);
         pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
         PMIX_RELEASE(trk);
     }
@@ -947,17 +1047,40 @@ static void _register_client(int sd, short args, void *cbdata)
             goto cleanup;
         }
         nptr->nspace = strdup(cd->proc.nspace);
+        if (NULL == nptr->nspace) {
+            /* see the matching comment in _register_nspace */
+            PMIX_RELEASE(nptr);
+            rc = PMIX_ERR_NOMEM;
+            goto cleanup;
+        }
         pmix_list_append(&pmix_globals.nspaces, &nptr->super);
     }
-    /* setup a peer object for this client - since the host server
-     * only deals with the original processes and not any clones,
-     * we know this function will be called only once per rank */
+    /* Setup a peer object for this client - since the host server only
+     * deals with the original processes and not any clones, this should
+     * be called only once per rank. Say so rather than trusting it: the
+     * "have we got everyone" test below is an exact equality against the
+     * length of the ranks list, so a second entry for a rank pushes that
+     * list permanently past nlocalprocs, all_registered is never set, and
+     * every collective involving this namespace hangs with nothing
+     * anywhere reporting why. */
+    PMIX_LIST_FOREACH (info, &nptr->ranks, pmix_rank_info_t) {
+        if (info->pname.rank == cd->proc.rank) {
+            PMIX_ERROR_LOG(PMIX_ERR_DUPLICATE_KEY);
+            rc = PMIX_ERR_DUPLICATE_KEY;
+            goto cleanup;
+        }
+    }
     info = PMIX_NEW(pmix_rank_info_t);
     if (NULL == info) {
         rc = PMIX_ERR_NOMEM;
         goto cleanup;
     }
     info->pname.nspace = strdup(nptr->nspace);
+    if (NULL == info->pname.nspace) {
+        PMIX_RELEASE(info);
+        rc = PMIX_ERR_NOMEM;
+        goto cleanup;
+    }
     info->pname.rank = cd->proc.rank;
     info->uid = cd->uid;
     info->gid = cd->gid;
@@ -973,13 +1096,14 @@ static void _register_client(int sd, short args, void *cbdata)
          * the host server could have spawned the local client and
          * it called back into the collective -before- our local event
          * would fire the register_client callback. Deal with that here. */
-        all_def = true;
         PMIX_LIST_FOREACH (trk, &pmix_server_globals.collectives, pmix_server_trkr_t) {
             /* if this tracker is already complete, then we
              * don't need to update it */
             if (trk->def_complete) {
                 continue;
             }
+            /* per-tracker - see the matching comment in _register_nspace */
+            all_def = true;
             /* the fact that the tracker is here means that the tracker was
              * created in response to at least one collective call being received
              * from a participant. However, not all local participants may have

--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -165,7 +165,7 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
     char **p, **tmp = NULL, *prs;
     char *nspace, *nd;
     pmix_proc_t *pa = NULL;
-    size_t m, n, np = 0, ninfo = 3;
+    size_t m, n, np = 0, nalloc = 0, ninfo = 3;
     int npeers;
     pmix_namespace_t *ns;
     pmix_buffer_t *reply;
@@ -288,15 +288,24 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
                 goto done;
             }
             /* transfer the results */
+            nalloc = np;
             np = 0;
             for (n = 0; NULL != tmp[n]; n++) {
-                /* find the nspace delimiter */
-                prs = strchr(tmp[n], ':');
+                /* Find the nspace delimiter, searching from the right. A
+                 * namespace is an arbitrary string assigned by the host and
+                 * may itself contain a colon, while the peer list appended
+                 * above is a comma-delimited list of ranks and cannot. So
+                 * the last colon is the one we inserted; taking the first
+                 * would split a namespace such as "job:a,b" in the middle,
+                 * and this pass would then find more comma-separated fields
+                 * in it than the counting pass above did - writing past the
+                 * end of the array that count sized. */
+                prs = strrchr(tmp[n], ':');
                 if (NULL == prs) {
                     /* should never happen, but silence a Coverity warning */
                     ret = PMIX_ERR_BAD_PARAM;
                     PMIx_Argv_free(tmp);
-                    PMIX_PROC_FREE(pa, np);
+                    PMIX_PROC_FREE(pa, nalloc);
                     pa = NULL;
                     np = 0;
                     PMIX_DESTRUCT(&cb);
@@ -305,7 +314,9 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
                 *prs = '\0';
                 ++prs;
                 p = PMIx_Argv_split(prs, ',');
-                for (m = 0; NULL != p[m]; m++) {
+                /* never write more entries than were allocated, whatever
+                 * the two passes make of a malformed peer list */
+                for (m = 0; NULL != p[m] && np < nalloc; m++) {
                     PMIX_LOAD_NSPACE(pa[np].nspace, tmp[n]);
                     pa[np].rank = strtoul(p[m], NULL, 10);
                     ++np;
@@ -403,6 +414,7 @@ process:
         PMIX_DESTRUCT(&cb);
         goto done;
     }
+    nalloc = np;
     /* transfer the results */
     for (n = 0; n < np; n++) {
         PMIX_LOAD_NSPACE(pa[n].nspace, nspace);
@@ -420,6 +432,9 @@ done:
     reply = PMIX_NEW(pmix_buffer_t);
     if (NULL == reply) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        if (NULL != pa) {
+            PMIX_PROC_FREE(pa, nalloc);
+        }
         PMIX_RELEASE(cd);
         return;
     }
@@ -453,7 +468,9 @@ complete:
     PMIX_RELEASE(cd);
 
     if (NULL != pa) {
-        PMIX_PROC_FREE(pa, np);
+        /* free what was allocated, not what was packed - the two differ
+         * if a malformed peer list left the fill short */
+        PMIX_PROC_FREE(pa, nalloc);
     }
 }
 
@@ -594,7 +611,20 @@ void pmix_server_locally_resolve_node(int sd, short args, void *cbdata)
     PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
     if (PMIX_SUCCESS != rc) {
         PMIX_DESTRUCT(&cb);
-        ret = rc;
+        if (PMIX_ERR_NOT_FOUND == rc) {
+            /* the namespace is known to us, it simply has no nodes
+             * assigned to it at the moment. docs/how-things-work/resolve.rst
+             * is explicit that this is a successfully executed request
+             * answered with a NULL node list, not a failure, and
+             * PMIx_Resolve_nodes says exactly that when it resolves the
+             * request out of its own store. Passing the fetch status
+             * straight back made the same server answer the same question
+             * two different ways depending on which side computed it, and
+             * denied the caller the SUCCESS the contract promises. */
+            ret = PMIX_SUCCESS;
+        } else {
+            ret = rc;
+        }
         goto done;
     }
 

--- a/src/server/pmix_server_resolve.c
+++ b/src/server/pmix_server_resolve.c
@@ -52,29 +52,14 @@
 #endif
 #include <event.h>
 
-#ifndef MAX
-#    define MAX(a, b) ((a) > (b) ? (a) : (b))
-#endif
-
-#include "src/class/pmix_hotel.h"
 #include "src/class/pmix_list.h"
-#include "src/common/pmix_attributes.h"
-#include "src/common/pmix_iof.h"
-#include "src/hwloc/pmix_hwloc.h"
 #include "src/mca/bfrops/base/base.h"
 #include "src/mca/gds/base/base.h"
-#include "src/mca/plog/plog.h"
-#include "src/mca/pnet/pnet.h"
-#include "src/mca/psensor/psensor.h"
 #include "src/mca/ptl/base/base.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
-#include "src/util/pmix_name_fns.h"
-#include "src/util/pmix_output.h"
-#include "src/util/pmix_environ.h"
 #include "src/util/pmix_printf.h"
 
-#include "src/client/pmix_client_ops.h"
 #include "src/server/pmix_server_ops.h"
 
 pmix_status_t pmix_server_resolve_peers(pmix_server_caddy_t *cd,
@@ -158,7 +143,7 @@ void pmix_server_locally_resolve_peers(int sd, short args, void *cbdata)
 {
     pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
     pmix_cb_t cb;
-    pmix_status_t rc, ret=PMIX_SUCCESS;
+    pmix_status_t rc, ret = PMIX_SUCCESS;
     pmix_info_t info[3];
     pmix_proc_t proc;
     pmix_kval_t *kv;

--- a/src/server/pmix_server_setup.c
+++ b/src/server/pmix_server_setup.c
@@ -58,6 +58,14 @@ static void _register_resources(int sd, short args, void *cbdata)
     pmix_kval_t *kv=NULL, kp;
     size_t n, m, ctxid;
     pmix_status_t rc = PMIX_SUCCESS;
+    /* the status handed back to the host. It is kept separate from "rc"
+     * because "rc" is the transient status of whichever sub-operation ran
+     * last: a later success must not erase an earlier failure, and the
+     * job-info unpack loop below ends on
+     * PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER by design - reporting that
+     * as the result told the host every registration carrying job info
+     * had failed */
+    pmix_status_t ret = PMIX_SUCCESS;
     bool gotctxid = false;
     pmix_list_t grpinfo, endpts;
     pmix_info_caddy_t *ept=NULL, *g=NULL;
@@ -69,6 +77,8 @@ static void _register_resources(int sd, short args, void *cbdata)
     char *nspace;
     pmix_proc_t *proc;
     pmix_scope_t scope;
+
+    PMIX_ACQUIRE_OBJECT(cd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_CONSTRUCT(&grpinfo, pmix_list_t);
@@ -76,12 +86,40 @@ static void _register_resources(int sd, short args, void *cbdata)
     for (n = 0; n < cd->ninfo; n++) {
         if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GROUP_INFO_ARRAY) ||
             PMIX_CHECK_KEY(&cd->info[n], PMIX_GROUP_INFO)) {
+            /* both spellings are walked below as an array of pmix_info_t,
+             * and the key alone does not make the union an array - see
+             * pmix_server_valid_darray */
+            if (!pmix_server_valid_darray(&cd->info[n], PMIX_INFO, 1)) {
+                PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+                if (PMIX_SUCCESS == ret) {
+                    ret = PMIX_ERR_TYPE_MISMATCH;
+                }
+                continue;
+            }
             g = PMIX_NEW(pmix_info_caddy_t);
+            if (NULL == g) {
+                ret = PMIX_ERR_NOMEM;
+                goto release;
+            }
             g->info = &cd->info[n];
             pmix_list_append(&grpinfo, &g->super);
 
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GROUP_ENDPT_DATA)) {
+            /* the procID and the scope occupy the first two positions of
+             * the array, so anything shorter than that describes nothing
+             * and indexing it would read past the array the host gave us */
+            if (!pmix_server_valid_darray(&cd->info[n], PMIX_INFO, 2)) {
+                PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+                if (PMIX_SUCCESS == ret) {
+                    ret = PMIX_ERR_TYPE_MISMATCH;
+                }
+                continue;
+            }
             ept = PMIX_NEW(pmix_info_caddy_t);
+            if (NULL == ept) {
+                ret = PMIX_ERR_NOMEM;
+                goto release;
+            }
             ept->info = &cd->info[n];
             ept->ninfo = 1;
             pmix_list_append(&endpts, &ept->super);
@@ -90,21 +128,49 @@ static void _register_resources(int sd, short args, void *cbdata)
             rc = PMIx_Value_get_number(&cd->info[n].value, &ctxid, PMIX_SIZE);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
+                if (PMIX_SUCCESS == ret) {
+                    ret = rc;
+                }
             } else {
                 gotctxid = true;
             }
 
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GROUP_JOB_INFO)) {
+            if (PMIX_BYTE_OBJECT != cd->info[n].value.type) {
+                PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+                if (PMIX_SUCCESS == ret) {
+                    ret = PMIX_ERR_TYPE_MISMATCH;
+                }
+                continue;
+            }
             pbo = (pmix_byte_object_t*)&cd->info[n].value.data.bo;
 
         } else {
             /* add any provided data to our global cache for all nspaces */
             kv = PMIX_NEW(pmix_kval_t);
+            if (NULL == kv) {
+                ret = PMIX_ERR_NOMEM;
+                goto release;
+            }
             kv->key = strdup(cd->info[n].key);
             kv->value = (pmix_value_t *) malloc(sizeof(pmix_value_t));
+            if (NULL == kv->key || NULL == kv->value) {
+                /* the value is raw malloc'd memory until the transfer
+                 * below populates it, and the kval destructor would run
+                 * value_destruct over whatever the heap happened to hold
+                 * there - so it has to go back by hand */
+                if (NULL != kv->value) {
+                    free(kv->value);
+                    kv->value = NULL;
+                }
+                PMIX_RELEASE(kv);
+                ret = PMIX_ERR_NOMEM;
+                goto release;
+            }
             PMIX_VALUE_XFER(rc, kv->value, &cd->info[n].value);
             if (PMIX_SUCCESS != rc) {
                 PMIX_RELEASE(kv);
+                ret = rc;
                 break;
             }
             pmix_list_append(&pmix_server_globals.gdata, &kv->super);
@@ -117,22 +183,24 @@ static void _register_resources(int sd, short args, void *cbdata)
         /* Each list member points to a pmix_info_t that contains
          * a data array of info about that proc */
         PMIX_LIST_FOREACH(ept, &endpts, pmix_info_caddy_t) {
-            // contains an array of proc info
-            if (NULL == ept->info->value.data.darray ||
-                NULL == ept->info->value.data.darray->array ||
-                2 > ept->info->value.data.darray->size) {
-                /* the procID and the scope occupy the first two positions,
-                 * so anything shorter than that describes nothing and
-                 * indexing it would read past the array the host gave us */
-                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-                rc = PMIX_ERR_BAD_PARAM;
-                continue;
-            }
+            /* the array itself was screened when it was collected above,
+             * so it is known to hold at least the two leading elements */
             pinfo = (pmix_info_t*)ept->info->value.data.darray->array;
             npinfo = ept->info->value.data.darray->size;
-            // procID is in the first position
+            /* procID is in the first position and the scope in the second,
+             * but the position alone does not make the union a proc
+             * pointer - a mistyped first element would be dereferenced by
+             * the store below as whatever address the host had there */
+            if (PMIX_PROC != pinfo[0].value.type ||
+                NULL == pinfo[0].value.data.proc ||
+                PMIX_SCOPE != pinfo[1].value.type) {
+                PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+                if (PMIX_SUCCESS == ret) {
+                    ret = PMIX_ERR_TYPE_MISMATCH;
+                }
+                continue;
+            }
             proc = pinfo[0].value.data.proc;
-            // scope is in the second position
             scope = pinfo[1].value.data.scope;
             // rest of the array contains endpts
             for (m=2; m < npinfo; m++) {
@@ -147,6 +215,9 @@ static void _register_resources(int sd, short args, void *cbdata)
                 PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, proc, scope, &kp);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
+                    if (PMIX_SUCCESS == ret) {
+                        ret = rc;
+                    }
                     continue;
                 }
             }
@@ -158,12 +229,14 @@ static void _register_resources(int sd, short args, void *cbdata)
     if (0 < pmix_list_get_size(&grpinfo)) {
         // must have been given a context ID
         if (!gotctxid) {
-            rc = PMIX_ERR_BAD_PARAM;
+            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+            ret = PMIX_ERR_BAD_PARAM;
             goto release;
         }
         /* Each list member points to a pmix_info_t that contains
          * a data array of info from a given proc */
         PMIX_LIST_FOREACH(g, &grpinfo, pmix_info_caddy_t) {
+            /* screened when it was collected above */
             iptr = (pmix_info_t*)g->info->value.data.darray->array;
             ninfo = g->info->value.data.darray->size;
 
@@ -171,15 +244,25 @@ static void _register_resources(int sd, short args, void *cbdata)
                 // this is just a single array of group info
                 rc = pmix_server_process_grpinfo(ctxid, iptr, ninfo);
                 if (PMIX_SUCCESS != rc) {
+                    ret = rc;
                     goto release;
                 }
             } else {
                 // contains an array of group info arrays
                 for (n=0; n < ninfo; n++) {
+                    /* each element is itself an array of group info - the
+                     * enclosing array's element type says nothing about
+                     * what its members carry */
+                    if (!pmix_server_valid_darray(&iptr[n], PMIX_INFO, 1)) {
+                        PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+                        ret = PMIX_ERR_TYPE_MISMATCH;
+                        goto release;
+                    }
                     pinfo = (pmix_info_t*)iptr[n].value.data.darray->array;
                     npinfo = iptr[n].value.data.darray->size;
                     rc = pmix_server_process_grpinfo(ctxid, pinfo, npinfo);
                     if (PMIX_SUCCESS != rc) {
+                        ret = rc;
                         goto release;
                     }
                 }
@@ -189,9 +272,16 @@ static void _register_resources(int sd, short args, void *cbdata)
 
     // if job info was provided, process it
     if (NULL != pbo) {
-        /* load it for unpacking */
+        /* Load it for unpacking, but do NOT take it: the byte object sits
+         * in the caller's own info array, which the host owns and keeps
+         * valid until our callback fires. PMIX_LOAD_BUFFER does not copy -
+         * it points the buffer at the payload and NULLs the source - so
+         * using it here emptied the host's info element and then leaked
+         * the blob, since this buffer is never destructed (destructing it
+         * would free memory the host still owns). Borrow instead. */
         PMIX_CONSTRUCT(&jobinfo, pmix_buffer_t);
-        PMIX_LOAD_BUFFER(pmix_globals.mypeer, &jobinfo, pbo->bytes, pbo->size);
+        PMIX_LOAD_BUFFER_NON_DESTRUCT(pmix_globals.mypeer, &jobinfo,
+                                      pbo->bytes, pbo->size);
 
         cnt = 1;
         PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &jobinfo, &bo, &cnt, PMIX_BYTE_OBJECT);
@@ -205,6 +295,9 @@ static void _register_resources(int sd, short args, void *cbdata)
             PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &bkt, &nspace, &cnt, PMIX_STRING);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
+                if (PMIX_SUCCESS == ret) {
+                    ret = rc;
+                }
                 PMIX_DESTRUCT(&bkt);
                 continue;
             }
@@ -212,6 +305,9 @@ static void _register_resources(int sd, short args, void *cbdata)
             PMIX_GDS_STORE_JOB_INFO(rc, pmix_globals.mypeer, nspace, &bkt);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
+                if (PMIX_SUCCESS == ret) {
+                    ret = rc;
+                }
             }
             free(nspace);
             PMIX_DESTRUCT(&bkt);
@@ -222,8 +318,13 @@ static void _register_resources(int sd, short args, void *cbdata)
              * to its parent, so the two are not interchangeable here */
             PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &jobinfo, &bo, &cnt, PMIX_BYTE_OBJECT);
         }
+        /* running the buffer dry is how this loop ends when every blob was
+         * consumed, so it is not a failure to report */
         if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
             PMIX_ERROR_LOG(rc);
+            if (PMIX_SUCCESS == ret) {
+                ret = rc;
+            }
         }
     }
 
@@ -232,7 +333,7 @@ release:
      * being dropped on the floor - on the normal path as well as this one */
     PMIX_LIST_DESTRUCT(&grpinfo);
     PMIX_LIST_DESTRUCT(&endpts);
-    cd->opcbfunc(rc, cd->cbdata);
+    cd->opcbfunc(ret, cd->cbdata);
     PMIX_RELEASE(cd);
 }
 
@@ -254,7 +355,15 @@ pmix_status_t PMIx_server_register_resources(pmix_info_t info[], size_t ninfo,
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* the handler walks the array "ninfo" times */
+    if (0 < ninfo && NULL == info) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
     cd->info = info;
     cd->ninfo = ninfo;
     cd->opcbfunc = cbfunc;
@@ -293,18 +402,33 @@ pmix_status_t PMIx_server_register_resources(pmix_info_t info[], size_t ninfo,
 static void _deregister_resources(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
-    pmix_kval_t *kv;
+    pmix_kval_t *kv, *knext;
     size_t n;
 
+    PMIX_ACQUIRE_OBJECT(cd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    /* find any matches in our global cache and remove them */
+    /* Find any matches in our global cache and remove them - the man page
+     * says "each matching entry" is deleted. The cache can legitimately
+     * hold more than one entry for a key: _register_resources appends
+     * without checking, so a host that re-registers a key to update its
+     * value leaves both behind, and the gds walk of this list stores them
+     * in order, so the later one is the one in effect. Stopping at the
+     * first match therefore removed the entry that was being shadowed and
+     * left the one the datastore was actually using: the deregistration
+     * silently did nothing. Clear every match, using the SAFE variant since
+     * the matching item is released inside the walk.
+     *
+     * Note this matches on the key alone. The man page also describes
+     * narrowing a removal with qualifiers - e.g. a PMIX_NODE_INFO_ARRAY
+     * naming one node's fabric device - and that is not implemented here,
+     * so such a request removes every entry carrying that key rather than
+     * the one the qualifiers describe. */
     for (n = 0; n < cd->ninfo; n++) {
-        PMIX_LIST_FOREACH (kv, &pmix_server_globals.gdata, pmix_kval_t) {
+        PMIX_LIST_FOREACH_SAFE (kv, knext, &pmix_server_globals.gdata, pmix_kval_t) {
             if (PMIX_CHECK_KEY(kv, cd->info[n].key)) {
                 pmix_list_remove_item(&pmix_server_globals.gdata, &kv->super);
                 PMIX_RELEASE(kv);
-                break;
             }
         }
     }
@@ -331,7 +455,15 @@ pmix_status_t PMIx_server_deregister_resources(pmix_info_t info[], size_t ninfo,
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* the handler walks the array "ninfo" times */
+    if (0 < ninfo && NULL == info) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
     cd->info = info;
     cd->ninfo = ninfo;
     cd->opcbfunc = cbfunc;
@@ -426,7 +558,15 @@ static void _setup_app(int sd, short args, void *cbdata)
         n = 0;
         PMIX_LIST_FOREACH (kv, &ilist, pmix_kval_t) {
             pmix_strncpy(fcd->info[n].key, kv->key, PMIX_MAX_KEYLEN);
-            PMIx_Value_xfer(&fcd->info[n].value, kv->value);
+            rc = PMIx_Value_xfer(&fcd->info[n].value, kv->value);
+            if (PMIX_SUCCESS != rc) {
+                /* the array would go up to the host with a hole in it and
+                 * nothing to say which element was never filled in */
+                PMIX_ERROR_LOG(rc);
+                _setup_op(rc, fcd);
+                fcd = NULL;
+                goto depart;
+            }
             ++n;
         }
     }
@@ -573,10 +713,17 @@ pmix_status_t PMIx_server_setup_local_support(const pmix_nspace_t nspace, pmix_i
     return PMIX_SUCCESS;
 }
 
+/* The preg components take these arguments at face value - the raw one
+ * hands "input" straight to strncmp/strdup and writes through "regexp"
+ * without looking - so the public entry points screen them here, the same
+ * way the regex2 pair below always has. */
 PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regexp)
 {
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
+    }
+    if (NULL == input || NULL == regexp) {
+        return PMIX_ERR_BAD_PARAM;
     }
 
     return pmix_preg.generate_node_regex(input, regexp);
@@ -589,7 +736,7 @@ PMIX_EXPORT pmix_status_t PMIx_generate_regex2(const char *input,
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
-    if (NULL == regex) {
+    if (NULL == input || NULL == regex) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -616,6 +763,9 @@ PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **regexp)
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
     }
+    if (NULL == input || NULL == regexp) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     return pmix_preg.generate_ppn(input, regexp);
 }
@@ -626,6 +776,11 @@ pmix_status_t PMIx_server_generate_locality_string(const pmix_cpuset_t *cpuset, 
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
+    }
+    /* hwloc screens the cpuset, but reports a bad one by writing NULL
+     * through the output pointer - so that one has to be screened here */
+    if (NULL == locality) {
+        return PMIX_ERR_BAD_PARAM;
     }
 
     /* just pass this down */
@@ -639,6 +794,11 @@ pmix_status_t PMIx_server_generate_cpuset_string(const pmix_cpuset_t *cpuset, ch
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
+    }
+    /* same as above: a bad cpuset is reported by writing NULL through the
+     * output pointer, so hwloc cannot be the one to screen it */
+    if (NULL == cpuset_string) {
+        return PMIX_ERR_BAD_PARAM;
     }
 
     /* just pass this down */

--- a/src/server/pmix_server_setup.c
+++ b/src/server/pmix_server_setup.c
@@ -143,7 +143,7 @@ static void _register_resources(int sd, short args, void *cbdata)
                 }
                 continue;
             }
-            pbo = (pmix_byte_object_t*)&cd->info[n].value.data.bo;
+            pbo = &cd->info[n].value.data.bo;
 
         } else {
             /* add any provided data to our global cache for all nspaces */
@@ -294,12 +294,11 @@ static void _register_resources(int sd, short args, void *cbdata)
             cnt = 1;
             PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &bkt, &nspace, &cnt, PMIX_STRING);
             if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                if (PMIX_SUCCESS == ret) {
-                    ret = rc;
-                }
+                /* this ends the walk, so the check below the loop is what
+                 * logs it and records it - doing either here as well
+                 * reports the same failure twice */
                 PMIX_DESTRUCT(&bkt);
-                continue;
+                break;
             }
             /* extract and process any proc-related info for this nspace */
             PMIX_GDS_STORE_JOB_INFO(rc, pmix_globals.mypeer, nspace, &bkt);

--- a/src/server/pmix_server_setup.c
+++ b/src/server/pmix_server_setup.c
@@ -547,7 +547,11 @@ pmix_status_t PMIx_server_setup_local_support(const pmix_nspace_t nspace, pmix_i
             /* we are ON the progress thread, so waiting for the event we
              * would post is waiting for ourselves - answer rather than
              * hang. The caller wanted the blocking form; the non-blocking
-             * one works fine from here */
+             * one works fine from here. The nspace copy is ours, and the
+             * handler that would have freed it is never going to run */
+            if (NULL != cd->nspace) {
+                free(cd->nspace);
+            }
             PMIX_RELEASE(cd);
             return PMIX_ERR_WOULD_BLOCK;
         }

--- a/src/server/pmix_server_switchyard.c
+++ b/src/server/pmix_server_switchyard.c
@@ -123,8 +123,12 @@ static void op_cbfunc(pmix_status_t status, void *cbdata)
     /* need to thread-shift this callback */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        /* we cannot answer the client, but the caddy is ours either way -
+         * dropping it strands the RETAIN it holds on the peer, and with it
+         * the peer and everything hanging off it, for the life of the
+         * server. Same as the finalize-race arm above. */
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        PMIX_RELEASE(cd);
         return;
     }
     scd->status = status;
@@ -150,8 +154,9 @@ static void op_cbfunc2(pmix_status_t status, void *cbdata)
     /* need to thread-shift this callback */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
-        /* nothing we can do */
+        /* the caddy is ours either way - see op_cbfunc */
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        PMIX_RELEASE(cd);
         return;
     }
     scd->status = status;
@@ -212,30 +217,46 @@ cleanup:
     }
 }
 
+/* Unlike op_cbfunc, what the host hands back here is the resource-block
+ * handler's own pmix_setup_caddy_t (pmix_server_resblk passes "scd" as the
+ * cbdata of the up-call), with the switchyard's server caddy nested inside
+ * it on cbdata. So this one owns three things, and neither destructor
+ * reaches the other two: scaddes does not free "nspace" and does not touch
+ * "cbdata". Both early returns below released only the outermost object -
+ * declared, on top of that, as the wrong type - and stranded the server
+ * caddy, the RETAIN it holds on the requesting peer, and the block name. */
 static void resop_cbfunc(pmix_status_t status, void *cbdata)
 {
-    pmix_shift_caddy_t *scd;
-    pmix_server_caddy_t *cd = (pmix_server_caddy_t *)cbdata;
+    pmix_shift_caddy_t *scdwrapper;
+    pmix_setup_caddy_t *scd = (pmix_setup_caddy_t *) cbdata;
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t *) scd->cbdata;
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "server:resop_cbfunc called with %s status",
                         PMIx_Error_string(status));
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
-        PMIX_RELEASE(cd);
-        return;
+        goto teardown;
     }
 
     /* need to thread-shift this callback */
-    scd = PMIX_NEW(pmix_shift_caddy_t);
-    if (NULL == scd) {
-        /* nothing we can do */
+    scdwrapper = PMIX_NEW(pmix_shift_caddy_t);
+    if (NULL == scdwrapper) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        return;
+        goto teardown;
     }
-    scd->status = status;
-    scd->cbdata = cbdata;
-    PMIX_THREADSHIFT(scd, _resopcbfunc);
+    scdwrapper->status = status;
+    scdwrapper->cbdata = cbdata;
+    PMIX_THREADSHIFT(scdwrapper, _resopcbfunc);
+    return;
+
+teardown:
+    /* the same three releases _resopcbfunc makes on its way out */
+    PMIX_RELEASE(cd);
+    if (NULL != scd->nspace) {
+        free(scd->nspace);
+    }
+    PMIX_RELEASE(scd);
 }
 
 /* the switchyard is the primary message handling function. It's purpose

--- a/src/server/pmix_server_switchyard.c
+++ b/src/server/pmix_server_switchyard.c
@@ -279,6 +279,7 @@ teardown:
 static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buffer_t *buf)
 {
     pmix_status_t rc = PMIX_ERR_NOT_SUPPORTED;
+    pmix_status_t ret;
     int32_t cnt;
     pmix_cmd_t cmd;
     pmix_server_caddy_t *cd;
@@ -414,14 +415,18 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
     }
 
     if (PMIX_COMMIT_CMD == cmd) {
-        rc = pmix_server_commit(peer, buf);
+        /* keep the commit's own status in a variable the pack does not
+         * write: PMIX_BFROPS_PACK assigns the status of the *pack* to the
+         * name it is given, so packing "rc" from "&rc" left the two
+         * meanings sharing one variable */
+        ret = pmix_server_commit(peer, buf);
         if (!PMIX_PEER_IS_V1(peer)) {
             reply = PMIX_NEW(pmix_buffer_t);
             if (NULL == reply) {
                 PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
                 return PMIX_ERR_NOMEM;
             }
-            PMIX_BFROPS_PACK(rc, peer, reply, &rc, 1, PMIX_STATUS);
+            PMIX_BFROPS_PACK(rc, peer, reply, &ret, 1, PMIX_STATUS);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
             }
@@ -724,7 +729,6 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
         return rc;
     }
 
-
     if (PMIX_RESOLVE_PEERS_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
         rc = pmix_server_resolve_peers(cd, buf, pmix_server_respeers_cbfunc);
@@ -767,7 +771,7 @@ void pmix_server_message_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
         if (PMIX_OPERATION_SUCCEEDED == ret) {
             ret = PMIX_SUCCESS;
         }
-        PMIX_BFROPS_PACK(rc, pr, reply, &ret, 1, PMIX_STATUS);
+        PMIX_BFROPS_PACK(rc, peer, reply, &ret, 1, PMIX_STATUS);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
         }

--- a/test/simple/simptimeout.c
+++ b/test/simple/simptimeout.c
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
         /* check timeout on Get */
         proc.rank = 1;
         pmix_output(0, "TEST GET TIMEOUT");
-        if (PMIX_ERR_TIMEOUT == (rc = PMIx_Get(&proc, "1234", &info, 1, &val))) {
+        if (PMIX_ERR_TIMEOUT != (rc = PMIx_Get(&proc, "1234", &info, 1, &val))) {
             pmix_output(0, "Client ns %s rank %d: PMIx_Get did not timeout: %s", myproc.nspace,
                         myproc.rank, PMIx_Error_string(rc));
             goto done;

--- a/test/simple/simptimeout.c
+++ b/test/simple/simptimeout.c
@@ -139,6 +139,18 @@ int main(int argc, char **argv)
         }
         pmix_output(0, "CONNECT TIMEOUT SUCCEEDED");
 
+        /* check timeout on disconnect. Like connect, this has to time out
+         * in the server's local-collection phase - the other ranks never
+         * call, so the host is never asked and cannot be the one to
+         * bound it */
+        pmix_output(0, "TEST DISCONNECT TIMEOUT");
+        if (PMIX_ERR_TIMEOUT != (rc = PMIx_Disconnect(&proc, 1, &info, 1))) {
+            pmix_output(0, "Client ns %s rank %d: PMIx_Disconnect did not timeout: %s",
+                        myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        pmix_output(0, "DISCONNECT TIMEOUT SUCCEEDED");
+
         /* check timeout on Get */
         proc.rank = 1;
         pmix_output(0, "TEST GET TIMEOUT");

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -347,6 +347,24 @@ Two things about the setup are easy to get wrong and were:
 The multi-node half of this file — the actual remote fetch — is
 [`contrib/dockerswarm/run-server-tests.sh`](../../contrib/dockerswarm/AGENTS.md).
 
+### `server_fabric` — and what a SKIP is for
+
+[`server_fabric.c`](server_fabric.c) drives `pmix_server_device_dists()`
+the way the switchyard does, to pin down that a locally computed distance
+array is handed to the completion callback with a **release function**
+rather than freed on the next line. That callback only thread-shifts, so
+the reply is packed from the array after the handler has returned, and
+freeing it there put freed heap on the wire.
+
+It is the one program here that reports **SKIP**, and the reason is worth
+copying rather than avoiding: hwloc needs at least one OS device to
+measure a distance against, and a bare macOS host has none, so the
+library correctly answers `PMIX_ERR_NOT_FOUND` and there is no result to
+hold the contract against. Reporting that as a pass would be a green line
+asserting nothing — on the developer platform, permanently. The
+assertions run on Linux, where hwloc reports network and block devices.
+Everything ahead of the computation runs on both.
+
 ### `resolve_api` — the local half of `PMIx_Resolve_peers`/`_nodes`
 
 [`resolve_api.c`](resolve_api.c) is the only program in this suite that

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence
 
 client_api_SOURCES = \
         client_api.c
@@ -333,6 +333,12 @@ server_control_SOURCES = \
         server_control.c
 server_control_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 server_control_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+server_fence_SOURCES = \
+        server_fence.c
+server_fence_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+server_fence_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 server_dmodex_SOURCES = \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve
 
 client_api_SOURCES = \
         client_api.c
@@ -339,6 +339,12 @@ server_connect_SOURCES = \
         server_connect.c
 server_connect_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 server_connect_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+server_resolve_SOURCES = \
+        server_resolve.c
+server_resolve_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+server_resolve_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 server_fence_SOURCES = \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex
 
 client_api_SOURCES = \
         client_api.c
@@ -333,4 +333,10 @@ server_control_SOURCES = \
         server_control.c
 server_control_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 server_control_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+server_dmodex_SOURCES = \
+        server_dmodex.c
+server_dmodex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+server_dmodex_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric
 
 client_api_SOURCES = \
         client_api.c
@@ -339,4 +339,10 @@ server_dmodex_SOURCES = \
         server_dmodex.c
 server_dmodex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 server_dmodex_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+server_fabric_SOURCES = \
+        server_fabric.c
+server_fabric_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+server_fabric_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control
 
 client_api_SOURCES = \
         client_api.c
@@ -327,4 +327,10 @@ spawn_api_SOURCES = \
         spawn_api.c
 spawn_api_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 spawn_api_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+server_control_SOURCES = \
+        server_control.c
+server_control_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+server_control_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup
 
 client_api_SOURCES = \
         client_api.c
@@ -345,6 +345,12 @@ server_resolve_SOURCES = \
         server_resolve.c
 server_resolve_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 server_resolve_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+server_setup_SOURCES = \
+        server_setup.c
+server_setup_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+server_setup_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 server_fence_SOURCES = \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect
 
 client_api_SOURCES = \
         client_api.c
@@ -333,6 +333,12 @@ server_control_SOURCES = \
         server_control.c
 server_control_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 server_control_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+server_connect_SOURCES = \
+        server_connect.c
+server_connect_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+server_connect_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 server_fence_SOURCES = \

--- a/test/unit/collect_job_info.c
+++ b/test/unit/collect_job_info.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 static int npass = 0;
 static int nfail = 0;
@@ -133,7 +134,8 @@ int main(int argc, char **argv)
     pmix_status_t rc;
     static pmix_server_module_t mymodule = {0};
     const char *nspace = "collect-job-test";
-    pmix_proc_t procs[1];
+    const char *bare = "collect-job-test-bare";
+    pmix_proc_t procs[2];
     pmix_data_buffer_t dbuf;
     char *unpacked = NULL;
     int32_t cnt;
@@ -208,6 +210,31 @@ int main(int argc, char **argv)
 
     rc = PMIx_server_collect_job_info(procs, 1, NULL);
     report("NULL buffer is rejected", PMIX_ERR_BAD_PARAM == rc);
+    PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
+
+    /* A namespace we cannot answer for must not cost the caller the
+     * namespaces we can. Registering a *client* creates the namespace
+     * entry without any job info behind it, so the fetch for it fails
+     * while the fully registered one above succeeds. The per-namespace
+     * fetch status used to be left in the variable the whole request
+     * reported, so the outcome depended on which namespace happened to
+     * be last - and the API only hands the buffer back on success, so
+     * this one unanswerable namespace discarded the other's job info
+     * entirely. */
+    PMIX_LOAD_PROCID(&procs[1], bare, 0);
+    rc = PMIx_server_register_client(&procs[1], geteuid(), getegid(), NULL, NULL, NULL);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(stderr, "register_client failed: %s\n", PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+    PMIX_LOAD_PROCID(&procs[0], nspace, PMIX_RANK_WILDCARD);
+    PMIX_DATA_BUFFER_CONSTRUCT(&dbuf);
+    rc = PMIx_server_collect_job_info(procs, 2, &dbuf);
+    report("an unanswerable namespace does not fail the request",
+           PMIX_SUCCESS == rc);
+    report("the answerable namespace's job info survives it",
+           PMIX_SUCCESS == rc && 0 < dbuf.bytes_used);
     PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);

--- a/test/unit/event_chain.c
+++ b/test/unit/event_chain.c
@@ -855,9 +855,9 @@ static pmix_status_t client_evreq(pmix_status_t *codes, size_t ncodes, bool dere
     return rc;
 }
 
-/* Count how many peers are recorded against the server's default-handler
- * entry, and say whether the entry exists at all. */
-static size_t default_reg_peers(bool *exists)
+/* Count how many peers are recorded against the server's entry for a
+ * code, and say whether the entry exists at all. */
+static size_t code_reg_peers(pmix_status_t code, bool *exists)
 {
     pmix_regevents_info_t *reginfo;
     pmix_peer_events_info_t *pr;
@@ -865,7 +865,7 @@ static size_t default_reg_peers(bool *exists)
 
     *exists = false;
     PMIX_LIST_FOREACH (reginfo, &pmix_server_globals.events, pmix_regevents_info_t) {
-        if (PMIX_MAX_ERR_CONSTANT != reginfo->code) {
+        if (code != reginfo->code) {
             continue;
         }
         *exists = true;
@@ -899,34 +899,78 @@ static void test_default_registration(void)
 
     fprintf(stdout, "default-handler registration:\n");
 
-    before = default_reg_peers(&existed);
+    before = code_reg_peers(PMIX_MAX_ERR_CONSTANT, &existed);
     report("no default entry exists yet", !existed && 0 == before);
 
     rc = client_evreq(NULL, 0, false);
     report("registering with no codes succeeds",
            PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc);
 
-    after = default_reg_peers(&exists);
+    after = code_reg_peers(PMIX_MAX_ERR_CONSTANT, &exists);
     report("the default entry was created", exists);
     report("the registrant is on it", 1 == after);
 
     /* a second default registration joins the same entry rather than
      * making another one */
     rc = client_evreq(NULL, 0, false);
-    after = default_reg_peers(&exists);
+    after = code_reg_peers(PMIX_MAX_ERR_CONSTANT, &exists);
     report("a second default registration joins the same entry",
            exists && 2 == after);
 
-    /* and deregistration finds what registration created. A client drops a
-     * default handler by naming PMIX_MAX_ERR_CONSTANT explicitly, not by
-     * sending an empty code list - see pmix_deregister_event_hdlr(). */
+    /* And deregistration finds what registration created - all of it. A
+     * client drops a default handler by naming PMIX_MAX_ERR_CONSTANT
+     * explicitly, not by sending an empty code list (see
+     * pmix_deregister_event_hdlr), and it sends that deregistration only
+     * once its _last_ handler for the code is gone. So every entry this
+     * peer holds for the code is stale by then. Removing just the first
+     * left one behind for the life of the connection: the server kept
+     * forwarding the code to a peer with no handler for it, and the
+     * entry could never be pruned, so the host was never told to stop
+     * either. */
     rc = client_evreq(&wildcard, 1, true);
-    after = default_reg_peers(&exists);
-    report("deregistering removes one registrant", 1 == after);
+    after = code_reg_peers(PMIX_MAX_ERR_CONSTANT, &exists);
+    report("deregistering clears every registration this peer holds",
+           !exists && 0 == after);
 
+    /* and a deregistration with nothing left to find is harmless */
     rc = client_evreq(&wildcard, 1, true);
-    after = default_reg_peers(&exists);
-    report("deregistering the last one empties the entry", 0 == after);
+    after = code_reg_peers(PMIX_MAX_ERR_CONSTANT, &exists);
+    report("a repeated deregistration is harmless", !exists && 0 == after);
+}
+
+/* The duplicate entries above are not an artifact of the default-handler
+ * case: they are how an ordinary coded registration behaves too, because
+ * the client library packs a handler's whole code list whenever any code
+ * in that list is new to the server. So a client that registers one
+ * handler for {A} and a second for {A, B} sends both lists, and the
+ * server records two registrations for A - deliberately, since each
+ * carries its own PMIX_EVENT_AFFECTED_PROC filter. It then sends exactly
+ * one deregistration for A, when its last handler for A goes away. */
+static void test_duplicate_code_registrations(void)
+{
+    pmix_status_t one[1] = {EVUT_CODE_ORDER};
+    pmix_status_t two[2] = {EVUT_CODE_ORDER, EVUT_CODE_ORDER2};
+    bool exists = false;
+    size_t n;
+
+    fprintf(stdout, "duplicate code registrations:\n");
+
+    client_evreq(one, 1, false);
+    client_evreq(two, 2, false);
+    n = code_reg_peers(EVUT_CODE_ORDER, &exists);
+    report("a code named by two handlers is recorded twice",
+           exists && 2 == n);
+    n = code_reg_peers(EVUT_CODE_ORDER2, &exists);
+    report("the code named by only one is recorded once", exists && 1 == n);
+
+    /* the single deregistration the client sends has to clear both */
+    client_evreq(one, 1, true);
+    n = code_reg_peers(EVUT_CODE_ORDER, &exists);
+    report("one deregistration clears both entries", !exists && 0 == n);
+
+    client_evreq(&two[1], 1, true);
+    n = code_reg_peers(EVUT_CODE_ORDER2, &exists);
+    report("the untouched code deregisters normally", !exists && 0 == n);
 }
 
 static void test_enviro_handshake(void)
@@ -1410,6 +1454,7 @@ int main(int argc, char **argv)
     /* must run before anything registers, so the default entry really is
      * absent when we ask for one */
     test_default_registration();
+    test_duplicate_code_registrations();
 
     /* registration placement and chain progression */
     test_chain_order();

--- a/test/unit/iof_output.c
+++ b/test/unit/iof_output.c
@@ -121,6 +121,39 @@ static bool deliver(const pmix_proc_t *src, pmix_iof_channel_t channel,
     return true;
 }
 
+/* What the blocking form of the two IOF push APIs returned when called
+ * from the progress thread, and a flag saying the attempt has happened. */
+static pmix_status_t wb_deliver = PMIX_SUCCESS;
+static pmix_status_t wb_flow = PMIX_SUCCESS;
+static volatile bool wb_done = false;
+
+/* Runs on the progress thread - a delivery completion is invoked from
+ * there, which is exactly the position a host is in when it forwards
+ * output from inside one of our callbacks.
+ *
+ * Both APIs must refuse the blocking form here rather than wait on the
+ * loop they are standing in. What that refusal must NOT do is hand the
+ * request caddy back with our proc and byte object still attached: the
+ * caddy destructor frees both unconditionally, so the refusal used to
+ * free two objects living in this frame. Against an unfixed library
+ * this aborts in the allocator rather than failing a check. */
+static void wouldblock_cbfunc(pmix_status_t status, void *cbdata)
+{
+    pmix_proc_t src;
+    pmix_byte_object_t bo;
+    (void) status;
+    (void) cbdata;
+
+    PMIX_LOAD_PROCID(&src, "wouldblock", 0);
+    bo.bytes = (char *) "never emitted\n";
+    bo.size = 14;
+    wb_deliver = PMIx_server_IOF_deliver(&src, PMIX_FWD_STDOUT_CHANNEL, &bo,
+                                         NULL, 0, NULL, NULL);
+    wb_flow = PMIx_server_IOF_flow_control(&src, PMIX_FWD_STDIN_CHANNEL, true,
+                                           NULL, 0, NULL, NULL);
+    wb_done = true;
+}
+
 /* nothing here reaches a host upcall - the module only has to exist */
 static pmix_server_module_t mymodule = {.push_stdin = NULL};
 
@@ -247,6 +280,37 @@ int main(int argc, char **argv)
     got = collect(efd, buf, 6);
     report("stderr still flows after a source closed",
            6 == got && 0 == strcmp(buf, "delta\n"));
+
+    /* ---- the blocking form, attempted from the progress thread ---- */
+    {
+        pmix_byte_object_t bo;
+        int i;
+
+        PMIX_LOAD_PROCID(&src, "outtest", 4);
+        bo.bytes = (char *) "epsilon\n";
+        bo.size = 8;
+        /* this frame owns src and bo, and must still own them when the
+         * completion returns - hence the wait rather than a fire and
+         * forget */
+        rc = PMIx_server_IOF_deliver(&src, PMIX_FWD_STDOUT_CHANNEL, &bo, NULL, 0,
+                                     wouldblock_cbfunc, NULL);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(out, "PMIx_server_IOF_deliver failed: %s\n", PMIx_Error_string(rc));
+            PMIx_server_finalize();
+            return 1;
+        }
+        for (i = 0; i < WAIT_TRIES && !wb_done; i++) {
+            usleep(WAIT_USEC);
+        }
+        report("a delivery completion runs and is answered", wb_done);
+        report("blocking IOF deliver from the progress thread is refused",
+               PMIX_ERR_WOULD_BLOCK == wb_deliver);
+        report("blocking IOF flow control from the progress thread is refused",
+               PMIX_ERR_WOULD_BLOCK == wb_flow);
+        got = collect(rfd, buf, 8);
+        report("and the delivery that carried us there was still written",
+               8 == got && 0 == strcmp(buf, "epsilon\n"));
+    }
 
     PMIx_server_finalize();
     close(rfd);

--- a/test/unit/iof_output.c
+++ b/test/unit/iof_output.c
@@ -45,6 +45,10 @@
 #include "include/pmix.h"
 #include "include/pmix_server.h"
 
+#include "src/include/pmix_globals.h"
+#include "src/mca/bfrops/bfrops.h"
+#include "src/server/pmix_server_ops.h"
+
 #define WAIT_USEC    20000
 #define WAIT_TRIES   250
 #define SETTLE_TRIES 25
@@ -155,7 +159,62 @@ static void wouldblock_cbfunc(pmix_status_t status, void *cbdata)
 }
 
 /* nothing here reaches a host upcall - the module only has to exist */
-static pmix_server_module_t mymodule = {.push_stdin = NULL};
+/* iof_pull only has to be non-NULL: the deregistration cases below are
+ * all rejected before the handler reaches it */
+static pmix_status_t stub_iof_pull(const pmix_proc_t procs[], size_t nprocs,
+                                   const pmix_info_t directives[], size_t ndirs,
+                                   pmix_iof_channel_t channels,
+                                   pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    (void) procs;
+    (void) nprocs;
+    (void) directives;
+    (void) ndirs;
+    (void) channels;
+    (void) cbfunc;
+    (void) cbdata;
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+static pmix_server_module_t mymodule = {.push_stdin = NULL,
+                                        .iof_pull = stub_iof_pull};
+
+static void iof_op_stub(pmix_status_t status, void *cbdata)
+{
+    (void) status;
+    (void) cbdata;
+}
+
+/* Drive one IOF DEREGISTER off a hand-packed wire buffer whose directive
+ * count is whatever the caller says. The handler sizes its array as
+ * "count + 1" so it can append the stop directive, and seeds that last
+ * slot itself - so a count near SIZE_MAX wraps the sum to zero,
+ * PMIx_Info_create answers NULL for a zero-element array, and the seed
+ * is written at info[SIZE_MAX]. A count that merely fails to survive the
+ * round trip through the int32_t the unpack consumes is the same
+ * hazard one step smaller. Both must be refused before any allocation. */
+static pmix_status_t do_iofdereg(size_t claimed_ninfo)
+{
+    pmix_buffer_t *buf;
+    pmix_status_t rc;
+    size_t refid = 0;
+
+    buf = PMIX_NEW(pmix_buffer_t);
+    if (NULL == buf) {
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &claimed_ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &refid, 1, PMIX_SIZE);
+    }
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return rc;
+    }
+    rc = pmix_server_iofdereg(pmix_globals.mypeer, buf, iof_op_stub, NULL);
+    PMIX_RELEASE(buf);
+    return rc;
+}
 
 /* replace "fd" with the write end of a fresh pipe, handing back a
  * non-blocking read end */
@@ -311,6 +370,19 @@ int main(int argc, char **argv)
         report("and the delivery that carried us there was still written",
                8 == got && 0 == strcmp(buf, "epsilon\n"));
     }
+
+    /* ---- wire counts a client controls, in the deregister handler ----
+     * these run last on purpose: a rejection logs to stderr, which is
+     * still a pipe nothing reads from here on */
+    report("a deregister count that wraps the +1 is refused",
+           PMIX_ERR_BAD_PARAM == do_iofdereg(SIZE_MAX));
+    report("a deregister count that truncates is refused",
+           PMIX_ERR_BAD_PARAM == do_iofdereg((size_t) 0x80000000UL));
+    /* and the screen must not cost the handler its ordinary job: a
+     * well-formed count carries on to the handler lookup, which is what
+     * rejects this one - nothing is registered under that refid */
+    report("a well-formed deregister gets past the screen",
+           PMIX_ERR_NOT_FOUND == do_iofdereg(0));
 
     PMIx_server_finalize();
     close(rfd);

--- a/test/unit/progress_threads.c
+++ b/test/unit/progress_threads.c
@@ -415,6 +415,45 @@ static void test_blocking_call_from_progress_thread(void)
 }
 
 /* ------------------------------------------------------------------
+ * The process-set entry points must screen what the host hands them
+ *
+ * Both are public APIs, so the host can pass anything, and every one of
+ * these arguments used to be carried straight onto the progress thread
+ * and dereferenced there: a NULL name reaches strdup and strcmp, a NULL
+ * member array reaches memcpy, and a zero member count makes
+ * PMIx_Data_array_create answer NULL - which was then read for its
+ * "array" member. Each case below segfaults an unfixed library rather
+ * than failing, the same bargain test/unit/iof_output.c makes.
+ */
+static void test_pset_params(void)
+{
+    pmix_proc_t members[2];
+    pmix_status_t rc;
+
+    PMIX_LOAD_PROCID(&members[0], "pset.ut.ns", 0);
+    PMIX_LOAD_PROCID(&members[1], "pset.ut.ns", 1);
+
+    rc = PMIx_server_define_process_set(members, 2, NULL);
+    report("pset:define rejects a NULL name", PMIX_ERR_BAD_PARAM == rc);
+
+    rc = PMIx_server_define_process_set(NULL, 2, "ut-pset");
+    report("pset:define rejects a NULL member array", PMIX_ERR_BAD_PARAM == rc);
+
+    rc = PMIx_server_define_process_set(members, 0, "ut-pset");
+    report("pset:define rejects a zero member count", PMIX_ERR_BAD_PARAM == rc);
+
+    rc = PMIx_server_delete_process_set(NULL);
+    report("pset:delete rejects a NULL name", PMIX_ERR_BAD_PARAM == rc);
+
+    /* a well-formed pair still has to work, or the screens above would
+     * be indistinguishable from a function that refuses everything */
+    rc = PMIx_server_define_process_set(members, 2, "ut-pset");
+    report("pset:a well-formed set is defined", PMIX_SUCCESS == rc);
+    rc = PMIx_server_delete_process_set("ut-pset");
+    report("pset:and deleted again", PMIX_SUCCESS == rc);
+}
+
+/* ------------------------------------------------------------------
  * The void deregistration APIs must report a dropped request
  *
  * PMIx_server_deregister_nspace and PMIx_server_deregister_client are
@@ -490,6 +529,7 @@ int main(int argc, char **argv)
     test_unknown_name();
     test_cpu_list_validation();
     test_blocking_call_from_progress_thread();
+    test_pset_params();
     /* must come last - it stops the shared progress thread */
     test_void_deregisters_report_a_dropped_request();
 

--- a/test/unit/server_connect.c
+++ b/test/unit/server_connect.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for pmix_server_connect() and
+ * pmix_server_disconnect(), driven exactly as the switchyard drives them
+ * - a wire buffer packed by hand and a peer - so no DVM, no client, and
+ * no second process is involved.
+ *
+ * These cover the malformed-count screens, which both handlers share with
+ * pmix_server_fence(): see the header of test/unit/server_fence.c for why
+ * this family needs them when most of src/server does not. In short, the
+ * info count is used to *index* the array before anything has been
+ * unpacked into it - two slots are seeded at info[ninf] and info[ninf+1],
+ * so a count near SIZE_MAX wraps "ninf + 2" down to a one-element array
+ * and writes the seeds far outside it - and the proc count is multiplied
+ * by sizeof(pmix_proc_t) to size the proc array, with the size_t rather
+ * than the int32_t the unpack consumed driving the qsort and the free
+ * afterwards.
+ *
+ * The info-count cases *crash* an unfixed library rather than failing it,
+ * the same bargain test/unit/server_fence.c and test/unit/iof_output.c
+ * make.
+ *
+ * The well-formed case asserts only that the request is not rejected as a
+ * bad parameter: a screen that turned every connect into PMIX_ERR_BAD_PARAM
+ * would satisfy every case above it, and that is what this guards against.
+ * What the handler then does with a well-formed connect depends on the
+ * host module and belongs to the multi-node suite.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/class/pmix_list.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/bfrops/bfrops.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+static void op_stub(pmix_status_t status, void *cbdata)
+{
+    (void) status;
+    (void) cbdata;
+}
+
+/* carrier for driving the handlers on the progress thread - they touch
+ * pmix_server_globals.collectives, so they must not be called from
+ * main(). The pmix_event_t is the thread-shift member required of every
+ * caddy. */
+typedef struct {
+    pmix_event_t ev;
+    pmix_lock_t lock;
+    bool disconnect;
+    size_t nprocs;      /* the count to put on the wire */
+    size_t nprocs_real; /* how many procs actually to pack */
+    size_t ninf;        /* the count to put on the wire */
+    size_t ninf_real;   /* how many info structs actually to pack */
+    pmix_status_t status;
+} cut_req_t;
+
+static void do_op(int sd, short args, void *cbdata)
+{
+    cut_req_t *r = (cut_req_t *) cbdata;
+    pmix_buffer_t buf;
+    pmix_server_caddy_t *cd;
+    pmix_proc_t proc;
+    pmix_info_t dir;
+    pmix_status_t rc;
+    size_t n;
+    bool flag = true;
+
+    (void) sd;
+    (void) args;
+
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    PMIX_BFROPS_ASSIGN_TYPE(pmix_globals.mypeer, &buf);
+
+    /* the proc count, then the procs - the two may disagree on purpose */
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &r->nprocs, 1, PMIX_SIZE);
+    for (n = 0; PMIX_SUCCESS == rc && n < r->nprocs_real; n++) {
+        /* a namespace this server has never been told about, so the
+         * tracker comes out non-local and definition-complete */
+        PMIX_LOAD_PROCID(&proc, "connect.ut.ns", (pmix_rank_t) n);
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &proc, 1, PMIX_PROC);
+    }
+    /* the info count, then the info structs */
+    if (PMIX_SUCCESS == rc) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &r->ninf, 1, PMIX_SIZE);
+    }
+    for (n = 0; PMIX_SUCCESS == rc && n < r->ninf_real; n++) {
+        PMIX_INFO_LOAD(&dir, PMIX_EMBED_BARRIER, &flag, PMIX_BOOL);
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &dir, 1, PMIX_INFO);
+        PMIX_INFO_DESTRUCT(&dir);
+    }
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DESTRUCT(&buf);
+        r->status = rc;
+        PMIX_WAKEUP_THREAD(&r->lock);
+        return;
+    }
+
+    cd = PMIX_NEW(pmix_server_caddy_t);
+    if (NULL == cd) {
+        PMIX_DESTRUCT(&buf);
+        r->status = PMIX_ERR_NOMEM;
+        PMIX_WAKEUP_THREAD(&r->lock);
+        return;
+    }
+    PMIX_RETAIN(pmix_globals.mypeer);
+    cd->peer = pmix_globals.mypeer;
+    cd->hdr.tag = 0;
+
+    if (r->disconnect) {
+        rc = pmix_server_disconnect(cd, &buf, op_stub);
+    } else {
+        rc = pmix_server_connect(cd, &buf, op_stub);
+    }
+    if (PMIX_SUCCESS != rc) {
+        /* the switchyard owns the caddy on a non-success return */
+        PMIX_RELEASE(cd);
+    }
+    PMIX_DESTRUCT(&buf);
+    r->status = rc;
+    PMIX_WAKEUP_THREAD(&r->lock);
+}
+
+static pmix_status_t drive(bool disconnect, size_t nprocs, size_t nprocs_real,
+                           size_t ninf, size_t ninf_real)
+{
+    cut_req_t req;
+    pmix_status_t rc;
+
+    memset(&req, 0, sizeof(req));
+    PMIX_CONSTRUCT_LOCK(&req.lock);
+    req.disconnect = disconnect;
+    req.nprocs = nprocs;
+    req.nprocs_real = nprocs_real;
+    req.ninf = ninf;
+    req.ninf_real = ninf_real;
+    PMIX_THREADSHIFT(&req, do_op);
+    PMIX_WAIT_THREAD(&req.lock);
+    rc = req.status;
+    PMIX_DESTRUCT_LOCK(&req.lock);
+    return rc;
+}
+
+/* the completions thread-shift, so let anything queued behind us run
+ * before we finalize. PMIx_Store_internal blocks on the progress thread,
+ * so anything queued ahead of it has run by the time it returns. */
+static void progress_barrier(void)
+{
+    pmix_value_t v;
+
+    PMIX_VALUE_LOAD(&v, "barrier", PMIX_STRING);
+    PMIx_Store_internal(&pmix_globals.myid, "server-connect-ut.barrier", &v);
+    PMIX_VALUE_DESTRUCT(&v);
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_status_t rc;
+    int i;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "server_connect: connect/disconnect handler unit tests\n");
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* both handlers carry the same two screens, so run the same cases
+     * against each rather than trusting them to stay in step */
+    for (i = 0; i < 2; i++) {
+        bool dis = (1 == i);
+        const char *who = dis ? "disconnect" : "connect";
+        char name[128];
+
+        /* SIZE_MAX wraps "ninf + 2" to 1: the array is allocated with
+         * room for one element and the seeds are then written at info[0]
+         * and info[SIZE_MAX]. Against an unfixed library this is where
+         * the program dies. */
+        rc = drive(dis, 1, 1, SIZE_MAX, 0);
+        snprintf(name, sizeof(name), "%s rejects an info count of SIZE_MAX", who);
+        report(name, PMIX_ERR_BAD_PARAM == rc);
+
+        rc = drive(dis, 1, 1, (size_t) 0x80000000ULL, 0);
+        snprintf(name, sizeof(name), "%s rejects an info count that truncates negative", who);
+        report(name, PMIX_ERR_BAD_PARAM == rc);
+
+        rc = drive(dis, (size_t) 1 << 40, 1, 0, 0);
+        snprintf(name, sizeof(name), "%s rejects an oversized proc count", who);
+        report(name, PMIX_ERR_BAD_PARAM == rc);
+
+        rc = drive(dis, 0, 0, 0, 0);
+        snprintf(name, sizeof(name), "%s rejects a zero proc count", who);
+        report(name, PMIX_ERR_BAD_PARAM == rc);
+
+        /* the screens must not simply reject everything */
+        rc = drive(dis, 1, 1, 1, 1);
+        snprintf(name, sizeof(name), "%s accepts a well-formed request", who);
+        report(name, PMIX_ERR_BAD_PARAM != rc);
+
+        progress_barrier();
+    }
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/server_control.c
+++ b/test/unit/server_control.c
@@ -117,6 +117,25 @@ static pmix_status_t stub_log2(const pmix_proc_t *client,
     return PMIX_SUCCESS;
 }
 
+/* what the switchyard's query callback was told */
+static bool qry_fired = false;
+static pmix_status_t qry_status = PMIX_SUCCESS;
+
+static void qry_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo,
+                       void *cbdata, pmix_release_cbfunc_t relfn, void *relcbd)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t *) cbdata;
+
+    (void) info;
+    (void) ninfo;
+    qry_fired = true;
+    qry_status = status;
+    if (NULL != relfn) {
+        relfn(relcbd);
+    }
+    PMIX_RELEASE(cd);
+}
+
 /* the handler refuses to run at all without one of these, but none of the
  * cases below is supposed to reach it: they are all pure cleanup requests,
  * which the server answers itself */
@@ -214,6 +233,65 @@ static pmix_status_t do_log(time_t timestamp,
     return rc;
 }
 
+/* Drive one server-side QUERY carrying a single key and a single
+ * qualifier, packed with whatever value type the caller names. The
+ * server unpacks these off the wire, so it cannot lean on the screening
+ * PMIx_Query_info_nb does in the requestor's own process. */
+static pmix_status_t do_query(const char *key, const char *qualkey,
+                              const void *qualval, pmix_data_type_t qualtype)
+{
+    pmix_buffer_t *buf;
+    pmix_server_caddy_t *cd;
+    pmix_query_t qry;
+    pmix_status_t rc;
+    size_t nqueries = 1;
+
+    qry_fired = false;
+    qry_status = PMIX_SUCCESS;
+
+    PMIX_QUERY_CONSTRUCT(&qry);
+    PMIX_ARGV_APPEND(rc, qry.keys, key);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_QUERY_DESTRUCT(&qry);
+        return rc;
+    }
+    qry.nqual = 1;
+    PMIX_INFO_CREATE(qry.qualifiers, 1);
+    PMIX_INFO_LOAD(&qry.qualifiers[0], qualkey, qualval, qualtype);
+
+    buf = PMIX_NEW(pmix_buffer_t);
+    if (NULL == buf) {
+        PMIX_QUERY_DESTRUCT(&qry);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &nqueries, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &qry, 1, PMIX_QUERY);
+    }
+    PMIX_QUERY_DESTRUCT(&qry);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return rc;
+    }
+
+    cd = PMIX_NEW(pmix_server_caddy_t);
+    if (NULL == cd) {
+        PMIX_RELEASE(buf);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_RETAIN(pmix_globals.mypeer);
+    cd->peer = pmix_globals.mypeer;
+    cd->hdr.tag = 0;
+
+    rc = pmix_server_query(pmix_globals.mypeer, buf, qry_cbfunc, cd);
+    if (PMIX_SUCCESS != rc) {
+        /* the switchyard owns the caddy on a non-success return */
+        PMIX_RELEASE(cd);
+    }
+    PMIX_RELEASE(buf);
+    return rc;
+}
+
 /* Build and drive a JOB_CONTROL request carrying no targets, so the
  * cleanup directives land on the requesting peer's namespace epilog. */
 static pmix_status_t do_job_ctrl(pmix_info_t *info, size_t ninfo)
@@ -246,6 +324,19 @@ static pmix_status_t do_job_ctrl(pmix_info_t *info, size_t ninfo)
     rc = pmix_server_job_ctrl(pmix_globals.mypeer, buf, NULL, NULL);
     PMIX_RELEASE(buf);
     return rc;
+}
+
+/* A blocking round trip through the progress thread. pmix_server_query
+ * thread-shifts, so this is what makes its completion observable without
+ * a sleep: anything queued ahead of this call has run by the time it
+ * returns. */
+static void progress_barrier(void)
+{
+    pmix_value_t v;
+
+    PMIX_VALUE_LOAD(&v, "barrier", PMIX_STRING);
+    PMIx_Store_internal(&pmix_globals.myid, "server-control-ut.barrier", &v);
+    PMIX_VALUE_DESTRUCT(&v);
 }
 
 static pmix_cleanup_dir_t *only_epilog_dir(size_t *count)
@@ -335,6 +426,35 @@ int main(int argc, char **argv)
 
     PMIX_INFO_DESTRUCT(&data);
     PMIX_INFO_DESTRUCT(&dirs[0]);
+
+    /* --- query qualifiers arrive off the wire and must be screened ---- */
+    {
+        pmix_proc_t qp;
+        pmix_rank_t qr = 1;
+
+        PMIX_LOAD_PROCID(&qp, "server-control-ut-nspace", 0);
+        rc = do_query(PMIX_QUERY_NAMESPACES, PMIX_PROCID, &qp, PMIX_PROC);
+        progress_barrier();
+        report("well-formed PROCID qualifier is accepted",
+               PMIX_SUCCESS == rc && qry_fired && PMIX_ERR_BAD_PARAM != qry_status);
+
+        /* a PROCID tagged as a string makes the union a char* - reading
+         * it as a pmix_proc_t* walks off the end of that string */
+        rc = do_query(PMIX_QUERY_NAMESPACES, PMIX_PROCID, "not-a-proc", PMIX_STRING);
+        progress_barrier();
+        report("mistyped PROCID qualifier is rejected",
+               PMIX_SUCCESS == rc && qry_fired && PMIX_ERR_BAD_PARAM == qry_status);
+
+        rc = do_query(PMIX_QUERY_NAMESPACES, PMIX_NSPACE, &qr, PMIX_PROC_RANK);
+        progress_barrier();
+        report("mistyped NSPACE qualifier is rejected",
+               PMIX_SUCCESS == rc && qry_fired && PMIX_ERR_BAD_PARAM == qry_status);
+
+        rc = do_query(PMIX_QUERY_NAMESPACES, PMIX_RANK, "not-a-rank", PMIX_STRING);
+        progress_barrier();
+        report("mistyped RANK qualifier is rejected",
+               PMIX_SUCCESS == rc && qry_fired && PMIX_ERR_BAD_PARAM == qry_status);
+    }
 
     /* --- job control: register a cleanup directory -------------------- */
     PMIX_INFO_LOAD(&jc[0], PMIX_REGISTER_CLEANUP_DIR, CTLUT_DIR, PMIX_STRING);

--- a/test/unit/server_control.c
+++ b/test/unit/server_control.c
@@ -37,6 +37,20 @@
  *      PMIX_LOG_TIMESTAMP appended as well when the sender supplied a
  *      non-zero timestamp.
  *
+ *   get_credential: the host's reply info is copied, not borrowed
+ *      pmix_credential_cbfunc_t carries no (release_fn, release_cbdata)
+ *      pair, so nothing the host passes to it survives the return of the
+ *      call - and pmix_server_cred_cbfunc only thread-shifts, packing the
+ *      reply later on the progress thread. The credential itself was
+ *      always copied; the info array beside it was parked by pointer, so
+ *      a host that built it on its stack (the natural thing to do for a
+ *      one-element answer) had the server pack that frame after it had
+ *      been reused. The stub below deliberately destructs and overwrites
+ *      its array the instant the callback returns, so the queued reply
+ *      carries a recognizable key only if the copy really happened.
+ *      Read back from the peer's send queue, which is where a reply to a
+ *      socketless peer comes to rest.
+ *
  *   job control: a repeated cleanup directory upgrades the registered entry
  *      PMIX_REGISTER_CLEANUP_DIR for a path already on the epilog is a
  *      duplicate, and the RFC precedence rule is that the more permissive
@@ -56,6 +70,7 @@
 #include "src/class/pmix_list.h"
 #include "src/include/pmix_globals.h"
 #include "src/mca/bfrops/bfrops.h"
+#include "src/mca/ptl/ptl_types.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/server/pmix_server_ops.h"
 
@@ -65,6 +80,10 @@
 #include <unistd.h>
 
 #define CTLUT_DIR "/tmp/pmix-server-control-ut-no-such-dir"
+
+/* the sentinel the credential case looks for in the queued reply */
+#define CTLUT_CREDKEY "credut.key"
+#define CTLUT_CREDVAL "credut-value"
 
 static int npass = 0;
 static int nfail = 0;
@@ -78,6 +97,11 @@ static void report(const char *name, int passed)
         fprintf(stdout, "  FAIL: %s\n", name);
         ++nfail;
     }
+}
+
+static void skip(const char *name, const char *why)
+{
+    fprintf(stdout, "  SKIP: %s (%s)\n", name, why);
 }
 
 /* what the host's log2 entry point was handed */
@@ -161,6 +185,111 @@ static void op_stub(pmix_status_t status, void *cbdata)
 {
     (void) status;
     (void) cbdata;
+}
+
+/* Answer the credential request from data this frame owns, then take it
+ * all back. pmix_credential_cbfunc_t hands down no release function, so
+ * this is exactly what the contract permits - and it is what a server
+ * that parked the array rather than copying it cannot survive. */
+static bool cred_fired = false;
+
+/* Overwrite through a volatile pointer: a plain memset over a local the
+ * function never reads again is dead code the compiler may drop, and the
+ * whole point of the case is that the overwrite really happens. */
+static void scribble(void *addr, size_t len)
+{
+    volatile unsigned char *p = (volatile unsigned char *) addr;
+    size_t n;
+
+    for (n = 0; n < len; n++) {
+        p[n] = 0x5a;
+    }
+}
+
+static pmix_status_t stub_get_credential(const pmix_proc_t *proc,
+                                         const pmix_info_t directives[], size_t ndirs,
+                                         pmix_credential_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_info_t reply[1];
+    pmix_byte_object_t cred;
+    char bytes[4] = {'c', 'r', 'e', 'd'};
+
+    (void) proc;
+    (void) directives;
+    (void) ndirs;
+
+    cred_fired = true;
+    cred.bytes = bytes;
+    cred.size = sizeof(bytes);
+    PMIX_INFO_LOAD(&reply[0], CTLUT_CREDKEY, CTLUT_CREDVAL, PMIX_STRING);
+
+    cbfunc(PMIX_SUCCESS, &cred, reply, 1, cbdata);
+
+    /* everything above is ours again the moment that call returns */
+    PMIX_INFO_DESTRUCT(&reply[0]);
+    scribble(reply, sizeof(reply));
+    scribble(bytes, sizeof(bytes));
+    return PMIX_SUCCESS;
+}
+
+/* Take the reply the server queued to a peer that has no socket. With
+ * sd < 0 the send event is never armed, so the message simply comes to
+ * rest on the peer and can be read back here. */
+static pmix_buffer_t *take_queued_reply(void)
+{
+    pmix_peer_t *peer = pmix_globals.mypeer;
+    pmix_ptl_send_t *snd = peer->send_msg;
+    pmix_buffer_t *buf;
+
+    if (NULL == snd) {
+        return NULL;
+    }
+    peer->send_msg = NULL;
+    buf = snd->data;
+    /* the buffer is ours now - the send's destructor would release it */
+    snd->data = NULL;
+    PMIX_RELEASE(snd);
+    return buf;
+}
+
+/* Drive one GET_CREDENTIAL request. The wire form is just the directive
+ * count followed by the directives. */
+static pmix_status_t do_get_credential(void)
+{
+    pmix_buffer_t *buf;
+    pmix_server_caddy_t *cd;
+    pmix_status_t rc;
+    size_t ndirs = 0;
+
+    cred_fired = false;
+
+    buf = PMIX_NEW(pmix_buffer_t);
+    if (NULL == buf) {
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &ndirs, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return rc;
+    }
+
+    cd = PMIX_NEW(pmix_server_caddy_t);
+    if (NULL == cd) {
+        PMIX_RELEASE(buf);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_RETAIN(pmix_globals.mypeer);
+    cd->peer = pmix_globals.mypeer;
+    cd->hdr.tag = 0;
+
+    rc = pmix_server_get_credential(pmix_globals.mypeer, buf,
+                                    pmix_server_cred_cbfunc, cd);
+    if (PMIX_SUCCESS != rc) {
+        /* the switchyard owns the caddy on a non-success return */
+        PMIX_RELEASE(cd);
+    }
+    PMIX_RELEASE(buf);
+    return rc;
 }
 
 /* Build the wire form of a LOG request as a >= 3.0 client sends it:
@@ -382,6 +511,7 @@ int main(int argc, char **argv)
 
     mymodule.log2 = stub_log2;
     mymodule.job_control = stub_job_control;
+    mymodule.get_credential = stub_get_credential;
 
     rc = PMIx_server_init(&mymodule, NULL, 0);
     if (PMIX_SUCCESS != rc) {
@@ -454,6 +584,70 @@ int main(int argc, char **argv)
         progress_barrier();
         report("mistyped RANK qualifier is rejected",
                PMIX_SUCCESS == rc && qry_fired && PMIX_ERR_BAD_PARAM == qry_status);
+    }
+
+    /* --- the credential reply must carry a copy of the host's info ---- */
+    {
+        pmix_buffer_t *reply;
+        pmix_status_t ret = PMIX_SUCCESS;
+        pmix_byte_object_t bo;
+        pmix_info_t *rinfo = NULL;
+        size_t rninfo = 0;
+        int32_t cnt;
+
+        /* nothing should be parked on us before this */
+        reply = take_queued_reply();
+        if (NULL != reply) {
+            PMIX_RELEASE(reply);
+        }
+
+        rc = do_get_credential();
+        progress_barrier();
+        report("credential request accepted", PMIX_SUCCESS == rc);
+        report("credential request reached the host", cred_fired);
+
+        reply = take_queued_reply();
+        if (NULL == reply) {
+            skip("credential reply carries the host's info",
+                 "no reply came to rest on this peer");
+        } else {
+            PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
+            cnt = 1;
+            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, reply, &ret, &cnt, PMIX_STATUS);
+            report("credential reply carries a status", PMIX_SUCCESS == rc);
+            report("credential reply reports success", PMIX_SUCCESS == ret);
+            if (PMIX_SUCCESS == rc && PMIX_SUCCESS == ret) {
+                cnt = 1;
+                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, reply, &bo, &cnt,
+                                   PMIX_BYTE_OBJECT);
+                report("credential reply carries the credential",
+                       PMIX_SUCCESS == rc && 4 == bo.size && NULL != bo.bytes
+                           && 0 == memcmp(bo.bytes, "cred", 4));
+                cnt = 1;
+                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, reply, &rninfo, &cnt, PMIX_SIZE);
+                if (PMIX_SUCCESS == rc && 1 == rninfo) {
+                    PMIX_INFO_CREATE(rinfo, rninfo);
+                    cnt = (int32_t) rninfo;
+                    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, reply, rinfo, &cnt,
+                                       PMIX_INFO);
+                }
+                report("credential reply carries one info", PMIX_SUCCESS == rc
+                           && 1 == rninfo && NULL != rinfo);
+                /* the host destructed and overwrote its array before it
+                 * returned, so this only survives a real copy */
+                report("credential reply kept the host's key",
+                       NULL != rinfo && PMIX_CHECK_KEY(&rinfo[0], CTLUT_CREDKEY));
+                report("credential reply kept the host's value",
+                       NULL != rinfo && PMIX_STRING == rinfo[0].value.type
+                           && NULL != rinfo[0].value.data.string
+                           && 0 == strcmp(rinfo[0].value.data.string, CTLUT_CREDVAL));
+                if (NULL != rinfo) {
+                    PMIX_INFO_FREE(rinfo, rninfo);
+                }
+            }
+            PMIX_BYTE_OBJECT_DESTRUCT(&bo);
+            PMIX_RELEASE(reply);
+        }
     }
 
     /* --- job control: register a cleanup directory -------------------- */

--- a/test/unit/server_control.c
+++ b/test/unit/server_control.c
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for two of the directive/service command handlers
+ * in src/server/pmix_server_control.c: pmix_server_log() and
+ * pmix_server_job_ctrl(). Both are driven exactly as the switchyard drives
+ * them - a wire buffer packed by hand and a peer - so no DVM, no client,
+ * and no second process is involved.
+ *
+ * What is pinned down here:
+ *
+ *   log: the counts that arrive off the wire
+ *      Both counts are carried in a size_t and then consumed through the
+ *      int32_t count that PMIX_BFROPS_UNPACK takes. Every sibling handler
+ *      in that file survives a count that does not fit, because it only
+ *      ever uses the value to size an allocation that is immediately
+ *      unpacked into - and the unpack screens a NULL destination and
+ *      returns PMIX_ERR_BAD_PARAM. This handler is the exception twice
+ *      over: it *indexes* the directive array to append the log source
+ *      before anything has been unpacked into it, and it hands
+ *      (info, ninfo) straight to plog even when the unpack was skipped.
+ *      So a directive count of 0x80000000 truncated to a negative int32_t
+ *      and the source was written at that negative offset off a NULL
+ *      array. The bad-directive-count case therefore *crashes* an
+ *      unfixed library rather than failing - the same bargain
+ *      test/unit/iof_output.c makes.
+ *
+ *   log: the source directive is still appended
+ *      The screen above must not cost the handler its actual job. A
+ *      well-formed request has to come out of it with the caller's
+ *      directives intact plus PMIX_LOG_SOURCE appended, and with
+ *      PMIX_LOG_TIMESTAMP appended as well when the sender supplied a
+ *      non-zero timestamp.
+ *
+ *   job control: a repeated cleanup directory upgrades the registered entry
+ *      PMIX_REGISTER_CLEANUP_DIR for a path already on the epilog is a
+ *      duplicate, and the RFC precedence rule is that the more permissive
+ *      of the two flag sets wins. The upgrade has to be applied to the
+ *      entry sitting on the epilog, not to the request-local copy that is
+ *      discarded moments later - the latter compiles, runs, and silently
+ *      does nothing, so a second PMIx_Job_control asking for recursive
+ *      cleanup of an already-registered directory never took effect.
+ *      This case fails, rather than crashes, against an unfixed library.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/class/pmix_list.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/bfrops/bfrops.h"
+#include "src/runtime/pmix_rte.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define CTLUT_DIR "/tmp/pmix-server-control-ut-no-such-dir"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* what the host's log2 entry point was handed */
+static bool log_fired = false;
+static size_t log_ndata = 0;
+static size_t log_ndirs = 0;
+static bool log_saw_source = false;
+static bool log_saw_timestamp = false;
+
+static pmix_status_t stub_log2(const pmix_proc_t *client,
+                               const pmix_info_t data[], size_t ndata,
+                               const pmix_info_t directives[], size_t ndirs,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    size_t n;
+    (void) client;
+    (void) data;
+
+    log_fired = true;
+    log_ndata = ndata;
+    log_ndirs = ndirs;
+    log_saw_source = false;
+    log_saw_timestamp = false;
+    for (n = 0; n < ndirs; n++) {
+        if (PMIX_CHECK_KEY(&directives[n], PMIX_LOG_SOURCE)) {
+            log_saw_source = true;
+        } else if (PMIX_CHECK_KEY(&directives[n], PMIX_LOG_TIMESTAMP)) {
+            log_saw_timestamp = true;
+        }
+    }
+    /* complete synchronously - the arrays above belong to the caddy the
+     * completion is about to release, so everything we want out of them
+     * has already been copied */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+/* the handler refuses to run at all without one of these, but none of the
+ * cases below is supposed to reach it: they are all pure cleanup requests,
+ * which the server answers itself */
+static bool jobctrl_fired = false;
+static pmix_status_t stub_job_control(const pmix_proc_t *requestor,
+                                      const pmix_proc_t targets[], size_t ntargets,
+                                      const pmix_info_t directives[], size_t ndirs,
+                                      pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    (void) requestor;
+    (void) targets;
+    (void) ntargets;
+    (void) directives;
+    (void) ndirs;
+    (void) cbfunc;
+    (void) cbdata;
+
+    jobctrl_fired = true;
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+static void op_stub(pmix_status_t status, void *cbdata)
+{
+    (void) status;
+    (void) cbdata;
+}
+
+/* Build the wire form of a LOG request as a >= 3.0 client sends it:
+ * timestamp, ninfo, info[], ndirs, directives[]. The two counts are passed
+ * separately from the arrays so a caller can lie about them. */
+static pmix_buffer_t *build_log_request(time_t timestamp,
+                                        size_t claimed_ninfo, pmix_info_t *info,
+                                        size_t actual_ninfo,
+                                        size_t claimed_ndirs, pmix_info_t *dirs,
+                                        size_t actual_ndirs)
+{
+    pmix_buffer_t *buf;
+    pmix_status_t rc;
+
+    buf = PMIX_NEW(pmix_buffer_t);
+    if (NULL == buf) {
+        return NULL;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &timestamp, 1, PMIX_TIME);
+    if (PMIX_SUCCESS != rc) {
+        goto err;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &claimed_ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        goto err;
+    }
+    if (0 < actual_ninfo) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, info, actual_ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            goto err;
+        }
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &claimed_ndirs, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        goto err;
+    }
+    if (0 < actual_ndirs) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, dirs, actual_ndirs, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            goto err;
+        }
+    }
+    return buf;
+
+err:
+    PMIX_RELEASE(buf);
+    return NULL;
+}
+
+static pmix_status_t do_log(time_t timestamp,
+                            size_t claimed_ninfo, pmix_info_t *info, size_t actual_ninfo,
+                            size_t claimed_ndirs, pmix_info_t *dirs, size_t actual_ndirs)
+{
+    pmix_buffer_t *buf;
+    pmix_status_t rc;
+
+    log_fired = false;
+    log_ndata = 0;
+    log_ndirs = 0;
+    log_saw_source = false;
+    log_saw_timestamp = false;
+
+    buf = build_log_request(timestamp, claimed_ninfo, info, actual_ninfo,
+                            claimed_ndirs, dirs, actual_ndirs);
+    if (NULL == buf) {
+        return PMIX_ERR_NOMEM;
+    }
+    rc = pmix_server_log(pmix_globals.mypeer, buf, op_stub, NULL);
+    PMIX_RELEASE(buf);
+    return rc;
+}
+
+/* Build and drive a JOB_CONTROL request carrying no targets, so the
+ * cleanup directives land on the requesting peer's namespace epilog. */
+static pmix_status_t do_job_ctrl(pmix_info_t *info, size_t ninfo)
+{
+    pmix_buffer_t *buf;
+    pmix_status_t rc;
+    size_t ntargets = 0;
+
+    jobctrl_fired = false;
+
+    buf = PMIX_NEW(pmix_buffer_t);
+    if (NULL == buf) {
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &ntargets, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return rc;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return rc;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, info, ninfo, PMIX_INFO);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return rc;
+    }
+    rc = pmix_server_job_ctrl(pmix_globals.mypeer, buf, NULL, NULL);
+    PMIX_RELEASE(buf);
+    return rc;
+}
+
+static pmix_cleanup_dir_t *only_epilog_dir(size_t *count)
+{
+    pmix_epilog_t *epi = &pmix_globals.mypeer->nptr->epilog;
+    pmix_cleanup_dir_t *cd, *found = NULL;
+
+    *count = 0;
+    PMIX_LIST_FOREACH (cd, &epi->cleanup_dirs, pmix_cleanup_dir_t) {
+        ++(*count);
+        if (NULL == found) {
+            found = cd;
+        }
+    }
+    return found;
+}
+
+static void drain_epilog_dirs(void)
+{
+    pmix_epilog_t *epi = &pmix_globals.mypeer->nptr->epilog;
+    pmix_list_item_t *item;
+
+    /* drain rather than PMIX_LIST_DESTRUCT: the epilog owns the list and
+     * will destruct it itself, and PMIX_LIST_DESTRUCT is not idempotent */
+    while (NULL != (item = pmix_list_remove_first(&epi->cleanup_dirs))) {
+        PMIX_RELEASE(item);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_status_t rc;
+    pmix_info_t data, dirs[1], jc[2];
+    pmix_cleanup_dir_t *cd;
+    size_t ndirs;
+    bool flag = true;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "server_control: server-side log and job-control unit tests\n");
+
+    mymodule.log2 = stub_log2;
+    mymodule.job_control = stub_job_control;
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    /* take the gateway question out of the picture: with this set the
+     * handler always passes the record up to the host, which is the arm
+     * these cases are about */
+    pmix_log_host_only = true;
+
+    PMIX_INFO_LOAD(&data, PMIX_LOG_STDERR, "hello", PMIX_STRING);
+    PMIX_INFO_LOAD(&dirs[0], PMIX_LOG_GENERATE_TIMESTAMP, &flag, PMIX_BOOL);
+
+    /* --- a well-formed record reaches the host with the source added --- */
+    rc = do_log(0, 1, &data, 1, 1, dirs, 1);
+    report("well-formed log accepted", PMIX_SUCCESS == rc);
+    report("well-formed log reached the host", log_fired);
+    report("well-formed log kept the caller's data", 1 == log_ndata);
+    report("well-formed log appended the source", 2 == log_ndirs && log_saw_source);
+    report("well-formed log added no timestamp", !log_saw_timestamp);
+
+    /* --- a record carrying a timestamp gets that appended too --------- */
+    rc = do_log(1234567, 1, &data, 1, 1, dirs, 1);
+    report("timestamped log accepted", PMIX_SUCCESS == rc);
+    report("timestamped log appended source and timestamp",
+           3 == log_ndirs && log_saw_source && log_saw_timestamp);
+
+    /* --- a record with no directives at all still gets a source ------- */
+    rc = do_log(0, 0, NULL, 0, 0, NULL, 0);
+    report("empty log accepted", PMIX_SUCCESS == rc);
+    report("empty log still carries the source", 1 == log_ndirs && log_saw_source);
+
+    /* --- counts that do not survive the trip through int32_t ---------- */
+    rc = do_log(0, (size_t) 0x80000000UL, &data, 1, 1, dirs, 1);
+    report("log rejects an unusable info count", PMIX_ERR_BAD_PARAM == rc);
+    report("log did not hand the host a bogus info count", !log_fired);
+
+    rc = do_log(0, 1, &data, 1, (size_t) 0x80000000UL, dirs, 1);
+    report("log rejects an unusable directive count", PMIX_ERR_BAD_PARAM == rc);
+    report("log did not hand the host a bogus directive count", !log_fired);
+
+    PMIX_INFO_DESTRUCT(&data);
+    PMIX_INFO_DESTRUCT(&dirs[0]);
+
+    /* --- job control: register a cleanup directory -------------------- */
+    PMIX_INFO_LOAD(&jc[0], PMIX_REGISTER_CLEANUP_DIR, CTLUT_DIR, PMIX_STRING);
+    rc = do_job_ctrl(jc, 1);
+    report("cleanup directory registered", PMIX_OPERATION_SUCCEEDED == rc);
+    report("cleanup registration stayed local to us", !jobctrl_fired);
+    cd = only_epilog_dir(&ndirs);
+    report("epilog holds exactly one directory", 1 == ndirs && NULL != cd);
+    report("registered directory is not recursive",
+           NULL != cd && !cd->recurse && !cd->leave_topdir);
+
+    /* --- the same directory again, now asking for recursion ----------- */
+    PMIX_INFO_LOAD(&jc[1], PMIX_CLEANUP_RECURSIVE, &flag, PMIX_BOOL);
+    rc = do_job_ctrl(jc, 2);
+    report("repeated cleanup directory accepted", PMIX_OPERATION_SUCCEEDED == rc);
+    cd = only_epilog_dir(&ndirs);
+    report("repeat did not duplicate the entry", 1 == ndirs && NULL != cd);
+    report("repeat upgraded the registered entry to recursive",
+           NULL != cd && cd->recurse);
+    PMIX_INFO_DESTRUCT(&jc[1]);
+
+    /* --- and once more asking to leave the top directory -------------- */
+    PMIX_INFO_LOAD(&jc[1], PMIX_CLEANUP_LEAVE_TOPDIR, &flag, PMIX_BOOL);
+    rc = do_job_ctrl(jc, 2);
+    report("third cleanup directive accepted", PMIX_OPERATION_SUCCEEDED == rc);
+    cd = only_epilog_dir(&ndirs);
+    report("third request did not duplicate the entry", 1 == ndirs && NULL != cd);
+    report("third request added leave-topdir", NULL != cd && cd->leave_topdir);
+    report("third request did not undo recursion", NULL != cd && cd->recurse);
+    PMIX_INFO_DESTRUCT(&jc[1]);
+    PMIX_INFO_DESTRUCT(&jc[0]);
+
+    drain_epilog_dirs();
+
+    PMIx_server_finalize();
+
+    fprintf(stdout, "server_control: %d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/server_dmodex.c
+++ b/test/unit/server_dmodex.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for src/server/pmix_server_dmodex.c - the two data
+ * calls the host makes down into us.
+ *
+ * The case that matters is the deferral. PMIx_server_dmodex_request asks
+ * for the modex data of one of our local clients on behalf of a remote
+ * server; if that client has not committed its data yet, the request is
+ * parked on pmix_server_globals.remote_pnd and the host's response
+ * function is not called. The *only* thing that ever took a request back
+ * off that list was the target committing - so a target that departs
+ * without committing (it aborted, it never called PMIx_Put, its namespace
+ * was torn down) left the host holding a request it would never hear
+ * about again, and the remote client blocked in PMIx_Get behind it waited
+ * forever. The mirror image on the other deferral list, local_reqs, has
+ * been handled by pmix_server_purge_events for some time; this is the
+ * same rule applied to the list going the other way.
+ *
+ * Ordering here is deterministic rather than timed. PMIx_server_dmodex_request
+ * thread-shifts and returns, so the parking happens on the progress
+ * thread; PMIx_Store_internal is a blocking call onto that same thread,
+ * so when it returns, everything queued ahead of it - including our
+ * deferred request - has already run. PMIx_server_deregister_nspace is
+ * then driven in its blocking form, so purge_events has completed by the
+ * time it returns and the response function has either fired or never
+ * will. No sleeps, no polling.
+ *
+ * Test cases:
+ *
+ *   store internal, then read it back      -> the value survives the xfer
+ *   store internal with a NULL value       -> PMIX_ERR_BAD_PARAM
+ *   dmodex for an uncommitted local rank   -> parked, host not answered
+ *   that rank's nspace is deregistered     -> host answered with an error
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/class/pmix_list.h"
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define DMUT_NSPACE "server-dmodex-ut"
+#define DMUT_NPROCS 2
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* what the host's dmodex response function was told */
+static bool dm_fired = false;
+static pmix_status_t dm_status = PMIX_SUCCESS;
+
+static void dmresponse(pmix_status_t status, char *data, size_t sz, void *cbdata)
+{
+    (void) data;
+    (void) sz;
+    (void) cbdata;
+
+    dm_fired = true;
+    dm_status = status;
+}
+
+static size_t nparked(void)
+{
+    return pmix_list_get_size(&pmix_server_globals.remote_pnd);
+}
+
+/* A blocking round trip through the progress thread. Anything queued onto
+ * that thread before this call has been serviced by the time it returns. */
+static void progress_barrier(void)
+{
+    pmix_value_t v;
+
+    PMIX_VALUE_LOAD(&v, "barrier", PMIX_STRING);
+    PMIx_Store_internal(&pmix_globals.myid, "server-dmodex-ut.barrier", &v);
+    PMIX_VALUE_DESTRUCT(&v);
+}
+
+static pmix_status_t register_job(void)
+{
+    pmix_info_t info[2];
+    pmix_nspace_t ns;
+    pmix_proc_t proc;
+    pmix_status_t rc;
+    uint32_t nprocs = DMUT_NPROCS;
+    pmix_rank_t r;
+
+    PMIX_INFO_LOAD(&info[0], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&info[1], PMIX_UNIV_SIZE, &nprocs, PMIX_UINT32);
+
+    PMIX_LOAD_NSPACE(ns, DMUT_NSPACE);
+    rc = PMIx_server_register_nspace(ns, DMUT_NPROCS, info, 2, NULL, NULL);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+
+    for (r = 0; r < DMUT_NPROCS; r++) {
+        PMIX_LOAD_PROCID(&proc, DMUT_NSPACE, r);
+        rc = PMIx_server_register_client(&proc, geteuid(), getegid(), NULL, NULL, NULL);
+        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+            return rc;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_status_t rc;
+    pmix_proc_t target;
+    pmix_value_t val, *got = NULL;
+    pmix_nspace_t ns;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "server_dmodex: host-facing data call unit tests\n");
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* --- PMIx_Store_internal round trip ------------------------------ */
+    PMIX_VALUE_LOAD(&val, "stored-value", PMIX_STRING);
+    rc = PMIx_Store_internal(&pmix_globals.myid, "server-dmodex-ut.key", &val);
+    report("store internal accepted", PMIX_SUCCESS == rc);
+    PMIX_VALUE_DESTRUCT(&val);
+
+    rc = PMIx_Get(&pmix_globals.myid, "server-dmodex-ut.key", NULL, 0, &got);
+    report("stored value reads back", PMIX_SUCCESS == rc && NULL != got
+                                          && PMIX_STRING == got->type
+                                          && NULL != got->data.string
+                                          && 0 == strcmp(got->data.string, "stored-value"));
+    if (NULL != got) {
+        PMIX_VALUE_RELEASE(got);
+        got = NULL;
+    }
+
+    /* --- and it screens the value it is about to dereference --------- */
+    rc = PMIx_Store_internal(&pmix_globals.myid, "server-dmodex-ut.bad", NULL);
+    report("store internal rejects a NULL value", PMIX_ERR_BAD_PARAM == rc);
+
+    /* --- a dmodex request for a rank that has not committed ---------- */
+    rc = register_job();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "register_job failed: %s\n", PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    dm_fired = false;
+    PMIX_LOAD_PROCID(&target, DMUT_NSPACE, 0);
+    rc = PMIx_server_dmodex_request(&target, dmresponse, NULL);
+    report("dmodex request accepted", PMIX_SUCCESS == rc);
+    progress_barrier();
+    report("uncommitted rank defers the request", 1 == nparked());
+    report("deferred request does not answer the host yet", !dm_fired);
+
+    /* --- the target departs without ever committing ------------------ */
+    PMIX_LOAD_NSPACE(ns, DMUT_NSPACE);
+    PMIx_server_deregister_nspace(ns, NULL, NULL);
+    progress_barrier();
+    report("departure drained the deferred request", 0 == nparked());
+    report("departure answered the host", dm_fired);
+    report("departure answered with a failure status",
+           dm_fired && PMIX_SUCCESS != dm_status);
+
+    PMIx_server_finalize();
+
+    fprintf(stdout, "server_dmodex: %d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/server_fabric.c
+++ b/test/unit/server_fabric.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit test for pmix_server_device_dists() in
+ * src/server/pmix_server_fabric.c, driven exactly as the switchyard
+ * drives it - a wire buffer packed by hand and a peer - so no DVM, no
+ * client, and no second process is involved.
+ *
+ * What is pinned down here:
+ *
+ *   the distance array must outlive the call that computed it
+ *      pmix_server_dist_cbfunc, which is what the switchyard hands this
+ *      handler, does nothing but thread-shift: the reply is packed from
+ *      the array later, on the progress thread. The handler used to pass
+ *      (NULL, NULL) for the callback's (release_fn, release_cbdata) pair
+ *      and free the array on the next line, so every locally answered
+ *      PMIx_Compute_distances packed freed heap into its reply. The
+ *      deterministic half of that is the contract: a producer whose data
+ *      is consumed after it returns has to supply a release function.
+ *      This case fails against an unfixed library on that assertion
+ *      alone, without depending on what the freed memory happened to
+ *      hold.
+ *
+ *      The second half - reading the array after the handler has
+ *      returned - is a use-after-free against an unfixed library that a
+ *      plain run will usually get away with. It is here for valgrind,
+ *      and it is why this program is worth running under it.
+ *
+ *   the borrowed-topology path must not leak its source string
+ *      A request that carries no topology means "use your own", which is
+ *      the common case. pmix_hwloc_unpack_topology still strdup's a
+ *      "hwloc" source for it, and the handler then points the topology
+ *      at the global one - so the destruct at the end is skipped and
+ *      nothing else would ever free that string. This case cannot assert
+ *      the leak in-process; it exists so that the path is walked under
+ *      valgrind, where the leak is one record per request.
+ *
+ * What this cannot assert on every host, and why: hwloc has to find at
+ * least one OS device to measure a distance against. A bare macOS host
+ * reports none, so pmix_hwloc_compute_distances answers
+ * PMIX_ERR_NOT_FOUND and the cases above have no answer to hold a
+ * contract against - they report SKIP carrying that status rather than
+ * passing vacuously. Everything ahead of the computation still runs
+ * there: the hand-packed buffer unpacks, the "use your own topology"
+ * path is taken, and the supplied cpuset is accepted. On Linux, where
+ * hwloc reports network and block devices, the assertions run.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/hwloc/pmix_hwloc.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/bfrops/bfrops.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+static void skip(const char *name, const char *why)
+{
+    fprintf(stdout, "  SKIP: %s (%s)\n", name, why);
+}
+
+/* What the handler handed its completion callback. We deliberately keep
+ * the array pointer rather than copying it: reading it after the handler
+ * has returned is the whole point of the first case. */
+static bool dist_fired = false;
+static pmix_status_t dist_status = PMIX_SUCCESS;
+static pmix_device_distance_t *dist_array = NULL;
+static size_t dist_ndist = 0;
+static pmix_release_cbfunc_t dist_relfn = NULL;
+static void *dist_relcbd = NULL;
+
+static void dist_cbfunc(pmix_status_t status, pmix_device_distance_t *dist,
+                        size_t ndist, void *cbdata,
+                        pmix_release_cbfunc_t relfn, void *relcbd)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t *) cbdata;
+
+    dist_fired = true;
+    dist_status = status;
+    dist_array = dist;
+    dist_ndist = ndist;
+    dist_relfn = relfn;
+    dist_relcbd = relcbd;
+
+    /* stand in for pmix_server_dist_cbfunc, which parks exactly these on
+     * a shift caddy and returns - it does not consume any of them here */
+    if (NULL != cd) {
+        PMIX_RELEASE(cd);
+    }
+}
+
+/* Pack a COMPUTE_DEVICE_DISTANCES request the way a client does: a
+ * topology, a cpuset, then the directive count and array. A NULL
+ * topology asks the server to use its own. */
+static pmix_status_t do_device_dists(pmix_cpuset_t *cpuset)
+{
+    pmix_buffer_t *buf;
+    pmix_server_caddy_t *cd;
+    pmix_topology_t topo = {NULL, NULL};
+    pmix_status_t rc;
+    size_t ninfo = 0;
+
+    dist_fired = false;
+    dist_array = NULL;
+    dist_ndist = 0;
+    dist_relfn = NULL;
+    dist_relcbd = NULL;
+
+    buf = PMIX_NEW(pmix_buffer_t);
+    if (NULL == buf) {
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &topo, 1, PMIX_TOPO);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, cpuset, 1, PMIX_PROC_CPUSET);
+    }
+    if (PMIX_SUCCESS == rc) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &ninfo, 1, PMIX_SIZE);
+    }
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return rc;
+    }
+
+    cd = PMIX_NEW(pmix_server_caddy_t);
+    if (NULL == cd) {
+        PMIX_RELEASE(buf);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_RETAIN(pmix_globals.mypeer);
+    cd->peer = pmix_globals.mypeer;
+    cd->hdr.tag = 0;
+
+    rc = pmix_server_device_dists(cd, buf, dist_cbfunc);
+    if (PMIX_SUCCESS != rc) {
+        /* the switchyard owns the caddy on a non-success return */
+        PMIX_RELEASE(cd);
+    }
+    PMIX_RELEASE(buf);
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_cpuset_t cpuset;
+    pmix_status_t rc;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "server_fabric: server-side device-distance unit tests\n");
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* Supply a cpuset of our own. Leaving it out sends the handler to the
+     * datastore for the requestor's binding, which a bare unit-test
+     * server has never been told - so the request would fail before ever
+     * reaching the computation these cases are about. */
+    memset(&cpuset, 0, sizeof(cpuset));
+    rc = pmix_hwloc_parse_cpuset_string("hwloc:0", &cpuset);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "could not build a cpuset: %s\n", PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    rc = do_device_dists(&cpuset);
+
+    if (PMIX_SUCCESS != rc || !dist_fired) {
+        /* hwloc found nothing to measure against on this machine, or
+         * declined - there is no answer to hold the contract against, and
+         * that is a property of the host rather than of the library */
+        /* PMIX_ERR_NOT_FOUND from here means hwloc walked the topology
+         * and found no OS devices to measure against - true of a bare
+         * macOS host, and a property of the machine rather than of the
+         * library. Everything ahead of the computation still ran: the
+         * hand-packed buffer unpacked, the borrowed-topology path was
+         * taken, and the supplied cpuset was accepted. */
+        skip("distance request answered", PMIx_Error_string(rc));
+    } else {
+        report("distance request accepted", PMIX_SUCCESS == dist_status);
+
+        /* The deterministic assertion. The callback that really receives
+         * this only thread-shifts, so whoever produced the array has to
+         * keep it alive until the chain is done with it - which is what
+         * the release pair is for. Passing (NULL, NULL) and freeing the
+         * array in the handler is the defect this pins down. */
+        report("a locally computed distance array carries a release function",
+               NULL != dist_relfn);
+
+        /* And the array must still be readable at the point the real
+         * callback would pack it - i.e. now, after the handler returned.
+         * Against an unfixed library this reads freed memory. */
+        if (0 < dist_ndist && NULL != dist_array) {
+            report("the distance array survives the handler's return",
+                   NULL != dist_array[0].uuid);
+        } else {
+            skip("the distance array survives the handler's return",
+                 "host reported no devices");
+        }
+
+        /* releasing through the function we were given must be enough -
+         * anything the handler freed itself would be a double free here */
+        if (NULL != dist_relfn) {
+            dist_relfn(dist_relcbd);
+            report("releasing through the callback's own function is clean", true);
+        }
+    }
+
+    pmix_hwloc_destruct_cpuset(&cpuset);
+    PMIx_server_finalize();
+
+    fprintf(stdout, "server_fabric: %d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/server_fence.c
+++ b/test/unit/server_fence.c
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for pmix_server_fence(), driven exactly as the
+ * switchyard drives it - a wire buffer packed by hand and a peer - so no
+ * DVM, no client, and no second process is involved.
+ *
+ * What is pinned down here:
+ *
+ *   the counts that arrive off the wire
+ *      A fence message carries a proc count and an info count, both as a
+ *      size_t, and both are then consumed through the int32_t that
+ *      PMIX_BFROPS_UNPACK takes. Most handlers in src/server survive a
+ *      count that does not fit, because their only use of it is to size
+ *      an allocation the unpack immediately guards - and the unpack
+ *      screens a NULL destination. This handler is not that, twice over:
+ *
+ *        - the info count is used to *index* the array before anything
+ *          has been unpacked into it. Two slots are seeded, at info[ninf]
+ *          and info[ninf+1], so a count near SIZE_MAX wraps "ninf + 2"
+ *          down to a one-element array and writes the seeds far outside
+ *          it. That is an out-of-bounds write driven straight off the
+ *          wire by a local client.
+ *        - the proc count is multiplied by sizeof(pmix_proc_t) to size
+ *          the proc array, and it is that size_t - not the int32_t the
+ *          unpack consumed - which the qsort and the free below walk.
+ *
+ *      Both must now be rejected before they reach an allocator. The
+ *      info case *crashes* an unfixed library rather than failing, the
+ *      same bargain test/unit/server_control.c and test/unit/iof_output.c
+ *      make; the proc case answers PMIX_ERR_NOMEM there instead, so it
+ *      fails rather than crashes.
+ *
+ *   the screen must not cost the handler its job
+ *      A well-formed fence still has to build its tracker and reach the
+ *      host with the seeded slots intact and in order: the caller's
+ *      directives first, then PMIX_SORTED_PROC_ARRAY, then
+ *      PMIX_LOCAL_COLLECTIVE_STATUS last. pmix_server_fence reads that
+ *      last slot *positionally* - trk->info[trk->ninfo-1] - on two of its
+ *      completion arms, so the layout is load-bearing rather than
+ *      incidental, and a suite made only of malformed-count cases would
+ *      not notice a screen that rejected everything.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/class/pmix_list.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/bfrops/bfrops.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* what the host's fence_nb entry point was handed */
+static bool fence_fired = false;
+static size_t fence_nprocs = 0;
+static size_t fence_ninfo = 0;
+static bool fence_status_last = false;
+static bool fence_sorted_next_to_last = false;
+
+static pmix_status_t stub_fence_nb(const pmix_proc_t procs[], size_t nprocs,
+                                   const pmix_info_t info[], size_t ninfo,
+                                   char *data, size_t ndata,
+                                   pmix_modex_cbfunc_t cbfunc, void *cbdata)
+{
+    (void) procs;
+    (void) data;
+    (void) ndata;
+    (void) cbfunc;
+    (void) cbdata;
+
+    fence_fired = true;
+    fence_nprocs = nprocs;
+    fence_ninfo = ninfo;
+    fence_status_last = false;
+    fence_sorted_next_to_last = false;
+    if (NULL != info && 2 <= ninfo) {
+        fence_status_last = PMIX_CHECK_KEY(&info[ninfo - 1], PMIX_LOCAL_COLLECTIVE_STATUS);
+        fence_sorted_next_to_last = PMIX_CHECK_KEY(&info[ninfo - 2], PMIX_SORTED_PROC_ARRAY);
+    }
+    /* decline, so the handler takes its host-error arm: it detaches our
+     * caddy from the tracker and drives the completion, which tears the
+     * tracker down. Accepting would instead leave the completion to us,
+     * and queueing a reply to a peer with no socket is not something this
+     * program can do. */
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+/* carrier for driving pmix_server_fence on the progress thread - it
+ * touches pmix_server_globals.collectives, so it must not be called from
+ * main(). The pmix_event_t is the thread-shift member required of every
+ * caddy. */
+typedef struct {
+    pmix_event_t ev;
+    pmix_lock_t lock;
+    size_t nprocs;      /* the count to put on the wire */
+    size_t nprocs_real; /* how many procs actually to pack */
+    size_t ninf;        /* the count to put on the wire */
+    size_t ninf_real;   /* how many info structs actually to pack */
+    pmix_status_t status;
+} fut_req_t;
+
+static void do_fence(int sd, short args, void *cbdata)
+{
+    fut_req_t *r = (fut_req_t *) cbdata;
+    pmix_buffer_t buf;
+    pmix_server_caddy_t *cd;
+    pmix_proc_t proc;
+    pmix_info_t dir;
+    pmix_status_t rc;
+    size_t n;
+    bool collect = false;
+
+    (void) sd;
+    (void) args;
+
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    PMIX_BFROPS_ASSIGN_TYPE(pmix_globals.mypeer, &buf);
+
+    /* the proc count, then the procs. The two may disagree on purpose:
+     * that is the whole point of the malformed-count cases. */
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &r->nprocs, 1, PMIX_SIZE);
+    for (n = 0; PMIX_SUCCESS == rc && n < r->nprocs_real; n++) {
+        /* a namespace this server has never been told about: new_tracker
+         * then marks the tracker non-local and definition-complete, so a
+         * well-formed request completes on this one contribution */
+        PMIX_LOAD_PROCID(&proc, "fence.ut.ns", (pmix_rank_t) n);
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &proc, 1, PMIX_PROC);
+    }
+    /* the info count, then the info structs */
+    if (PMIX_SUCCESS == rc) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &r->ninf, 1, PMIX_SIZE);
+    }
+    for (n = 0; PMIX_SUCCESS == rc && n < r->ninf_real; n++) {
+        PMIX_INFO_LOAD(&dir, PMIX_COLLECT_DATA, &collect, PMIX_BOOL);
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &dir, 1, PMIX_INFO);
+        PMIX_INFO_DESTRUCT(&dir);
+    }
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DESTRUCT(&buf);
+        r->status = rc;
+        PMIX_WAKEUP_THREAD(&r->lock);
+        return;
+    }
+
+    cd = PMIX_NEW(pmix_server_caddy_t);
+    if (NULL == cd) {
+        PMIX_DESTRUCT(&buf);
+        r->status = PMIX_ERR_NOMEM;
+        PMIX_WAKEUP_THREAD(&r->lock);
+        return;
+    }
+    PMIX_RETAIN(pmix_globals.mypeer);
+    cd->peer = pmix_globals.mypeer;
+    cd->hdr.tag = 0;
+
+    rc = pmix_server_fence(cd, &buf, pmix_server_modex_cbfunc);
+    if (PMIX_SUCCESS != rc) {
+        /* the switchyard owns the caddy on a non-success return */
+        PMIX_RELEASE(cd);
+    }
+    PMIX_DESTRUCT(&buf);
+    r->status = rc;
+    PMIX_WAKEUP_THREAD(&r->lock);
+}
+
+static pmix_status_t drive_fence(size_t nprocs, size_t nprocs_real,
+                                 size_t ninf, size_t ninf_real)
+{
+    fut_req_t req;
+    pmix_status_t rc;
+
+    memset(&req, 0, sizeof(req));
+    PMIX_CONSTRUCT_LOCK(&req.lock);
+    req.nprocs = nprocs;
+    req.nprocs_real = nprocs_real;
+    req.ninf = ninf;
+    req.ninf_real = ninf_real;
+    PMIX_THREADSHIFT(&req, do_fence);
+    PMIX_WAIT_THREAD(&req.lock);
+    rc = req.status;
+    PMIX_DESTRUCT_LOCK(&req.lock);
+    return rc;
+}
+
+/* The fence completion thread-shifts, so let anything queued behind us
+ * run before we look at the results or finalize. PMIx_Store_internal
+ * blocks on the progress thread, so anything queued ahead of it has run
+ * by the time it returns. */
+static void progress_barrier(void)
+{
+    pmix_value_t v;
+
+    PMIX_VALUE_LOAD(&v, "barrier", PMIX_STRING);
+    PMIx_Store_internal(&pmix_globals.myid, "server-fence-ut.barrier", &v);
+    PMIX_VALUE_DESTRUCT(&v);
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_status_t rc;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "server_fence: server-side fence handler unit tests\n");
+
+    mymodule.fence_nb = stub_fence_nb;
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* --- an info count that cannot survive the round trip --- *
+     * SIZE_MAX wraps "ninf + 2" to 1: the array is allocated with room
+     * for one element and the seeds are then written at info[0] and
+     * info[SIZE_MAX]. Against an unfixed library this is where the
+     * program dies. */
+    rc = drive_fence(1, 1, SIZE_MAX, 0);
+    report("fence rejects an info count of SIZE_MAX", PMIX_ERR_BAD_PARAM == rc);
+
+    /* the same class one step away from the wrap: a count that truncates
+     * to a negative int32_t, which is what the sibling handlers screen */
+    rc = drive_fence(1, 1, (size_t) 0x80000000ULL, 0);
+    report("fence rejects an info count that truncates negative",
+           PMIX_ERR_BAD_PARAM == rc);
+
+    /* --- a proc count that cannot survive the round trip --- */
+    rc = drive_fence((size_t) 1 << 40, 1, 0, 0);
+    report("fence rejects an oversized proc count", PMIX_ERR_BAD_PARAM == rc);
+
+    /* zero procs was always refused - the client has to name at least
+     * its own namespace */
+    rc = drive_fence(0, 0, 0, 0);
+    report("fence rejects a zero proc count", PMIX_ERR_BAD_PARAM == rc);
+
+    progress_barrier();
+
+    /* --- a well-formed fence still reaches the host --- *
+     * one proc, one directive. The handler seeds two more slots, and the
+     * order of those two is what its own completion arms read back
+     * positionally. */
+    fence_fired = false;
+    rc = drive_fence(1, 1, 1, 1);
+    progress_barrier();
+    report("well-formed fence reaches the host", fence_fired);
+    report("host is handed the caller's procs", 1 == fence_nprocs);
+    report("host is handed the directives plus two seeded slots", 3 == fence_ninfo);
+    report("PMIX_LOCAL_COLLECTIVE_STATUS is the last slot", fence_status_last);
+    report("PMIX_SORTED_PROC_ARRAY sits just ahead of it", fence_sorted_next_to_last);
+    /* the stub declined, so the handler must have handed the caddy back
+     * to the switchyard rather than keeping it */
+    report("a declining host leaves the caddy to the switchyard",
+           PMIX_ERR_NOT_SUPPORTED == rc);
+
+    /* nothing may be left parked on the collectives list */
+    report("no tracker is left behind",
+           0 == pmix_list_get_size(&pmix_server_globals.collectives));
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/server_fence.c
+++ b/test/unit/server_fence.c
@@ -45,6 +45,32 @@
  *      completion arms, so the layout is load-bearing rather than
  *      incidental, and a suite made only of malformed-count cases would
  *      not notice a screen that rejected everything.
+ *
+ *   the completion answers every participant, with the right status
+ *      pmix_server_modex_cbfunc is the other half of this handler: it is
+ *      what the host calls when the fence resolves, and it owes a reply
+ *      to each caddy the tracker collected. Two things about that loop
+ *      are invisible with a single participant, which is all the cases
+ *      above build:
+ *
+ *        - the status packed for each client is the collective's own,
+ *          held in a local across the whole loop, and
+ *          PMIX_GDS_MARK_MODEX_COMPLETE *assigns* the variable it is
+ *          given. Writing it into that local reported a failed fence as
+ *          PMIX_SUCCESS to every participant after the first - and the
+ *          gds/hash entry point is a no-op returning PMIX_SUCCESS, so it
+ *          did so on every ordinary server.
+ *        - a failure serving one participant used to leave the loop, and
+ *          the tracker release at the foot of the function then frees the
+ *          remaining caddies without a reply. Nothing else ever answers
+ *          them, so those clients sit in PMIx_Fence forever.
+ *
+ *      The case below drives the completion directly with a failing
+ *      status over a two-participant tracker and reads back what was
+ *      actually queued for each. Queueing works here because a peer
+ *      whose sd is negative never has its send event armed, so the
+ *      messages come to rest on send_msg and send_queue - the same idiom
+ *      test/unit/server_control.c uses to inspect a reply.
  */
 
 #include "src/include/pmix_config.h"
@@ -55,6 +81,7 @@
 #include "src/class/pmix_list.h"
 #include "src/include/pmix_globals.h"
 #include "src/mca/bfrops/bfrops.h"
+#include "src/mca/ptl/ptl_types.h"
 #include "src/server/pmix_server_ops.h"
 
 #include <stdio.h>
@@ -207,6 +234,97 @@ static pmix_status_t drive_fence(size_t nprocs, size_t nprocs_real,
     return rc;
 }
 
+/* --- driving pmix_server_modex_cbfunc over a two-participant tracker ---
+ *
+ * The tracker and its caddies touch pmix_server_globals.collectives, so
+ * they are built on the progress thread like everything else here. The
+ * completion itself is called from main(), which is exactly how a host
+ * calls it - it does nothing but thread-shift. */
+typedef struct {
+    pmix_event_t ev;
+    pmix_lock_t lock;
+    size_t nparticipants;
+    pmix_server_trkr_t *trk;
+} trkbuild_t;
+
+static void build_tracker(int sd, short args, void *cbdata)
+{
+    trkbuild_t *b = (trkbuild_t *) cbdata;
+    pmix_server_trkr_t *trk;
+    pmix_server_caddy_t *cd;
+    size_t n;
+
+    (void) sd;
+    (void) args;
+
+    trk = PMIX_NEW(pmix_server_trkr_t);
+    if (NULL == trk) {
+        b->trk = NULL;
+        PMIX_WAKEUP_THREAD(&b->lock);
+        return;
+    }
+    trk->type = PMIX_FENCENB_CMD;
+    trk->collect_type = PMIX_COLLECT_NO;
+    trk->nlocal = (uint32_t) b->nparticipants;
+    trk->def_complete = true;
+    trk->host_called = true;
+    for (n = 0; n < b->nparticipants; n++) {
+        cd = PMIX_NEW(pmix_server_caddy_t);
+        PMIX_RETAIN(pmix_globals.mypeer);
+        cd->peer = pmix_globals.mypeer;
+        cd->hdr.tag = (uint32_t) (100 + n);
+        pmix_list_append(&trk->local_cbs, &cd->super);
+    }
+    /* the completion unlinks it from here, so it has to be on the list */
+    pmix_list_append(&pmix_server_globals.collectives, &trk->super);
+    b->trk = trk;
+    PMIX_WAKEUP_THREAD(&b->lock);
+}
+
+/* Take the next reply the server queued for our own peer. With no socket
+ * the send event is never armed, so the first lands on send_msg and the
+ * rest accumulate on send_queue. */
+static pmix_buffer_t *take_queued_reply(void)
+{
+    pmix_peer_t *peer = pmix_globals.mypeer;
+    pmix_ptl_send_t *snd = peer->send_msg;
+    pmix_buffer_t *buf;
+
+    if (NULL != snd) {
+        peer->send_msg = NULL;
+    } else {
+        snd = (pmix_ptl_send_t *) pmix_list_remove_first(&peer->send_queue);
+        if (NULL == snd) {
+            return NULL;
+        }
+    }
+    buf = snd->data;
+    /* the buffer is ours now - the send's destructor would release it */
+    snd->data = NULL;
+    PMIX_RELEASE(snd);
+    return buf;
+}
+
+/* unpack the status a queued reply leads with; PMIX_ERR_NOT_FOUND if
+ * there was no reply at all */
+static pmix_status_t next_reply_status(void)
+{
+    pmix_buffer_t *reply;
+    pmix_status_t st, rc;
+    int32_t cnt = 1;
+
+    reply = take_queued_reply();
+    if (NULL == reply) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, reply, &st, &cnt, PMIX_STATUS);
+    PMIX_RELEASE(reply);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    return st;
+}
+
 /* The fence completion thread-shifts, so let anything queued behind us
  * run before we look at the results or finalize. PMIx_Store_internal
  * blocks on the progress thread, so anything queued ahead of it has run
@@ -283,6 +401,43 @@ int main(int argc, char **argv)
     /* nothing may be left parked on the collectives list */
     report("no tracker is left behind",
            0 == pmix_list_get_size(&pmix_server_globals.collectives));
+
+    /* --- the completion answers every participant with the collective's
+     *     own status --- *
+     * Two participants, and a fence the host failed. Against an unfixed
+     * library the first reply carries PMIX_ERR_TIMEOUT and the second
+     * carries PMIX_SUCCESS, because PMIX_GDS_MARK_MODEX_COMPLETE
+     * overwrote the status local after the first was packed. */
+    {
+        trkbuild_t b;
+        pmix_status_t st1, st2;
+
+        memset(&b, 0, sizeof(b));
+        PMIX_CONSTRUCT_LOCK(&b.lock);
+        b.nparticipants = 2;
+        PMIX_THREADSHIFT(&b, build_tracker);
+        PMIX_WAIT_THREAD(&b.lock);
+        PMIX_DESTRUCT_LOCK(&b.lock);
+
+        report("a two-participant tracker was built", NULL != b.trk);
+        if (NULL != b.trk) {
+            /* drain anything an earlier case may have left queued */
+            while (NULL != take_queued_reply()) {
+                continue;
+            }
+            pmix_server_modex_cbfunc(PMIX_ERR_TIMEOUT, NULL, 0, b.trk, NULL, NULL);
+            progress_barrier();
+
+            st1 = next_reply_status();
+            st2 = next_reply_status();
+            report("the first participant is told the fence failed",
+                   PMIX_ERR_TIMEOUT == st1);
+            report("the second participant is told the same thing",
+                   PMIX_ERR_TIMEOUT == st2);
+            report("the completion leaves no tracker behind",
+                   0 == pmix_list_get_size(&pmix_server_globals.collectives));
+        }
+    }
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 

--- a/test/unit/server_fence.c
+++ b/test/unit/server_fence.c
@@ -71,6 +71,27 @@
  *      whose sd is negative never has its send event armed, so the
  *      messages come to rest on send_msg and send_queue - the same idiom
  *      test/unit/server_control.c uses to inspect a reply.
+ *
+ *   a namespace registration updates each pending tracker on its own
+ *      A collective that arrives before its namespaces are registered
+ *      parks, and _register_nspace is what later finishes defining it.
+ *      Two things there are invisible with a single tracker over a single
+ *      namespace, which is all any single-node functional test builds:
+ *
+ *        - the local count for a PMIX_RANK_WILDCARD participant was
+ *          *assigned* rather than accumulated, so a fence naming two
+ *          wildcard namespaces kept only the last-registered one's count.
+ *          It then went up to the host as soon as that many local procs
+ *          had contributed, and the rest of its participants arrived to
+ *          find the tracker gone.
+ *        - "are all this tracker's namespaces registered" was computed in
+ *          a variable hoisted above the tracker loop, so one tracker
+ *          naming a namespace we have not been told about left every
+ *          tracker behind it in the list marked incomplete. Whether a
+ *          collective completed depended on its position in the list.
+ *
+ *      The case below builds three trackers in a known order and reads
+ *      back what a registration did to each.
  */
 
 #include "src/include/pmix_config.h"
@@ -87,6 +108,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 static int npass = 0;
 static int nfail = 0;
@@ -338,6 +360,56 @@ static void progress_barrier(void)
     PMIX_VALUE_DESTRUCT(&v);
 }
 
+/* Three trackers built in a known list order, so a registration can be
+ * observed acting on each of them separately. new_tracker touches
+ * pmix_server_globals.collectives, so it runs on the progress thread. */
+typedef struct {
+    pmix_event_t ev;
+    pmix_lock_t lock;
+    pmix_server_trkr_t *acc;
+    pmix_server_trkr_t *bad;
+    pmix_server_trkr_t *carry;
+} regtrk_t;
+
+static void build_reg_trackers(int sd, short args, void *cbdata)
+{
+    regtrk_t *r = (regtrk_t *) cbdata;
+    pmix_proc_t procs[2];
+
+    (void) sd;
+    (void) args;
+
+    PMIX_LOAD_PROCID(&procs[0], "regnsA", PMIX_RANK_WILDCARD);
+    PMIX_LOAD_PROCID(&procs[1], "regnsB", PMIX_RANK_WILDCARD);
+    r->acc = pmix_server_new_tracker(NULL, procs, 2, PMIX_FENCENB_CMD);
+
+    PMIX_LOAD_PROCID(&procs[0], "regnsC", PMIX_RANK_WILDCARD);
+    r->bad = pmix_server_new_tracker(NULL, procs, 1, PMIX_FENCENB_CMD);
+
+    PMIX_LOAD_PROCID(&procs[0], "regnsB", PMIX_RANK_WILDCARD);
+    r->carry = pmix_server_new_tracker(NULL, procs, 1, PMIX_FENCENB_CMD);
+
+    PMIX_WAKEUP_THREAD(&r->lock);
+}
+
+static void drop_reg_trackers(int sd, short args, void *cbdata)
+{
+    regtrk_t *r = (regtrk_t *) cbdata;
+
+    (void) sd;
+    (void) args;
+
+    /* unlink before releasing - being on the list is not a reference */
+    pmix_list_remove_item(&pmix_server_globals.collectives, &r->acc->super);
+    PMIX_RELEASE(r->acc);
+    pmix_list_remove_item(&pmix_server_globals.collectives, &r->bad->super);
+    PMIX_RELEASE(r->bad);
+    pmix_list_remove_item(&pmix_server_globals.collectives, &r->carry->super);
+    PMIX_RELEASE(r->carry);
+
+    PMIX_WAKEUP_THREAD(&r->lock);
+}
+
 int main(int argc, char **argv)
 {
     static pmix_server_module_t mymodule = {0};
@@ -436,6 +508,67 @@ int main(int argc, char **argv)
                    PMIX_ERR_TIMEOUT == st2);
             report("the completion leaves no tracker behind",
                    0 == pmix_list_get_size(&pmix_server_globals.collectives));
+        }
+    }
+
+    /* --- a registration updates each pending tracker independently --- *
+     * Three namespaces: A fully registered up front, B registered only
+     * after the trackers exist, and C known (a client was registered for
+     * it) but whose nspace never is. Three trackers, in list order:
+     *
+     *   acc   {A wildcard, B wildcard} - new_tracker counts A only
+     *   bad   {C wildcard}             - can never be fully defined
+     *   carry {B wildcard}             - defined the moment B registers
+     *
+     * Registering B must take acc's count to A+B rather than replacing it
+     * with B, and must judge carry on carry's own namespaces rather than
+     * on the flag bad just cleared. */
+    {
+        regtrk_t r;
+        pmix_proc_t pr;
+        pmix_nspace_t ns;
+
+        PMIX_LOAD_PROCID(&pr, "regnsA", 0);
+        PMIx_server_register_client(&pr, geteuid(), getegid(), NULL, NULL, NULL);
+        PMIX_LOAD_PROCID(&pr, "regnsA", 1);
+        PMIx_server_register_client(&pr, geteuid(), getegid(), NULL, NULL, NULL);
+        PMIX_LOAD_NSPACE(ns, "regnsA");
+        PMIx_server_register_nspace(ns, 2, NULL, 0, NULL, NULL);
+
+        PMIX_LOAD_PROCID(&pr, "regnsB", 0);
+        PMIx_server_register_client(&pr, geteuid(), getegid(), NULL, NULL, NULL);
+        PMIX_LOAD_PROCID(&pr, "regnsB", 1);
+        PMIx_server_register_client(&pr, geteuid(), getegid(), NULL, NULL, NULL);
+        PMIX_LOAD_PROCID(&pr, "regnsC", 0);
+        PMIx_server_register_client(&pr, geteuid(), getegid(), NULL, NULL, NULL);
+
+        memset(&r, 0, sizeof(r));
+        PMIX_CONSTRUCT_LOCK(&r.lock);
+        PMIX_THREADSHIFT(&r, build_reg_trackers);
+        PMIX_WAIT_THREAD(&r.lock);
+        PMIX_DESTRUCT_LOCK(&r.lock);
+
+        report("three pending trackers were built",
+               NULL != r.acc && NULL != r.bad && NULL != r.carry);
+        if (NULL != r.acc && NULL != r.bad && NULL != r.carry) {
+            report("only the registered namespace is counted to start",
+                   2 == r.acc->nlocal);
+
+            PMIX_LOAD_NSPACE(ns, "regnsB");
+            PMIx_server_register_nspace(ns, 2, NULL, 0, NULL, NULL);
+            progress_barrier();
+
+            report("registering the second namespace adds to the count",
+                   4 == r.acc->nlocal);
+            report("a tracker naming an unregistered namespace stays undefined",
+                   !r.bad->def_complete);
+            report("a later tracker is judged on its own namespaces",
+                   r.carry->def_complete);
+
+            PMIX_CONSTRUCT_LOCK(&r.lock);
+            PMIX_THREADSHIFT(&r, drop_reg_trackers);
+            PMIX_WAIT_THREAD(&r.lock);
+            PMIX_DESTRUCT_LOCK(&r.lock);
         }
     }
 

--- a/test/unit/server_get.c
+++ b/test/unit/server_get.c
@@ -53,6 +53,11 @@
  *   unknown nspace + IMMEDIATE     -> PMIX_ERR_NOT_FOUND, nothing parked
  *   local rank not yet connected,
  *      + IMMEDIATE                 -> PMIX_ERR_NOT_FOUND, nothing parked
+ *   info count that wraps the
+ *      allocation                  -> PMIX_ERR_BAD_PARAM (kills an
+ *                                     unfixed library rather than
+ *                                     failing it - see the case)
+ *   info count that truncates      -> PMIX_ERR_BAD_PARAM
  *   WILDCARD rank                  -> job-level data handed to the callback
  *   WILDCARD, missing reserved key -> PMIX_ERR_NOT_FOUND, callback untouched
  *   WILDCARD, missing plain key    -> unchanged: success, empty payload
@@ -78,6 +83,7 @@
 #include "src/mca/bfrops/bfrops.h"
 #include "src/server/pmix_server_ops.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -169,6 +175,67 @@ static pmix_buffer_t *build_get_request(const char *nspace, pmix_rank_t rank,
         }
     }
     return buf;
+}
+
+/* Build a GET request whose info count is a lie: the count is packed but
+ * no info structs follow it. A handler that trusts the count never gets as
+ * far as the unpack that would have caught it. */
+static pmix_buffer_t *build_bad_ninfo_request(const char *nspace, pmix_rank_t rank,
+                                              size_t ninfo)
+{
+    pmix_buffer_t *buf;
+    pmix_status_t rc;
+    char *cptr = (char *) nspace;
+
+    buf = PMIX_NEW(pmix_buffer_t);
+    if (NULL == buf) {
+        return NULL;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &cptr, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return NULL;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &rank, 1, PMIX_PROC_RANK);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return NULL;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return NULL;
+    }
+    return buf;
+}
+
+static pmix_status_t do_bad_ninfo_get(size_t ninfo)
+{
+    pmix_server_caddy_t *cd;
+    pmix_buffer_t *buf;
+    pmix_status_t rc;
+
+    cb_fired = false;
+
+    buf = build_bad_ninfo_request(GETUT_NSPACE, 3, ninfo);
+    if (NULL == buf) {
+        return PMIX_ERR_NOMEM;
+    }
+    cd = PMIX_NEW(pmix_server_caddy_t);
+    if (NULL == cd) {
+        PMIX_RELEASE(buf);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_RETAIN(pmix_globals.mypeer);
+    cd->peer = pmix_globals.mypeer;
+    cd->hdr.tag = 0;
+
+    rc = pmix_server_get(buf, get_cbfunc, cd);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(cd);
+    }
+    PMIX_RELEASE(buf);
+    return rc;
 }
 
 /* Drive one server-side GET. Returns what pmix_server_get() returned; the
@@ -327,6 +394,26 @@ int main(int argc, char **argv)
            PMIX_ERR_NOT_FOUND == rc);
     report("unconnected local rank with IMMEDIATE parks nothing", nothing_parked());
     PMIX_INFO_DESTRUCT(&imm);
+
+    /* --- a lying info count off the wire ---------------------------- */
+    /* The count is packed and no info structs follow it, so nothing
+     * downstream screens it. PMIx_Info_create multiplies it by
+     * sizeof(pmix_info_t) with no overflow guard and then constructs that
+     * many elements, so this value - chosen to wrap the product - hands
+     * back a two-element allocation the constructor loop walks off the end
+     * of. Like the info-count case in server_fence.c, this one kills an
+     * unfixed library rather than failing it. */
+    rc = do_bad_ninfo_get((SIZE_MAX / sizeof(pmix_info_t)) + 2);
+    report("wrapping info count is rejected", PMIX_ERR_BAD_PARAM == rc);
+    report("wrapping info count parks nothing", nothing_parked());
+
+    /* the same screen catches the count that merely truncates: it names a
+     * different number of directives than the scan below the unpack walks.
+     * Express it in terms of INT32_MAX rather than a shift, so it is still
+     * a rejected value where size_t is 32 bits wide */
+    rc = do_bad_ninfo_get(((size_t) INT32_MAX) + 1);
+    report("truncating info count is rejected", PMIX_ERR_BAD_PARAM == rc);
+    report("truncating info count parks nothing", nothing_parked());
 
     /* --- job-level data still comes back ---------------------------- */
     rc = do_get(GETUT_NSPACE, PMIX_RANK_WILDCARD, PMIX_JOB_SIZE, NULL, 0);

--- a/test/unit/server_resolve.c
+++ b/test/unit/server_resolve.c
@@ -1,0 +1,507 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for the server side of the two "resolve" convenience
+ * APIs - pmix_server_resolve_peers() / pmix_server_resolve_node() and the
+ * progress-thread handlers they defer to, in src/server/pmix_server_resolve.c.
+ *
+ * The process comes up as a PMIx server with a stub host module that
+ * deliberately provides no "query" entry point. That is what puts these
+ * tests on the code path they are about: with no host to relay to, both
+ * handlers thread-shift and answer out of the local datastore, which is the
+ * half of the file a single process can reach at all.
+ *
+ * Two behaviors are pinned down.
+ *
+ *   the aggregate peer walk and its two passes
+ *      A request naming no namespace walks every namespace we know, builds
+ *      one "<nspace>:<peerlist>" string per namespace, and counts the peers
+ *      as it goes. It then allocates a proc array of that size and walks the
+ *      strings a *second* time to fill it, splitting each back apart at the
+ *      delimiter. The two passes have to agree, and they did not: the split
+ *      took the *first* colon, while a namespace is an arbitrary string the
+ *      host chose and may contain one of its own. For a namespace such as
+ *      "res:ut,x" the second pass therefore found three comma-separated
+ *      fields where the first pass had counted two peers, and wrote past the
+ *      end of the array that count had sized.
+ *
+ *      RESUT_NSPACE_ODD below is exactly that shape. Against an unfixed
+ *      library this case reports the wrong peer count and the wrong
+ *      namespaces, and the out-of-bounds write may well take the process
+ *      down before it gets that far - the same bargain test/unit/iof_output.c
+ *      makes with its wrap case.
+ *
+ *   the node-resolution status contract
+ *      docs/how-things-work/resolve.rst is explicit: a namespace that is
+ *      known but has no nodes assigned to it right now is a *successfully
+ *      executed* request answered with a NULL node list, not a failure.
+ *      PMIx_Resolve_nodes says exactly that when it resolves the request out
+ *      of the client's own store; the server handed the raw fetch status
+ *      back instead, so the same server answered the same question two
+ *      different ways depending on which side computed it.
+ *
+ * Test cases:
+ *
+ *   aggregate resolve_peers over two nspaces -> SUCCESS, every registered
+ *                                               rank, correct namespaces
+ *   resolve_peers naming one nspace          -> SUCCESS, that nspace's ranks
+ *   resolve_node naming a mapped nspace      -> SUCCESS, our hostname
+ *   resolve_node naming an unmapped nspace   -> SUCCESS, NULL node list
+ *   resolve_node naming an unknown nspace    -> PMIX_ERR_INVALID_NAMESPACE
+ *
+ * Replies are read back off the peer's send queue rather than out of a host
+ * stub: PMIX_SERVER_QUEUE_REPLY never arms the send event for a peer whose
+ * sd is negative, so the message comes to rest on send_msg and a single
+ * process can unpack exactly what the server packed. That idiom is
+ * documented in test/unit/server_control.c and shared with
+ * test/unit/server_fence.c.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/include/pmix_globals.h"
+#include "src/mca/bfrops/bfrops.h"
+#include "src/mca/ptl/base/base.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* a perfectly ordinary namespace */
+#define RESUT_NSPACE_PLAIN "resolve-ut"
+/* a namespace carrying the delimiter the aggregate walk inserts, followed
+ * by a comma - the shape the two-pass split used to disagree about */
+#define RESUT_NSPACE_ODD   "res:ut,x"
+/* registered with a job size but no node map, so it is known to us and has
+ * no node list */
+#define RESUT_NSPACE_BARE  "resolve-ut-bare"
+
+#define RESUT_NPROCS 2
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* Take the reply the handler queued. The peer has no socket, so the send
+ * event is never armed: the first lands on send_msg and the rest accumulate
+ * on send_queue. */
+static pmix_buffer_t *take_queued_reply(void)
+{
+    pmix_peer_t *peer = pmix_globals.mypeer;
+    pmix_ptl_send_t *snd = peer->send_msg;
+    pmix_buffer_t *buf;
+
+    if (NULL != snd) {
+        peer->send_msg = NULL;
+    } else {
+        snd = (pmix_ptl_send_t *) pmix_list_remove_first(&peer->send_queue);
+        if (NULL == snd) {
+            return NULL;
+        }
+    }
+    buf = snd->data;
+    /* the buffer is ours now - the send's destructor would release it */
+    snd->data = NULL;
+    PMIX_RELEASE(snd);
+    return buf;
+}
+
+/* Both handlers thread-shift, so let anything queued behind us run before
+ * we look at the reply. PMIx_Store_internal blocks on the progress thread,
+ * so everything queued ahead of it has run by the time it returns. */
+static void progress_barrier(void)
+{
+    pmix_value_t v;
+
+    PMIX_VALUE_LOAD(&v, "barrier", PMIX_STRING);
+    PMIx_Store_internal(&pmix_globals.myid, "resolve-ut.barrier", &v);
+    PMIX_VALUE_DESTRUCT(&v);
+}
+
+/* Build a caddy shaped the way the switchyard builds one. */
+static pmix_server_caddy_t *make_caddy(void)
+{
+    pmix_server_caddy_t *cd;
+
+    cd = PMIX_NEW(pmix_server_caddy_t);
+    if (NULL == cd) {
+        return NULL;
+    }
+    PMIX_RETAIN(pmix_globals.mypeer);
+    cd->peer = pmix_globals.mypeer;
+    cd->hdr.tag = 0;
+    return cd;
+}
+
+/* Drive one resolve_peers request and unpack whatever it queued. The proc
+ * array, when there is one, is handed back through the two OUT
+ * parameters. */
+static pmix_status_t do_resolve_peers(const char *nodename, const char *nspace,
+                                      pmix_proc_t **procs, size_t *nprocs)
+{
+    pmix_server_caddy_t *cd;
+    pmix_buffer_t *buf, *reply;
+    pmix_status_t rc, ret;
+    char *cptr;
+    int32_t cnt;
+
+    *procs = NULL;
+    *nprocs = 0;
+
+    buf = PMIX_NEW(pmix_buffer_t);
+    if (NULL == buf) {
+        return PMIX_ERR_NOMEM;
+    }
+    cptr = (char *) nodename;
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &cptr, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return rc;
+    }
+    cptr = (char *) nspace;
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &cptr, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return rc;
+    }
+
+    cd = make_caddy();
+    if (NULL == cd) {
+        PMIX_RELEASE(buf);
+        return PMIX_ERR_NOMEM;
+    }
+    rc = pmix_server_resolve_peers(cd, buf, pmix_server_respeers_cbfunc);
+    PMIX_RELEASE(buf);
+    if (PMIX_SUCCESS != rc) {
+        /* the switchyard owns the caddy on a non-success return */
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+    progress_barrier();
+
+    reply = take_queued_reply();
+    if (NULL == reply) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, reply, &ret, &cnt, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(reply);
+        return rc;
+    }
+    if (PMIX_SUCCESS == ret) {
+        cnt = 1;
+        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, reply, nprocs, &cnt, PMIX_SIZE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(reply);
+            return rc;
+        }
+        if (0 < *nprocs) {
+            PMIX_PROC_CREATE(*procs, *nprocs);
+            cnt = (int32_t) *nprocs;
+            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, reply, *procs, &cnt, PMIX_PROC);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_PROC_FREE(*procs, *nprocs);
+                *procs = NULL;
+                *nprocs = 0;
+                PMIX_RELEASE(reply);
+                return rc;
+            }
+        }
+    }
+    PMIX_RELEASE(reply);
+    return ret;
+}
+
+/* Drive one resolve_node request. The node list, when there is one, is
+ * handed back through *nodelist - which stays NULL when the server answered
+ * success with nothing, which is a legal answer. */
+static pmix_status_t do_resolve_node(const char *nspace, char **nodelist)
+{
+    pmix_server_caddy_t *cd;
+    pmix_buffer_t *buf, *reply;
+    pmix_status_t rc, ret;
+    char *cptr;
+    int32_t cnt;
+
+    *nodelist = NULL;
+
+    buf = PMIX_NEW(pmix_buffer_t);
+    if (NULL == buf) {
+        return PMIX_ERR_NOMEM;
+    }
+    cptr = (char *) nspace;
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &cptr, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(buf);
+        return rc;
+    }
+
+    cd = make_caddy();
+    if (NULL == cd) {
+        PMIX_RELEASE(buf);
+        return PMIX_ERR_NOMEM;
+    }
+    rc = pmix_server_resolve_node(cd, buf, pmix_server_resnodes_cbfunc);
+    PMIX_RELEASE(buf);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+    progress_barrier();
+
+    reply = take_queued_reply();
+    if (NULL == reply) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, reply, &ret, &cnt, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(reply);
+        return rc;
+    }
+    if (PMIX_SUCCESS == ret) {
+        cnt = 1;
+        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, reply, nodelist, &cnt, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(reply);
+            return rc;
+        }
+    }
+    PMIX_RELEASE(reply);
+    return ret;
+}
+
+/* Register a namespace with RESUT_NPROCS ranks, all of them on this node.
+ * The node map is what makes the gds derive the PMIX_LOCAL_PEERS entry the
+ * peer walk reads back. */
+static pmix_status_t register_mapped(const char *nsname)
+{
+    pmix_info_t info[4];
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    char *noderegex = NULL, *ppnregex = NULL;
+    uint32_t nprocs = RESUT_NPROCS;
+
+    PMIx_generate_regex(pmix_globals.hostname, &noderegex);
+    PMIx_generate_ppn("0,1", &ppnregex);
+
+    PMIX_INFO_LOAD(&info[0], PMIX_NODE_MAP, noderegex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&info[1], PMIX_PROC_MAP, ppnregex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&info[2], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&info[3], PMIX_UNIV_SIZE, &nprocs, PMIX_UINT32);
+
+    PMIX_LOAD_NSPACE(ns, nsname);
+    rc = PMIx_server_register_nspace(ns, RESUT_NPROCS, info, 4, NULL, NULL);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_INFO_DESTRUCT(&info[2]);
+    PMIX_INFO_DESTRUCT(&info[3]);
+    free(noderegex);
+    free(ppnregex);
+    return rc;
+}
+
+/* Register a namespace with no node map at all: known to us, with no node
+ * list to answer a resolve_node with. */
+static pmix_status_t register_bare(const char *nsname)
+{
+    pmix_info_t info[2];
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    uint32_t nprocs = RESUT_NPROCS;
+
+    PMIX_INFO_LOAD(&info[0], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&info[1], PMIX_UNIV_SIZE, &nprocs, PMIX_UINT32);
+
+    PMIX_LOAD_NSPACE(ns, nsname);
+    rc = PMIx_server_register_nspace(ns, 0, info, 2, NULL, NULL);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    return rc;
+}
+
+/* how many of the returned procs name this nspace, and are their ranks the
+ * ones that were registered for it? */
+static size_t count_ranks(pmix_proc_t *procs, size_t nprocs, const char *nsname,
+                          bool *ranks_ok)
+{
+    size_t n, found = 0;
+    bool seen[RESUT_NPROCS];
+
+    for (n = 0; n < RESUT_NPROCS; n++) {
+        seen[n] = false;
+    }
+    for (n = 0; n < nprocs; n++) {
+        if (0 != strncmp(procs[n].nspace, nsname, PMIX_MAX_NSLEN)) {
+            continue;
+        }
+        ++found;
+        if (procs[n].rank < RESUT_NPROCS) {
+            seen[procs[n].rank] = true;
+        }
+    }
+    *ranks_ok = true;
+    for (n = 0; n < RESUT_NPROCS; n++) {
+        if (!seen[n]) {
+            *ranks_ok = false;
+        }
+    }
+    return found;
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_status_t rc;
+    pmix_proc_t *procs = NULL;
+    size_t nprocs = 0, nplain, nodd;
+    char *nodelist = NULL;
+    bool ranks_ok = false, odd_ok = false;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "server_resolve: server-side resolve_peers/resolve_node unit tests\n");
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    /* the stub module has no query entry point, which is the configuration
+     * these tests need - assert it rather than assume it */
+    if (NULL != pmix_host_server.query) {
+        fprintf(stderr, "test setup error: host module advertises query\n");
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    rc = register_mapped(RESUT_NSPACE_PLAIN);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "register %s failed: %s\n", RESUT_NSPACE_PLAIN, PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+    rc = register_mapped(RESUT_NSPACE_ODD);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "register %s failed: %s\n", RESUT_NSPACE_ODD, PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+    rc = register_bare(RESUT_NSPACE_BARE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "register %s failed: %s\n", RESUT_NSPACE_BARE, PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    /* --- one namespace, our node --------------------------------------- */
+    rc = do_resolve_peers(NULL, RESUT_NSPACE_PLAIN, &procs, &nprocs);
+    report("resolve_peers for a mapped nspace succeeds", PMIX_SUCCESS == rc);
+    nplain = count_ranks(procs, nprocs, RESUT_NSPACE_PLAIN, &ranks_ok);
+    report("resolve_peers returns both of its ranks",
+           RESUT_NPROCS == nprocs && RESUT_NPROCS == nplain && ranks_ok);
+    if (NULL != procs) {
+        PMIX_PROC_FREE(procs, nprocs);
+        procs = NULL;
+    }
+
+    /* --- the same, for the namespace carrying a colon ------------------- */
+    rc = do_resolve_peers(NULL, RESUT_NSPACE_ODD, &procs, &nprocs);
+    report("resolve_peers for a colon-bearing nspace succeeds", PMIX_SUCCESS == rc);
+    nodd = count_ranks(procs, nprocs, RESUT_NSPACE_ODD, &ranks_ok);
+    report("resolve_peers returns both of its ranks under its real name",
+           RESUT_NPROCS == nprocs && RESUT_NPROCS == nodd && ranks_ok);
+    if (NULL != procs) {
+        PMIX_PROC_FREE(procs, nprocs);
+        procs = NULL;
+    }
+
+    /* --- the aggregate walk over every namespace ------------------------
+     * This is the case the two-pass split used to get wrong. The counting
+     * pass credits RESUT_NSPACE_ODD with two peers; a split on the *first*
+     * colon finds three fields in "res:ut,x:0,1" and writes a third entry
+     * past the end of the array those counts sized. */
+    rc = do_resolve_peers(NULL, NULL, &procs, &nprocs);
+    report("aggregate resolve_peers succeeds", PMIX_SUCCESS == rc);
+    report("aggregate resolve_peers returns exactly the registered peers",
+           (2 * RESUT_NPROCS) == nprocs);
+    nplain = count_ranks(procs, nprocs, RESUT_NSPACE_PLAIN, &ranks_ok);
+    report("aggregate resolve_peers attributes the plain nspace correctly",
+           RESUT_NPROCS == nplain && ranks_ok);
+    nodd = count_ranks(procs, nprocs, RESUT_NSPACE_ODD, &odd_ok);
+    report("aggregate resolve_peers attributes the colon-bearing nspace correctly",
+           RESUT_NPROCS == nodd && odd_ok);
+    if (NULL != procs) {
+        PMIX_PROC_FREE(procs, nprocs);
+        procs = NULL;
+    }
+
+    /* --- resolve_node against a mapped namespace ------------------------ */
+    rc = do_resolve_node(RESUT_NSPACE_PLAIN, &nodelist);
+    report("resolve_node for a mapped nspace succeeds", PMIX_SUCCESS == rc);
+    report("resolve_node names this host",
+           NULL != nodelist && NULL != strstr(nodelist, pmix_globals.hostname));
+    if (NULL != nodelist) {
+        free(nodelist);
+        nodelist = NULL;
+    }
+
+    /* --- resolve_node against a namespace with no nodes assigned --------
+     * docs/how-things-work/resolve.rst calls this a successfully executed
+     * request answered with a NULL node list. The server used to hand back
+     * the raw fetch status instead. */
+    rc = do_resolve_node(RESUT_NSPACE_BARE, &nodelist);
+    report("resolve_node for an nspace with no nodes reports success",
+           PMIX_SUCCESS == rc);
+    report("resolve_node for an nspace with no nodes returns no list",
+           NULL == nodelist);
+    if (NULL != nodelist) {
+        free(nodelist);
+        nodelist = NULL;
+    }
+
+    /* --- resolve_node against a namespace we never heard of -------------
+     * that one really is an error, and a different one */
+    rc = do_resolve_node("no-such-nspace-at-all", &nodelist);
+    report("resolve_node for an unknown nspace reports an invalid namespace",
+           PMIX_ERR_INVALID_NAMESPACE == rc);
+    if (NULL != nodelist) {
+        free(nodelist);
+        nodelist = NULL;
+    }
+
+    PMIx_server_finalize();
+
+    fprintf(stdout, "server_resolve: %d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/server_setup.c
+++ b/test/unit/server_setup.c
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for src/server/pmix_server_setup.c - the calls a
+ * host makes to prepare a job before its processes run, plus the small
+ * helper APIs it uses to build that information.
+ *
+ * Everything here is driven through the *public* entry points in their
+ * blocking form, so the ordering is deterministic: a blocking
+ * PMIx_server_* call does not return until its handler has run on the
+ * progress thread and woken us. No sleeps, no polling.
+ *
+ * What each case pins down:
+ *
+ *   argument screens - the helper APIs hand their arguments straight to
+ *     a preg component or to hwloc, both of which take them at face value
+ *     (preg/raw strncmp's the input and writes through the output pointer
+ *     without looking; the hwloc string generators report a bad cpuset by
+ *     writing NULL through the output pointer, so they cannot be the ones
+ *     to screen it). A NULL argument used to take the library down.
+ *
+ *   job info - PMIX_GROUP_JOB_INFO carries a packed blob, which the
+ *     handler walks until the buffer runs dry. Two things were wrong with
+ *     that. The loop ends on PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER by
+ *     design, and that status was handed back as the result, so every
+ *     registration carrying job info told the host it had failed. And the
+ *     blob was loaded with PMIX_LOAD_BUFFER, which does not copy - it
+ *     points the buffer at the payload and NULLs the source - so the
+ *     handler emptied the caller's own byte object and then leaked the
+ *     blob, since the buffer is never destructed. The blob here is built
+ *     by PMIx_server_collect_job_info, which is what produces this format
+ *     in the first place.
+ *
+ *   deregistration - the man page says "each matching entry" is deleted.
+ *     The cache legitimately holds more than one entry per key, because
+ *     registration appends without checking, and the gds walk stores them
+ *     in order so the *later* one is the one in effect. Stopping at the
+ *     first match removed the shadowed entry and left the live one, so
+ *     the deregistration silently did nothing.
+ *
+ *   mistyped group arrays - a key does not make the union an array. The
+ *     PMIX_GROUP_INFO and PMIX_GROUP_ENDPT_DATA arms read
+ *     value.data.darray (and, inside the endpt array, value.data.proc) on
+ *     the strength of the key alone, so a host that got the type wrong
+ *     had the server dereference whatever it had put there. Each is
+ *     paired with a well-formed request so the screens are held to
+ *     accepting what they should.
+ *
+ * Three groups of case here kill an unfixed library rather than failing
+ * it - the argument screens and both mistyped arrays - which is the same
+ * bargain test/unit/iof_output.c makes, and the point of it: every one of
+ * them is reachable from an ordinary host, not from a hostile one. That
+ * was verified rather than assumed, by reverting each screen in turn and
+ * re-running: SIGSEGV (exit 139) each time, with no output at all, since
+ * stdout is block-buffered when the harness captures it. So a regression
+ * here looks like an empty log and a signal, not like a FAIL line.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/class/pmix_list.h"
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define SUT_NSPACE "server-setup-ut"
+#define SUT_NPROCS 2
+#define SUT_KEY    "pmix.test.setup.key"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+/* a blocking registration reports success as PMIX_OPERATION_SUCCEEDED */
+static bool ok(pmix_status_t rc)
+{
+    return (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc);
+}
+
+static size_t ncached(void)
+{
+    return pmix_list_get_size(&pmix_server_globals.gdata);
+}
+
+static pmix_status_t register_job(void)
+{
+    pmix_info_t info[2];
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    uint32_t nprocs = SUT_NPROCS;
+
+    PMIX_INFO_LOAD(&info[0], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&info[1], PMIX_UNIV_SIZE, &nprocs, PMIX_UINT32);
+
+    PMIX_LOAD_NSPACE(ns, SUT_NSPACE);
+    rc = PMIx_server_register_nspace(ns, SUT_NPROCS, info, 2, NULL, NULL);
+
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/* the helper APIs screen what they are handed                         */
+/* ------------------------------------------------------------------ */
+static void test_arg_screens(void)
+{
+    pmix_cpuset_t cpuset;
+    pmix_status_t rc;
+    char *out = NULL;
+
+    rc = PMIx_generate_regex(NULL, &out);
+    report("generate_regex rejects a NULL input", PMIX_ERR_BAD_PARAM == rc);
+    rc = PMIx_generate_regex("nodeA,nodeB", NULL);
+    report("generate_regex rejects a NULL output", PMIX_ERR_BAD_PARAM == rc);
+
+    rc = PMIx_generate_ppn(NULL, &out);
+    report("generate_ppn rejects a NULL input", PMIX_ERR_BAD_PARAM == rc);
+    rc = PMIx_generate_ppn("0,1;2,3", NULL);
+    report("generate_ppn rejects a NULL output", PMIX_ERR_BAD_PARAM == rc);
+
+    rc = PMIx_generate_regex2(NULL, NULL, 0, NULL);
+    report("generate_regex2 rejects NULL arguments", PMIX_ERR_BAD_PARAM == rc);
+
+    /* the cpuset is never looked at - the output pointer is written
+     * through before anything else happens */
+    PMIX_CPUSET_CONSTRUCT(&cpuset);
+    rc = PMIx_server_generate_locality_string(&cpuset, NULL);
+    report("generate_locality_string rejects a NULL output", PMIX_ERR_BAD_PARAM == rc);
+    rc = PMIx_server_generate_cpuset_string(&cpuset, NULL);
+    report("generate_cpuset_string rejects a NULL output", PMIX_ERR_BAD_PARAM == rc);
+
+    /* and the two resource entry points walk the array ninfo times */
+    rc = PMIx_server_register_resources(NULL, 2, NULL, NULL);
+    report("register_resources rejects a NULL array", PMIX_ERR_BAD_PARAM == rc);
+    rc = PMIx_server_deregister_resources(NULL, 2, NULL, NULL);
+    report("deregister_resources rejects a NULL array", PMIX_ERR_BAD_PARAM == rc);
+
+    /* a well-formed call still works */
+    rc = PMIx_generate_regex("nodeA,nodeB", &out);
+    report("generate_regex still answers a good request",
+           PMIX_SUCCESS == rc && NULL != out);
+    if (NULL != out) {
+        free(out);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* register/deregister of ordinary keys                                */
+/* ------------------------------------------------------------------ */
+static void test_cache(void)
+{
+    pmix_info_t info;
+    pmix_status_t rc;
+    size_t base;
+
+    base = ncached();
+
+    PMIX_INFO_LOAD(&info, SUT_KEY, "first", PMIX_STRING);
+    rc = PMIx_server_register_resources(&info, 1, NULL, NULL);
+    report("register_resources accepts an ordinary key", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    report("the key is cached", base + 1 == ncached());
+
+    /* re-register the same key with a new value: nothing dedups, so the
+     * cache now holds two entries and the later one is the one the gds
+     * walk leaves in effect */
+    PMIX_INFO_LOAD(&info, SUT_KEY, "second", PMIX_STRING);
+    rc = PMIx_server_register_resources(&info, 1, NULL, NULL);
+    report("re-registering the key is accepted", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    report("the cache holds both entries", base + 2 == ncached());
+
+    /* one deregistration must clear every entry carrying that key */
+    PMIX_INFO_LOAD(&info, SUT_KEY, NULL, PMIX_UNDEF);
+    rc = PMIx_server_deregister_resources(&info, 1, NULL, NULL);
+    report("deregister_resources accepts the key", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    report("deregistration cleared every matching entry", base == ncached());
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIX_GROUP_JOB_INFO                                                 */
+/* ------------------------------------------------------------------ */
+static void test_job_info(void)
+{
+    pmix_data_buffer_t dbuf;
+    pmix_byte_object_t bo;
+    pmix_proc_t proc;
+    pmix_info_t info;
+    pmix_status_t rc;
+    size_t original;
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&dbuf);
+    PMIX_LOAD_PROCID(&proc, SUT_NSPACE, PMIX_RANK_WILDCARD);
+    rc = PMIx_server_collect_job_info(&proc, 1, &dbuf);
+    if (PMIX_SUCCESS != rc || 0 == dbuf.bytes_used) {
+        report("collect_job_info produced a blob", false);
+        PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
+        return;
+    }
+    report("collect_job_info produced a blob", true);
+
+    /* hand it over exactly as a host would - PMIX_INFO_LOAD copies, so
+     * what we hold afterwards is our own byte object, and the library
+     * has no business emptying it */
+    PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
+    bo.bytes = dbuf.base_ptr;
+    bo.size = dbuf.bytes_used;
+    PMIX_INFO_LOAD(&info, PMIX_GROUP_JOB_INFO, &bo, PMIX_BYTE_OBJECT);
+    original = info.value.data.bo.size;
+
+    rc = PMIx_server_register_resources(&info, 1, NULL, NULL);
+    report("registering job info reports success, not end-of-buffer", ok(rc));
+    report("the caller's byte object is left intact",
+           NULL != info.value.data.bo.bytes && original == info.value.data.bo.size);
+
+    PMIX_INFO_DESTRUCT(&info);
+    PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
+}
+
+/* ------------------------------------------------------------------ */
+/* group info and endpoint arrays, well-formed and mistyped            */
+/* ------------------------------------------------------------------ */
+static void test_group_arrays(void)
+{
+    pmix_data_array_t darray;
+    pmix_info_t info[2], *iptr;
+    pmix_proc_t proc;
+    pmix_status_t rc;
+    pmix_scope_t scope = PMIX_REMOTE;
+    size_t ctxid = 42;
+    uint32_t junk = 7;
+
+    PMIX_LOAD_PROCID(&proc, SUT_NSPACE, 0);
+
+    /* --- a well-formed group info array ---------------------------- */
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 2, PMIX_INFO);
+    iptr = (pmix_info_t *) darray.array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_PROCID, &proc, PMIX_PROC);
+    PMIX_INFO_LOAD(&iptr[1], "pmix.test.setup.grpkey", "grpval", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_CONTEXT_ID, &ctxid, PMIX_SIZE);
+    PMIX_INFO_LOAD(&info[1], PMIX_GROUP_INFO, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+    rc = PMIx_server_register_resources(info, 2, NULL, NULL);
+    report("a well-formed group info array is accepted", ok(rc));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+
+    /* --- the same key carrying a scalar ----------------------------- */
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_CONTEXT_ID, &ctxid, PMIX_SIZE);
+    PMIX_INFO_LOAD(&info[1], PMIX_GROUP_INFO, &junk, PMIX_UINT32);
+
+    rc = PMIx_server_register_resources(info, 2, NULL, NULL);
+    report("group info that is not an array is rejected, not dereferenced",
+           !ok(rc));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+
+    /* --- a well-formed endpoint array ------------------------------- */
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 3, PMIX_INFO);
+    iptr = (pmix_info_t *) darray.array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_PROCID, &proc, PMIX_PROC);
+    PMIX_INFO_LOAD(&iptr[1], PMIX_DATA_SCOPE, &scope, PMIX_SCOPE);
+    PMIX_INFO_LOAD(&iptr[2], "pmix.test.setup.endpt", "endptval", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_ENDPT_DATA, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+    rc = PMIx_server_register_resources(info, 1, NULL, NULL);
+    report("a well-formed endpoint array is accepted", ok(rc));
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    /* --- the same array with a scalar where the procID belongs ------ */
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 3, PMIX_INFO);
+    iptr = (pmix_info_t *) darray.array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_PROCID, &junk, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[1], PMIX_DATA_SCOPE, &scope, PMIX_SCOPE);
+    PMIX_INFO_LOAD(&iptr[2], "pmix.test.setup.endpt", "endptval", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_ENDPT_DATA, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+    rc = PMIx_server_register_resources(info, 1, NULL, NULL);
+    report("an endpoint array with a mistyped procID is rejected", !ok(rc));
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    /* --- group info without the context ID it requires -------------- */
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 2, PMIX_INFO);
+    iptr = (pmix_info_t *) darray.array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_PROCID, &proc, PMIX_PROC);
+    PMIX_INFO_LOAD(&iptr[1], "pmix.test.setup.grpkey", "grpval", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_INFO, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+    rc = PMIx_server_register_resources(info, 1, NULL, NULL);
+    report("group info without a context ID is a bad param",
+           PMIX_ERR_BAD_PARAM == rc);
+    PMIX_INFO_DESTRUCT(&info[0]);
+}
+
+int main(int argc, char **argv)
+{
+    static pmix_server_module_t mymodule = {0};
+    pmix_status_t rc;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stdout, "server_setup: job-preparation unit tests\n");
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    rc = register_job();
+    if (!ok(rc)) {
+        fprintf(stderr, "register_nspace failed: %s\n", PMIx_Error_string(rc));
+        PMIx_server_finalize();
+        return 1;
+    }
+
+    test_arg_screens();
+    test_cache();
+    test_job_info();
+    test_group_arrays();
+
+    PMIx_server_finalize();
+
+    fprintf(stdout, "server_setup: %d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/test/unit/singleton_register.c
+++ b/test/unit/singleton_register.c
@@ -6,7 +6,9 @@
  *
  * $HEADER$
  *
- * Unit tests for the PMIX_SINGLETON directive to PMIx_server_init().
+ * Unit tests for directives handed to PMIx_server_init() - PMIX_SINGLETON
+ * and PMIX_ALLOC_MAU. Both are values that come straight from the host,
+ * and the key says only what the directive is, never what is in the value.
  *
  * The value of PMIX_SINGLETON is the string representation of a proc ID -
  * i.e., "nspace.rank" - naming the singleton the server was started to
@@ -19,6 +21,15 @@
  * it did wrong. These tests pin the accept/reject boundary: a well-formed
  * value must register the singleton, and every malformed value must come
  * back as PMIX_ERR_BAD_PARAM without a crash.
+ *
+ * PMIX_ALLOC_MAU carries a pmix_data_array_t that belongs to the *caller*.
+ * Init stores it in the datastore, which deep-copies it - but it built the
+ * kval it stored through by pointing the value straight at the caller's
+ * array, and a kval destructor frees a PMIX_DATA_ARRAY payload outright.
+ * So releasing that kval handed the host's array back to the heap while
+ * the host still held it, and the host's own free of it was a double free.
+ * The test asserts both halves: the array still reads correctly after init
+ * returns, and the caller can still free it.
  *
  * Each case runs in a forked child because PMIx_server_init() can only be
  * meaningfully called once per process - a failed init leaves init_called
@@ -160,6 +171,112 @@ static void check(const char *name, const char *value, bool badtype, const char 
     report(name, expected == WEXITSTATUS(status), detail);
 }
 
+/* Attempt an init carrying PMIX_ALLOC_MAU. When "badtype" is set the
+ * directive is loaded as a scalar so the type screen is exercised;
+ * otherwise it carries a well-formed two-element array that this function
+ * owns, reads back after init, and then frees - which is where an init
+ * that released the caller's array shows up, as a double free. */
+static void mau_child(bool badtype)
+{
+    pmix_data_array_t *darray;
+    pmix_info_t *iptr;
+    pmix_info_t info;
+    pmix_status_t rc;
+    uint32_t scalar = 42;
+
+    PMIX_INFO_CONSTRUCT(&info);
+    PMIX_LOAD_KEY(info.key, PMIX_ALLOC_MAU);
+
+    if (badtype) {
+        info.value.type = PMIX_UINT32;
+        info.value.data.uint32 = scalar;
+        rc = PMIx_server_init(&mymodule, &info, 1);
+        if (PMIX_ERR_BAD_PARAM == rc) {
+            exit(CHILD_BADPARAM);
+        }
+        if (PMIX_SUCCESS == rc) {
+            PMIx_server_finalize();
+            exit(CHILD_ACCEPTED);
+        }
+        fprintf(stderr, "     init returned %s\n", PMIx_Error_string(rc));
+        exit(CHILD_OTHERERR);
+    }
+
+    PMIX_DATA_ARRAY_CREATE(darray, 2, PMIX_INFO);
+    if (NULL == darray) {
+        exit(CHILD_OTHERERR);
+    }
+    iptr = (pmix_info_t *) darray->array;
+    PMIX_INFO_LOAD(&iptr[0], "mau.first", "one", PMIX_STRING);
+    PMIX_INFO_LOAD(&iptr[1], "mau.second", "two", PMIX_STRING);
+
+    info.value.type = PMIX_DATA_ARRAY;
+    info.value.data.darray = darray;
+
+    rc = PMIx_server_init(&mymodule, &info, 1);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "     init returned %s\n", PMIx_Error_string(rc));
+        exit(CHILD_OTHERERR);
+    }
+
+    /* our array must have survived init untouched */
+    if (darray != info.value.data.darray || 2 != darray->size ||
+        NULL == darray->array) {
+        PMIx_server_finalize();
+        exit(CHILD_NOTFOUND);
+    }
+    iptr = (pmix_info_t *) darray->array;
+    if (!PMIX_CHECK_KEY(&iptr[0], "mau.first") ||
+        !PMIX_CHECK_KEY(&iptr[1], "mau.second")) {
+        PMIx_server_finalize();
+        exit(CHILD_NOTFOUND);
+    }
+
+    PMIx_server_finalize();
+    /* and we must still be able to give it back - against a library that
+     * released it for us this is a double free, and the allocator aborts */
+    PMIX_DATA_ARRAY_FREE(darray);
+    exit(CHILD_OK);
+}
+
+/* fork a child to attempt a PMIX_ALLOC_MAU init, then check its status */
+static void check_mau(const char *name, bool badtype, int expected)
+{
+    pid_t pid;
+    int status;
+    char detail[256];
+
+    fflush(stdout);
+    fflush(stderr);
+
+    pid = fork();
+    if (0 > pid) {
+        report(name, 0, "fork failed");
+        return;
+    }
+    if (0 == pid) {
+        mau_child(badtype);
+        /* not reached */
+        exit(CHILD_OTHERERR);
+    }
+
+    if (pid != waitpid(pid, &status, 0)) {
+        report(name, 0, "waitpid failed");
+        return;
+    }
+    if (WIFSIGNALED(status)) {
+        snprintf(detail, sizeof(detail), "server died on signal %d", WTERMSIG(status));
+        report(name, 0, detail);
+        return;
+    }
+    if (!WIFEXITED(status)) {
+        report(name, 0, "child did not exit normally");
+        return;
+    }
+    snprintf(detail, sizeof(detail), "expected exit %d, got %d", expected, WEXITSTATUS(status));
+    report(name, expected == WEXITSTATUS(status), detail);
+}
+
 /* a nspace longer than PMIX_MAX_NSLEN cannot name a real nspace */
 static char *overlong(void)
 {
@@ -208,6 +325,13 @@ int main(int argc, char **argv)
 
     /* the directive must carry a string */
     check("wrong data type", NULL, true, NULL, 0, CHILD_BADPARAM);
+
+    fprintf(stdout, "\nPMIX_ALLOC_MAU handling\n");
+
+    /* the caller's array must survive init and still be freeable */
+    check_mau("array is left to its owner", false, CHILD_OK);
+    /* the directive must carry a data array */
+    check_mau("wrong data type", true, CHILD_BADPARAM);
 
     fprintf(stdout, "\n%d passed, %d failed\n", npass, nfail);
     return (0 == nfail) ? 0 : 1;


### PR DESCRIPTION
The `src/server` deep review, one file at a time, five lenses per file —
memory and lifetime, threading and the PMIx boundary, error paths and
control flow, portability and representation, and caller contracts —
rather than the same read five times. All twenty files in the directory
are now covered.

Forty-two commits. Substantive fixes and style sweeps are kept separate so
neither obscures the other. 166 findings fixed; 83 raised and then refuted
under verification, with the reasoning recorded in `src/server/AGENTS.md`
so the next pass does not re-derive them.

The three source-split commits this branch was built on are already
upstream (`c2e6236e`, `ff322c8c`, `56c0f4c2`) and were dropped on rebase.

## The bug patterns, rather than a list of 166

Nearly everything here falls into a handful of shapes that recur across
the directory. They are worth reading as patterns because each turned up
in more than one file:

**The caddy-ownership contract at the switchyard boundary.** A handler
returning `PMIX_SUCCESS` has taken ownership; anything else leaves it with
the switchyard. Success paths that forgot to release leaked the caddy and
the `PMIX_RETAIN` it holds on the requesting peer — pinning that peer, and
everything hanging off it, for the life of the server. Error paths that
released a caddy the switchyard would also release double-freed it. Both
halves appeared repeatedly, including in a handler whose comment described
the very discipline the code did not implement.

**The host's release function, on the arms that "can do nothing".** Every
callback handed a `(relfn, relcbdata)` pair owes the host that call —
including on the arm where it has just failed to allocate its own caddy,
and including the `progress_thread_stopped` early-out. That flag goes up
while `PMIx_server_finalize` is running, which is exactly when an
in-flight host completion lands, and the host process outlives our
finalize, so what is dropped there is stranded for good. Eighteen such
arms in the info-reply family alone.

**Completion loops that abandon participants.** A collective's completion
owes a reply to every caddy on `local_cbs`. Leaving the loop on a
per-participant failure freed the remaining caddies without a reply, so
nothing in the tree would ever answer them. The group engine had the same
defect in a different dress: detaching only the caller's caddy and
releasing the block answered one client and silently freed the other N−1.

**Wire counts used before, or without, the unpack.** Every count arrives
as a `size_t` and is consumed through an `int32_t`. That is harmless where
the only use is sizing an array the unpack immediately guards — but the
collective handlers size `ninfo + 2` and seed two slots *before* anything
is unpacked, so a count near `SIZE_MAX` wraps to a one-element array and
writes at `info[SIZE_MAX]`. An out-of-bounds write a local client drives
directly. Fence, connect, disconnect, group, and the classic publish /
lookup / unpublish / spawn commands all now carry a round-trip screen.

**Reading a union on the strength of the key alone.** An info array a
handler unpacked off the wire — or received from the host — carries
whatever type tag the sender chose. Taking `PMIX_EVENT_AFFECTED_PROC` or
`PMIX_GROUP_ID` straight out of it had the server dereference a pointer
the peer picked.

**Deferred-request lifetimes.** A dmodex tracker cannot be discarded by
releasing it, because every parked request holds a reference of its own —
so the object survived, unreachable, off the list where anything could
drain it. The mirror image on `remote_pnd` left the host holding a request
it would never hear about again, and the client blocked in `PMIx_Get`
behind it waited forever.

**Reading a `PMIX_LIST_FOREACH` variable after the loop.** It points at
the list sentinel. No sanitizer flags it — the read stays inside the
enclosing object — and the garbage is usually out of range and
accidentally produces the right answer.

Individually notable: `PMIX_ALLOC_MAU` in `PMIx_server_init` freed the
host's own data array, making the host's free of it a double free; the
aggregate peer walk split on the first colon where the delimiter is the
last, writing past the end of its array for a namespace whose name
contains one; and `pmix_server_execute_collective` assembled a modex
bucket no receiving server could parse, invisible to `make check` because
a single-node run never defers a fence.

## Documentation

`src/server/AGENTS.md` is substantially expanded: the reply-ownership
contract, the caddy zoo and its three different ownership rules, the
tracker lifecycle, the two-level group engine, and — the part worth the
most — what was *refuted*, and why. A reader who wonders whether a failed
`PMIX_SERVER_QUEUE_REPLY` strands a client, or why the deregister-events
arm answers nothing, now finds the answer instead of re-deriving it.

## Tests

New and extended unit tests under `test/unit`, all wired into `make
check`: server-side get, fence, connect, dmodex, control, fabric, resolve,
setup, and the event chain. Several of them kill an unfixed library rather
than failing it — that was verified by reverting each screen in turn, and
it is noted in each file's header, because a regression there looks like
an empty log and a signal rather than a FAIL line.

`make check` passes in full — 68 unit tests plus the `test/`, `util` and
`class` suites. Builds are warning-free under `--enable-devel-check`.
Multi-node behavior was exercised through
`contrib/dockerswarm/run-server-tests.sh`, which is the only leak check
anywhere that runs against the *server* library.

## Known gaps — not addressed here

- **`PMIX_GROUP_ENDPT_DATA` is documented with two contradictory types.**
  `include/pmix_common.h.in` declares it `(pmix_byte_object_t)`, while the
  code and `PMIx_server_register_resources(3)` treat it as a
  `pmix_data_array_t*` of `pmix_info_t` whose leading two elements are the
  proc ID and the scope. Nothing in the tree produces the attribute, so
  neither statement is exercised. The header comment looks like the stale
  one — `PMIX_GROUP_JOB_INFO` directly below it genuinely is a byte object
  and is read as one — but settling that needs the Standard, so this
  flags it rather than editing a published attribute's documented type.
  The new type screen means a host that gets it wrong now receives
  `PMIX_ERR_TYPE_MISMATCH` instead of segfaulting the server either way.
- **Qualifier-narrowed resource deregistration is documented but not
  implemented.** `PMIx_server_deregister_resources(3)` describes removing
  one node's fabric device via a `PMIX_NODE_INFO_ARRAY`; the code matches
  on the key alone. This branch makes it delete *every* matching entry,
  which the man page's "each matching entry" requires and which is right
  for scalar keys — but it makes the array case coarser than the
  documentation promises. Implementing the qualifier match, or narrowing
  the man page, is a design call rather than a review fix.
- **The switchyard callback fixes are untested.** Both arms corrected in
  `op_cbfunc` / `op_cbfunc2` / `resop_cbfunc` are a failed allocation and
  a finalize race, neither reachable from a unit test without fault
  injection.
