### PR TITLE
Stop counting a finalized peer as a lost collective participant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,6 +279,7 @@ test/unit/collective_status
 test/unit/collect_job_info
 test/unit/trk_complete
 test/unit/tracker_match
+test/unit/trk_peer_lost
 test/unit/client_cycle
 test/unit/tool_cycle
 test/unit/event_chain

--- a/docs/how-things-work/collectives/tracking_plan.rst
+++ b/docs/how-things-work/collectives/tracking_plan.rst
@@ -173,8 +173,15 @@ practice* for the rationale.
 
 The two tracker lists therefore remain separate
 (``pmix_server_globals.collectives`` and ``.grp_collectives``);
-``lost_connection`` traverses both — the fence family inline and the
-group family through the exported ``pmix_server_grp_peer_lost``.
+``lost_connection`` traverses both, through one exported entry point per
+family: ``pmix_server_trk_peer_lost`` (fence family, in
+``pmix_server_fence.c`` beside the tracker engine it walks) and
+``pmix_server_grp_peer_lost`` (group family). The fence-family routine
+was inline in ``lost_connection`` when first written and was lifted out
+later, so that the two families' loss accounting reads the same way and
+so that either can be driven directly by a unit test
+(``test/unit/trk_peer_lost.c``). References below to the fence family's
+"block in ``lost_connection``" describe that routine.
 
 Rewriting ``lost_connection`` (fence family — done)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/how-things-work/collectives/tracking_spec.rst
+++ b/docs/how-things-work/collectives/tracking_spec.rst
@@ -142,10 +142,11 @@ three sets of local participants:
     contribution.
 
 ``departed``
-    Local participants that were lost (connection dropped, abnormal
-    termination) **before** contributing. A participant enters
-    ``departed`` only if it was expected and had not already
-    contributed.
+    Local participants that were lost (abnormal termination) **before**
+    contributing. A participant enters ``departed`` only if it was
+    expected and had not already contributed. A rank that dropped its
+    connection by calling ``PMIx_Finalize`` is **not** departed — see
+    *A graceful finalize is not a departure* below.
 
 Completion rule
 ~~~~~~~~~~~~~~~
@@ -205,6 +206,42 @@ Note the asymmetry with the current implementation, which in every case
 both decrements the expected count *and* removes any prior contribution.
 Case A above forbids both of those adjustments; that is the specific
 change that fixes the vulnerability.
+
+A graceful finalize is not a departure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Neither case applies to a socket that dropped because the client called
+``PMIx_Finalize``. Such a rank has **not** left the accounting: the
+server deliberately keeps it — ``nptr->nlocalprocs`` is not decremented,
+the peer object is tombstoned rather than retired, and the rank stays a
+registered member of its namespace — precisely so it may ``PMIx_Init``
+again and be counted. Every tracker's ``expected`` set therefore still
+contains it, and it is still free to contribute.
+
+Recording it in ``departed`` as well counts the one rank twice, and the
+collective can then complete without it. The MPI Sessions cycle
+(``PMIx_Init`` → fence → ``PMIx_Finalize``, repeatedly) makes that
+routine: the ranks of cycle *N* finalizing behind a faster peer that has
+already opened cycle *N+1*'s fence satisfy that fence's ``expected``
+count between them, so it completes on a single contribution and reports
+``PMIX_ERR_LOST_CONNECTION``. The fence sequence then desynchronizes by
+whole cycles — the surviving ranks open a fence the fast rank has
+already passed, its next fence merges into theirs (a collect/no-collect
+mismatch there surfaces as ``PMIX_ERR_INVALID_ARG``), and the run either
+limps on out of step or wedges. See issue #4113, and #3931 for the
+original diagnosis.
+
+The rule is therefore: **loss accounting applies to an abnormal
+termination only.** A finalizing rank that had already contributed is
+Case A in any event, so ignoring the finalize entirely gives up nothing
+but Case B — which is the case that must not fire here.
+
+The corollary is that a rank which finalizes and never returns, while
+its peers wait in a collective it was expected to join, leaves them
+waiting. That program is erroneous — it is no different from a rank that
+simply never calls — and the remedy is the one PMIx already offers for
+it, ``PMIX_TIMEOUT``. The alternative, guessing that the rank is not
+coming back, is what breaks every well-formed program that recycles.
 
 Status reporting on loss
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -366,6 +403,10 @@ all times:
    completion** for that tracker.
 #. **The rules apply uniformly** to fence, connect, disconnect, and group
    operations, and to both directly-connected clients and their clones.
+#. **Loss accounting is driven by abnormal termination only.** A rank
+   whose connection dropped because it called ``PMIx_Finalize`` is never
+   recorded as departed and never degrades a collective's status, since
+   it remains in the expected set and may return.
 #. **Participation logic is shared, not copied.** Fence, connect, and
    disconnect are tracked by one tracker representation with one
    completion predicate and one lost-connection routine. Group operations,

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -7,6 +7,20 @@ series, in reverse chronological order.
 7.0.0 -- TBD
 ------------
 Detailed changes since v6.1.0:
+ - A collective no longer counts a participant's orderly PMIx_Finalize
+   as the loss of that participant. Such a rank has not left - its local
+   process count is deliberately retained and its peer object tombstoned
+   rather than retired, so it may PMIx_Init again and contribute -
+   and recording it as departed counted it twice, letting the collective
+   complete without it and return PMIX_ERR_PARTIAL_SUCCESS or
+   PMIX_ERR_LOST_CONNECTION to the ranks that did participate. A client
+   rapidly cycling init/finalize, as an MPI Sessions application does,
+   could thereby drift by whole fence cycles and intermittently hang.
+   Loss accounting now applies to an abnormal termination only. One
+   deliberate consequence: a rank that finalizes and does not return,
+   while its peers wait in a collective that names it, now leaves them
+   waiting rather than collapsing the collective - PMIX_TIMEOUT is the
+   remedy there
  - PMIx_Disconnect now honors PMIX_TIMEOUT while the server is still
    collecting local contributions, as PMIx_Fence and PMIx_Connect
    already did. Until every local participant has called, the request

--- a/examples/pubstress.c
+++ b/examples/pubstress.c
@@ -55,6 +55,8 @@ int main(int argc, char **argv)
     int iters;
     size_t ninfo, bcount=0;
     char *keys[3];
+    pmix_proc_t *fenceprocs;
+    size_t nfence;
 
     if (1 < argc) {
         iters = strtol(argv[1], NULL, 10);
@@ -269,8 +271,25 @@ int main(int argc, char **argv)
         }
     }
 
-    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
-    rc = PMIx_Fence(&proc, 1, NULL, 0);
+    /* Hold the BIGTEST participants here so that rank 2 does not unpublish
+     * those keys before ranks 3+ have finished looking them up. Name only
+     * those ranks: ranks 0 and 1 ran the FOOBAR/BAZ exchange above and have
+     * already gone on to PMIx_Finalize, so a wildcard fence would name them
+     * as participants and wait forever for a contribution that will never
+     * arrive. A rank that departs normally remains an expected participant
+     * in any collective that names it. */
+    nfence = nprocs - 2;
+    PMIX_PROC_CREATE(fenceprocs, nfence);
+    for (n = 0; n < (int) nfence; n++) {
+        PMIX_LOAD_PROCID(&fenceprocs[n], myproc.nspace, n + 2);
+    }
+    rc = PMIx_Fence(fenceprocs, nfence, NULL, 0);
+    PMIX_PROC_FREE(fenceprocs, nfence);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
     if (2 == myproc.rank) {
         if (0 > asprintf(&keys[0], "BIGTEST:%s.%u:%d", myproc.nspace, myproc.rank, 0)) {
             goto done;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -80,12 +80,19 @@ static void lost_connection(pmix_peer_t *peer)
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
 
         if (!PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
-            /* account for the loss of this client in any local collective it
+            /* Account for the loss of this client in any local collective it
              * was participating in - the fence/connect/disconnect family and
-             * the group family are tracked on separate lists, so each has
-             * its own entry point. Note that the proc would not have been
-             * added to any collective tracker until after it successfully
-             * connected */
+             * the group family are tracked on separate lists, so each has its
+             * own entry point. Note that the proc would not have been added
+             * to any collective tracker until after it successfully
+             * connected.
+             *
+             * Both routines account only for an ABNORMAL termination. A peer
+             * that dropped its connection by calling PMIx_Finalize has not
+             * left the collectives' accounting - the rank remains expected,
+             * exactly as the untouched nlocalprocs below says it is - and
+             * both routines return without doing anything for it. See
+             * pmix_server_trk_peer_lost() and issue #4113. */
             pmix_server_trk_peer_lost(peer);
             pmix_server_grp_peer_lost(peer);
 

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -59,15 +59,9 @@ static void _notify_complete(pmix_status_t status, void *cbdata)
 
 static void lost_connection(pmix_peer_t *peer)
 {
-    pmix_server_trkr_t *trk, *tnxt;
-    pmix_server_caddy_t *rinfo;
-    pmix_proclist_t *dp;
     pmix_ptl_posted_recv_t *rcv;
     pmix_buffer_t buf;
     pmix_ptl_hdr_t hdr;
-    pmix_status_t rc;
-    bool flag;
-    size_t n;
 
     /* stop all events */
     if (peer->recv_ev_active) {
@@ -86,164 +80,13 @@ static void lost_connection(pmix_peer_t *peer)
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
 
         if (!PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
-            /* if I am a server, then we need to ensure that
-             * we properly account for the loss of this client
-             * from any local collectives in which it was
-             * participating - note that the proc would not
-             * have been added to any collective tracker until
-             * after it successfully connected */
-            PMIX_LIST_FOREACH_SAFE (trk, tnxt, &pmix_server_globals.collectives, pmix_server_trkr_t) {
-                /* check if this peer should be participating in this collective */
-                flag = false;
-                for (n=0; n < trk->npcs; n++) {
-                    if (PMIX_CHECK_NAMES(&trk->pcs[n], &peer->info->pname)) {
-                        flag = true;
-                        break;
-                    }
-                }
-                if (!flag) {
-                    continue;
-                }
-                /* Determine whether this participant has already contributed.
-                 * Its rank counts as contributed if any of its local peers -
-                 * the client or a fork/exec'd clone sharing the same name -
-                 * has an entry on local_cbs. If so, the contribution and the
-                 * data it already delivered stand: we ignore the loss for
-                 * this collective. We do NOT reduce the expected count and do
-                 * NOT remove the contribution, so the collective neither
-                 * completes early nor drops the departed peer's data. The
-                 * dead peer's reply caddy is harmless - its socket has been
-                 * closed, so the eventual QUEUE_REPLY is dropped rather than
-                 * sent. */
-                flag = false;
-                PMIX_LIST_FOREACH (rinfo, &trk->local_cbs, pmix_server_caddy_t) {
-                    if (PMIX_CHECK_NAMES(&rinfo->peer->info->pname, &peer->info->pname)) {
-                        flag = true;
-                        break;
-                    }
-                }
-                if (flag) {
-                    /* already contributed - nothing to account for */
-                    continue;
-                }
-                /* This participant had not yet contributed and now never will.
-                 * Record its rank as departed (once) so the collective can
-                 * complete on the remaining live participants instead of
-                 * hanging forever. Participation is tracked per rank, matching
-                 * the way nlocal is counted, so a clone sharing the name does
-                 * not add a second departed entry. */
-                flag = false;
-                PMIX_LIST_FOREACH (dp, &trk->departed, pmix_proclist_t) {
-                    if (PMIX_CHECK_NAMES(&dp->proc, &peer->info->pname)) {
-                        flag = true;
-                        break;
-                    }
-                }
-                if (!flag) {
-                    dp = PMIX_NEW(pmix_proclist_t);
-                    PMIX_LOAD_PROCID(&dp->proc, peer->info->pname.nspace,
-                                     peer->info->pname.rank);
-                    pmix_list_append(&trk->departed, &dp->super);
-                }
-                /* report the collective's health to the surviving participants:
-                 * partial success if any expected participant is still awaited,
-                 * else lost-connection */
-                if ((pmix_list_get_size(&trk->local_cbs) +
-                     pmix_list_get_size(&trk->departed)) < trk->nlocal) {
-                    rc = PMIX_ERR_PARTIAL_SUCCESS;
-                } else {
-                    rc = PMIX_ERR_LOST_CONNECTION;
-                }
-                /* record the collective's health in the status slot the
-                 * participant handlers seeded (located by key, since connect
-                 * appends info after it - see pmix_server_set_collective_status) */
-                pmix_server_set_collective_status(trk->info, trk->ninfo, rc);
-                /* if the host has already been called for this tracker,
-                 * then the local phase is frozen - just wait for the host
-                 * to return from the operation */
-                if (trk->host_called) {
-                    continue;
-                }
-                /* are we now locally complete? */
-                if (pmix_server_trk_complete(trk)) {
-                    /* The loss of this participant is about to complete the
-                     * collective, so an armed PMIX_TIMEOUT timer has to come
-                     * down first - this is the same rule pmix_server_fence
-                     * applies at its own completion point, and this sweep is
-                     * where a timer is most likely to be armed, since a
-                     * timeout is exactly what a participant dropping its
-                     * connection would otherwise produce. Every arm below
-                     * either hands the tracker to the host or drives a
-                     * completion function, and both end with the tracker
-                     * unlinked and released: a timer left armed then fires
-                     * fence_timeout/connect_timeout on freed memory, or
-                     * races the host's completion for the right to release
-                     * it a second time. */
-                    if (trk->event_active) {
-                        pmix_event_del(&trk->ev);
-                        trk->event_active = false;
-                    }
-                    /* if this is a local-only collective, then resolve it now */
-                    if (trk->local) {
-                        /* everyone else has called in - we need to let them know
-                         * that this proc has disappeared
-                         * as otherwise the collective will never complete */
-                        if (PMIX_FENCENB_CMD == trk->type) {
-                            if (NULL != trk->modexcbfunc) {
-                                trk->modexcbfunc(rc, NULL, 0, trk, NULL, NULL);
-                            }
-                        } else if (PMIX_CONNECTNB_CMD == trk->type) {
-                            if (NULL != trk->op_cbfunc) {
-                                trk->op_cbfunc(rc, trk);
-                            }
-                        } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
-                            if (NULL != trk->op_cbfunc) {
-                                trk->op_cbfunc(rc, trk);
-                            }
-                        } else if (PMIX_GROUP_CONSTRUCT_CMD == trk->type) {
-                            if (NULL != trk->op_cbfunc) {
-                                trk->op_cbfunc(rc, trk);
-                            }
-                        }
-                    } else {
-                        /* if the host has not been called, then we need to pass the call
-                         * up to the host as otherwise the global collective will hang */
-                        if (PMIX_FENCENB_CMD == trk->type) {
-                            trk->host_called = true;
-                            rc = pmix_host_server.fence_nb(trk->pcs, trk->npcs, trk->info,
-                                                           trk->ninfo, NULL, 0,
-                                                           trk->modexcbfunc, trk);
-                            if (PMIX_SUCCESS != rc) {
-                                pmix_list_remove_item(&pmix_server_globals.collectives,
-                                                      &trk->super);
-                                PMIX_RELEASE(trk);
-                            }
-                        } else if (PMIX_CONNECTNB_CMD == trk->type) {
-                            trk->host_called = true;
-                            rc = pmix_host_server.connect(trk->pcs, trk->npcs, trk->info,
-                                                          trk->ninfo, trk->op_cbfunc, trk);
-                            if (PMIX_SUCCESS != rc) {
-                                pmix_list_remove_item(&pmix_server_globals.collectives,
-                                                      &trk->super);
-                                PMIX_RELEASE(trk);
-                            }
-                        } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
-                            trk->host_called = true;
-                            rc = pmix_host_server.disconnect(trk->pcs, trk->npcs, trk->info,
-                                                             trk->ninfo, trk->op_cbfunc, trk);
-                            if (PMIX_SUCCESS != rc) {
-                                pmix_list_remove_item(&pmix_server_globals.collectives,
-                                                      &trk->super);
-                                PMIX_RELEASE(trk);
-                            }
-                        }
-                    }
-                }
-            }
-
-            /* account for the loss in any in-flight group construct/destruct
-             * collectives as well - these are tracked separately from the
-             * fence/connect/disconnect collectives above */
+            /* account for the loss of this client in any local collective it
+             * was participating in - the fence/connect/disconnect family and
+             * the group family are tracked on separate lists, so each has
+             * its own entry point. Note that the proc would not have been
+             * added to any collective tracker until after it successfully
+             * connected */
+            pmix_server_trk_peer_lost(peer);
             pmix_server_grp_peer_lost(peer);
 
             /* if the peer simply died without finalizing,

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -56,7 +56,7 @@ module where it cannot, and queue replies back. The file map:
 | `pmix_server_control.c` | The directive and service commands: query, log, allocate, job control, monitor, credential get and validate, session control, resource blocks, and the job-data cache refresh. |
 | `pmix_server_fabric.c` | `fabric_register` / `fabric_update` and the device-distance computation. |
 | `pmix_server_classes.c` | The `PMIX_CLASS_INSTANCE` con/destructors for every type declared in `pmix_server_ops.h` or `pmix_globals.h`, so the ownership rules a destructor encodes can be read in one place. A type private to a single file keeps its class beside it — `grp_block_t`/`grp_trk_t`/`grp_shifter_t` in `pmix_server_group.c`, `rank_blob_t` in `pmix_server_fence.c`, `pmix_dmdx_reply_caddy_t` in `pmix_server_get.c`, `pmix_srvr_epi_caddy_t` in `pmix_server_control.c`. |
-| `pmix_server_fence.c` | The fence collective (barrier + modex data exchange) **and the shared collective-tracker engine** — `pmix_server_get_tracker`, `pmix_server_new_tracker`, `pmix_server_collect_data`, `pmix_server_commit`, plus the two predicates every family consults: `pmix_server_trk_complete` and `pmix_server_set_collective_status`. Also `PMIx_server_collect_job_info`, the public API a host uses to pull packed job-level info for a set of procs. |
+| `pmix_server_fence.c` | The fence collective (barrier + modex data exchange) **and the shared collective-tracker engine** — `pmix_server_get_tracker`, `pmix_server_new_tracker`, `pmix_server_collect_data`, `pmix_server_commit`, plus the two predicates every family consults: `pmix_server_trk_complete` and `pmix_server_set_collective_status`, and the family's lost-connection accounting `pmix_server_trk_peer_lost` (the group family's counterpart lives in `pmix_server_group.c`). Also `PMIx_server_collect_job_info`, the public API a host uses to pull packed job-level info for a set of procs. |
 | `pmix_server_connect.c` | The connect / disconnect collectives (built on the same tracker engine). |
 | `pmix_server_group.c` | The group collectives (construct/destruct/leave/invite) — a **two-level** block/tracker engine distinct from the fence tracker, plus the peer-lost / member-left fault paths. |
 | `pmix_server_get.c` | Server-side `PMIx_Get` and direct modex (dmodex): the local-satisfy-vs-remote-fetch decision tree, the `local_reqs` / `remote_pnd` deferred-request lists, and the registration-completion re-entry points. |
@@ -614,6 +614,17 @@ contributing; the `>=` is deliberately tolerant of over-count from
 fork/exec'd clones. Participation is tracked **by identity**: a peer that
 already contributed (is on `local_cbs`) is never moved to `departed`, so
 its loss can neither complete the collective early nor discard its data.
+
+**`departed` means abnormally terminated, not gone.** The two loss
+entry points — `pmix_server_trk_peer_lost` and
+`pmix_server_grp_peer_lost`, both called from `lost_connection` — return
+immediately for a peer with `finalized` set. A rank that dropped its
+socket by calling `PMIx_Finalize` is still expected: `nlocalprocs` is
+deliberately *not* decremented for it and its peer object is tombstoned
+rather than retired, so it can `PMIx_Init` again and contribute. Counting
+it in `departed` as well counts the rank twice and lets a collective
+complete without it — which is how a client cycling init/finalize (MPI
+Sessions) desynchronized its fence sequence by whole cycles (#4113).
 
 **The tracker lifecycle contract (memorize this — it is the source of
 the trickiest bugs):**

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -1335,3 +1335,169 @@ pmix_status_t pmix_server_get_collective_status(pmix_info_t *info, size_t ninfo)
     }
     return PMIX_SUCCESS;
 }
+
+/* Account for a lost peer across every in-flight fence/connect/disconnect
+ * collective. This is the fence family's counterpart to the group family's
+ * pmix_server_grp_peer_lost(), and both are called from the one place that
+ * learns a client's socket has dropped - lost_connection() in the PTL base.
+ * It lives here, beside the tracker engine it walks, so the two families'
+ * loss accounting sits next to the state it touches and can be exercised
+ * directly by a unit test (test/unit/trk_peer_lost.c).
+ *
+ * The tracker may be released here (a loss can complete the collective), so
+ * the walk uses FOREACH_SAFE. */
+void pmix_server_trk_peer_lost(pmix_peer_t *peer)
+{
+    pmix_server_trkr_t *trk, *tnxt;
+    pmix_server_caddy_t *rinfo;
+    pmix_proclist_t *dp;
+    pmix_status_t rc;
+    bool flag;
+    size_t n;
+
+    PMIX_LIST_FOREACH_SAFE (trk, tnxt, &pmix_server_globals.collectives, pmix_server_trkr_t) {
+        /* check if this peer should be participating in this collective */
+        flag = false;
+        for (n = 0; n < trk->npcs; n++) {
+            if (PMIX_CHECK_NAMES(&trk->pcs[n], &peer->info->pname)) {
+                flag = true;
+                break;
+            }
+        }
+        if (!flag) {
+            continue;
+        }
+        /* Determine whether this participant has already contributed.
+         * Its rank counts as contributed if any of its local peers -
+         * the client or a fork/exec'd clone sharing the same name -
+         * has an entry on local_cbs. If so, the contribution and the
+         * data it already delivered stand: we ignore the loss for
+         * this collective. We do NOT reduce the expected count and do
+         * NOT remove the contribution, so the collective neither
+         * completes early nor drops the departed peer's data. The
+         * dead peer's reply caddy is harmless - its socket has been
+         * closed, so the eventual QUEUE_REPLY is dropped rather than
+         * sent. */
+        flag = false;
+        PMIX_LIST_FOREACH (rinfo, &trk->local_cbs, pmix_server_caddy_t) {
+            if (PMIX_CHECK_NAMES(&rinfo->peer->info->pname, &peer->info->pname)) {
+                flag = true;
+                break;
+            }
+        }
+        if (flag) {
+            /* already contributed - nothing to account for */
+            continue;
+        }
+        /* This participant had not yet contributed and now never will.
+         * Record its rank as departed (once) so the collective can
+         * complete on the remaining live participants instead of
+         * hanging forever. Participation is tracked per rank, matching
+         * the way nlocal is counted, so a clone sharing the name does
+         * not add a second departed entry. */
+        flag = false;
+        PMIX_LIST_FOREACH (dp, &trk->departed, pmix_proclist_t) {
+            if (PMIX_CHECK_NAMES(&dp->proc, &peer->info->pname)) {
+                flag = true;
+                break;
+            }
+        }
+        if (!flag) {
+            dp = PMIX_NEW(pmix_proclist_t);
+            PMIX_LOAD_PROCID(&dp->proc, peer->info->pname.nspace,
+                             peer->info->pname.rank);
+            pmix_list_append(&trk->departed, &dp->super);
+        }
+        /* report the collective's health to the surviving participants:
+         * partial success if any expected participant is still awaited,
+         * else lost-connection */
+        if ((pmix_list_get_size(&trk->local_cbs) +
+             pmix_list_get_size(&trk->departed)) < trk->nlocal) {
+            rc = PMIX_ERR_PARTIAL_SUCCESS;
+        } else {
+            rc = PMIX_ERR_LOST_CONNECTION;
+        }
+        /* record the collective's health in the status slot the
+         * participant handlers seeded (located by key, since connect
+         * appends info after it - see pmix_server_set_collective_status) */
+        pmix_server_set_collective_status(trk->info, trk->ninfo, rc);
+        /* if the host has already been called for this tracker,
+         * then the local phase is frozen - just wait for the host
+         * to return from the operation */
+        if (trk->host_called) {
+            continue;
+        }
+        /* are we now locally complete? */
+        if (pmix_server_trk_complete(trk)) {
+            /* The loss of this participant is about to complete the
+             * collective, so an armed PMIX_TIMEOUT timer has to come
+             * down first - this is the same rule pmix_server_fence
+             * applies at its own completion point, and this sweep is
+             * where a timer is most likely to be armed, since a
+             * timeout is exactly what a participant dropping its
+             * connection would otherwise produce. Every arm below
+             * either hands the tracker to the host or drives a
+             * completion function, and both end with the tracker
+             * unlinked and released: a timer left armed then fires
+             * fence_timeout/connect_timeout on freed memory, or
+             * races the host's completion for the right to release
+             * it a second time. */
+            if (trk->event_active) {
+                pmix_event_del(&trk->ev);
+                trk->event_active = false;
+            }
+            /* if this is a local-only collective, then resolve it now */
+            if (trk->local) {
+                /* everyone else has called in - we need to let them know
+                 * that this proc has disappeared
+                 * as otherwise the collective will never complete */
+                if (PMIX_FENCENB_CMD == trk->type) {
+                    if (NULL != trk->modexcbfunc) {
+                        trk->modexcbfunc(rc, NULL, 0, trk, NULL, NULL);
+                    }
+                } else if (PMIX_CONNECTNB_CMD == trk->type) {
+                    if (NULL != trk->op_cbfunc) {
+                        trk->op_cbfunc(rc, trk);
+                    }
+                } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
+                    if (NULL != trk->op_cbfunc) {
+                        trk->op_cbfunc(rc, trk);
+                    }
+                } else if (PMIX_GROUP_CONSTRUCT_CMD == trk->type) {
+                    if (NULL != trk->op_cbfunc) {
+                        trk->op_cbfunc(rc, trk);
+                    }
+                }
+            } else {
+                /* if the host has not been called, then we need to pass the call
+                 * up to the host as otherwise the global collective will hang */
+                if (PMIX_FENCENB_CMD == trk->type) {
+                    trk->host_called = true;
+                    rc = pmix_host_server.fence_nb(trk->pcs, trk->npcs, trk->info,
+                                                   trk->ninfo, NULL, 0,
+                                                   trk->modexcbfunc, trk);
+                    if (PMIX_SUCCESS != rc) {
+                        pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+                        PMIX_RELEASE(trk);
+                    }
+                } else if (PMIX_CONNECTNB_CMD == trk->type) {
+                    trk->host_called = true;
+                    rc = pmix_host_server.connect(trk->pcs, trk->npcs, trk->info,
+                                                  trk->ninfo, trk->op_cbfunc, trk);
+                    if (PMIX_SUCCESS != rc) {
+                        pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+                        PMIX_RELEASE(trk);
+                    }
+                } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
+                    trk->host_called = true;
+                    rc = pmix_host_server.disconnect(trk->pcs, trk->npcs, trk->info,
+                                                     trk->ninfo, trk->op_cbfunc, trk);
+                    if (PMIX_SUCCESS != rc) {
+                        pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+                        PMIX_RELEASE(trk);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -1344,6 +1344,15 @@ pmix_status_t pmix_server_get_collective_status(pmix_info_t *info, size_t ninfo)
  * loss accounting sits next to the state it touches and can be exercised
  * directly by a unit test (test/unit/trk_peer_lost.c).
  *
+ * "Lost" means abnormal termination. A peer that dropped its connection by
+ * calling PMIx_Finalize has NOT left the accounting: nptr->nlocalprocs is
+ * deliberately left alone for it and the peer object is tombstoned rather
+ * than retired, so the rank remains an expected participant and is free to
+ * PMIx_Init again and contribute - which is exactly what a client cycling
+ * init/finalize (MPI Sessions) does. Recording such a rank as departed
+ * would count it twice and let a collective complete without it. See
+ * docs/how-things-work/collectives and issue #4113.
+ *
  * The tracker may be released here (a loss can complete the collective), so
  * the walk uses FOREACH_SAFE. */
 void pmix_server_trk_peer_lost(pmix_peer_t *peer)
@@ -1354,6 +1363,11 @@ void pmix_server_trk_peer_lost(pmix_peer_t *peer)
     pmix_status_t rc;
     bool flag;
     size_t n;
+
+    if (peer->finalized) {
+        /* an orderly departure - not a loss */
+        return;
+    }
 
     PMIX_LIST_FOREACH_SAFE (trk, tnxt, &pmix_server_globals.collectives, pmix_server_trkr_t) {
         /* check if this peer should be participating in this collective */

--- a/src/server/pmix_server_group.c
+++ b/src/server/pmix_server_group.c
@@ -1494,13 +1494,24 @@ static void account_departed(grp_block_t *blk, const pmix_proc_t *proc)
 }
 
 /* Account for a lost peer across all in-flight group construct/destruct blocks.
- * This is the group-family analog of the fence/connect/disconnect accounting in
- * lost_connection(), expressed in the group's two-level structure, and is
- * called from that same handler. See account_departed(). */
+ * This is the group-family analog of pmix_server_trk_peer_lost(), expressed in
+ * the group's two-level structure, and is called from the same handler. See
+ * account_departed().
+ *
+ * As there, "lost" means an abnormal termination: a peer that dropped its
+ * connection by calling PMIx_Finalize remains an expected participant (its
+ * rank stays registered and counted, so it may PMIx_Init again and
+ * contribute), and recording it as departed would let a block complete
+ * without it. See pmix_server_trk_peer_lost() and issue #4113. */
 void pmix_server_grp_peer_lost(pmix_peer_t *peer)
 {
     grp_block_t *blk, *bnext;
     pmix_proc_t proc;
+
+    if (peer->finalized) {
+        /* an orderly departure - not a loss */
+        return;
+    }
 
     /* the peer's identity is carried as a pmix_name_t; account_departed works
      * in terms of pmix_proc_t (as the group membership arrays do), so convert */

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -548,7 +548,9 @@ PMIX_EXPORT void pmix_server_set_collective_status(pmix_info_t *info, size_t nin
 PMIX_EXPORT pmix_status_t pmix_server_get_collective_status(pmix_info_t *info, size_t ninfo);
 
 /* the two lost-connection entry points, one per tracker family - both are
- * called from lost_connection() in the PTL base */
+ * called from lost_connection() in the PTL base, and both account only for
+ * an abnormal termination (a peer that called PMIx_Finalize remains an
+ * expected participant and is ignored) */
 PMIX_EXPORT void pmix_server_trk_peer_lost(pmix_peer_t *peer);
 
 PMIX_EXPORT void pmix_server_grp_peer_lost(pmix_peer_t *peer);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -547,6 +547,10 @@ PMIX_EXPORT void pmix_server_set_collective_status(pmix_info_t *info, size_t nin
 
 PMIX_EXPORT pmix_status_t pmix_server_get_collective_status(pmix_info_t *info, size_t ninfo);
 
+/* the two lost-connection entry points, one per tracker family - both are
+ * called from lost_connection() in the PTL base */
+PMIX_EXPORT void pmix_server_trk_peer_lost(pmix_peer_t *peer);
+
 PMIX_EXPORT void pmix_server_grp_peer_lost(pmix_peer_t *peer);
 
 PMIX_EXPORT void pmix_server_grp_member_left(const char *grpid, const pmix_proc_t *proc);

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup
 
 client_api_SOURCES = \
         client_api.c
@@ -193,6 +193,12 @@ tracker_match_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 tracker_match_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+trk_peer_lost_SOURCES = \
+        trk_peer_lost.c
+trk_peer_lost_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+trk_peer_lost_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 client_cycle_SOURCES = \
         client_cycle.c
 client_cycle_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -267,7 +273,7 @@ iof_output_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 clean-local:
-	rm -f compress compress_block preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf
+	rm -f compress compress_block preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf
 
 ptl_uri_SOURCES = \
         ptl_uri.c

--- a/test/unit/trk_peer_lost.c
+++ b/test/unit/trk_peer_lost.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * White-box unit tests for pmix_server_trk_peer_lost().
+ *
+ * This is the fence/connect/disconnect family's lost-connection accounting:
+ * the server calls it when a client's socket drops, and it decides, for every
+ * in-flight tracker the departing rank participates in, whether that rank is
+ * still being waited on. The rules it must implement (see
+ * docs/how-things-work/collectives):
+ *
+ *   Case A   the rank had already contributed -> the loss is ignored, the
+ *            contribution and its data stand.
+ *   Case B   the rank had not contributed and never will -> it is recorded on
+ *            'departed' so the collective can complete on the survivors, and
+ *            the collective's status is degraded.
+ *   Neither  the peer merely called PMIx_Finalize. That is not a loss: the
+ *            rank stays registered and counted (nlocalprocs is deliberately
+ *            left alone for it), so it remains an expected participant and may
+ *            PMIx_Init again and contribute. Recording it as departed counts
+ *            the rank twice and lets the collective complete without it -
+ *            which is what desynchronized the fence sequence of a client
+ *            cycling init/finalize (issue #4113).
+ *
+ * The last of those is the one with teeth, so it is tested as a pair: the same
+ * tracker, one contribution short of complete, and a departing peer that
+ * differs only in whether it finalized. Abnormal loss must complete the
+ * collective; a finalize must leave it waiting.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        ++nfail;
+    }
+}
+
+#define TEST_NSPACE "trkloss.ns"
+
+/* records that the collective's completion function was driven, without
+ * touching the tracker - the test owns its lifetime */
+static int completions = 0;
+static pmix_status_t completion_status = PMIX_SUCCESS;
+
+static void fake_modexcbfunc(pmix_status_t status, const char *data, size_t ndata,
+                             void *cbdata, pmix_release_cbfunc_t relfn, void *relcbd)
+{
+    PMIX_HIDE_UNUSED_PARAMS(data, ndata, cbdata, relfn, relcbd);
+    ++completions;
+    completion_status = status;
+}
+
+/* a peer carrying just the identity and the finalized flag that the loss
+ * accounting reads */
+static pmix_peer_t *make_peer(pmix_rank_t rank, bool finalized)
+{
+    pmix_peer_t *peer;
+
+    peer = PMIX_NEW(pmix_peer_t);
+    peer->info = PMIX_NEW(pmix_rank_info_t);
+    peer->info->pname.nspace = strdup(TEST_NSPACE);
+    peer->info->pname.rank = rank;
+    peer->finalized = finalized;
+    return peer;
+}
+
+/* a local fence tracker over ranks 0..nlocal-1 of TEST_NSPACE, carrying the
+ * status slot the participant handlers seed */
+static pmix_server_trkr_t *make_trk(uint32_t nlocal)
+{
+    pmix_server_trkr_t *trk;
+    pmix_status_t seed = PMIX_SUCCESS;
+    uint32_t n;
+
+    trk = PMIX_NEW(pmix_server_trkr_t);
+    trk->type = PMIX_FENCENB_CMD;
+    trk->def_complete = true;
+    trk->local = true;
+    trk->nlocal = nlocal;
+    trk->modexcbfunc = fake_modexcbfunc;
+    PMIX_PROC_CREATE(trk->pcs, nlocal);
+    trk->npcs = nlocal;
+    for (n = 0; n < nlocal; n++) {
+        PMIX_LOAD_PROCID(&trk->pcs[n], TEST_NSPACE, n);
+    }
+    PMIX_INFO_CREATE(trk->info, 1);
+    trk->ninfo = 1;
+    PMIX_INFO_LOAD(&trk->info[0], PMIX_LOCAL_COLLECTIVE_STATUS, &seed, PMIX_STATUS);
+    pmix_list_append(&pmix_server_globals.collectives, &trk->super);
+    return trk;
+}
+
+/* record a contribution from the given rank */
+static void contribute(pmix_server_trkr_t *trk, pmix_rank_t rank)
+{
+    pmix_server_caddy_t *cd;
+
+    cd = PMIX_NEW(pmix_server_caddy_t);
+    cd->peer = make_peer(rank, false);
+    pmix_list_append(&trk->local_cbs, &cd->super);
+}
+
+static void release_trk(pmix_server_trkr_t *trk)
+{
+    pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+    PMIX_RELEASE(trk);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    static pmix_server_module_t mymodule = {0};
+    pmix_server_trkr_t *trk;
+    pmix_peer_t *peer;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== collective lost-connection accounting unit tests ===\n\n");
+
+    /* Case B: an abnormal loss before contributing is recorded as departed,
+     * and degrades the status - two of four ranks are still awaited, so the
+     * collective is only partially successful, not over */
+    trk = make_trk(4);
+    contribute(trk, 0);
+    peer = make_peer(1, false);
+    completions = 0;
+    pmix_server_trk_peer_lost(peer);
+    report("abnormal loss is recorded as departed",
+           1 == pmix_list_get_size(&trk->departed));
+    report("abnormal loss degrades the status",
+           PMIX_ERR_PARTIAL_SUCCESS == pmix_server_get_collective_status(trk->info, trk->ninfo));
+    report("abnormal loss does not remove the contribution",
+           1 == pmix_list_get_size(&trk->local_cbs));
+    report("an incomplete collective is not driven to completion", 0 == completions);
+    PMIX_RELEASE(peer);
+    release_trk(trk);
+
+    /* Case A: a loss after contributing is ignored entirely */
+    trk = make_trk(4);
+    contribute(trk, 1);
+    peer = make_peer(1, false);
+    pmix_server_trk_peer_lost(peer);
+    report("a loss after contributing records no departure",
+           0 == pmix_list_get_size(&trk->departed));
+    report("a loss after contributing leaves the status alone",
+           PMIX_SUCCESS == pmix_server_get_collective_status(trk->info, trk->ninfo));
+    PMIX_RELEASE(peer);
+    release_trk(trk);
+
+    /* a peer that is not a participant is not accounted for at all */
+    trk = make_trk(2);
+    peer = make_peer(7, false);
+    pmix_server_trk_peer_lost(peer);
+    report("a non-participant records no departure",
+           0 == pmix_list_get_size(&trk->departed));
+    PMIX_RELEASE(peer);
+    release_trk(trk);
+
+    /* The #4113 pair. Two local ranks, one has contributed: the departure of
+     * the other is the last thing the collective is waiting on.
+     *
+     * Abnormal loss -> it will never contribute, so complete on the survivor
+     * and tell it the connection was lost. */
+    trk = make_trk(2);
+    contribute(trk, 0);
+    peer = make_peer(1, false);
+    completions = 0;
+    completion_status = PMIX_SUCCESS;
+    pmix_server_trk_peer_lost(peer);
+    report("a final abnormal loss completes the collective", 1 == completions);
+    report("a final abnormal loss reports lost-connection",
+           PMIX_ERR_LOST_CONNECTION == completion_status);
+    PMIX_RELEASE(peer);
+    release_trk(trk);
+
+    /* Graceful finalize -> the rank is still expected (it may PMIx_Init again
+     * and contribute), so nothing is recorded, nothing is degraded, and the
+     * collective keeps waiting for it. */
+    trk = make_trk(2);
+    contribute(trk, 0);
+    peer = make_peer(1, true);
+    completions = 0;
+    pmix_server_trk_peer_lost(peer);
+    report("a finalize records no departure",
+           0 == pmix_list_get_size(&trk->departed));
+    report("a finalize leaves the status alone",
+           PMIX_SUCCESS == pmix_server_get_collective_status(trk->info, trk->ninfo));
+    report("a finalize does not complete the collective", 0 == completions);
+    report("a finalize leaves the tracker in flight",
+           1 == pmix_list_get_size(&pmix_server_globals.collectives));
+    PMIX_RELEASE(peer);
+    release_trk(trk);
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    PMIx_server_finalize();
+
+    return (0 == nfail) ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

A client that cycles `PMIx_Init` → fence → `PMIx_Finalize` — one cycle per
`MPI_Session_init`/`MPI_Session_finalize`, so an ordinary MPI Sessions
application — drifts apart by whole cycles and eventually wedges. Mid-run
fences return `PMIX_ERR_PARTIAL_SUCCESS`, `PMIX_ERR_LOST_CONNECTION` or
`PMIX_ERR_INVALID_ARG`, and a run occasionally leaves one rank in a fence the
others passed long ago. Two cycles are enough: the stock `hello_sessions_c`
example has been intermittently hanging Open MPI's CI.

Reported in #4113, with a standalone reproducer (client + `simptest`, no MPI
in the stack).

## Cause

This is the half of #3931 that #3934 did not close — #3931's own summary named
it. #3934 fixed the *accounting*, so that losing a peer can no longer discard
its contribution or lower the bar beneath the survivors. It left the
assumption underneath in place: that a dropped socket means the rank is gone.

It does not, when the client dropped it by calling `PMIx_Finalize`. We go out
of our way to keep such a rank — `nlocalprocs` is deliberately not decremented
for it, and its peer object is tombstoned rather than retired, precisely so it
can `PMIx_Init` again and be counted. Every tracker's expected count therefore
still includes it, and it is still free to contribute. Recording it on
`departed` as well counts the one rank twice, and the collective can then
complete without it.

Under cycling that is routine. The ranks of cycle N finalize behind a faster
peer that has already opened cycle N+1's fence; between them they satisfy that
fence's expected count, so it completes on a single contribution and reports
`LOST_CONNECTION`. The others come back and open a fence the fast rank has
already left; its next fence merges into theirs; and because the first fence of
a cycle collects and the second does not, the merged tracker's `collect_type`
goes `INVALID` and everyone gets `INVALID_ARG`. From there the sequence is out
of step, and re-converges only by luck. All three reported error codes and the
whole-cycle drift come from that one mistake.

## Fix

Both loss entry points now return at once for a peer that finalized: loss
accounting is for an abnormal termination only. Nothing is given up by it — a
finalizing peer that had already contributed is Case A anyway, so the only case
skipped is Case B, which is the one that must not fire here.

The corollary is written down in the spec rather than left to be discovered: a
rank that finalizes and never comes back, while its peers wait in a collective
it was expected to join, now leaves them waiting. That program is erroneous —
no different from a rank that simply never calls — and `PMIX_TIMEOUT` is the
remedy PMIx already offers for it. Guessing that a finalized rank is not coming
back is what breaks every well-formed program that recycles.

## Commits

1. **Give the fence family's loss accounting its own entry point** — a pure
   move, no behavior change. The group family's accounting has been an exported
   routine beside its trackers since it was written; the fence family's was 160
   lines inline in `lost_connection()`, in the PTL base, two subsystems from the
   tracker engine whose state it edits. It becomes
   `pmix_server_trk_peer_lost()` in `pmix_server_fence.c`, the exact counterpart
   of `pmix_server_grp_peer_lost()` — which is also what makes it reachable from
   a unit test.
2. **Stop counting a finalized peer as a lost collective participant** — the
   fix itself, the spec/plan/`AGENTS.md` updates, and the new test.

## Testing

`test/unit/trk_peer_lost.c` (13 assertions) pins the distinction as a pair,
because that is the whole of the bug: the same tracker, one contribution short
of complete, and a departing peer that differs only in whether it finalized.
The abnormal loss must complete the collective on the survivor and report
`LOST_CONNECTION`; the finalize must record no departure, degrade no status,
and leave the tracker in flight. Case A, the non-participant, and the
status-degradation arms are covered alongside.

The issue's reproducer, 4 ranks against `simptest` on macOS/arm64 (8 cores)
with 3× CPU load and a fresh `TMPDIR` per run:

| build | runs × cycles | hangs | `-52` | `-33` | `-61` |
|---|---|---|---|---|---|
| master `0fa75209` | 5 × 200 | **5/5** | 498 | 192 | 114 |
| this branch | 5 × 200 | 0/5 | 0 | 0 | 0 |
| this branch | 5 × 400 | 0/5 | 0 | 0 | 0 |

Every baseline run left 3 of its 4 ranks wedged until the timeout fired.

`make check`: 130 tests, 130 pass, 0 fail. Clean, warning-free build.

Fixes #4113
