### PR TITLE
Deliver an allocation request's results whatever its status

### DIFF
--- a/src/common/pmix_alloc.c
+++ b/src/common/pmix_alloc.c
@@ -144,13 +144,20 @@ static void alloc_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         results->status = rc;
         goto complete;
     }
-    if (PMIX_SUCCESS != results->status) {
-        goto complete;
-    }
-
-    /* unpack any returned data */
+    /* unpack any returned data - the server packs it whatever the status is,
+     * and a status that is not PMIX_SUCCESS can still be carrying results:
+     * an operation the host accepted but has not finished (a Slurm
+     * allocation extend answers PMIX_OPERATION_IN_PROGRESS while handing
+     * back the allocation id the requester needs to track it) reaches here
+     * exactly that way. A reply that carries nothing but its status - which
+     * is what an error raised before the host was ever called looks like -
+     * simply runs out of buffer, and that is not an error either. */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &results->ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+        results->ninfo = 0;
+        goto complete;
+    }
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         results->status = rc;
@@ -165,8 +172,10 @@ static void alloc_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
             results->status = rc;
             goto complete;
         }
-        /* locally cache the results */
-        for (n = 0; n < results->ninfo; n++) {
+        /* locally cache the results, but only those of a request that
+         * completed: caching what an in-progress or failed request handed
+         * back would let it shadow the answer the completed one brings */
+        for (n = 0; PMIX_SUCCESS == results->status && n < results->ninfo; n++) {
             kv = PMIX_NEW(pmix_kval_t);
             kv->key = strdup(results->info[n].key);
             PMIX_VALUE_CREATE(kv->value, 1);


### PR DESCRIPTION
`alloc_cbfunc` unpacked an allocation reply's info array only when the status was exactly `PMIX_SUCCESS`:

```c
    if (PMIX_SUCCESS != results->status) {
        goto complete;
    }
```

The server (`_alloccbfunc`) packs status, `ninfo` and `info` unconditionally, so for every other status the results were read off the wire and dropped, and the requester's callback ran with `ninfo == 0`.

The case that found it: PRRTE's `ras/slurm` now answers an allocation **extend** in two phases — phase one reports `PMIX_OPERATION_IN_PROGRESS` and returns the allocation id, and `PMIX_DVM_IS_READY` follows when the daemons on the granted nodes are up. The requesting tool got an empty info array, so it never learned the id of the allocation it had just been granted and could not correlate the completion event with its request. The grow itself worked; only the answer was lost.

The change:

- unpack the results whenever the reply carries them, rather than only on success;
- treat `PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER` on the count as "this reply carries only a status" — that is what an error raised before the host module was ever called looks like, and it must not overwrite the status the caller is being handed;
- cache the values into the local store only for a request that *completed*, so an in-progress or failed request's keys cannot shadow the ones the completed request brings later.

Verified against PRRTE master in the `contrib/dockerswarm` harness: the same `elastic extend 2` that printed nothing but `PHASE 1 (acceptance): allocation request returned PMIX_OPERATION_IN_PROGRESS` now returns `pmix.alloc.id` and `pmix.rm.name` with it.