### PR TITLE
Cancel a collective's timer before its last participant is mourned

### DIFF
--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -166,6 +166,23 @@ static void lost_connection(pmix_peer_t *peer)
                 }
                 /* are we now locally complete? */
                 if (pmix_server_trk_complete(trk)) {
+                    /* The loss of this participant is about to complete the
+                     * collective, so an armed PMIX_TIMEOUT timer has to come
+                     * down first - this is the same rule pmix_server_fence
+                     * applies at its own completion point, and this sweep is
+                     * where a timer is most likely to be armed, since a
+                     * timeout is exactly what a participant dropping its
+                     * connection would otherwise produce. Every arm below
+                     * either hands the tracker to the host or drives a
+                     * completion function, and both end with the tracker
+                     * unlinked and released: a timer left armed then fires
+                     * fence_timeout/connect_timeout on freed memory, or
+                     * races the host's completion for the right to release
+                     * it a second time. */
+                    if (trk->event_active) {
+                        pmix_event_del(&trk->ev);
+                        trk->event_active = false;
+                    }
                     /* if this is a local-only collective, then resolve it now */
                     if (trk->local) {
                         /* everyone else has called in - we need to let them know


### PR DESCRIPTION
The lost-connection sweep in `ptl_base_sendrecv.c` accounts a departed
peer against every local collective it was participating in. When that
loss is what completes the collective, the sweep either hands the tracker
up to the host or drives the completion function — and both of those end
with the tracker unlinked from `pmix_server_globals.collectives` and
released.

An armed `PMIX_TIMEOUT` timer was left running across all of it. The
tracker destructor does not delete the event, so what remains is a timer
pointing at freed memory: `fence_timeout` or `connect_timeout` fires on
it, or — on the arm where the host accepted the collective — our timeout
and the host's completion race for the right to release the tracker a
second time.

This is the same reasoning `pmix_server_fence` gives at its own completion
point, where it deletes the timer before passing the tracker up and says
why at the call site. This sweep is where a timer is most likely to be
armed in the first place, since a participant dropping its connection is
exactly the situation a `PMIX_TIMEOUT` exists to bound.

The timer is now deleted once, at the point local completion is
established, which covers every arm below it: the local-only completions,
the three host up-calls, and the releases those up-calls perform when the
host refuses.

I checked the one thing that would make this a regression rather than a
fix — whether any path under that test leaves the tracker alive and still
needing its timeout. None does: trackers on `collectives` are only ever
fence, connect or disconnect, and all three are disposed of in both the
local and the non-local branch.

Found during the `src/server` deep review (#4115), where it had been
recorded in `AGENTS.md` as a known defect in a neighbouring directory.

## Testing

- `test/simple/simptimeout` driven under `simptest`, all three collective
  timeouts passing.
- `test/simple/simpdie` — a client dying mid-collective, which is the path
  actually modified.
- `make check` green; build warning-free under `--enable-devel-check`.
