### PR TITLE
Report, everywhere, a blocking call that cannot be serviced

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,10 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv', 'py*/**']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv', 'py*/**',
+                    # shared body text included by many man pages; not a
+                    # document of its own
+                    'man/no-blocking-in-progress-thread.rst']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/man/man3/PMIx_Abort.3.rst
+++ b/docs/man/man3/PMIx_Abort.3.rst
@@ -111,6 +111,9 @@ Any other negative value indicates an appropriate error condition. PMIx error
 constants are defined in ``pmix_common.h``.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,

--- a/docs/man/man3/PMIx_Allocation_request.3.rst
+++ b/docs/man/man3/PMIx_Allocation_request.3.rst
@@ -314,6 +314,9 @@ conveyed in that event through the ``PMIX_ALLOC_STATUS`` (pmix_status_t)
 attribute, which carries the completion status of the allocation request.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Resource_block(3) <man3-PMIx_Resource_block>`,

--- a/docs/man/man3/PMIx_Commit.3.rst
+++ b/docs/man/man3/PMIx_Commit.3.rst
@@ -81,6 +81,9 @@ a collective synchronization such as :ref:`PMIx_Fence(3) <man3-PMIx_Fence>` befo
 the peers issue :ref:`PMIx_Get(3) <man3-PMIx_Get>`.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Put(3) <man3-PMIx_Put>`,

--- a/docs/man/man3/PMIx_Compute_distances.3.rst
+++ b/docs/man/man3/PMIx_Compute_distances.3.rst
@@ -191,6 +191,9 @@ inconsistent results from calls to this API by different threads if the
 ``PMIX_CPUBIND_THREAD`` binding envelope was used when generating the ``cpuset``.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Load_topology(3) <man3-PMIx_Load_topology>`,

--- a/docs/man/man3/PMIx_Connect.3.rst
+++ b/docs/man/man3/PMIx_Connect.3.rst
@@ -182,6 +182,9 @@ connected to the parent process upon successful launch, following the same
 semantics described here.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,

--- a/docs/man/man3/PMIx_Data_pack.3.rst
+++ b/docs/man/man3/PMIx_Data_pack.3.rst
@@ -134,6 +134,9 @@ Packing and unpacking are strictly ordered, complementary operations: values mus
 unpacked in the same sequence, and with the same types, in which they were packed.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Data_unpack(3) <man3-PMIx_Data_unpack>`,
    :ref:`PMIx_Data_copy(3) <man3-PMIx_Data_copy>`,

--- a/docs/man/man3/PMIx_Data_unpack.3.rst
+++ b/docs/man/man3/PMIx_Data_unpack.3.rst
@@ -149,6 +149,9 @@ sequence of :ref:`PMIx_Data_pack(3) <man3-PMIx_Data_pack>` calls is recovered wi
 matching sequence of ``PMIx_Data_unpack`` calls issued in the same order.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Data_pack(3) <man3-PMIx_Data_pack>`,
    :ref:`PMIx_Data_copy(3) <man3-PMIx_Data_copy>`,

--- a/docs/man/man3/PMIx_Deregister_event_handler.3.rst
+++ b/docs/man/man3/PMIx_Deregister_event_handler.3.rst
@@ -85,6 +85,9 @@ Any other negative value indicates an appropriate error condition. PMIx error
 constants are defined in ``pmix_common.h``.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Register_event_handler(3) <man3-PMIx_Register_event_handler>`,
    :ref:`PMIx_Notify_event(3) <man3-PMIx_Notify_event>`,

--- a/docs/man/man3/PMIx_Disconnect.3.rst
+++ b/docs/man/man3/PMIx_Disconnect.3.rst
@@ -169,6 +169,9 @@ every job terminated as a result. Calling ``PMIx_Disconnect`` before finalizing
 avoids these events.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,

--- a/docs/man/man3/PMIx_Fabric_register.3.rst
+++ b/docs/man/man3/PMIx_Fabric_register.3.rst
@@ -226,6 +226,9 @@ tools, and other servers that call these functions will have their requests
 forwarded to the server supporting the scheduler.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Fabric_update(3) <man3-PMIx_Fabric_update>`,
    :ref:`PMIx_Fabric_deregister(3) <man3-PMIx_Fabric_deregister>`,

--- a/docs/man/man3/PMIx_Fabric_update.3.rst
+++ b/docs/man/man3/PMIx_Fabric_update.3.rst
@@ -109,6 +109,9 @@ information; the other is to register for ``PMIX_FABRIC_UPDATE_PENDING`` and
 :ref:`PMIx_Fabric_register(3) <man3-PMIx_Fabric_register>` for details.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Fabric_register(3) <man3-PMIx_Fabric_register>`,
    :ref:`PMIx_Fabric_deregister(3) <man3-PMIx_Fabric_deregister>`,

--- a/docs/man/man3/PMIx_Fence.3.rst
+++ b/docs/man/man3/PMIx_Fence.3.rst
@@ -155,6 +155,17 @@ accepted for processing and the final status will be delivered to ``cbfunc``.
 * ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
   library's progress engine has been stopped.
 * ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
+* ``PMIX_ERR_WOULD_BLOCK`` |mdash| the call would have blocked the PMIx progress
+  thread from within that thread. See `NOTES`_.
+
+A ``NULL`` ``cbfunc`` passed to ``PMIx_Fence_nb`` makes that call **blocking**:
+it does not return until the fence completes, and its return value is the
+result of the fence rather than an indication that the request was accepted.
+That is the general PMIx convention for a non-blocking entry point handed no
+callback. It can only be honored where the operation's entire result is a
+status, as it is here |mdash| an entry point that has no way to hand back what
+the caller asked for, such as :ref:`PMIx_Get_nb(3) <man3-PMIx_Get>`, rejects a
+``NULL`` ``cbfunc`` with ``PMIX_ERR_BAD_PARAM`` instead.
 
 For a singleton process there are no peers to synchronize with, so the blocking
 form returns ``PMIX_SUCCESS`` (and the non-blocking form
@@ -162,6 +173,22 @@ form returns ``PMIX_SUCCESS`` (and the non-blocking form
 
 Any other negative value indicates an appropriate error condition. PMIx error
 constants are defined in ``pmix_common.h``.
+
+
+NOTES
+-----
+
+**Neither blocking form may be called from the PMIx progress thread.** The
+reply that releases the caller is delivered by that thread, so waiting for it
+from within it waits forever. This reaches any code running in a PMIx callback
+|mdash| an event handler registered with
+:ref:`PMIx_Register_event_handler(3) <man3-PMIx_Register_event_handler>` above
+all. Both ``PMIx_Fence`` and the blocking (``NULL`` ``cbfunc``) form of
+``PMIx_Fence_nb`` detect this and return ``PMIX_ERR_WOULD_BLOCK`` immediately,
+accompanied by a diagnostic naming the call.
+
+To fence from a handler, call ``PMIx_Fence_nb`` with a callback: that form is
+meant to be driven from the progress thread and is unaffected.
 
 
 .. seealso::

--- a/docs/man/man3/PMIx_Fence.3.rst
+++ b/docs/man/man3/PMIx_Fence.3.rst
@@ -156,7 +156,8 @@ accepted for processing and the final status will be delivered to ``cbfunc``.
   library's progress engine has been stopped.
 * ``PMIX_ERR_INIT`` |mdash| the PMIx library has not been initialized.
 * ``PMIX_ERR_WOULD_BLOCK`` |mdash| the call would have blocked the PMIx progress
-  thread from within that thread. See `NOTES`_.
+  thread from within that thread. See
+  `PROGRESS THREAD RESTRICTION`_.
 
 A ``NULL`` ``cbfunc`` passed to ``PMIx_Fence_nb`` makes that call **blocking**:
 it does not return until the fence completes, and its return value is the
@@ -175,20 +176,7 @@ Any other negative value indicates an appropriate error condition. PMIx error
 constants are defined in ``pmix_common.h``.
 
 
-NOTES
------
-
-**Neither blocking form may be called from the PMIx progress thread.** The
-reply that releases the caller is delivered by that thread, so waiting for it
-from within it waits forever. This reaches any code running in a PMIx callback
-|mdash| an event handler registered with
-:ref:`PMIx_Register_event_handler(3) <man3-PMIx_Register_event_handler>` above
-all. Both ``PMIx_Fence`` and the blocking (``NULL`` ``cbfunc``) form of
-``PMIx_Fence_nb`` detect this and return ``PMIX_ERR_WOULD_BLOCK`` immediately,
-accompanied by a diagnostic naming the call.
-
-To fence from a handler, call ``PMIx_Fence_nb`` with a callback: that form is
-meant to be driven from the progress thread and is unaffected.
+.. include:: /man/no-blocking-in-progress-thread.rst
 
 
 .. seealso::

--- a/docs/man/man3/PMIx_Finalize.3.rst
+++ b/docs/man/man3/PMIx_Finalize.3.rst
@@ -100,6 +100,9 @@ should instead call ``PMIx_tool_finalize``, and processes hosting a PMIx server
 should call ``PMIx_server_finalize``.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Abort(3) <man3-PMIx_Abort>`,

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -366,6 +366,9 @@ process has published, not only the key named in the call, so one refresh
 updates the caller's whole view of that process.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Put(3) <man3-PMIx_Put>`,

--- a/docs/man/man3/PMIx_Get_credential.3.rst
+++ b/docs/man/man3/PMIx_Get_credential.3.rst
@@ -161,6 +161,9 @@ by the PMIx library and must not be released or modified by the caller; it is
 unrelated to the ``info`` array passed into the call.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Validate_credential(3) <man3-PMIx_Validate_credential>`,

--- a/docs/man/man3/PMIx_Group_construct.3.rst
+++ b/docs/man/man3/PMIx_Group_construct.3.rst
@@ -300,6 +300,9 @@ was successfully accepted for processing; the final status is delivered to
 Any other value indicates an appropriate error condition.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>`,
    :ref:`PMIx_Group_join(3) <man3-PMIx_Group_join>`,

--- a/docs/man/man3/PMIx_Group_destruct.3.rst
+++ b/docs/man/man3/PMIx_Group_destruct.3.rst
@@ -162,6 +162,9 @@ Any other value indicates an appropriate error condition, such as the failure of
 member process when ``PMIX_GROUP_NOTIFY_TERMINATION`` was not requested.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>`,
    :ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>`,

--- a/docs/man/man3/PMIx_Group_invite.3.rst
+++ b/docs/man/man3/PMIx_Group_invite.3.rst
@@ -224,6 +224,9 @@ was successfully accepted for processing; the final status is delivered to
 Any other value indicates an appropriate error condition.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>`,
    :ref:`PMIx_Group_join(3) <man3-PMIx_Group_join>`,

--- a/docs/man/man3/PMIx_Group_join.3.rst
+++ b/docs/man/man3/PMIx_Group_join.3.rst
@@ -193,6 +193,9 @@ and the callback is not invoked if any other value is returned.
 Any other value indicates an appropriate error condition.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>`,
    :ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>`,

--- a/docs/man/man3/PMIx_Group_leave.3.rst
+++ b/docs/man/man3/PMIx_Group_leave.3.rst
@@ -130,6 +130,9 @@ invoked if any other value is returned.
 Any other value indicates an appropriate error condition.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Group_construct(3) <man3-PMIx_Group_construct>`,
    :ref:`PMIx_Group_invite(3) <man3-PMIx_Group_invite>`,

--- a/docs/man/man3/PMIx_IOF_deregister.3.rst
+++ b/docs/man/man3/PMIx_IOF_deregister.3.rst
@@ -119,6 +119,9 @@ The ``iofhdlr`` passed here must be the identifier returned by the matching
 identifier results in an error.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`,
    :ref:`PMIx_IOF_push(3) <man3-PMIx_IOF_push>`,

--- a/docs/man/man3/PMIx_IOF_pull.3.rst
+++ b/docs/man/man3/PMIx_IOF_pull.3.rst
@@ -206,6 +206,9 @@ namespace is supported but should be used with care due to the bandwidth and
 memory footprint it can incur.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_IOF_push(3) <man3-PMIx_IOF_push>`,
    :ref:`PMIx_IOF_deregister(3) <man3-PMIx_IOF_deregister>`,

--- a/docs/man/man3/PMIx_IOF_push.3.rst
+++ b/docs/man/man3/PMIx_IOF_push.3.rst
@@ -157,6 +157,9 @@ supported but should be used with care due to the bandwidth and memory
 footprint it can incur.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`,
    :ref:`PMIx_IOF_deregister(3) <man3-PMIx_IOF_deregister>`,

--- a/docs/man/man3/PMIx_Job_control.3.rst
+++ b/docs/man/man3/PMIx_Job_control.3.rst
@@ -225,6 +225,9 @@ the allocation APIs to build coordinated responses to failures and other events
 delivered to the affected processes.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,

--- a/docs/man/man3/PMIx_Load_topology.3.rst
+++ b/docs/man/man3/PMIx_Load_topology.3.rst
@@ -100,6 +100,9 @@ the caller should inspect the returned ``source`` field to verify that the
 returned topology description is compatible with the caller's code.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Compute_distances(3) <man3-PMIx_Compute_distances>`,

--- a/docs/man/man3/PMIx_Log.3.rst
+++ b/docs/man/man3/PMIx_Log.3.rst
@@ -283,6 +283,9 @@ generated timestamp:
     PMIx_Info_destruct(&directive);
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Info_construct(3) <man3-PMIx_Info_construct>`,
    :ref:`PMIx_Info_create(3) <man3-PMIx_Info_create>`,

--- a/docs/man/man3/PMIx_Lookup.3.rst
+++ b/docs/man/man3/PMIx_Lookup.3.rst
@@ -186,6 +186,9 @@ requester whose user ID matches the publisher and whose process falls within the
 publication range.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Publish(3) <man3-PMIx_Publish>`,

--- a/docs/man/man3/PMIx_Notify_event.3.rst
+++ b/docs/man/man3/PMIx_Notify_event.3.rst
@@ -213,6 +213,9 @@ removed with
 :ref:`PMIx_Deregister_event_handler(3) <man3-PMIx_Deregister_event_handler>`.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Register_event_handler(3) <man3-PMIx_Register_event_handler>`,

--- a/docs/man/man3/PMIx_Process_monitor.3.rst
+++ b/docs/man/man3/PMIx_Process_monitor.3.rst
@@ -353,6 +353,9 @@ Support for individual monitoring actions and directives is implementation- and
 host-environment-dependent.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Heartbeat(3) <man3-PMIx_Heartbeat>`,

--- a/docs/man/man3/PMIx_Publish.3.rst
+++ b/docs/man/man3/PMIx_Publish.3.rst
@@ -159,6 +159,9 @@ same user whose range includes the requesting process. Choose the publication
 range deliberately so the intended recipients fall within it.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Lookup(3) <man3-PMIx_Lookup>`,

--- a/docs/man/man3/PMIx_Put.3.rst
+++ b/docs/man/man3/PMIx_Put.3.rst
@@ -133,6 +133,9 @@ obtained with :ref:`PMIx_Get(3) <man3-PMIx_Get>` by supplying the matching
 qualifiers, allowing several distinct values to be posted under the same key.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`,

--- a/docs/man/man3/PMIx_Query_info.3.rst
+++ b/docs/man/man3/PMIx_Query_info.3.rst
@@ -381,6 +381,9 @@ static key value, however, ``PMIx_Get`` is typically faster because it avoids th
 overhead of constructing and processing the ``pmix_query_t`` structure.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Finalize(3) <man3-PMIx_Finalize>`,

--- a/docs/man/man3/PMIx_Register_attributes.3.rst
+++ b/docs/man/man3/PMIx_Register_attributes.3.rst
@@ -106,6 +106,9 @@ describes an alternative signature for this function that takes an array of
 release accepts the simpler ``NULL``-terminated string array shown here.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,

--- a/docs/man/man3/PMIx_Register_event_handler.3.rst
+++ b/docs/man/man3/PMIx_Register_event_handler.3.rst
@@ -229,6 +229,9 @@ positive values, or negative values beyond the ``PMIX_EXTERNAL_ERR_BASE``
 boundary.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Deregister_event_handler(3) <man3-PMIx_Deregister_event_handler>`,
    :ref:`PMIx_Notify_event(3) <man3-PMIx_Notify_event>`,

--- a/docs/man/man3/PMIx_Resolve_nodes.3.rst
+++ b/docs/man/man3/PMIx_Resolve_nodes.3.rst
@@ -107,6 +107,9 @@ is the normal indication that no nodes host processes in the requested namespace
 |mdash| it is not an error.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,

--- a/docs/man/man3/PMIx_Resolve_peers.3.rst
+++ b/docs/man/man3/PMIx_Resolve_peers.3.rst
@@ -113,6 +113,9 @@ The returned ``procs`` array is owned by the caller and must be released with
 the node hosts no processes in the requested namespace |mdash| it is not an error.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Query_info(3) <man3-PMIx_Query_info>`,

--- a/docs/man/man3/PMIx_Resource_block.3.rst
+++ b/docs/man/man3/PMIx_Resource_block.3.rst
@@ -156,6 +156,9 @@ resource-block request against itself and will receive
 published PMIx Standard.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Allocation_request(3) <man3-PMIx_Allocation_request>`,

--- a/docs/man/man3/PMIx_Session_control.3.rst
+++ b/docs/man/man3/PMIx_Session_control.3.rst
@@ -182,6 +182,9 @@ non-blocking behavior based on whether ``cbfunc`` is ``NULL``.
 published PMIx Standard.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Allocation_request(3) <man3-PMIx_Allocation_request>`,

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -455,6 +455,9 @@ distinctly from ``PMIX_SUCCESS``. The blocking ``PMIx_Spawn`` absorbs this case
 internally and simply returns ``PMIX_SUCCESS`` with the namespace populated.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Connect(3) <man3-PMIx_Connect>`,

--- a/docs/man/man3/PMIx_Store_internal.3.rst
+++ b/docs/man/man3/PMIx_Store_internal.3.rst
@@ -94,6 +94,9 @@ available to other processes, use :ref:`PMIx_Put(3) <man3-PMIx_Put>` followed by
 :ref:`PMIx_Commit(3) <man3-PMIx_Commit>` instead.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Put(3) <man3-PMIx_Put>`,

--- a/docs/man/man3/PMIx_Unpublish.3.rst
+++ b/docs/man/man3/PMIx_Unpublish.3.rst
@@ -136,6 +136,9 @@ must match the one used at publication time. After a successful unpublish, the
 same key may be published again within that range.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Publish(3) <man3-PMIx_Publish>`,

--- a/docs/man/man3/PMIx_Validate_credential.3.rst
+++ b/docs/man/man3/PMIx_Validate_credential.3.rst
@@ -169,6 +169,9 @@ described in the credential, though the precise contents depend on the host
 environment and its associated security system.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_Init(3) <man3-PMIx_Init>`,
    :ref:`PMIx_Get_credential(3) <man3-PMIx_Get_credential>`,

--- a/docs/man/man3/PMIx_server_IOF_deliver.3.rst
+++ b/docs/man/man3/PMIx_server_IOF_deliver.3.rst
@@ -161,6 +161,9 @@ collects output from remote processes and injects it here, and the library
 routes it to whichever local clients requested it.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_IOF_pull(3) <man3-PMIx_IOF_pull>`,

--- a/docs/man/man3/PMIx_server_IOF_flow_control.3.rst
+++ b/docs/man/man3/PMIx_server_IOF_flow_control.3.rst
@@ -168,6 +168,9 @@ existed. A host can detect support at build time through the
 ``PMIX_CAP_IOF_FLOW_CONTROL`` capability flag in ``pmix_version.h``.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_server_IOF_deliver(3) <man3-PMIx_server_IOF_deliver>`,

--- a/docs/man/man3/PMIx_server_collect_job_info.3.rst
+++ b/docs/man/man3/PMIx_server_collect_job_info.3.rst
@@ -105,6 +105,9 @@ Standard. It is available only after the server library has been initialized
 with :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,

--- a/docs/man/man3/PMIx_server_define_process_set.3.rst
+++ b/docs/man/man3/PMIx_server_define_process_set.3.rst
@@ -100,6 +100,9 @@ the definition on the local server; it does not propagate it to peer
 servers.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_server_delete_process_set(3) <man3-PMIx_server_delete_process_set>`,

--- a/docs/man/man3/PMIx_server_delete_process_set.3.rst
+++ b/docs/man/man3/PMIx_server_delete_process_set.3.rst
@@ -87,6 +87,9 @@ only removes the definition on the local server; it does not propagate the
 deletion to peer servers.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_server_define_process_set(3) <man3-PMIx_server_define_process_set>`,

--- a/docs/man/man3/PMIx_server_deliver_inventory.3.rst
+++ b/docs/man/man3/PMIx_server_deliver_inventory.3.rst
@@ -137,6 +137,9 @@ Any other negative value indicates an appropriate error condition. PMIx error
 constants are defined in ``pmix_common.h``.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_server_collect_inventory(3) <man3-PMIx_server_collect_inventory>`,

--- a/docs/man/man3/PMIx_server_deregister_client.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_client.3.rst
@@ -97,6 +97,9 @@ example, during finalize), the request is silently dropped and any provided
 ``cbfunc`` is not invoked.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_register_client(3) <man3-PMIx_server_register_client>`,
    :ref:`PMIx_server_deregister_nspace(3) <man3-PMIx_server_deregister_nspace>`,

--- a/docs/man/man3/PMIx_server_deregister_nspace.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_nspace.3.rst
@@ -99,6 +99,9 @@ example, during finalize), the request is silently dropped and any provided
 ``cbfunc`` is not invoked.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
    :ref:`PMIx_server_deregister_client(3) <man3-PMIx_server_deregister_client>`,

--- a/docs/man/man3/PMIx_server_deregister_resources.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_resources.3.rst
@@ -139,6 +139,9 @@ environment determines that client processes should no longer have access to the
 information.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_server_register_resources(3) <man3-PMIx_server_register_resources>`,

--- a/docs/man/man3/PMIx_server_register_client.3.rst
+++ b/docs/man/man3/PMIx_server_register_client.3.rst
@@ -139,6 +139,9 @@ of a connecting process against those registered here before completing the
 connection.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_deregister_client(3) <man3-PMIx_server_deregister_client>`,
    :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,

--- a/docs/man/man3/PMIx_server_register_nspace.3.rst
+++ b/docs/man/man3/PMIx_server_register_nspace.3.rst
@@ -220,6 +220,9 @@ Large ``PMIX_NODE_MAP`` and ``PMIX_PROC_MAP`` values are commonly generated in
 compressed form using ``PMIx_generate_regex2`` prior to registration.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_deregister_nspace(3) <man3-PMIx_server_deregister_nspace>`,
    :ref:`PMIx_server_register_client(3) <man3-PMIx_server_register_client>`,

--- a/docs/man/man3/PMIx_server_register_resources.3.rst
+++ b/docs/man/man3/PMIx_server_register_resources.3.rst
@@ -169,6 +169,9 @@ the library; the library cleans it up as part of normal finalization. Use
 only when client processes should no longer have access to the information.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_server_deregister_resources(3) <man3-PMIx_server_deregister_resources>`,

--- a/docs/man/man3/PMIx_server_setup_local_support.3.rst
+++ b/docs/man/man3/PMIx_server_setup_local_support.3.rst
@@ -140,6 +140,9 @@ this API has no additional effect once
 those operations for that namespace.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_server_setup_application(3) <man3-PMIx_server_setup_application>`,

--- a/docs/man/man3/PMIx_tool_attach_to_server.3.rst
+++ b/docs/man/man3/PMIx_tool_attach_to_server.3.rst
@@ -152,6 +152,9 @@ server among them, and
 :ref:`PMIx_tool_disconnect(3) <man3-PMIx_tool_disconnect>` to drop a connection.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
    :ref:`PMIx_tool_disconnect(3) <man3-PMIx_tool_disconnect>`,

--- a/docs/man/man3/PMIx_tool_disconnect.3.rst
+++ b/docs/man/man3/PMIx_tool_disconnect.3.rst
@@ -86,6 +86,9 @@ To close *all* connections and release the library, call
 currently connected servers before selecting one to disconnect.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
    :ref:`PMIx_tool_finalize(3) <man3-PMIx_tool_finalize>`,

--- a/docs/man/man3/PMIx_tool_get_servers.3.rst
+++ b/docs/man/man3/PMIx_tool_get_servers.3.rst
@@ -86,6 +86,9 @@ and should be freed with ``PMIX_PROC_FREE(servers, nservers)``; the Python
 binding returns an ordinary list and frees the underlying array automatically.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
    :ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`,

--- a/docs/man/man3/PMIx_tool_set_server.3.rst
+++ b/docs/man/man3/PMIx_tool_set_server.3.rst
@@ -114,6 +114,9 @@ This function is available only to processes that initialized as *tools*
 via :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`.
 
 
+.. include:: /man/no-blocking-in-progress-thread.rst
+
+
 .. seealso::
    :ref:`PMIx_tool_init(3) <man3-PMIx_tool_init>`,
    :ref:`PMIx_tool_attach_to_server(3) <man3-PMIx_tool_attach_to_server>`,

--- a/docs/man/no-blocking-in-progress-thread.rst
+++ b/docs/man/no-blocking-in-progress-thread.rst
@@ -1,0 +1,24 @@
+PROGRESS THREAD RESTRICTION
+---------------------------
+
+**A blocking PMIx call must not be made from within the PMIx progress
+thread.** Any code the library itself invokes runs on that thread: an
+event handler registered through
+:ref:`PMIx_Register_event_handler(3) <man3-PMIx_Register_event_handler>`,
+a callback passed to a non-blocking PMIx API, and |mdash| in a server or
+tool |mdash| the completion of a host-module up-call. A blocking call
+waits for work that the progress thread has to perform, so making one
+from that thread waits for itself and never returns. The PMIx Standard
+disallows it, and there is no way for an implementation to service such
+a request.
+
+Where this call has a blocking form |mdash| including the blocking
+behavior a non-blocking entry point adopts when it is passed a ``NULL``
+``cbfunc`` |mdash| that form detects the situation and returns
+``PMIX_ERR_WOULD_BLOCK`` immediately, accompanied by a diagnostic naming
+the call. Nothing is done and no callback is invoked.
+
+``PMIX_ERR_WOULD_BLOCK`` here is not a transient condition to retry: it
+reports a call that cannot be serviced from where it was made. Reissue
+it as the non-blocking form with a callback, or from a thread of your
+own.

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -283,3 +283,13 @@ Detailed changes since v6.1.0:
    exchange the library no longer performs. That stale type reached the
    generated attribute dictionary as well, so it is what the
    attribute-support queries and pattrs reported for the attribute
+ - PMIx_Fence, and the blocking form of PMIx_Fence_nb, now report
+   PMIX_ERR_WOULD_BLOCK when called from the PMIx progress thread instead
+   of hanging there. The reply that releases the caller is delivered by
+   that thread, so waiting for it from within it waits for itself - which
+   is what any code running in a PMIx callback, an event handler above
+   all, would have done. The diagnostic names the call. PMIx_Fence_nb
+   with a callback is unaffected: that form is meant to be driven from a
+   handler. Note the blocking form of PMIx_Fence_nb is the one a caller
+   selects by passing a NULL cbfunc; the man page now says so, since the
+   other non-blocking entry points give that a different meaning

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -283,13 +283,16 @@ Detailed changes since v6.1.0:
    exchange the library no longer performs. That stale type reached the
    generated attribute dictionary as well, so it is what the
    attribute-support queries and pattrs reported for the attribute
- - PMIx_Fence, and the blocking form of PMIx_Fence_nb, now report
-   PMIX_ERR_WOULD_BLOCK when called from the PMIx progress thread instead
-   of hanging there. The reply that releases the caller is delivered by
-   that thread, so waiting for it from within it waits for itself - which
-   is what any code running in a PMIx callback, an event handler above
-   all, would have done. The diagnostic names the call. PMIx_Fence_nb
-   with a callback is unaffected: that form is meant to be driven from a
-   handler. Note the blocking form of PMIx_Fence_nb is the one a caller
-   selects by passing a NULL cbfunc; the man page now says so, since the
-   other non-blocking entry points give that a different meaning
+ - Every blocking PMIx entry point now reports PMIX_ERR_WOULD_BLOCK when
+   called from within the PMIx progress thread, rather than hanging
+   there. Making such a call has always been disallowed - the work that
+   would release the caller is what that thread was about to do - but
+   only a minority of entry points said so, and the rest simply stopped:
+   an event handler that called PMIx_Fence, PMIx_Connect or
+   PMIx_Group_construct wedged the process with nothing reported. The
+   screen now covers all of them, sixty-one call sites, and emits a
+   diagnostic naming the call. Where the wait is conditional on a NULL
+   cbfunc - the fence, notify and event-registration entry points - only
+   that path is screened, since with a callback those are meant to be
+   driven from a handler. The affected man pages carry a PROGRESS THREAD
+   RESTRICTION section stating the rule and the return code

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -44,23 +44,6 @@ and makes the array case correspondingly more destructive.  Either the
 qualifier match is implemented, or the man page is narrowed to describe
 what the code does.
 
-``PMIx_Fence_nb`` blocks when handed a ``NULL`` callback
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-It is the only non-blocking entry point in ``src/client`` that does.  A
-caller who chose the ``_nb`` form precisely to stay off a blocking path
-gets a blocking call, and one issued from an event handler on the
-progress thread deadlocks outright.  Every way of resolving it is a
-behavior change to a released public API rather than a fix: rejecting
-``NULL`` breaks any caller relying on the block, and returning without
-waiting silently converts that caller's synchronization into a
-fire-and-forget.  Nothing in the library depends on the answer —
-``PMIx_Fence`` passes its own callback and does not take this branch.
-
-.. note:: This directory has **four** different meanings for a ``NULL``
-          callback; check which one applies before copying a ``NULL``
-          test between entry points.  See ``src/client/AGENTS.md``.
-
 A host ``spawn`` that returns ``PMIX_OPERATION_SUCCEEDED`` is dropped
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1123,36 +1123,61 @@ empty array and returns `PMIX_ERR_NOT_A_MEMBER`.
 
 *Noted, not changed:*
 
-- **`PMIx_Fence_nb` blocks when handed a NULL `cbfunc`**, and it is the
-  only `_nb` entry point in this directory that does. It allocates its
-  caddy, sends, and then takes a `PMIX_WAIT_THREAD` branch of its own —
-  so a caller who chose the non-blocking form precisely to stay off a
-  blocking path gets a blocking call, and one that deadlocks outright if
-  it was issued from an event handler on the progress thread. Note the
-  directory has **four** different meanings for a NULL `cbfunc` and this
-  is the last: `PMIx_Get_nb`, `PMIx_Compute_distances_nb` and
-  `PMIx_Group_invite_nb` reject it with `PMIX_ERR_BAD_PARAM`, the two
-  fabric `_nb` entry points read it as "the caddy is in `cbdata`" (see
-  the invariant above), the remaining group `_nb` entry points
-  (`PMIx_Group_construct_nb`, `PMIx_Group_join_nb`, `PMIx_Group_leave_nb`,
-  `PMIx_Group_destruct_nb`) **and `PMIx_Spawn_nb`** accept it as
-  fire-and-forget — their reply handlers all test `NULL != cb->cbfunc`
-  (`NULL != fcd->spcbfunc` for spawn, in both `wait_cbfunc` and
-  `_lclcbfunc`) before completing, and the operation still takes effect —
-  and fence blocks. Check which one you are looking at before copying a
-  NULL test between them.
+- **A NULL `cbfunc` means "run this as the blocking form", and
+  `PMIx_Fence_nb` is where that convention is visible in this
+  directory.** It allocates its caddy, sends, and then takes a
+  `PMIX_WAIT_THREAD` branch of its own; `wait_cbfunc` wakes that lock
+  rather than invoking a callback for exactly this case. This entry used
+  to call it an anomaly — "the only `_nb` in this directory that blocks",
+  one of "four different meanings". That reads the exceptions as the
+  rule. **The convention is the project's, and it is not confined to this
+  directory**; what varies is whether a given entry point can express it.
+
+  It can be honored wherever the operation's whole result is a status.
+  Where the result can only come back *through* the callback, there is
+  nothing to honor it with — the `_nb` signature has no out-parameter its
+  blocking sibling would have — so those reject a NULL with
+  `PMIX_ERR_BAD_PARAM` and say why at the site: `PMIx_Get_nb` ("no way to
+  return the result"), `PMIx_Compute_distances_nb`, `PMIx_Group_invite_nb`.
+  Read those as the convention being inapplicable, not contradicted.
+
+  Two other readings live here and are worth knowing before you copy a
+  NULL test between entry points. The two fabric `_nb` entry points use
+  NULL to mean "the caddy is in `cbdata`" (see the invariant above) —
+  their blocking wrappers' internal signal, and the reason `frecv` writes
+  the *caller's* status field directly. And `PMIx_Group_construct_nb`,
+  `PMIx_Group_join_nb`, `PMIx_Group_leave_nb`, `PMIx_Group_destruct_nb`
+  and `PMIx_Spawn_nb` accept it as fire-and-forget: their reply handlers
+  test `NULL != cb->cbfunc` (`NULL != fcd->spcbfunc` for spawn, in both
+  `wait_cbfunc` and `_lclcbfunc`) and the operation still takes effect,
+  but nobody is told when it finishes.
 
   This entry used to name `PMIx_Group_construct_nb` among the rejecters.
   It does not reject: it has never tested `cbfunc` at all, and
   `construct_cbfunc` is written for the NULL case. Do not "restore" a
   check that was never there.
 
-  Left alone because every way of resolving it is a behavior change to a
-  released public API rather than a fix: rejecting NULL breaks any caller
-  relying on the block, and returning without waiting silently converts
-  their synchronization into a fire-and-forget. `PMIx_Fence` does not go
-  through this branch — it passes `op_cbfunc` — so nothing in the library
-  depends on the answer.
+  **The deadlock half of this is now closed; the shape is not.** Both
+  blocking paths — `PMIx_Fence` and the NULL-`cbfunc` form here — screen
+  `pmix_progress_thread_check_blocking()` and return
+  `PMIX_ERR_WOULD_BLOCK` rather than waiting on the progress thread from
+  the progress thread. The screen is deliberately *only* on the NULL
+  case in `PMIx_Fence_nb`: with a callback that entry point is meant to
+  be driven from a handler. What is left alone is whether an `_nb`
+  entry point should have a blocking mode at all, and that is a behavior
+  change to a released public API rather than a fix — rejecting NULL
+  breaks any caller relying on the block, and returning without waiting
+  silently converts their synchronization into a fire-and-forget.
+  Nothing in the library depends on the answer: `PMIx_Fence` passes
+  `op_cbfunc` and does not take this branch.
+
+  **These are the first two uses of that screen in `src/client`**, and
+  the same exposure exists at every other blocking entry point in this
+  directory — a `PMIx_Get`, `PMIx_Connect` or `PMIx_Group_construct`
+  issued from a handler hangs exactly as a fence did. Sweeping them is
+  worth doing as one piece of work rather than one file at a time; the
+  server side has carried the screen at thirteen entry points for a
+  while, and `src/server/pmix_server_setup.c` is the shape to copy.
 
 The sweep found two leaks, both on error paths that only a failing
 server can reach, and both fixed: `job_data()` dropped the `nspace`

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1171,13 +1171,25 @@ empty array and returns `PMIX_ERR_NOT_A_MEMBER`.
   Nothing in the library depends on the answer: `PMIx_Fence` passes
   `op_cbfunc` and does not take this branch.
 
-  **These are the first two uses of that screen in `src/client`**, and
-  the same exposure exists at every other blocking entry point in this
-  directory — a `PMIx_Get`, `PMIx_Connect` or `PMIx_Group_construct`
-  issued from a handler hangs exactly as a fence did. Sweeping them is
-  worth doing as one piece of work rather than one file at a time; the
-  server side has carried the screen at thirteen entry points for a
-  while, and `src/server/pmix_server_setup.c` is the shape to copy.
+  **Every blocking entry point in the tree now carries that screen** —
+  sixty-one call sites, swept in one pass rather than a file at a time,
+  because the exposure was never particular to fence: a `PMIx_Get`,
+  `PMIx_Connect` or `PMIx_Group_construct` issued from a handler hung
+  exactly as a fence did. `PMIx_Get` and the three `PMIx_IOF_*` entry
+  points already had it before that sweep, as did thirteen
+  `PMIx_server_*` ones; `src/server/pmix_server_setup.c` remains the
+  shape to copy.
+
+  Two rules for adding an entry point here. **If it can wait, screen
+  it**, immediately before the first thing that can block and *after*
+  the early-outs that return without blocking — a singleton fence, an
+  unconnected client and a `PMIX_OPERATION_SUCCEEDED` all answer
+  without waiting, and turning those into `PMIX_ERR_WOULD_BLOCK` would
+  break calls that work. **And screen only the blocking path**: where
+  the wait is conditional on a NULL `cbfunc` (fence, notify, the two
+  event registrations), the guard carries the same condition, because
+  with a callback those entry points are meant to be driven from a
+  handler.
 
 The sweep found two leaks, both on error paths that only a failing
 server can reach, and both fixed: `job_data()` dropped the `nspace`

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1258,6 +1258,15 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         return PMIX_SUCCESS;
     }
 
+    /* the teardown below waits on the progress thread more than once, and
+     * it stops that thread - so from the thread itself this is not merely
+     * a deadlock, it is the thread ending itself mid-callback */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Finalize"))) {
+        /* put the reference back - we did not finalize */
+        pmix_atomic_fetch_add(&client_init_cntr, 1);
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     // mark we are no longer initialized
     pmix_atomic_unset_bool(&pmix_globals.initialized);
     pmix_globals.init_called = false;
@@ -1420,6 +1429,12 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
     /* if we aren't connected, don't attempt to send */
     if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Abort"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a buffer to hold the message */
@@ -1588,6 +1603,12 @@ PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope,
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Put"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     /* create a callback object */
     cb = PMIX_NEW(pmix_cb_t);
     cb->scope = scope;
@@ -1752,6 +1773,12 @@ PMIX_EXPORT pmix_status_t PMIx_Commit(void)
     }
     if (PMIX_UNLIKELY(!pmix_atomic_check_bool(&pmix_globals.connected))) {
         return PMIX_ERR_UNREACH;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Commit"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object */

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -55,6 +55,7 @@
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "pmix_client_ops.h"
@@ -123,6 +124,12 @@ PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
 
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Connect"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object as we need to pass it to the
@@ -437,6 +444,12 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect(const pmix_proc_t procs[], size_t npro
 
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Disconnect"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object as we need to pass it to the

--- a/src/client/pmix_client_fabric.c
+++ b/src/client/pmix_client_fabric.c
@@ -53,6 +53,7 @@
 #include "src/mca/pnet/base/base.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
 
@@ -214,6 +215,12 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_register(pmix_fabric_t *fabric,
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:fabric register");
 
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Fabric_register"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     /* create a callback object so we can be notified when
      * the non-blocking operation is complete */
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
@@ -348,6 +355,12 @@ PMIX_EXPORT pmix_status_t PMIx_Fabric_update(pmix_fabric_t *fabric)
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:fabric update");
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Fabric_update"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
 
     /* create a callback object so we can be notified when
      * the non-blocking operation is complete */

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -51,6 +51,7 @@
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/ptl/ptl.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
@@ -89,6 +90,12 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
 
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* the reply that would release us is delivered by the progress
+     * thread, so waiting for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Fence"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object as we need to pass it to the
@@ -151,6 +158,16 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* a NULL cbfunc makes this the blocking form - see the note on the
+     * wait below - so it inherits the blocking form's hazard: the reply
+     * it waits for is delivered by the progress thread. Only that case
+     * is screened; with a callback this entry point is meant to be
+     * driven from a handler */
+    if (PMIX_UNLIKELY(NULL == cbfunc &&
+                      pmix_progress_thread_check_blocking("PMIx_Fence_nb"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     /* check for bozo input */
     if (PMIX_UNLIKELY(NULL == procs && 0 != nprocs)) {
         return PMIX_ERR_BAD_PARAM;
@@ -209,6 +226,14 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
         return rc;
     }
 
+    /* A NULL cbfunc means the caller wants this operation to complete
+     * before we return - the one entry point in this directory that
+     * reads it that way, and the reason the screen at the top of this
+     * function exists. Every other _nb here either rejects a NULL, reads
+     * it as "the caddy is in cbdata", or treats it as fire-and-forget;
+     * check which one you are looking at before copying a NULL test
+     * between them. wait_cbfunc wakes this lock rather than invoking a
+     * callback precisely for this case. */
     if (NULL == cbfunc) {
         PMIX_WAIT_THREAD(&cb->lock);
         rc = cb->status;

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -56,6 +56,7 @@
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_printf.h"
 
@@ -411,6 +412,12 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[], const pmix_proc
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Group_construct"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when
      * the return message is recvd */
@@ -578,6 +585,12 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct(const char grp[],
 
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Group_destruct"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object as we need to pass it to the
@@ -1451,6 +1464,12 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[], const pmix_proc_t 
         return PMIX_ERR_BAD_PARAM;
     }
 
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Group_invite"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     cb = PMIX_NEW(pmix_group_tracker_t);
     if (PMIX_UNLIKELY(NULL == cb)) {
         return PMIX_ERR_NOMEM;
@@ -1862,6 +1881,12 @@ PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[], const pmix_proc_t *l
         return PMIX_ERR_BAD_PARAM;
     }
 
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Group_join"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     /* create a callback object as we need to pass it to the
      * recv routine so we know which lock to release when
      * the return message is recvd */
@@ -2033,6 +2058,12 @@ PMIX_EXPORT pmix_status_t PMIx_Group_leave(const char grp[],
 
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Group_leave"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object as we need to pass it to the

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -53,6 +53,7 @@
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "pmix_client_ops.h"
@@ -83,6 +84,12 @@ PMIX_EXPORT pmix_status_t PMIx_Publish(const pmix_info_t info[], size_t ninfo)
 
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Publish"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object to let us know when it is done */
@@ -218,6 +225,12 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup(pmix_pdata_t pdata[], size_t ndata, const 
         if ('\0' != pdata[i].key[0]) {
             PMIx_Argv_append_nosize(&keys, pdata[i].key);
         }
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Lookup"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object as we need to pass it to the
@@ -363,6 +376,12 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish(char **keys, const pmix_info_t info[], 
 
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Unpublish"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object as we need to pass it to the

--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -55,6 +55,7 @@
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_printf.h"
 
@@ -472,6 +473,13 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_ns
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves - both the host query
+     * below and the local fallback complete there */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Resolve_peers"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     // if the nodename is NULL, then they are asking for our
     // local host
     if (NULL == nodename) {
@@ -844,6 +852,13 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **
 
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves - both the host query
+     * below and the local fallback complete there */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Resolve_nodes"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     // if we are a server, see if our host can answer the

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -59,6 +59,7 @@
 #include "src/util/pmix_basename.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/pmix_getcwd.h"
@@ -120,6 +121,12 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
 
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Spawn"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object */

--- a/src/client/pmix_client_topology.c
+++ b/src/client/pmix_client_topology.c
@@ -24,6 +24,7 @@
 #include "src/client/pmix_client_ops.h"
 #include "src/hwloc/pmix_hwloc.h"
 #include "src/include/pmix_globals.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_error.h"
 
 static void _loadtp(int sd, short args, void *cbdata)
@@ -46,6 +47,12 @@ PMIX_EXPORT pmix_status_t PMIx_Load_topology(pmix_topology_t *topo)
 
     if (PMIX_UNLIKELY(pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped))) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Load_topology"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
@@ -166,6 +173,12 @@ pmix_status_t PMIx_Compute_distances(pmix_topology_t *topo, pmix_cpuset_t *cpuse
 
     *distances = NULL;
     *ndist = 0;
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Compute_distances"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
 
     /* create a callback object so we can be notified when
      * the non-blocking operation is complete */

--- a/src/common/pmix_alloc.c
+++ b/src/common/pmix_alloc.c
@@ -30,6 +30,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -225,6 +226,12 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request(pmix_alloc_directive_t directi
     }
     *results = NULL;
     *nresults = 0;
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Allocation_request"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when
@@ -503,6 +510,12 @@ PMIX_EXPORT pmix_status_t PMIx_Resource_block(pmix_resource_block_directive_t di
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "%s pmix:resource block op",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Resource_block"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -19,6 +19,7 @@
 #include "include/pmix_server.h"
 
 #include "src/client/pmix_client_ops.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/include/pmix_globals.h"
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/gds/base/base.h"
@@ -155,6 +156,12 @@ PMIX_EXPORT pmix_status_t PMIx_Register_attributes(char *function, char *attrs[]
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Register_attributes"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     scd = PMIX_NEW(pmix_setup_caddy_t);

--- a/src/common/pmix_control.c
+++ b/src/common/pmix_control.c
@@ -30,6 +30,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -166,6 +167,12 @@ PMIX_EXPORT pmix_status_t PMIx_Job_control(const pmix_proc_t targets[], size_t n
     }
     if (NULL != nresults) {
         *nresults = 0;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Job_control"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* create a callback object as we need to pass it to the

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -34,6 +34,7 @@
 #include "include/pmix.h"
 
 #include "src/client/pmix_client_ops.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/include/pmix_globals.h"
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/pcompress/pcompress.h"
@@ -197,6 +198,11 @@ PMIX_EXPORT pmix_status_t PMIx_Data_pack(const pmix_proc_t *target, pmix_data_bu
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         // must threadshift this request as it accesses
         // global data
+        /* the lookup runs on the progress thread and we wait for it, so
+         * from that thread we would be waiting for ourselves */
+        if (pmix_progress_thread_check_blocking("PMIx_Data_pack/unpack")) {
+            return PMIX_ERR_WOULD_BLOCK;
+        }
         PMIX_CONSTRUCT(&scd, pmix_shift_caddy_t);
         scd.proc = (pmix_proc_t*)target;
         PMIX_THREADSHIFT(&scd, _findpeer);
@@ -285,6 +291,11 @@ PMIX_EXPORT pmix_status_t PMIx_Data_unpack(const pmix_proc_t *target, pmix_data_
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
         // must threadshift this request as it accesses
         // global data
+        /* the lookup runs on the progress thread and we wait for it, so
+         * from that thread we would be waiting for ourselves */
+        if (pmix_progress_thread_check_blocking("PMIx_Data_pack/unpack")) {
+            return PMIX_ERR_WOULD_BLOCK;
+        }
         PMIX_CONSTRUCT(&scd, pmix_shift_caddy_t);
         scd.proc = (pmix_proc_t*)target;
         PMIX_THREADSHIFT(&scd, _findpeer);

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -29,6 +29,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -102,6 +103,12 @@ PMIX_EXPORT pmix_status_t PMIx_Log(const pmix_info_t data[], size_t ndata,
     pmix_output_verbose(2, pmix_plog_base_framework.framework_output,
                         "%s pmix:log",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Log"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when

--- a/src/common/pmix_monitor.c
+++ b/src/common/pmix_monitor.c
@@ -30,6 +30,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -103,6 +104,12 @@ pmix_status_t PMIx_Process_monitor(const pmix_info_t *monitor, pmix_status_t err
     }
     *results = NULL;
     *nresults = 0;
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Process_monitor"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
 
     /* create a callback object as we need to pass it to the
      * recv routine so we know which callback to use when

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -30,6 +30,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -546,6 +547,12 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info(pmix_query_t queries[], size_t nquerie
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Query_info"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* pass this to the non-blocking version for processing */

--- a/src/common/pmix_security.c
+++ b/src/common/pmix_security.c
@@ -28,6 +28,7 @@
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -148,6 +149,12 @@ PMIX_EXPORT pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t n
         return PMIX_ERR_BAD_PARAM;
     }
     PMIX_BYTE_OBJECT_CONSTRUCT(credential);
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Get_credential"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
 
     PMIX_CONSTRUCT(&cb, pmix_query_caddy_t);
     rc = PMIx_Get_credential_nb(info, ninfo, mycdcb, &cb);
@@ -386,6 +393,12 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cre
     }
     if (NULL != nresults) {
         *nresults = 0;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Validate_credential"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     PMIX_CONSTRUCT(&cb, pmix_query_caddy_t);

--- a/src/common/pmix_session.c
+++ b/src/common/pmix_session.c
@@ -30,6 +30,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -235,6 +236,12 @@ pmix_status_t PMIx_Session_control(uint32_t sessionID,
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_Session_control"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     cd = PMIX_NEW(pmix_shift_caddy_t);

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -22,6 +22,7 @@
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -113,6 +114,13 @@ PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status, const pmix_pro
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* a NULL cbfunc asks for the blocking form, and what would release
+     * it runs on the progress thread. With a callback this entry point
+     * is meant to be driven from a handler and is unaffected */
+    if (NULL == cbfunc && pmix_progress_thread_check_blocking("PMIx_Notify_event")) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     scd = PMIX_NEW(pmix_shift_caddy_t);

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -19,6 +19,7 @@
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 
 #include "src/client/pmix_client_ops.h"
@@ -1007,6 +1008,13 @@ PMIX_EXPORT pmix_status_t PMIx_Register_event_handler(pmix_status_t codes[], siz
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* a NULL cbfunc asks for the blocking form, and what would release
+     * it runs on the progress thread. With a callback this entry point
+     * is meant to be driven from a handler and is unaffected */
+    if (NULL == cbfunc && pmix_progress_thread_check_blocking("PMIx_Register_event_handler")) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     /* need to thread shift this request so we can access
      * our global data to register this *local* event handler */
     cd = PMIX_NEW(pmix_rshift_caddy_t);
@@ -1410,6 +1418,13 @@ PMIX_EXPORT pmix_status_t PMIx_Deregister_event_handler(size_t event_hdlr_ref,
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* a NULL cbfunc asks for the blocking form, and what would release
+     * it runs on the progress thread. With a callback this entry point
+     * is meant to be driven from a handler and is unaffected */
+    if (NULL == cbfunc && pmix_progress_thread_check_blocking("PMIx_Deregister_event_handler")) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* need to thread shift this request */

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -67,6 +67,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
 
@@ -758,6 +759,12 @@ pmix_status_t PMIx_server_collect_job_info(pmix_proc_t *procs, size_t nprocs,
 
     // we need to threadshift this request as it accesses
     // global data
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_server_collect_job_info"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     cb.procs = procs;
     cb.nprocs = nprocs;

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1991,6 +1991,12 @@ pmix_status_t PMIx_tool_attach_to_server(pmix_proc_t *myproc, pmix_proc_t *serve
         return PMIX_ERR_BAD_PARAM;
     }
 
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_tool_attach_to_server"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     cb = PMIX_NEW(pmix_cb_t);
     cb->info = info;
     cb->ninfo = ninfo;
@@ -2103,6 +2109,12 @@ pmix_status_t PMIx_tool_disconnect(const pmix_proc_t *server)
         return PMIX_ERR_NOT_AVAILABLE;
     }
 
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_tool_disconnect"))) {
+        return PMIX_ERR_WOULD_BLOCK;
+    }
+
     /* disc() dereferences this whenever it is not NULL; a NULL server is
      * the documented "just mark me disconnected" form */
     cb = PMIX_NEW(pmix_cb_t);
@@ -2207,6 +2219,12 @@ pmix_status_t PMIx_tool_get_servers(pmix_proc_t *servers[], size_t *nservers)
     /* both OUT parameters are written unconditionally below */
     if (NULL == servers || NULL == nservers) {
         return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_tool_get_servers"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     cb = PMIX_NEW(pmix_cb_t);
@@ -2336,6 +2354,12 @@ pmix_status_t PMIx_tool_set_server(const pmix_proc_t *server,
 
     if (NULL == server) {
         return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* what would release us runs on the progress thread, so waiting
+     * for it from that thread waits for ourselves */
+    if (PMIX_UNLIKELY(pmix_progress_thread_check_blocking("PMIx_tool_set_server"))) {
+        return PMIX_ERR_WOULD_BLOCK;
     }
 
     /* threadshift this so we can access global structures */


### PR DESCRIPTION
Calling a blocking PMIx API from within the progress thread has always been disallowed — the work that would release the caller is what that thread was about to do — but only a minority of entry points said so. Thirteen `PMIx_server_*` calls, `PMIx_Get` and the three `PMIx_IOF_*` calls screened for it and returned `PMIX_ERR_WOULD_BLOCK` with a diagnostic naming the call. The rest simply stopped: an event handler that called `PMIx_Fence`, `PMIx_Connect` or `PMIx_Group_construct` wedged the process with nothing said about why.

**First commit** closes it for the fence pair, which is where the open item came from. **Second commit** sweeps the rest — 61 call sites now — covering every public entry point that can wait: the client collectives and their group, publish, spawn, resolve, topology and fabric siblings; the common query, log, alloc, control, monitor, session, security and data calls; the event notify and registration pair; the tool attach/disconnect/set-server/get-servers calls; and `PMIx_Put`, `PMIx_Commit`, `PMIx_Abort`, `PMIx_Finalize`.

### Placement rules

Both are written into `src/client/AGENTS.md`, because both had to be respected site by site:

- The screen goes immediately before the first thing that can block, and **after** the early-outs that return *without* blocking. A singleton fence, an unconnected client and a `PMIX_OPERATION_SUCCEEDED` all answer without waiting — turning those into an error would break calls that work today.
- Where the wait is conditional on a `NULL` `cbfunc` — fence, notify, the two event registrations — the guard carries the same condition. With a callback those entry points are *meant* to be driven from a handler.

`PMIx_Finalize` needs one thing extra: it has already decremented the init refcount by the time it can be screened, so the guard puts that back before returning. It is also the one call where this is not merely a deadlock — the thread would be stopping itself mid-callback.

The init entry points are deliberately **not** screened: no progress thread exists yet when they run, so the check could only answer false.

### Documentation

The 59 affected man pages carry a new **PROGRESS THREAD RESTRICTION** section stating the rule, naming what runs on that thread (event handlers, non-blocking callbacks, host up-call completions), and saying that the call returns `PMIX_ERR_WOULD_BLOCK` rather than proceeding — since nobody would otherwise expect that status. It is one shared file included by each page rather than 59 copies to drift apart.

`PMIx_Fence(3)` additionally records that a `NULL` `cbfunc` selects the blocking form, and that this is the general PMIx convention wherever an operation's whole result is a status — the entry points that reject a `NULL` (`PMIx_Get_nb` and kin) do so only because they have no out-parameter to return the result through. `src/client/AGENTS.md` previously called that "four competing meanings", which read the exceptions as the rule; corrected.

### Testing

No new test. The screen sits below the `connected` gate on the client entry points, so a singleton stops earlier and a unit-test server is never connected; reaching it needs a connected client calling a blocking API from its own event handler, which is a `test/simple` or swarm-suite shape.

Verified: clean build under `--enable-devel-check`; `make check` 21/21 in `test/` and 70/70 + 10/10 + 7/7 in `test/unit/`; docs clean under `-W`.