### PR TITLE
Give the group endpoint attribute the type it carries

### DIFF
--- a/docs/man/man3/PMIx_server_register_resources.3.rst
+++ b/docs/man/man3/PMIx_server_register_resources.3.rst
@@ -110,8 +110,14 @@ following attributes, which receive special handling:
 * ``PMIX_GROUP_INFO_ARRAY`` / ``PMIX_GROUP_INFO`` (pmix_data_array_t\*) |mdash|
   group information to be stored in the server's hash table. Requires a
   ``PMIX_GROUP_CONTEXT_ID`` to also be provided.
-* ``PMIX_GROUP_ENDPT_DATA`` (pmix_data_array_t\*) |mdash| per-process endpoint
-  information to be stored for the group.
+* ``PMIX_GROUP_ENDPT_DATA`` (pmix_data_array_t\*) |mdash| an array of
+  ``pmix_info_t`` carrying the endpoint data contributed by one member of the
+  group during construction. The first element must be that process'
+  ``PMIX_PROCID`` and the second the ``PMIX_DATA_SCOPE`` at which the remaining
+  elements are to be stored. This is the shape the PMIx client library builds
+  when it contributes endpoint data to a group construct, where it is keyed as
+  ``PMIX_PROC_INFO_ARRAY``; the host relabels each contribution with this
+  attribute when handing it back to the server.
 * ``PMIX_GROUP_CONTEXT_ID`` (size_t) |mdash| the context identifier associated
   with the group information being stored.
 * ``PMIX_GROUP_JOB_INFO`` (pmix_byte_object_t) |mdash| packed job-level

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -275,3 +275,11 @@ Detailed changes since v6.1.0:
    directive array a launcher-spawned server uses to attach to its parent,
    and the result caddies of PMIx_server_setup_application and
    PMIx_server_collect_inventory when the caller supplies no callback
+ - PMIX_GROUP_ENDPT_DATA is now documented with the type it actually
+   carries: a pmix_data_array_t* of pmix_info_t, led by the contributing
+   process' PMIX_PROCID and the PMIX_DATA_SCOPE at which the remaining
+   elements are to be stored. The header had described it as a
+   pmix_byte_object_t, which was the shape of a group-construct data
+   exchange the library no longer performs. That stale type reached the
+   generated attribute dictionary as well, so it is what the
+   attribute-support queries and pattrs reported for the attribute

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1351,7 +1351,11 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_GROUP_ASSIGN_CONTEXT_ID        "pmix.grp.actxid"       // (bool) request that the RM assign a unique numerical (size_t) ID to this group
 #define PMIX_GROUP_CONTEXT_ID               "pmix.grp.ctxid"        // (size_t) context ID assigned to group
 #define PMIX_GROUP_LOCAL_ONLY               "pmix.grp.lcl"          // (bool) group operation only involves local procs
-#define PMIX_GROUP_ENDPT_DATA               "pmix.grp.endpt"        // (pmix_byte_object_t) data collected to be shared during construction
+#define PMIX_GROUP_ENDPT_DATA               "pmix.grp.endpt"        // (pmix_data_array_t*) Array of pmix_info_t containing the endpoint data
+                                                                    //        contributed by one member of a group during construction, to be
+                                                                    //        stored by the PMIx server. The array starts with the PMIX_PROCID
+                                                                    //        of the contributing process, followed by the PMIX_DATA_SCOPE at
+                                                                    //        which the remaining elements are to be stored
 #define PMIX_GROUP_NAMES                    "pmix.pgrp.nm"          // (pmix_data_array_t*) Returns an array of string names of the process groups
                                                                     //        in which the given process is a member.
 #define PMIX_GROUP_INFO                     "pmix.grp.info"         // (pmix_data_array_t*) Array of pmix_info_t containing data that is to be

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -1308,28 +1308,19 @@ static pmix_status_t grp_fn(pmix_group_operation_t op, char *gpid,
                             pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
     mylog_t *lg = (mylog_t *) malloc(sizeof(mylog_t));
-    size_t n;
     size_t ctxid = 1;
     pmix_data_array_t darray;
-    PMIX_HIDE_UNUSED_PARAMS(op, gpid, procs, nprocs);
+    PMIX_HIDE_UNUSED_PARAMS(op, gpid, procs, nprocs, directives, ndirs);
 
     memset(lg, 0, sizeof(mylog_t));
     if (PMIX_GROUP_CONSTRUCT == op) {
-        lg->ninfo = 3;
+        lg->ninfo = 2;
         PMIX_INFO_CREATE(lg->info, lg->ninfo);
         PMIX_INFO_LOAD(&lg->info[0], PMIX_GROUP_CONTEXT_ID, &ctxid, PMIX_SIZE);
         darray.array = (pmix_proc_t*)procs;
         darray.type = PMIX_PROC;
         darray.size = nprocs;
         PMIX_INFO_LOAD(&lg->info[1], PMIX_GROUP_MEMBERSHIP, &darray, PMIX_DATA_ARRAY);
-        lg->ninfo = 2;
-        for (n=0; n < ndirs; n++) {
-            if (PMIX_CHECK_KEY(&directives[n], PMIX_GROUP_ENDPT_DATA)) {
-                PMIX_INFO_XFER(&lg->info[2], &directives[n]);
-                lg->ninfo = 3;
-                break;
-            }
-        }
     }
     lg->infocbfunc = cbfunc;
     lg->cbdata = cbdata;


### PR DESCRIPTION
`PMIX_GROUP_ENDPT_DATA` has been declared in `pmix_common.h.in` as a `pmix_byte_object_t` since it was added in 2018 (f3d738a6), when the server packed its local participants' modex data into a single blob, handed it to the host with the group operation, and stored what came back. The library has not done that for several releases, and nothing in the tree produces or consumes a byte object under this key today.

What the key names now is one process' endpoint contribution, and all three parties to it agree on the shape:

- `get_endpts()` in `src/client/pmix_client_group.c` builds an array of `pmix_info_t` led by the contributor's `PMIX_PROCID` and the `PMIX_DATA_SCOPE` at which the remaining elements are to be stored, and contributes it to the construct keyed as `PMIX_PROC_INFO_ARRAY`.
- PRRTE's `grpcomm/group` collects those contributions (`prte_grpcomm_group_parse_directives` harvests `PMIX_PROC_INFO_ARRAY`), circulates them, and hands each value back to the server through `PMIx_server_register_resources` relabelled as `PMIX_GROUP_ENDPT_DATA`.
- `_register_resources` reads exactly that: a data array whose first two elements are the proc and the scope, with the endpoint keys behind them.

So the first commit corrects the header comment — which also corrects the generated `pmix_dictionary.c`, and therefore the type the attribute-support queries and `pattrs` report — and states on the `PMIx_server_register_resources(3)` man page what the array has to contain rather than only that it is one. News entry added.

The second commit removes the last trace of the retired design: `simptest`'s `group_fn` scanned the construct directives for `PMIX_GROUP_ENDPT_DATA` and echoed what it found back in its response — the host's half of the byte-object round trip. Nothing has put that key in the directives for several releases, so the scan never matched and the third info slot the response array was sized for was never filled.

No functional change: the value's type travels in the `pmix_value_t`, so nothing on the wire or in the type screens moves.

Verified: `make` clean under the tree's `--enable-devel-check` configuration, `make check` 21/21 in `test/` and 70/70 in `test/unit/` (including `server_setup`, which covers this arm), `run_simptest.sh -n 4` OK, and the docs build clean under `-W`.

The PMIx Standard carries the same stale type and lists the attribute against the `pmix_server_grp_fn_t` up-call rather than against `PMIx_server_register_resources`; that is being handled separately.