### PR TITLE
Remove what a deregistration named, and nothing else

### DIFF
--- a/docs/man/man3/PMIx_server_deregister_resources.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_resources.3.rst
@@ -83,16 +83,34 @@ As with all non-blocking PMIx APIs, when a callback is supplied the caller
 DIRECTIVES
 ----------
 
-The ``key`` of each ``info`` element selects the entry to remove. Qualifiers may
-be included to scope the removal, for example:
+The ``key`` of each ``info`` element selects the entries to remove. An element
+whose value is **not** a data array selects by key alone: every registered entry
+carrying that key is removed.
 
-* ``PMIX_NODE_INFO_ARRAY`` (pmix_data_array_t\*) |mdash| scope the removal to a
-  specific node, identified within the array by ``PMIX_NODEID`` or
-  ``PMIX_HOSTNAME``.
-* ``PMIX_FABRIC_DEVICE_NAME`` (char*) |mdash| the name of a fabric device to
-  remove.
-* ``PMIX_DEVICE_ID`` (char*) |mdash| a system-unique device identifier; sufficient
-  on its own to remove the corresponding device.
+An element whose value **is** a ``pmix_data_array_t`` of ``pmix_info_t`` narrows
+the removal. Two kinds of member are recognized within it:
+
+* ``PMIX_NODEID`` (uint32_t) or ``PMIX_HOSTNAME`` (char*) |mdash| *identifiers*.
+  They restrict the removal to the registered entries describing that node. A
+  hostname must match exactly; ``PMIX_HOSTNAME_ALIASES`` is not consulted. An
+  array carrying no identifier applies to every entry with that key, which is how
+  a device that is unique across the system is removed without naming its node.
+* any other member |mdash| a *target*. It selects the elements to remove from
+  within the entries the identifiers chose. A target matches an element directly
+  (same key, same value), or matches an element that *contains* it: a
+  ``PMIX_FABRIC_DEVICE`` element carries its own array of ``pmix_info_t``, so a
+  target naming the device by ``PMIX_FABRIC_DEVICE_NAME`` or ``PMIX_DEVICE_ID``
+  removes that whole device from the node.
+
+An array carrying identifiers and no target removes the whole entry for the node
+it names. If removing the targets leaves an entry describing nothing |mdash| only
+the identifiers remain |mdash| the entry itself is removed, since what would be
+left is what an empty registration would have produced.
+
+For example, to remove one fabric device from a given node, the ``info`` array
+might include a ``PMIX_NODE_INFO_ARRAY`` containing the ``PMIX_NODEID`` or
+``PMIX_HOSTNAME`` that identifies the node hosting the device, together with a
+``PMIX_FABRIC_DEVICE_NAME`` specifying the device.
 
 
 CALLBACK FUNCTION
@@ -137,6 +155,14 @@ finalizing the library |mdash| the library cleans up such information as part of
 its normal finalize operations. Deregistration is needed only when the host
 environment determines that client processes should no longer have access to the
 information.
+
+.. important:: Deregistration takes effect for namespaces registered
+               **after** the call. Non-namespace resource information is copied
+               into a namespace's data store when that namespace is registered,
+               so a namespace already registered |mdash| and any client already
+               running under it |mdash| retains the information. A host that
+               needs the data withheld from a running job cannot achieve that
+               with this call alone.
 
 
 .. seealso::

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -283,3 +283,16 @@ Detailed changes since v6.1.0:
    exchange the library no longer performs. That stale type reached the
    generated attribute dictionary as well, so it is what the
    attribute-support queries and pattrs reported for the attribute
+ - PMIx_server_deregister_resources now honors the qualifiers its man page
+   describes. A request element carrying a data array narrows the removal:
+   PMIX_NODEID/PMIX_HOSTNAME choose the entries it applies to, and any
+   other member of the array chooses the elements to remove from within
+   them - matching an element directly or matching one that contains it,
+   which is how a PMIX_FABRIC_DEVICE is named by its PMIX_FABRIC_DEVICE_NAME
+   or PMIX_DEVICE_ID. Removing the last element an entry described removes
+   the entry as well. Previously every such request matched on the key
+   alone, so the man page's own example - remove one node's fabric device -
+   deleted every node entry the server held. Note that deregistration
+   governs the namespaces registered after it: non-namespace information is
+   copied into a namespace's data store when that namespace is registered,
+   so a job already running retains it

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -525,10 +525,31 @@ the *later* one the one in effect. `_deregister_resources` stopped at the
 first match, so it removed the shadowed entry and left the live one: the
 deregistration silently did nothing. It now clears every entry carrying
 the key, which is what the man page ("each matching entry") requires.
-Note what is still missing there: the man page also describes narrowing a
-removal with qualifiers — a `PMIX_NODE_INFO_ARRAY` naming one node's
-fabric device — and nothing implements that, so such a request removes
-every entry carrying that key rather than the one described.
+
+**A request element carrying a data array is a qualified removal, and the
+two kinds of member in it do different things.** `PMIX_NODEID` and
+`PMIX_HOSTNAME` are *identifiers*: they choose which entries the request
+applies to, and an array carrying none applies to every entry with that
+key. Anything else is a *target*: it chooses elements to remove from
+inside those entries, matching an element directly or matching one that
+contains it — which is how a `PMIX_FABRIC_DEVICE`, whose own array
+carries the device's name and id, is named by either of them. An array
+with identifiers and no target removes the whole entry. Removing the last
+element an entry described removes the entry too, rather than leaving a
+husk naming a node and nothing else, which would seed every namespace
+registered afterwards with it. Before this, the walk matched on the key
+alone, so the man page's own example — one node's fabric device — deleted
+every node entry in the cache.
+
+**What no version of this can do is retract data already handed out.**
+`gdata` is copied into a namespace's hash tables once, when that
+namespace is first registered (`hash_cache_job_info`, guarded by the
+per-namespace `gdata_added`), and nothing re-reads it afterwards. So a
+deregistration governs the namespaces registered *after* it and leaves
+every running client's copy in place. Closing that needs a
+delete-a-key entry point the `gds` module struct does not have, and it
+cannot be built the obvious way for `shmem3`, whose lock-free read path
+is the reason it is fast. See `docs/todo.rst`.
 
 **The helper APIs are pass-throughs, so the public entry point is the
 only place their arguments get screened.** `PMIx_generate_regex` /

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -573,16 +573,19 @@ alone. `pmix_server_valid_darray` is that screen, shared with
 types still need checking by hand, since the array being of the right
 element type says nothing about what a given element carries.
 
-One thing to know before writing a host against this: `pmix_common.h`
-documents `PMIX_GROUP_ENDPT_DATA` as a `pmix_byte_object_t`, while both
-this code and
-[`PMIx_server_register_resources(3)`](../../docs/man/man3/PMIx_server_register_resources.3.rst)
-treat it as a `pmix_data_array_t` of `pmix_info_t` whose first two
-elements are the proc ID and the scope. Nothing in the tree produces the
-attribute, so neither statement is being exercised. The header comment
-looks like the stale one — `PMIX_GROUP_JOB_INFO` immediately below it
-*is* a byte object and is read as one — but that has not been settled
-against the Standard, so it is flagged here rather than quietly changed.
+One thing to know before writing a host against this: the shape
+`PMIX_GROUP_ENDPT_DATA` carries here is the one a client builds. The
+array is `get_endpts()`'s in
+[`src/client/pmix_client_group.c`](../client/pmix_client_group.c) — the
+contributor's `PMIX_PROCID`, then the `PMIX_DATA_SCOPE` its remaining
+elements are to be stored at — contributed to the construct as
+`PMIX_PROC_INFO_ARRAY` and relabelled by the host when it hands each
+contribution back through this API. `pmix_common.h` described the
+attribute as a `pmix_byte_object_t` until August 2026; that was the
+shape of a group-construct exchange the library stopped performing
+several releases ago, and nothing in the tree had produced or consumed
+it since. `PMIX_GROUP_JOB_INFO` immediately below it *is* a byte object
+and is read as one.
 
 ## The collective-tracker engine (fence / connect / disconnect)
 

--- a/src/server/pmix_server_setup.c
+++ b/src/server/pmix_server_setup.c
@@ -398,11 +398,208 @@ pmix_status_t PMIx_server_register_resources(pmix_info_t info[], size_t ninfo,
     return PMIX_SUCCESS;
 }
 
+/* The two keys that say which node an array describes. Everything else
+ * in a qualifier names something to remove from the entry those two
+ * select, and everything else in a stored entry is something that entry
+ * describes. */
+static bool is_node_identifier(const pmix_info_t *info)
+{
+    return (PMIX_CHECK_KEY(info, PMIX_NODEID) || PMIX_CHECK_KEY(info, PMIX_HOSTNAME));
+}
+
+/* Read the node a qualifier array names.
+ *
+ * A request element carrying a data array is asking for a *narrowed*
+ * removal - this key, on that node, and possibly only these parts of it -
+ * rather than the removal of every entry carrying the key. The
+ * identifiers select the entry; anything else in the array selects
+ * elements within it. A qualifier carrying no identifier at all applies
+ * to every entry with that key, which is how a device that is unique
+ * system-wide is removed without naming its node.
+ *
+ * The keys do not make the union anything, so both are screened: these
+ * arrive from a host, which is free to get them wrong. */
+static pmix_status_t parse_node_qualifier(const pmix_info_t *info,
+                                          uint32_t *nodeid, bool *have_nodeid,
+                                          char **hostname, size_t *ntargets)
+{
+    pmix_info_t *iptr;
+    size_t n, niptr;
+    pmix_status_t rc;
+
+    *have_nodeid = false;
+    *hostname = NULL;
+    *ntargets = 0;
+
+    if (!pmix_server_valid_darray(info, PMIX_INFO, 1)) {
+        return PMIX_ERR_TYPE_MISMATCH;
+    }
+    iptr = (pmix_info_t *) info->value.data.darray->array;
+    niptr = info->value.data.darray->size;
+
+    for (n = 0; n < niptr; n++) {
+        if (PMIX_CHECK_KEY(&iptr[n], PMIX_NODEID)) {
+            rc = PMIx_Value_get_number(&iptr[n].value, nodeid, PMIX_UINT32);
+            if (PMIX_SUCCESS != rc) {
+                return PMIX_ERR_TYPE_MISMATCH;
+            }
+            *have_nodeid = true;
+
+        } else if (PMIX_CHECK_KEY(&iptr[n], PMIX_HOSTNAME)) {
+            if (PMIX_STRING != iptr[n].value.type ||
+                NULL == iptr[n].value.data.string) {
+                return PMIX_ERR_TYPE_MISMATCH;
+            }
+            *hostname = iptr[n].value.data.string;
+
+        } else {
+            ++(*ntargets);
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+/* Does the qualifier ask for this stored element to go?
+ *
+ * A target matches the element directly - same key, same value - or
+ * matches something inside it, which is how a fabric device is named: a
+ * node array holds a PMIX_FABRIC_DEVICE element whose own array carries
+ * the device's name and id, so a qualifier naming the device by either
+ * one selects that whole sub-array. */
+static bool element_selected(pmix_info_t *qual, size_t nqual, pmix_info_t *stored)
+{
+    pmix_info_t *sub;
+    size_t n, m, nsub;
+
+    for (n = 0; n < nqual; n++) {
+        if (is_node_identifier(&qual[n])) {
+            continue;
+        }
+        if (PMIX_CHECK_KEY(stored, qual[n].key) &&
+            PMIX_EQUAL == PMIx_Value_compare(&qual[n].value, &stored->value)) {
+            return true;
+        }
+        if (!pmix_server_valid_darray(stored, PMIX_INFO, 1)) {
+            continue;
+        }
+        sub = (pmix_info_t *) stored->value.data.darray->array;
+        nsub = stored->value.data.darray->size;
+        for (m = 0; m < nsub; m++) {
+            if (PMIX_CHECK_KEY(&sub[m], qual[n].key) &&
+                PMIX_EQUAL == PMIx_Value_compare(&qual[n].value, &sub[m].value)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/* Remove from this entry every element the qualifier selects, rebuilding
+ * the stored array around the survivors.
+ *
+ * Reports through "empty" that nothing the entry described is left, so
+ * the caller drops the entry entirely rather than leave a husk naming a
+ * node and nothing else - which is what an empty registration would have
+ * produced, and would seed every namespace registered later with it. */
+static pmix_status_t prune_entry(pmix_kval_t *kv, pmix_info_t *qual, size_t nqual,
+                                 bool *empty)
+{
+    pmix_data_array_t *darray;
+    pmix_info_t *stored, *survivors;
+    size_t n, nstored, keep = 0, described = 0, k = 0;
+
+    *empty = false;
+    stored = (pmix_info_t *) kv->value->data.darray->array;
+    nstored = kv->value->data.darray->size;
+
+    /* count first: the replacement has to be sized before anything moves
+     * into it, and the answer also decides whether there is a
+     * replacement to build at all */
+    for (n = 0; n < nstored; n++) {
+        if (!element_selected(qual, nqual, &stored[n])) {
+            ++keep;
+            if (!is_node_identifier(&stored[n])) {
+                ++described;
+            }
+        }
+    }
+    if (keep == nstored) {
+        return PMIX_SUCCESS; /* the qualifier named nothing this entry has */
+    }
+    if (0 == described) {
+        *empty = true;
+        return PMIX_SUCCESS;
+    }
+
+    darray = PMIx_Data_array_create(keep, PMIX_INFO);
+    if (NULL == darray) {
+        return PMIX_ERR_NOMEM;
+    }
+    survivors = (pmix_info_t *) darray->array;
+    for (n = 0; n < nstored; n++) {
+        if (!element_selected(qual, nqual, &stored[n])) {
+            PMIX_INFO_XFER(&survivors[k], &stored[n]);
+            ++k;
+        }
+    }
+    /* the value owns the array it points at, so the one being displaced
+     * goes back through the same free that would have released it with
+     * the entry */
+    PMIx_Data_array_free(kv->value->data.darray);
+    kv->value->data.darray = darray;
+    return PMIX_SUCCESS;
+}
+
+/* Does this cached entry describe the node the qualifier named? Only an
+ * entry that is itself an array of info can, and its element types are
+ * no more ours to assume than the request's were - the entry came from a
+ * host too. A hostname must match exactly; PMIX_HOSTNAME_ALIASES is not
+ * consulted, since the host that registered the entry chose the spelling
+ * it wants to be addressed by. */
+static bool entry_names_node(pmix_kval_t *kv, uint32_t nodeid,
+                             bool have_nodeid, const char *hostname)
+{
+    pmix_info_t *iptr;
+    size_t n, niptr;
+    uint32_t nd;
+
+    if (NULL == kv->value || PMIX_DATA_ARRAY != kv->value->type ||
+        NULL == kv->value->data.darray ||
+        PMIX_INFO != kv->value->data.darray->type ||
+        NULL == kv->value->data.darray->array) {
+        return false;
+    }
+    iptr = (pmix_info_t *) kv->value->data.darray->array;
+    niptr = kv->value->data.darray->size;
+
+    for (n = 0; n < niptr; n++) {
+        if (have_nodeid && PMIX_CHECK_KEY(&iptr[n], PMIX_NODEID)) {
+            if (PMIX_SUCCESS == PMIx_Value_get_number(&iptr[n].value, &nd, PMIX_UINT32) &&
+                nd == nodeid) {
+                return true;
+            }
+
+        } else if (NULL != hostname && PMIX_CHECK_KEY(&iptr[n], PMIX_HOSTNAME)) {
+            if (PMIX_STRING == iptr[n].value.type &&
+                NULL != iptr[n].value.data.string &&
+                0 == strcmp(iptr[n].value.data.string, hostname)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 static void _deregister_resources(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t *) cbdata;
     pmix_kval_t *kv, *knext;
-    size_t n;
+    pmix_info_t *qual;
+    pmix_status_t rc, ret = PMIX_SUCCESS;
+    char *hostname;
+    uint32_t nodeid = 0;
+    bool have_nodeid, empty;
+    size_t n, nqual, ntargets;
 
     PMIX_ACQUIRE_OBJECT(cd);
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
@@ -418,21 +615,73 @@ static void _deregister_resources(int sd, short args, void *cbdata)
      * silently did nothing. Clear every match, using the SAFE variant since
      * the matching item is released inside the walk.
      *
-     * Note this matches on the key alone. The man page also describes
-     * narrowing a removal with qualifiers - e.g. a PMIX_NODE_INFO_ARRAY
-     * naming one node's fabric device - and that is not implemented here,
-     * so such a request removes every entry carrying that key rather than
-     * the one the qualifiers describe. */
+     * A request element carrying a data array is a qualified request: its
+     * node identifiers narrow the sweep to the entries describing that
+     * node, and anything else it carries narrows it further to elements
+     * within those entries - the fabric device the man page describes.
+     * An element carrying anything else selects by key alone, which is
+     * what the man page's "only the key fields are used" describes and
+     * what every in-tree registration produces. */
     for (n = 0; n < cd->ninfo; n++) {
-        PMIX_LIST_FOREACH_SAFE (kv, knext, &pmix_server_globals.gdata, pmix_kval_t) {
-            if (PMIX_CHECK_KEY(kv, cd->info[n].key)) {
+        if (PMIX_DATA_ARRAY == cd->info[n].value.type) {
+            rc = parse_node_qualifier(&cd->info[n], &nodeid, &have_nodeid,
+                                      &hostname, &ntargets);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                /* keep the first failure: a later element's success must
+                 * not erase it, and the host is owed the reason */
+                if (PMIX_SUCCESS == ret) {
+                    ret = rc;
+                }
+                continue;
+            }
+            qual = (pmix_info_t *) cd->info[n].value.data.darray->array;
+            nqual = cd->info[n].value.data.darray->size;
+
+            PMIX_LIST_FOREACH_SAFE (kv, knext, &pmix_server_globals.gdata, pmix_kval_t) {
+                if (!PMIX_CHECK_KEY(kv, cd->info[n].key)) {
+                    continue;
+                }
+                if ((have_nodeid || NULL != hostname) &&
+                    !entry_names_node(kv, nodeid, have_nodeid, hostname)) {
+                    continue;
+                }
+                if (0 < ntargets) {
+                    /* an entry that is not an array of info describes no
+                     * elements to take out of it */
+                    if (NULL == kv->value || PMIX_DATA_ARRAY != kv->value->type ||
+                        NULL == kv->value->data.darray ||
+                        PMIX_INFO != kv->value->data.darray->type ||
+                        NULL == kv->value->data.darray->array) {
+                        continue;
+                    }
+                    rc = prune_entry(kv, qual, nqual, &empty);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        if (PMIX_SUCCESS == ret) {
+                            ret = rc;
+                        }
+                        continue;
+                    }
+                    if (!empty) {
+                        continue;
+                    }
+                }
                 pmix_list_remove_item(&pmix_server_globals.gdata, &kv->super);
                 PMIX_RELEASE(kv);
+            }
+
+        } else {
+            PMIX_LIST_FOREACH_SAFE (kv, knext, &pmix_server_globals.gdata, pmix_kval_t) {
+                if (PMIX_CHECK_KEY(kv, cd->info[n].key)) {
+                    pmix_list_remove_item(&pmix_server_globals.gdata, &kv->super);
+                    PMIX_RELEASE(kv);
+                }
             }
         }
     }
 
-    cd->opcbfunc(PMIX_SUCCESS, cd->cbdata);
+    cd->opcbfunc(ret, cd->cbdata);
     PMIX_RELEASE(cd);
 }
 

--- a/test/unit/server_setup.c
+++ b/test/unit/server_setup.c
@@ -205,6 +205,231 @@ static void test_cache(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* qualified deregistration                                            */
+/* ------------------------------------------------------------------ */
+
+/* build a PMIX_NODE_INFO_ARRAY naming a host, optionally with a nodeid
+ * and a fabric device. PMIx_Info_load routes a PMIX_DATA_ARRAY through
+ * copy_darray, so the info owns a deep copy and the source is ours to
+ * destruct */
+static void load_node_array(pmix_info_t *dest, const char *host,
+                            bool have_id, uint32_t nodeid, const char *device)
+{
+    pmix_data_array_t darray;
+    pmix_info_t *iptr;
+    size_t n = 0, cnt = 1;
+
+    if (have_id) {
+        ++cnt;
+    }
+    if (NULL != device) {
+        ++cnt;
+    }
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, cnt, PMIX_INFO);
+    iptr = (pmix_info_t *) darray.array;
+    PMIX_INFO_LOAD(&iptr[n], PMIX_HOSTNAME, host, PMIX_STRING);
+    ++n;
+    if (have_id) {
+        PMIX_INFO_LOAD(&iptr[n], PMIX_NODEID, &nodeid, PMIX_UINT32);
+        ++n;
+    }
+    if (NULL != device) {
+        PMIX_INFO_LOAD(&iptr[n], PMIX_FABRIC_DEVICE_NAME, device, PMIX_STRING);
+        ++n;
+    }
+    PMIX_INFO_LOAD(dest, PMIX_NODE_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+}
+
+/* the same, carrying a nodeid and nothing else */
+static void load_nodeid_array(pmix_info_t *dest, uint32_t nodeid)
+{
+    pmix_data_array_t darray;
+    pmix_info_t *iptr;
+
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 1, PMIX_INFO);
+    iptr = (pmix_info_t *) darray.array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_NODEID, &nodeid, PMIX_UINT32);
+    PMIX_INFO_LOAD(dest, PMIX_NODE_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+}
+
+/* a node array carrying two fabric devices, each in its own sub-array -
+ * the shape PMIX_FABRIC_DEVICE describes, and the one a qualifier naming
+ * a device by name has to reach into */
+static void load_device_node(pmix_info_t *dest, const char *host, uint32_t nodeid,
+                             const char *dev1, const char *dev2)
+{
+    pmix_data_array_t darray, d1, d2;
+    pmix_info_t *iptr;
+
+    PMIX_DATA_ARRAY_CONSTRUCT(&d1, 1, PMIX_INFO);
+    PMIX_INFO_LOAD(&((pmix_info_t *) d1.array)[0], PMIX_FABRIC_DEVICE_NAME, dev1,
+                   PMIX_STRING);
+    PMIX_DATA_ARRAY_CONSTRUCT(&d2, 1, PMIX_INFO);
+    PMIX_INFO_LOAD(&((pmix_info_t *) d2.array)[0], PMIX_FABRIC_DEVICE_NAME, dev2,
+                   PMIX_STRING);
+
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 4, PMIX_INFO);
+    iptr = (pmix_info_t *) darray.array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_HOSTNAME, host, PMIX_STRING);
+    PMIX_INFO_LOAD(&iptr[1], PMIX_NODEID, &nodeid, PMIX_UINT32);
+    PMIX_INFO_LOAD(&iptr[2], PMIX_FABRIC_DEVICE, &d1, PMIX_DATA_ARRAY);
+    PMIX_INFO_LOAD(&iptr[3], PMIX_FABRIC_DEVICE, &d2, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&d1);
+    PMIX_DATA_ARRAY_DESTRUCT(&d2);
+
+    PMIX_INFO_LOAD(dest, PMIX_NODE_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+}
+
+/* does any cached node array still carry this device? */
+static bool cached_device(const char *name)
+{
+    pmix_kval_t *kv;
+    pmix_info_t *iptr, *sub;
+    size_t n, m;
+
+    PMIX_LIST_FOREACH (kv, &pmix_server_globals.gdata, pmix_kval_t) {
+        if (!PMIX_CHECK_KEY(kv, PMIX_NODE_INFO_ARRAY) || NULL == kv->value ||
+            PMIX_DATA_ARRAY != kv->value->type || NULL == kv->value->data.darray ||
+            NULL == kv->value->data.darray->array) {
+            continue;
+        }
+        iptr = (pmix_info_t *) kv->value->data.darray->array;
+        for (n = 0; n < kv->value->data.darray->size; n++) {
+            if (PMIX_DATA_ARRAY != iptr[n].value.type ||
+                NULL == iptr[n].value.data.darray ||
+                NULL == iptr[n].value.data.darray->array) {
+                continue;
+            }
+            sub = (pmix_info_t *) iptr[n].value.data.darray->array;
+            for (m = 0; m < iptr[n].value.data.darray->size; m++) {
+                if (PMIX_CHECK_KEY(&sub[m], PMIX_FABRIC_DEVICE_NAME) &&
+                    PMIX_STRING == sub[m].value.type &&
+                    NULL != sub[m].value.data.string &&
+                    0 == strcmp(sub[m].value.data.string, name)) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+/* does the cache still hold a node array naming this host? */
+static bool cached_node(const char *host)
+{
+    pmix_kval_t *kv;
+    pmix_info_t *iptr;
+    size_t n;
+
+    PMIX_LIST_FOREACH (kv, &pmix_server_globals.gdata, pmix_kval_t) {
+        if (!PMIX_CHECK_KEY(kv, PMIX_NODE_INFO_ARRAY) || NULL == kv->value ||
+            PMIX_DATA_ARRAY != kv->value->type || NULL == kv->value->data.darray ||
+            NULL == kv->value->data.darray->array) {
+            continue;
+        }
+        iptr = (pmix_info_t *) kv->value->data.darray->array;
+        for (n = 0; n < kv->value->data.darray->size; n++) {
+            if (PMIX_CHECK_KEY(&iptr[n], PMIX_HOSTNAME) &&
+                PMIX_STRING == iptr[n].value.type &&
+                NULL != iptr[n].value.data.string &&
+                0 == strcmp(iptr[n].value.data.string, host)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static void test_qualified_dereg(void)
+{
+    pmix_info_t info;
+    pmix_status_t rc;
+    size_t base;
+
+    base = ncached();
+
+    /* two nodes registered under the same key */
+    load_node_array(&info, "nodeA", true, 0, NULL);
+    rc = PMIx_server_register_resources(&info, 1, NULL, NULL);
+    report("register_resources accepts a node array", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    load_node_array(&info, "nodeB", true, 1, NULL);
+    rc = PMIx_server_register_resources(&info, 1, NULL, NULL);
+    report("register_resources accepts a second node array", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    report("both nodes are cached",
+           base + 2 == ncached() && cached_node("nodeA") && cached_node("nodeB"));
+
+    /* a qualifier naming one node by hostname removes that node only.
+     * Matching on the key alone - which is what this used to do - takes
+     * both, and nothing here can put the other one back */
+    load_node_array(&info, "nodeA", false, 0, NULL);
+    rc = PMIx_server_deregister_resources(&info, 1, NULL, NULL);
+    report("a hostname-qualified removal is accepted", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    report("the qualified removal took only the named node",
+           base + 1 == ncached() && !cached_node("nodeA") && cached_node("nodeB"));
+
+    /* the same, by nodeid alone - the qualifier carries no hostname, so
+     * only the nodeid can match it to the stored entry */
+    load_nodeid_array(&info, 1);
+    rc = PMIx_server_deregister_resources(&info, 1, NULL, NULL);
+    report("a nodeid-qualified removal is accepted", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    report("the nodeid-qualified removal took the second node",
+           base == ncached() && !cached_node("nodeB"));
+
+    /* a qualifier naming something inside the stored array takes that
+     * element out and leaves the rest of the node alone */
+    load_device_node(&info, "nodeC", 2, "mlx5_0", "mlx5_1");
+    rc = PMIx_server_register_resources(&info, 1, NULL, NULL);
+    report("register_resources accepts a node array carrying devices", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    load_node_array(&info, "nodeC", false, 0, "mlx5_0");
+    rc = PMIx_server_deregister_resources(&info, 1, NULL, NULL);
+    report("an element-level qualifier is accepted", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    report("the named device is gone and the node is not",
+           base + 1 == ncached() && cached_node("nodeC") &&
+           !cached_device("mlx5_0") && cached_device("mlx5_1"));
+
+    /* taking the last thing the entry described takes the entry: what is
+     * left names a node and nothing else, which is what an empty
+     * registration would have produced */
+    load_node_array(&info, "nodeC", false, 0, "mlx5_1");
+    rc = PMIx_server_deregister_resources(&info, 1, NULL, NULL);
+    report("removing the last device is accepted", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    report("the emptied entry was dropped",
+           base == ncached() && !cached_node("nodeC"));
+
+    /* re-register a plain node so the unqualified case below has
+     * something to clear */
+    load_node_array(&info, "nodeC", true, 2, NULL);
+    rc = PMIx_server_register_resources(&info, 1, NULL, NULL);
+    report("register_resources accepts a third node array", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* an unqualified request still selects by key alone */
+    PMIX_INFO_LOAD(&info, PMIX_NODE_INFO_ARRAY, NULL, PMIX_UNDEF);
+    rc = PMIx_server_deregister_resources(&info, 1, NULL, NULL);
+    report("an unqualified removal is accepted", ok(rc));
+    PMIX_INFO_DESTRUCT(&info);
+
+    report("the unqualified removal cleared the key", base == ncached());
+}
+
+/* ------------------------------------------------------------------ */
 /* PMIX_GROUP_JOB_INFO                                                 */
 /* ------------------------------------------------------------------ */
 static void test_job_info(void)
@@ -348,6 +573,7 @@ int main(int argc, char **argv)
 
     test_arg_screens();
     test_cache();
+    test_qualified_dereg();
     test_job_info();
     test_group_arrays();
 


### PR DESCRIPTION
`PMIx_server_deregister_resources` matched on the key alone. Its man page, following the Standard, describes narrowing a removal with qualifiers — a `PMIX_NODE_INFO_ARRAY` naming the node that hosts a fabric device, plus the device's name — and passing exactly that removed **every** node entry the server held. Over-removing is the worst of the available behaviors here: nothing in the library can put an entry back, and the host has no way to learn what went missing.

A request element carrying a data array is now read as the qualified request it is, and the two kinds of member in it do different things:

- **Identifiers** (`PMIX_NODEID`, `PMIX_HOSTNAME`) choose which entries the request applies to. An array carrying no identifier applies to every entry with that key — which is how a device that is unique across the system is removed without naming its node.
- **Targets** (anything else) choose the elements to remove from inside those entries. A target matches an element directly, or matches an element that *contains* it — which is what reaches a fabric device, since a node array holds a `PMIX_FABRIC_DEVICE` element carrying its own array of the device's name and id.

An array with identifiers and no target removes the whole entry, as before but narrowed to the node named. Removing the last element an entry described removes the entry too: what would be left names a node and nothing else, which is what an empty registration would have produced, and it would go on seeding every namespace registered afterwards.

The handler also reports what happened — it returned `PMIX_SUCCESS` unconditionally, so a malformed qualifier was indistinguishable from a removal that worked. Both halves of the walk screen what they read: the request comes from a host and the entries were registered by one, so neither array's element types are ours to assume.

Covered by `test/unit/server_setup.c`: two nodes registered under one key with the removal narrowed to each in turn (by hostname and by nodeid), a device removed from a node carrying two, the entry dropped when its last device goes, and the unqualified key-only removal still clearing every entry.

### What this does not change

Non-namespace information is copied into a namespace's data store when that namespace is registered — `hash_cache_job_info`, guarded by the per-namespace `gdata_added` — and nothing re-reads `gdata` afterwards. So a deregistration governs the namespaces registered *after* it and leaves a running job's copy in place. The man page now says so, and `src/server/AGENTS.md` records why closing it is not a small change: the `gds` module struct has no delete-a-key entry point, and one cannot be built the obvious way for `shmem3` without putting a lock on its read path.

Verified: `make` clean under the tree's `--enable-devel-check` configuration; `make check` 21/21 in `test/` and 70/70 + 10/10 + 7/7 in `test/unit/`; docs build clean under `-W`.