### PR TITLE
Stop a driven collective completion from being driven twice

### DIFF
--- a/docs/how-things-work/collectives/tracking_spec.rst
+++ b/docs/how-things-work/collectives/tracking_spec.rst
@@ -360,6 +360,31 @@ participants are still connected. Losing a participant after handoff only
 affects whether a reply can be delivered to that participant — never the
 completion or contents of the collective.
 
+**A driven completion claims the tracker.** ``host_called`` covers only
+the handoff to the host. A collective that never reaches the host - a
+strictly local fence is the ordinary case, and two error paths
+deliberately clear ``host_called`` - is completed by calling the
+tracker's own completion function, and that call is asynchronous: it
+thread-shifts, and only when the handler runs does it reply to the
+participants on ``local_cbs``, unlink the tracker from the collectives
+list and release it. Until then the tracker is still on the list and
+still satisfies the completion predicate, because ``local_cbs`` is
+drained by that handler and by nothing earlier. It therefore looks, to
+anything walking the list, exactly like a collective that is complete
+and unclaimed.
+
+Driving its completion a second time in that window hands two handlers
+the same tracker to unlink and release: the second reads and re-releases
+memory the first freed, and unlinks through freed list links, corrupting
+the collectives list. Admitting a *new* participant in that window is
+the same mistake from the other side - the caddy is freed with the
+tracker without ever being answered, hanging a client whose only mistake
+was to call its next collective promptly. A tracker whose completion has
+been driven must therefore be marked as spoken for, and every path that
+can reach a tracker - the lost-connection sweep, the collective timeouts,
+and the tracker lookup that joins a contributor to an in-flight
+collective - must honor that mark.
+
 **Group operations have the same requirement.** The group
 construct/destruct trackers (``grp_block_t`` / ``grp_trk_t`` on
 ``grp_collectives``) use the same counter-based accounting and are
@@ -401,6 +426,11 @@ all times:
    departed-before-contributing.**
 #. **After ``host_called`` is set, local loss accounting never re-drives
    completion** for that tracker.
+#. **Once a tracker's completion function has been driven, nothing drives
+   it again and no new participant joins it.** The completion is
+   asynchronous, so the tracker outlives the call on the collectives list;
+   for the duration it is spoken for, and every path that can reach a
+   tracker must skip it.
 #. **The rules apply uniformly** to fence, connect, disconnect, and group
    operations, and to both directly-connected clients and their clones.
 #. **Loss accounting is driven by abnormal termination only.** A rank

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -323,3 +323,19 @@ Detailed changes since v6.1.0:
    governs the namespaces registered after it: non-namespace information is
    copied into a namespace's data store when that namespace is registered,
    so a job already running retains it
+ - Fixed a double completion of a collective tracker that corrupted the
+   server's collectives list and could abort a later PMIx_server_finalize
+   with an invalid free. A collective the host never sees - a strictly
+   local fence is the ordinary case - is finished by driving the tracker's
+   completion function, which thread-shifts: until its handler runs the
+   tracker is still on the collectives list and still tests as complete,
+   because only that handler drains the participant list. Anything that
+   walked the list in that window - the lost-connection sweep, a queued
+   collective timeout - saw a complete, unclaimed collective and drove its
+   completion a second time, and two handlers then each unlinked and
+   released the same tracker. The host handoff was already guarded by
+   host_called; a local completion had no equivalent. A tracker whose
+   completion has been driven is now marked, and every path that can reach
+   one honors the mark - including the tracker lookup, which would
+   otherwise join a new contributor to a tracker about to be freed,
+   hanging that client

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -97,6 +97,21 @@ static void _findpeer(int sd, short args, void *cbdata)
         }
     }
 
+    /* not a local client - check the synthetic peers we built for
+     * foreign nspaces on an earlier pack/unpack */
+    for (i = 0; i < pmix_server_globals.peer_cache.size; i++) {
+        peer = (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.peer_cache, i);
+        if (NULL == peer) {
+            continue;
+        }
+        if (PMIx_Check_nspace(proc->nspace, peer->nptr->nspace)) {
+            scd->status = PMIX_SUCCESS;
+            scd->peer = peer;
+            PMIX_WAKEUP_THREAD(&scd->lock);
+            return;
+        }
+    }
+
     /* didn't find it, so try to get the library version of the target
      * from the host - the result will be cached, so we will only have
      * to retrieve it once */
@@ -150,8 +165,23 @@ static void _findpeer(int sd, short args, void *cbdata)
         PMIX_WAKEUP_THREAD(&scd->lock);
         return;
     }
-    /* cache the peer object */
-    pmix_pointer_array_add(&pmix_server_globals.clients, peer);
+    /* Cache the peer object so the next pack for this nspace can reuse it.
+     * It goes in the peer_cache, not the clients array: it stands for a
+     * foreign nspace, not a local client, and carries no rank_info, which
+     * every walker of the clients array reads as a matter of course.
+     * Record the index it lands at: peer->index is the object's own record
+     * of the slot it occupies, and the peer constructor leaves it at 0, so
+     * an unrecorded index has the peer claiming a slot that belongs to
+     * whatever else sits at the front of the array. */
+    peer->index = pmix_pointer_array_add(&pmix_server_globals.peer_cache, peer);
+    if (0 > peer->index) {
+        /* we could not cache it, and the caller only borrows what we hand
+         * back - returning it would leave nobody to free it */
+        PMIX_RELEASE(peer);
+        scd->status = PMIX_ERR_NOMEM;
+        PMIX_WAKEUP_THREAD(&scd->lock);
+        return;
+    }
     scd->status = PMIX_SUCCESS;
     scd->peer = peer;
     PMIX_WAKEUP_THREAD(&scd->lock);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -577,6 +577,22 @@ typedef struct {
     pmix_event_t ev;
     bool event_active;
     bool host_called; // tracker has been passed up to host
+    /* This tracker's completion function has been called, so the tracker is
+     * spoken for: the completion thread-shifts, and when it runs it replies
+     * to every participant on local_cbs, unlinks the tracker from
+     * pmix_server_globals.collectives and releases it.
+     *
+     * Until that handler runs the tracker is still ON the collectives list
+     * and still answers pmix_server_trk_complete() - local_cbs is drained
+     * by the handler, nothing earlier - so without this flag anything that
+     * walks the list in that window sees a tracker that looks complete and
+     * unclaimed, and drives its completion a second time. Two completions
+     * means two handlers for one tracker: the second reads and re-releases
+     * memory the first freed, and unlinks through freed list links. The
+     * host path is covered by host_called, but a strictly local collective
+     * never sets that (and two error paths deliberately clear it), which is
+     * exactly the common case. See the collectives directory guide. */
+    bool completion_fired;
     bool local;       // operation is strictly local
     char *id;         // string identifier for the collective
     pmix_cmd_t type;

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -730,6 +730,44 @@ now does both; the lost-connection sweep in
 `src/mca/ptl/base/ptl_base_sendrecv.c` still does not, and it is reached
 precisely when a `PMIX_TIMEOUT` timer is most likely to be armed.
 
+**Driving a tracker's completion claims it — `trk->completion_fired` says
+so.** `host_called` covers only the handoff to the host. A collective the
+host never sees — a strictly local fence is the *ordinary* case under
+`fence_localonly_opt`, and two error paths deliberately set `host_called`
+back to false — is finished by calling the tracker's own completion
+function, and every call site says the same reassuring thing: "the
+modexcbfunc thread-shifts the call prior to processing, so it is okay to
+call it directly from here." That is true about re-entrancy and
+misleading about lifetime. The shift means the tracker is still on
+`pmix_server_globals.collectives` when the call returns, and still
+answers `pmix_server_trk_complete()` — `local_cbs` is drained by the
+handler and by nothing earlier. So for that window the tracker looks, to
+anything walking the list, exactly like a collective that is complete and
+unclaimed.
+
+Two handlers for one tracker is a double free: each unlinks it from
+`collectives` and releases it, so the second reads and re-releases freed
+memory and unlinks through freed links. The list corruption outlives the
+event, and the abort usually lands much later — commonly in
+`PMIX_LIST_DESTRUCT(&pmix_server_globals.collectives)` inside
+`PMIx_server_finalize`, which is why openpmix#4112 reads as a teardown
+bug. The trigger is routine: four ranks finalize right after a fence, so
+a dropped socket reaches the sweep while the fence's own completion is
+still queued.
+
+The flag is set in `pmix_server_modex_cbfunc`, `pmix_server_cnct_cbfunc`
+and `pmix_server_discnct_cbfunc` — one choke point per family, right
+before the thread-shift — rather than at the dozen sites that drive a
+completion, so a new site cannot forget it. It is set only once the shift
+is certain: the `PMIX_NEW` failure returns above it leave the tracker
+unclaimed, which is what lets a later sweep still rescue it. Everything
+that can reach a tracker honors it: the lost-connection sweep, both
+collective timeouts (a timer whose event is already queued fires even
+though every handoff deletes it), and `pmix_server_get_tracker`, which
+must refuse to join a new contributor to a dying tracker — that caddy
+would be freed with the tracker and never answered, hanging a client
+whose only mistake was to call its next collective promptly.
+
 **`pmix_server_execute_collective` is the fourth up-call site, and it owes
 everything the other three do.** It is what fires a collective that a late
 `register_nspace` or `register_client` has just unblocked, and it had none

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -84,6 +84,7 @@ pmix_server_globals_t pmix_server_globals = {
     .module_set = false,
     .nspaces = PMIX_LIST_STATIC_INIT,
     .clients = PMIX_POINTER_ARRAY_STATIC_INIT,
+    .peer_cache = PMIX_POINTER_ARRAY_STATIC_INIT,
     .collectives = PMIX_LIST_STATIC_INIT,
     .remote_pnd = PMIX_LIST_STATIC_INIT,
     .local_reqs = PMIX_LIST_STATIC_INIT,
@@ -334,6 +335,8 @@ pmix_status_t pmix_server_initialize(void)
     /* setup the server-specific globals */
     PMIX_CONSTRUCT(&pmix_server_globals.clients, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_server_globals.clients, 1, INT_MAX, 1);
+    PMIX_CONSTRUCT(&pmix_server_globals.peer_cache, pmix_pointer_array_t);
+    pmix_pointer_array_init(&pmix_server_globals.peer_cache, 1, INT_MAX, 1);
     PMIX_CONSTRUCT(&pmix_server_globals.nspaces, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.collectives, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.remote_pnd, pmix_list_t);
@@ -1100,6 +1103,15 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
         }
     }
     PMIX_DESTRUCT(&pmix_server_globals.clients);
+    /* the synthetic peers we built to pack for foreign nspaces are ours
+     * alone - nothing else holds a reference on them */
+    for (i = 0; i < pmix_server_globals.peer_cache.size; i++) {
+        peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.peer_cache, i);
+        if (NULL != peer) {
+            PMIX_RELEASE(peer);
+        }
+    }
+    PMIX_DESTRUCT(&pmix_server_globals.peer_cache);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.nspaces);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.collectives);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.remote_pnd);

--- a/src/server/pmix_server_classes.c
+++ b/src/server/pmix_server_classes.c
@@ -72,6 +72,7 @@ static void tcon(pmix_server_trkr_t *t)
 {
     t->event_active = false;
     t->host_called = false;
+    t->completion_fired = false;
     t->local = true;
     t->id = NULL;
     memset(t->pname.nspace, 0, PMIX_MAX_NSLEN + 1);

--- a/src/server/pmix_server_connect.c
+++ b/src/server/pmix_server_connect.c
@@ -85,6 +85,12 @@ static void collective_timeout(int sd, short args, void *cbdata)
                         "ALERT: %s timeout fired",
                         (PMIX_CONNECTNB_CMD == trk->type) ? "connect" : "disconnect");
 
+    /* already spoken for - see the matching guard in fence_timeout */
+    if (trk->completion_fired) {
+        trk->event_active = false;
+        return;
+    }
+
     /* execute the provided callback function with the error */
     if (NULL != trk->op_cbfunc) {
         trk->op_cbfunc(PMIX_ERR_TIMEOUT, trk);

--- a/src/server/pmix_server_fence.c
+++ b/src/server/pmix_server_fence.c
@@ -277,6 +277,17 @@ pmix_server_trkr_t *pmix_server_get_tracker(char *id, pmix_proc_t *procs,
      * involve only a single proc with WILDCARD rank - so this
      * shouldn't take long */
     PMIX_LIST_FOREACH (trk, &pmix_server_globals.collectives, pmix_server_trkr_t) {
+        /* a tracker whose completion has been driven is on its way out -
+         * its handler is thread-shifted and will reply to everyone on
+         * local_cbs, unlink the tracker and release it. It is still on
+         * this list until then, but it must not take a new participant:
+         * that caddy would be freed with the tracker without ever being
+         * answered, hanging a client whose only mistake was to call the
+         * next collective quickly. Skip it and let the caller open a
+         * fresh tracker for the new operation. */
+        if (trk->completion_fired) {
+            continue;
+        }
         /* Collective operation if unique identified by
          * the set of participating processes and the type of collective,
          * or by the operation ID
@@ -578,6 +589,16 @@ static void fence_timeout(int sd, short args, void *cbdata)
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_output_verbose(2, pmix_server_globals.fence_output, "ALERT: fence timeout fired");
+
+    /* a completion already driven for this tracker owns it, and its
+     * handler will unlink and release it. Every hand-off deletes this
+     * timer, but a timer whose event is already queued fires anyway, so
+     * this is the guard that makes that harmless rather than a second
+     * completion of a tracker that is about to be freed. */
+    if (trk->completion_fired) {
+        trk->event_active = false;
+        return;
+    }
 
     /* execute the provided callback function with the error */
     if (NULL != trk->modexcbfunc) {
@@ -1446,6 +1467,18 @@ void pmix_server_trk_peer_lost(pmix_peer_t *peer)
          * then the local phase is frozen - just wait for the host
          * to return from the operation */
         if (trk->host_called) {
+            continue;
+        }
+        /* likewise if this tracker's completion has already been driven.
+         * It is still on the collectives list and still answers
+         * pmix_server_trk_complete() - its completion handler is
+         * thread-shifted and has not run yet - but it is spoken for, and
+         * completing it again would hand two handlers the same tracker to
+         * unlink and release. This is the common case, not an exotic one:
+         * a strictly local collective never sets host_called, so a
+         * participant dropping its connection in the window between a
+         * local fence completing and its handler running lands here. */
+        if (trk->completion_fired) {
             continue;
         }
         /* are we now locally complete? */

--- a/src/server/pmix_server_op_replies.c
+++ b/src/server/pmix_server_op_replies.c
@@ -287,6 +287,15 @@ void pmix_server_modex_cbfunc(pmix_status_t status, const char *data, size_t nda
     scd->tracker = tracker;
     scd->cbfunc.relfn = relfn;
     scd->relcbdata = relcbd;
+    /* the tracker is now spoken for - _mdxcbfunc will unlink and release
+     * it, so nothing walking the collectives list in the meantime may
+     * complete it again. Marked here rather than at the dozen sites that
+     * drive a completion, so a new one cannot forget to. Only once we know
+     * we are actually going to shift: the NOMEM return above leaves the
+     * tracker unclaimed, which is what lets a later sweep rescue it. */
+    if (NULL != tracker) {
+        tracker->completion_fired = true;
+    }
     PMIX_THREADSHIFT(scd, _mdxcbfunc);
 }
 
@@ -641,6 +650,10 @@ void pmix_server_cnct_cbfunc(pmix_status_t status, void *cbdata)
     }
     scd->status = status;
     scd->tracker = tracker;
+    /* the tracker is now spoken for - see pmix_server_modex_cbfunc */
+    if (NULL != tracker) {
+        tracker->completion_fired = true;
+    }
     PMIX_THREADSHIFT(scd, _cnct);
 }
 
@@ -733,6 +746,10 @@ void pmix_server_discnct_cbfunc(pmix_status_t status, void *cbdata)
     }
     scd->status = status;
     scd->tracker = tracker;
+    /* the tracker is now spoken for - see pmix_server_modex_cbfunc */
+    if (NULL != tracker) {
+        tracker->completion_fired = true;
+    }
     PMIX_THREADSHIFT(scd, _discnct);
 }
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -153,6 +153,14 @@ typedef struct {
     bool module_set;    // pmix_host_server has been set
     pmix_list_t nspaces;          // list of pmix_nspace_t for the nspaces we know about
     pmix_pointer_array_t clients; // array of pmix_peer_t local clients
+    /* array of synthetic pmix_peer_t objects created solely to carry the
+     * bfrops module of a foreign nspace we have been asked to pack data
+     * for. These are NOT local clients: they have no rank_info, no socket
+     * and no process behind them, so they are kept out of the clients
+     * array - everything that walks that array (monitoring, cleanup
+     * targeting, tool identity checks, peer lookup) reads peer->info as a
+     * matter of course. See _findpeer() in src/common/pmix_data.c */
+    pmix_pointer_array_t peer_cache;
     pmix_list_t collectives;      // list of active pmix_server_trkr_t
     pmix_list_t remote_pnd; // list of pmix_dmdx_remote_t awaiting arrival of data fror servicing
                             // remote req's

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1802,6 +1802,13 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
      * cycle. pmix_server_initialize (called unconditionally from
      * PMIx_tool_init) reconstructs all of these on the next init. */
     PMIX_DESTRUCT(&pmix_server_globals.clients);
+    for (n = 0; n < pmix_server_globals.peer_cache.size; n++) {
+        peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.peer_cache, n);
+        if (NULL != peer) {
+            PMIX_RELEASE(peer);
+        }
+    }
+    PMIX_DESTRUCT(&pmix_server_globals.peer_cache);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.nspaces);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.collectives);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.remote_pnd);

--- a/test/unit/tracker_match.c
+++ b/test/unit/tracker_match.c
@@ -111,6 +111,23 @@ int main(int argc, char **argv)
     found = pmix_server_get_tracker("no-such-collective", NULL, 0, PMIX_FENCENB_CMD);
     report("get_tracker rejects an unknown id", NULL == found);
 
+    /* A tracker whose completion has been driven is on its way out: the
+     * completion thread-shifts, and when it runs it answers everyone on
+     * local_cbs, unlinks the tracker and releases it. Until then it is
+     * still on the collectives list, so get_tracker can still see it - and
+     * must refuse it. Handing it to a new collective would append a caddy
+     * that gets freed with the tracker without ever being answered, hanging
+     * a client whose only mistake was to call the next collective quickly.
+     * Both identity routes have to refuse it, since either can reach a
+     * tracker in that state. */
+    t1->completion_fired = true;
+    found = pmix_server_get_tracker("trk-collective-A", NULL, 0, PMIX_FENCENB_CMD);
+    report("get_tracker refuses a fired tracker (by id)", NULL == found);
+
+    t2->completion_fired = true;
+    found = pmix_server_get_tracker(NULL, procsB, 2, PMIX_CONNECTNB_CMD);
+    report("get_tracker refuses a fired tracker (by proc set)", NULL == found);
+
     release_tracker(t1);
     release_tracker(t2);
 


### PR DESCRIPTION
Fixes https://github.com/openpmix/openpmix/issues/4112
Two independent fixes found while investigating #4112.

## 1. A driven collective completion could be driven twice

`host_called` covers only the handoff to the host. A collective the host
never sees — a strictly local fence, the ordinary case under
`fence_localonly_opt`, plus the two error paths that deliberately clear
`host_called` — is finished by calling the tracker's own completion
function, and every call site says the same reassuring thing: *"the
modexcbfunc thread-shifts the call prior to processing, so it is okay to
call it directly from here."*

That is true about re-entrancy and misleading about lifetime. Because the
call only shifts, the tracker is still on `pmix_server_globals.collectives`
when it returns, and still satisfies `pmix_server_trk_complete()` —
`local_cbs` is drained by the completion handler and by nothing earlier. For
that window the tracker looks, to anything walking the list, exactly like a
collective that is complete and unclaimed.

So a second driver completes it again. Two handlers then each reply to the
participants, unlink the same tracker and release it: the second reads and
re-releases memory the first freed, and unlinks through freed list links.
The corrupted list outlives the event, so the abort surfaces far away —
typically as an invalid free inside
`PMIX_LIST_DESTRUCT(&pmix_server_globals.collectives)` in
`PMIx_server_finalize`. That is why #4112 reads as a teardown bug and
reproduces only after heavy connect/disconnect churn.

The fix marks a tracker whose completion has been driven. The mark is set in
`pmix_server_modex_cbfunc`, `pmix_server_cnct_cbfunc` and
`pmix_server_discnct_cbfunc` — one choke point per family, immediately
before the thread-shift — rather than at the dozen sites that drive a
completion, so a new site cannot forget it; and only once the shift is
certain, since the allocation-failure returns above it must leave the
tracker unclaimed for a later sweep to rescue.

Everything that can reach a tracker honors it: the lost-connection sweep,
both collective timeouts (every handoff deletes the timer, but a timer whose
event is already queued fires anyway), and `pmix_server_get_tracker`.

That last one is the same defect from the other side, and is worth its own
attention: `get_tracker` would join a **new** contributor to a tracker
already on its way out. That caddy is then freed with the tracker without
ever being answered, hanging a client whose only mistake was to call its
next collective promptly.

## 2. The foreign-nspace pack peer does not belong in the clients array

`PMIx_Data_pack`/`unpack` against a target in a namespace with no local
client builds a synthetic peer whose only purpose is to carry that
namespace's bfrops module, and `_findpeer()` cached it in
`pmix_server_globals.clients`. That array is the server's *local clients*
list, walked by monitoring, the pstat peer census, job-control cleanup
targeting, the tool identity check, `pmix_get_peer_object` and IOF — every
one of which reads `peer->info->pname` as a matter of course. The synthetic
peer has no `rank_info` at all: it describes a namespace, not a process. The
dereference in `pmix_server_control.c` is reachable from an ordinary
`PMIx_Job_control_nb` cleanup request.

The same object was also added without recording the index it landed at.
`peer->index` is how a peer object names its own slot, the constructor
leaves it at 0, and `pmix_server_peer_finalized()` nulls a retiring peer's
slot by exactly that field.

These peers now get their own array. Nothing else has any business finding
them — `_findpeer` is the only thing that puts one there and the only thing
that looks one up. The index is recorded, and a failed add is treated as the
allocation failure it is rather than handing back a peer the caller only
borrows and nobody owns. I preferred this to adding NULL guards at the
walkers, and then verified the guards are unnecessary: both remaining paths
that add to `clients` set `info` before the add.

## Testing

`make check` passes (130 tests). Two new cases in
`test/unit/tracker_match.c` pin that `get_tracker` refuses a fired tracker
by either identity route; both fail without the guard and pass with it.

Measured with an ASan build under the #4112 reproducer (`simptest -n 4 -e
./pmixloop 400`, fresh TMPDIR per run, loaded machine):

| configuration | clean | hang | use-after-free |
|---|---|---|---|
| master before #4124 | 0/4 | 2 | 2 |
| + this tracker fix | 16/20 | 4 | 0 |
| + #4124 only | 20/20 | 0 | 0 |
| + #4124 and this fix | 20/20 | 0 | 0 |

Three captures on the pre-#4124 base, all identical: the tracker allocated
at `pmix_server_new_tracker` (`pmix_server_fence.c`), freed in `_mdxcbfunc`,
then read back at the first field `_mdxcbfunc` touches.

**One caveat, stated plainly.** Now that #4124 has landed,
`lost_connection` returns early for a cleanly-finalized peer — and every
disconnect in that reproducer *is* a clean finalize, so the sweep that
triggered the double completion no longer runs there. The trigger is masked
in that workload; the window in the code is unchanged for a peer that dies
**without** finalizing, which is the case the sweep exists to handle. So on
current master this rests on the code path and the unit tests rather than on
that reproducer.

The hangs in the table above belong to #4124, not to this PR — I checked
that specifically, and the tracker fix does not affect them.

Docs: the tracking specification had an invariant for the host handoff and
none for a local completion; it does now, as does `src/server/AGENTS.md`.