### PR TITLE
Refuse an atomic completion that cannot report its result

### DIFF
--- a/docs/man/man5/pmix_server_module_t.5.rst
+++ b/docs/man/man5/pmix_server_module_t.5.rst
@@ -107,10 +107,26 @@ completion will be signaled:
   the final result.
 * ``PMIX_OPERATION_SUCCEEDED`` |mdash| the operation completed immediately and
   successfully. The host **must not** invoke ``cbfunc``; the library treats the
-  operation as already finished.
+  operation as already finished. **Not permitted where the operation's result
+  can only be delivered through the callback** |mdash| see below.
 * Any other (error) value |mdash| the request failed and the host **will not**
   invoke ``cbfunc``. The library reports the error to the client directly and
   releases any state it was holding for the request.
+
+.. important:: ``PMIX_OPERATION_SUCCEEDED`` is **not** an allowed return from
+               ``spawn`` or ``direct_modex``, and is treated as an error by the
+               library. Those two operations produce a result |mdash| the
+               namespace of the launched job, and the requested data blob
+               |mdash| that the return code cannot carry, so the only channel
+               for it is ``cbfunc``. The library always supplies a non-``NULL``
+               ``cbfunc`` to both, so a host that has completed the work
+               immediately loses nothing by using it: **invoke the callback,
+               which may be done before returning, and return
+               ``PMIX_SUCCESS``**. A host that returns
+               ``PMIX_OPERATION_SUCCEEDED`` from either receives a diagnostic
+               naming the operation, and the request is failed to its
+               requestor with ``PMIX_ERR_NOT_SUPPORTED`` rather than being
+               reported as a success carrying no result.
 
 **Data ownership.** All data passed into a host callback is owned by the PMIx
 server library and must not be freed by the host. Conversely, data the host
@@ -219,7 +235,9 @@ satisfied from local data). The blob is returned through a
 ``pmix_modex_cbfunc_t``. A timeout directive may be supplied to bound the wait.
 The request may carry a ``PMIX_REQUIRED_KEY`` (char*) naming the specific key the
 requester is waiting on, allowing the host to defer its response until that key
-has been posted by the target process.
+has been posted by the target process. Like ``spawn``, this operation's result
+reaches the requestor only through the callback, so
+``PMIX_OPERATION_SUCCEEDED`` is not an allowed return from it.
 
 publish
 ^^^^^^^
@@ -253,7 +271,9 @@ spawn
 :ref:`PMIx_Spawn(3) <man3-PMIx_Spawn>`. Launches the given array of applications.
 A failure to start any process causes the entire request to be terminated and an
 error returned. The namespace of the spawned job is returned through a
-``pmix_spawn_cbfunc_t``. The job-level information accompanying the request may
+``pmix_spawn_cbfunc_t``, which is the **only** channel for it |mdash| so this
+operation must not answer ``PMIX_OPERATION_SUCCEEDED``, even when the launch
+completed before the callback returned. See the return-value contract above. The job-level information accompanying the request may
 include ``PMIX_REQUESTOR_IS_TOOL`` or ``PMIX_REQUESTOR_IS_CLIENT`` (bool),
 indicating whether the process that issued the spawn request is a tool or a
 client, respectively; a host may use this to apply different policies to

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -309,3 +309,17 @@ Detailed changes since v6.1.0:
    governs the namespaces registered after it: non-namespace information is
    copied into a namespace's data store when that namespace is registered,
    so a job already running retains it
+ - A host that answers a spawn or direct-modex up-call with
+   PMIX_OPERATION_SUCCEEDED is now told that it cannot, and the request
+   is failed to its requestor rather than reported as a success carrying
+   nothing. Both operations report a result - the namespace of the job
+   that was launched, or the data that was fetched - and the callback the
+   library supplies is the only channel for it, so an atomic completion
+   had nowhere to put the answer: a spawn came back to the application as
+   PMIX_SUCCESS with an empty namespace, over both the local and the
+   remote path, with nothing said. The library always supplies that
+   callback, so a host completing the work immediately can simply invoke
+   it - before returning, if it likes - and return PMIX_SUCCESS. The
+   pmix_server_module_t man page now states this, and PMIx_Spawn_nb no
+   longer returns PMIX_OPERATION_SUCCEEDED, which the Standard does not
+   define for it

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -55,24 +55,6 @@ design and is the reason that component exists.  Any real fix has to
 answer the ``shmem3`` case first; the messaging half is not worth building
 on its own.
 
-A host ``spawn`` that returns ``PMIX_OPERATION_SUCCEEDED`` is dropped
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The tree-wide convention for host up-calls is that
-``PMIX_OPERATION_SUCCEEDED`` means "done now, I will not call back — you
-invoke the completion yourself".  Both ``PMIx_Spawn_nb`` and
-``pmix_server_spawn`` instead treat it as an error: the caddy is
-released, the completion never fires, and the blocking ``PMIx_Spawn``
-wrapper maps the status to ``PMIX_SUCCESS`` and hands the caller an
-**empty namespace**.
-
-It is left alone because the spawn contract has no synchronous channel
-for the namespace in the first place, so a host completing atomically
-has no way to say what it launched; because both sites have the same
-shape, making this a convention rather than a divergence; and because
-nothing in the tree returns it.  Closing it properly means extending the
-``pmix_server_spawn_fn_t`` contract.
-
 ``PMIX_DATA_SCOPE`` is read without a type check
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1735,21 +1735,35 @@ other.
 
 *Noted, not changed — do not re-open these without new evidence:*
 
-- **A host `spawn` that returns `PMIX_OPERATION_SUCCEEDED` is dropped on
-  the floor.** The tree-wide host up-call convention (see
-  [`src/server/AGENTS.md`](../server/AGENTS.md)) is that
-  `PMIX_OPERATION_SUCCEEDED` means "done now, I will not call back — you
-  invoke the completion yourself", and this site treats it as an error:
-  it releases the caddy, never fires `fcd->spcbfunc`, and the blocking
-  `PMIx_Spawn` wrapper then maps the status to `PMIX_SUCCESS` and hands
-  the caller an **empty nspace**. Left alone because the spawn contract has
-  no synchronous channel for the namespace in the first place — a host
-  completing atomically has no way to tell us what it launched — so the
-  return is not really usable here; because `pmix_server_spawn` in
-  `src/server` has the identical shape, making this a convention rather
-  than a divergence; and because nothing in the tree returns it (`pfexec`
-  does not, and the in-tree host modules do not). Closing it properly means
-  extending the `pmix_server_spawn_fn_t` contract, not editing this branch.
+- **A host `spawn` that returns `PMIX_OPERATION_SUCCEEDED` is now
+  refused, and the reason generalizes.** The tree-wide up-call
+  convention (see [`src/server/AGENTS.md`](../server/AGENTS.md)) is that
+  the status means "done now, I will not call back — you invoke the
+  completion yourself". That works only where the operation's whole
+  result is a status. **Spawn's result is the namespace of the job that
+  was started, and the callback is its only channel** — so an atomic
+  completion has nowhere to put the answer. Until August 2026 this site
+  passed the status straight back, and the blocking `PMIx_Spawn` wrapper
+  mapped it to `PMIX_SUCCESS` with the caller's nspace left empty; the
+  remote path did the same by way of a synthesized status-only reply.
+  Both now emit the `atomic-completion-unsupported` diagnostic naming
+  the operation and fail the request with `PMIX_ERR_NOT_SUPPORTED`.
+
+  Two things follow. **The library always supplies a non-NULL `cbfunc`
+  to this up-call** — `localcbfunc` here, `pmix_server_spcbfunc` in
+  `src/server` — so a host that completed the work immediately loses
+  nothing: it invokes the callback, which it may do *before returning*,
+  and returns `PMIX_SUCCESS`. Both call sites are safe with an inline
+  callback, since each releases the caddy only when `rc != PMIX_SUCCESS`.
+  And **`PMIx_Spawn_nb` no longer returns `PMIX_OPERATION_SUCCEEDED` to
+  its caller**, which the Standard never defined for it — its return
+  section is a bare `\returnsimplenb`, unlike `PMIx_Fence_nb`, which
+  lists the status explicitly. The atomic-completion arm in the blocking
+  wrapper is gone with it; do not restore one.
+
+  `direct_modex` is the same class for the same reason (its product is a
+  data blob delivered through the callback) and now carries the same
+  diagnostic. Those two are the only up-calls in this position.
 - **The `spawn_iof_flags` stand-in is process-wide and is written from the
   caller's thread** (`stash_spawn_iof_flags`) while `spawn_or_global_flags()`
   in [`pmix_iof.c`](../common/pmix_iof.c) reads it on the progress thread.

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -60,6 +60,7 @@
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
 #include "src/runtime/pmix_progress_threads.h"
+#include "src/util/pmix_show_help.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/pmix_getcwd.h"
@@ -132,16 +133,13 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
     /* create a callback object */
     cb = PMIX_NEW(pmix_cb_t);
 
+    /* PMIx_Spawn_nb reports its result only through the callback - the
+     * namespace has nowhere else to travel - so it does not answer
+     * PMIX_OPERATION_SUCCEEDED and there is no atomic-completion arm to
+     * handle here. This used to test for one, and mapped it to
+     * PMIX_SUCCESS with the caller's namespace left empty */
     if (PMIX_UNLIKELY(PMIX_SUCCESS != (rc = PMIx_Spawn_nb(job_info, ninfo, apps, napps,
                                                            spawn_cbfunc, cb)))) {
-        /* note: the call may have returned PMIX_OPERATION_SUCCEEDED thus indicating
-         * that the spawn was atomically completed */
-        if (PMIX_OPERATION_SUCCEEDED == rc) {
-            if (NULL != cb->pname.nspace) {
-                PMIX_LOAD_NSPACE(nspace, cb->pname.nspace);
-            }
-            rc = PMIX_SUCCESS;
-        }
         PMIX_RELEASE(cb);
         return rc;
     }
@@ -541,6 +539,17 @@ envars_done:
                                     fcd->info, fcd->ninfo,
                                     fcd->apps, fcd->napps,
                                     localcbfunc, fcd);
+        /* PMIX_OPERATION_SUCCEEDED is not a usable answer here. This
+         * up-call's entire product is the namespace of the job that was
+         * started, and it comes back through the callback - which we
+         * always supply, so a host has no reason to withhold it. Taking
+         * the status at face value would hand our caller a success and
+         * an empty namespace, which it cannot act on and cannot detect */
+        if (PMIX_UNLIKELY(PMIX_OPERATION_SUCCEEDED == rc)) {
+            pmix_show_help("help-pmix-server.txt", "atomic-completion-unsupported",
+                           true, "PMIx_Spawn");
+            rc = PMIX_ERR_NOT_SUPPORTED;
+        }
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_RELEASE(fcd);
         }

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -1657,12 +1657,25 @@ misbehave by design).
   `_getnb_cbfunc` in `pmix_client_get.c` initializes its reported status
   to `PMIX_ERR_NOT_FOUND` and only overwrites it if a value actually
   turns up, so an empty success degrades to not-found at the requester -
-  the same bargain as the `refresh_cache` status above. And the
-  `direct_modex` up-call sites treat `PMIX_OPERATION_SUCCEEDED` as a
-  refusal rather than handling it as the third arm of the usual
-  tri-state. There is no coherent "done now, no callback" for this
-  up-call: its entire product is a data blob delivered through the
-  callback, and the header describes no such arm.
+  the same bargain as the `refresh_cache` status above.
+- **`PMIX_OPERATION_SUCCEEDED` is not a permitted return from `spawn` or
+  `direct_modex`, and both now say so.** The tri-state's third arm means
+  "done now, no callback — you invoke the completion yourself", which
+  works only where the operation's whole result is a status. These two
+  produce a result the return code cannot carry — the namespace of the
+  job that was launched, and the requested data blob — and the callback
+  is its only channel. Both `direct_modex` sites here already treated
+  the status as a refusal; they now emit the
+  `atomic-completion-unsupported` diagnostic naming the operation, as
+  `pmix_server_spawn` and `PMIx_Spawn_nb` do, so a host learns why its
+  request was failed rather than having it silently degrade. **The
+  library always supplies a non-NULL `cbfunc` to both**, so a host that
+  finished the work immediately invokes the callback — it may do so
+  before returning — and returns `PMIX_SUCCESS`. Every other up-call in
+  this directory can express its result in the status, and takes the
+  third arm normally. This is documented for hosts on the
+  [`pmix_server_module_t(5)`](../../docs/man/man5/pmix_server_module_t.5.rst)
+  man page.
 - **A public API's non-blocking form still has to clean up when the
   caller passes no callback.** `PMIx_server_setup_application` and
   `PMIx_server_collect_inventory` take a callback and have no blocking

--- a/src/server/help-pmix-server.txt
+++ b/src/server/help-pmix-server.txt
@@ -41,3 +41,20 @@ data type:
 The value must be a string of the form "nspace.rank" - for example,
 "singleton.0". The server cannot register the singleton and is
 unable to continue.
+#
+[atomic-completion-unsupported]
+The host environment answered a request with PMIX_OPERATION_SUCCEEDED,
+which is not a permitted return for this operation:
+
+  Operation:   %s
+
+This operation reports a result - the namespace of a job that was
+launched, or the data that was requested - and the only channel for
+that result is the callback function the PMIx server library supplied.
+That library always supplies one. There is therefore no way to return
+a result alongside PMIX_OPERATION_SUCCEEDED, and no way for the
+requesting process to learn the answer.
+
+A host that has completed the work immediately should invoke the
+callback function - it may do so before returning - and return
+PMIX_SUCCESS. The request has been failed to its requestor.

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -53,6 +53,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/util/pmix_show_help.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
 
@@ -789,6 +790,14 @@ request:
          * naming it - so take a reference for the host to hold */
         PMIX_RETAIN(lcd);
         rc = pmix_host_server.direct_modex(&lcd->proc, lcd->info, lcd->ninfo, dmdx_cbfunc, lcd);
+        /* this up-call's entire product is a data blob delivered through
+         * dmdx_cbfunc, so an atomic "success" carrying nothing cannot be
+         * acted on - say so rather than treating it as a bare refusal */
+        if (PMIX_UNLIKELY(PMIX_OPERATION_SUCCEEDED == rc)) {
+            pmix_show_help("help-pmix-server.txt", "atomic-completion-unsupported",
+                           true, "direct_modex");
+            rc = PMIX_ERR_NOT_SUPPORTED;
+        }
         if (PMIX_SUCCESS != rc) {
             /* may have a function entry but not support the request - it
              * will not call us back, so give the reference back */
@@ -924,6 +933,12 @@ void pmix_pending_nspace_requests(pmix_namespace_t *nptr)
                  * comment in pmix_server_get */
                 PMIX_RETAIN(cd);
                 rc = pmix_host_server.direct_modex(&cd->proc, cd->info, cd->ninfo, dmdx_cbfunc, cd);
+                if (PMIX_UNLIKELY(PMIX_OPERATION_SUCCEEDED == rc)) {
+                    /* see the matching note in pmix_server_get */
+                    pmix_show_help("help-pmix-server.txt", "atomic-completion-unsupported",
+                                   true, "direct_modex");
+                    rc = PMIX_ERR_NOT_SUPPORTED;
+                }
                 if (PMIX_SUCCESS != rc) {
                     PMIX_RELEASE(cd);
                 }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -70,6 +70,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/util/pmix_show_help.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
 
@@ -773,6 +774,16 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer, pmix_buffer_t *buf,
         rc = pmix_host_server.spawn(&proc, cd->info, cd->ninfo,
                                     cd->apps, cd->napps,
                                     pmix_server_spcbfunc, cd);
+        /* PMIX_OPERATION_SUCCEEDED cannot express this operation's result -
+         * the namespace of the job that was started, which comes back
+         * through the callback we always supply. Left alone it would reach
+         * the requesting client as a synthesized status-only reply, which
+         * that client reads as a success carrying no namespace */
+        if (PMIX_UNLIKELY(PMIX_OPERATION_SUCCEEDED == rc)) {
+            pmix_show_help("help-pmix-server.txt", "atomic-completion-unsupported",
+                           true, "PMIx_Spawn from a client");
+            rc = PMIX_ERR_NOT_SUPPORTED;
+        }
     } else {
         /* No host to ask, so fork/exec it ourselves. pfexec takes a caddy
          * of its own and releases it when the spawn completes, so give it


### PR DESCRIPTION
The host up-call convention is that `PMIX_OPERATION_SUCCEEDED` means "done now, I will not call back — you invoke the completion yourself". That works wherever the operation's whole result is a status. Two up-calls are not in that position: **spawn** produces the namespace of the job it started, **direct_modex** produces the data blob that was asked for, and in both cases `cbfunc` is the only channel for it.

So a host answering spawn that way was reporting a success that could not be acted on:

- *local path* — `PMIx_Spawn_nb` handed the status back and the blocking `PMIx_Spawn` wrapper mapped it to `PMIX_SUCCESS` with the caller's namespace left empty;
- *remote path* — the switchyard released the caddy and the message handler synthesized a status-only reply, which the requesting client reads as a success carrying no namespace (its short read of the namespace string is deliberately tolerated, for unrelated reasons).

Either way the application was told its spawn worked and given nothing to address.

### What this does

Refuses it at all four sites, with a `show_help` message naming the operation and saying what to do instead. The two `direct_modex` sites already treated the status as a refusal — they now say why rather than failing silently.

**Nothing is lost by refusing**, which is the point: the library always supplies a non-`NULL` `cbfunc` to both up-calls (`localcbfunc`, `pmix_server_spcbfunc`, `dmdx_cbfunc`). A host that has completed the work immediately invokes that callback — *before returning*, if it likes — and returns `PMIX_SUCCESS`, which carries the result. Both spawn sites are safe with an inline callback: each releases the caddy only when the return is not `PMIX_SUCCESS`.

`PMIx_Spawn_nb` also no longer returns `PMIX_OPERATION_SUCCEEDED` to its own caller. The Standard does not define that status for it — its return section is a bare `\returnsimplenb`, unlike `PMIx_Fence_nb` which lists it explicitly — so this was a module-level status leaking out through an application-level API. The blocking wrapper's arm for it goes with it.

### Documentation

`pmix_server_module_t(5)` now states the rule in its **return-value contract** and on both operation entries. This is a requirement on hosts and there was nowhere for them to read it; the `spawn` entry already said the namespace comes back through `pmix_spawn_cbfunc_t` without drawing the conclusion.

Nothing in the tree or in PRRTE returns `PMIX_OPERATION_SUCCEEDED` from either up-call today, so no working host changes behavior.

### Testing

Verified: clean build under `--enable-devel-check` (including the regenerated `show_help` content); `make check` 21/21 in `test/` and 70/70 + 10/10 + 7/7 in `test/unit/`; docs clean under `-W`.

No new test: reaching the refusal needs a host module that returns the status, which no in-tree host does — adding one to `simptest` would mean giving it a spawn it cannot host (see the note in `src/client/AGENTS.md` about `simptest` and spawn).