### PR TITLE
Check the type of a scope qualifier before believing it

### DIFF
--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -337,3 +337,13 @@ Detailed changes since v6.1.0:
    pmix_server_module_t man page now states this, and PMIx_Spawn_nb no
    longer returns PMIX_OPERATION_SUCCEEDED, which the Standard does not
    define for it
+ - A mistyped PMIX_DATA_SCOPE qualifier on PMIx_Get is now rejected with
+   PMIX_ERR_BAD_PARAM rather than taken at face value, on both the client
+   and the server side. The scope selects which table the datastore
+   searches, so reading it out of a union that holds something else
+   answered the request confidently and wrongly - it could not crash,
+   since a scope is only ever compared and never used as an index, which
+   is why it outlived the qualifiers beside it. Every other typed
+   qualifier in the same code already rejected a type mismatch. The
+   server-side read is the more exposed of the two: that info array
+   arrives off the wire, so its type tag is the requesting peer's word

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -55,16 +55,6 @@ design and is the reason that component exists.  Any real fix has to
 answer the ``shmem3`` case first; the messaging half is not worth building
 on its own.
 
-``PMIX_DATA_SCOPE`` is read without a type check
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``process_request()`` in ``src/client`` reads
-``info[n].value.data.scope`` directly.  Unlike the neighboring
-directives this cannot crash — it is a scalar read out of the union —
-but a mistyped directive silently produces the wrong scope and therefore
-a wrong answer.  "Reject" and "ignore" are both defensible; the choice
-is a behavior decision.
-
 Deferred work
 -------------
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -987,13 +987,28 @@ change here. Two clusters survived the earlier sweeps:
   and there is no singleton reproducer. It hardens the case where the
   datastore was filled from the server. Defensive, not demonstrated.
 
-*Noted, not changed:*
+*The one the sweep missed, closed later:*
 
-- `process_request()` takes `PMIX_DATA_SCOPE` as `info[n].value.data.scope`
-  with no type check. Unlike the others this cannot crash — it is a scalar
-  read out of the union — but a mistyped directive silently produces a
-  wrong scope and therefore a wrong answer. Left alone because "reject" and
-  "ignore" are both defensible and the choice is a behavior decision.
+- `process_request()` took `PMIX_DATA_SCOPE` as `info[n].value.data.scope`
+  with no type check, and this entry used to call that an open choice
+  between "reject" and "ignore". It was neither: **every other typed
+  qualifier in that same loop already rejects** — `PMIX_HOSTNAME` with an
+  explicit check, `PMIX_NODEID`/`PMIX_APPNUM`/`PMIX_SESSION_ID` through
+  `PMIx_Value_get_number` — and so does the server's own scope read in
+  `_register_resources`. Scope was simply the one left out, and it now
+  rejects with `PMIX_ERR_BAD_PARAM` like its neighbors.
+
+  Two things about it are worth keeping. It is the only member of this
+  class that **cannot crash**: a scope is compared against
+  `PMIX_LOCAL`/`PMIX_REMOTE`/`PMIX_GLOBAL` and never used as an index,
+  and `PMIx_Scope_string()` is a `switch` with a `default`, so the whole
+  cost of trusting it was a confidently wrong answer — which is why it
+  outlived the crashing members of its class by four sweeps. And the
+  **server had the same read**, in `pmix_server_get.c`, where the info
+  array came off the wire rather than from a local caller; that one is
+  fixed too. Only the type is checked, at both sites: nothing in the tree
+  range-checks an enum value, and a well-typed nonsense scope still falls
+  through to "no match".
 
 ### The stale-install trap — read this before believing any hand-built reproducer
 

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -164,6 +164,15 @@ static pmix_status_t process_request(const pmix_proc_t *proc, const char key[],
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_IMMEDIATE)) {
             lg->immediate = PMIX_INFO_TRUE(&info[n]);
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_DATA_SCOPE)) {
+            /* the key does not make the union a scope, and this qualifier
+             * comes straight from the caller. Unlike its neighbors a
+             * mistyped one cannot crash - a scope is only ever compared,
+             * never used as an index - but it selects which table is
+             * searched, so it turns a get into a confidently wrong answer.
+             * Rejecting matches every other typed qualifier here */
+            if (PMIX_UNLIKELY(PMIX_SCOPE != info[n].value.type)) {
+                return PMIX_ERR_BAD_PARAM;
+            }
             lg->scope = info[n].value.data.scope;
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_GET_REFRESH_CACHE)) {
             /* immediately query the server */

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -330,6 +330,16 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GET_REFRESH_CACHE)) {
             refresh_cache = PMIX_INFO_TRUE(&cd->info[n]);
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_DATA_SCOPE)) {
+            /* this array was unpacked off the wire, so the type tag is the
+             * peer's word rather than ours. A mistyped scope cannot crash -
+             * a scope is only ever compared, never used as an index - but
+             * it selects which table is searched, so taking it on trust
+             * answers the request confidently and wrongly */
+            if (PMIX_UNLIKELY(PMIX_SCOPE != cd->info[n].value.type)) {
+                rc = PMIX_ERR_BAD_PARAM;
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
             scope = cd->info[n].value.data.scope;
             scope_given = true;
         }

--- a/test/unit/client_api.c
+++ b/test/unit/client_api.c
@@ -537,6 +537,39 @@ static void test_get_hostname_qualifier(void)
     PMIX_INFO_DESTRUCT(&info);
 }
 
+/* PMIX_DATA_SCOPE selects which table a get searches. A mistyped one
+ * cannot crash - a scope is only ever compared, never used as an index -
+ * so the whole cost of taking it on trust is a confidently wrong answer,
+ * which is why this went unnoticed longer than its neighbors. */
+static void test_get_scope_qualifier(void)
+{
+    pmix_info_t info;
+    pmix_value_t *val = NULL;
+    pmix_status_t rc;
+    pmix_scope_t scope = PMIX_LOCAL;
+
+    fprintf(stdout, "\n-- PMIx_Get with a malformed PMIX_DATA_SCOPE qualifier --\n");
+
+    /* right key, wrong type: the union member read would be the low bytes
+     * of whatever else was stored there */
+    PMIX_INFO_LOAD(&info, PMIX_DATA_SCOPE, "not-a-scope", PMIX_STRING);
+    rc = PMIx_Get(NULL, "client.api.absent.key", &info, 1, &val);
+    check(PMIX_ERR_BAD_PARAM == rc, "PMIX_DATA_SCOPE qualifier of the wrong type rejected");
+    check(NULL == val, "the OUT value is still defined on that rejection");
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* and a well-formed one is still accepted - the screen has to let the
+     * ordinary case through, which a bare rejection test cannot show */
+    PMIX_INFO_LOAD(&info, PMIX_DATA_SCOPE, &scope, PMIX_SCOPE);
+    val = NULL;
+    rc = PMIx_Get(NULL, "client.api.absent.key", &info, 1, &val);
+    check(PMIX_ERR_BAD_PARAM != rc, "a well-formed PMIX_DATA_SCOPE qualifier is accepted");
+    PMIX_INFO_DESTRUCT(&info);
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+    }
+}
+
 /* PMIx_Spawn walks the apps array before it can know whether it will send
  * or fork, so an absent array has to be caught up front. */
 static void test_spawn_bad_params(void)
@@ -694,6 +727,7 @@ int main(int argc, char **argv)
     test_get_bad_params();
     test_get_pointer_and_static();
     test_get_hostname_qualifier();
+    test_get_scope_qualifier();
     test_put_bad_params();
     test_out_parameter_checks();
     test_compute_distances();

--- a/test/unit/server_get.c
+++ b/test/unit/server_get.c
@@ -340,6 +340,8 @@ int main(int argc, char **argv)
     static pmix_server_module_t mymodule = {0};
     pmix_status_t rc;
     pmix_info_t imm;
+    pmix_info_t scopeinfo;
+    pmix_scope_t scope;
     bool flag = true;
 
     (void) argc;
@@ -387,6 +389,25 @@ int main(int argc, char **argv)
     rc = do_get("no-such-nspace", 0, "some.key", &imm, 1);
     report("unknown nspace with IMMEDIATE reports not-found", PMIX_ERR_NOT_FOUND == rc);
     report("unknown nspace with IMMEDIATE parks nothing", nothing_parked());
+
+    /* --- a mistyped PMIX_DATA_SCOPE qualifier ----------------------- */
+    /* the directive arrives off the wire, so its type tag is the peer's
+     * word. Read raw, the scope would be the low bytes of a pointer -
+     * which cannot crash (a scope is only ever compared, never used as an
+     * index) but selects which table is searched, so the request would be
+     * answered confidently and wrongly */
+    PMIX_INFO_LOAD(&scopeinfo, PMIX_DATA_SCOPE, "not-a-scope", PMIX_STRING);
+    rc = do_get(GETUT_NSPACE, 0, "some.local.key", &scopeinfo, 1);
+    report("mistyped PMIX_DATA_SCOPE is rejected", PMIX_ERR_BAD_PARAM == rc);
+    report("mistyped PMIX_DATA_SCOPE parks nothing", nothing_parked());
+    PMIX_INFO_DESTRUCT(&scopeinfo);
+
+    /* and a well-formed one still reaches the ordinary answer */
+    scope = PMIX_LOCAL;
+    PMIX_INFO_LOAD(&scopeinfo, PMIX_DATA_SCOPE, &scope, PMIX_SCOPE);
+    rc = do_get(GETUT_NSPACE, 3, "some.remote.key", &scopeinfo, 1);
+    report("well-formed PMIX_DATA_SCOPE is accepted", PMIX_ERR_BAD_PARAM != rc);
+    PMIX_INFO_DESTRUCT(&scopeinfo);
 
     /* --- a local rank that has not connected yet -------------------- */
     rc = do_get(GETUT_NSPACE, 0, "some.local.key", &imm, 1);


### PR DESCRIPTION
`PMIX_DATA_SCOPE` selects which table the datastore searches. Both the client's request parser (`process_request()`) and the server's GET handler read it straight out of the value union on the strength of the key alone, so a qualifier carrying something else — a string, say — yielded the low bytes of a pointer as the scope, and the request was answered from whichever table that named.

**It cannot crash, and that is why it outlived the qualifiers beside it.** A scope is only ever compared against `PMIX_LOCAL`/`PMIX_REMOTE`/`PMIX_GLOBAL`, never used as an index, and `PMIx_Scope_string()` is a `switch` with a `default`. The whole cost is a confidently wrong answer — which no test would notice and no sanitizer would flag.

### There was no decision to make

`docs/todo.rst` recorded this as an open choice between "reject" and "ignore". It is neither: every other typed qualifier in the client's own loop already rejects a mismatch — `PMIX_HOSTNAME` with an explicit check, `PMIX_NODEID`/`PMIX_APPNUM`/`PMIX_SESSION_ID` by way of `PMIx_Value_get_number` — and so does the server's *other* scope read, in `_register_resources`. Scope was simply the one left out of that pattern, so this follows it.

The server's copy is the more exposed of the two, and the todo entry never mentioned it: that info array was unpacked **off the wire**, so the type tag is the requesting peer's word rather than a local caller's mistake — exactly the case `src/server/AGENTS.md` warns about.

Only the type is checked. Nothing in the tree range-checks an enum value, and a well-typed nonsense scope still falls through to "no match", so validating the enum here would be inventing a convention rather than following one.

### Testing

Covered at both sites, each paired with a well-formed request so the screen is held to accepting what it should:

- `test/unit/client_api.c` — the caller-supplied path (mistyped qualifier rejected; well-formed one accepted).
- `test/unit/server_get.c` — the wire path, using the existing hand-packed-request harness.

Both new server cases were observed failing against the unfixed library before the fix went in, so they have teeth.

Verified: clean build under `--enable-devel-check`; `make check` 21/21 in `test/` and 70/70 + 10/10 + 7/7 in `test/unit/`; docs clean under `-W`.