### PR TITLE
Three items from the deferred-work list

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -27,6 +27,16 @@ so that they are not repeatedly "rediscovered" and re-fixed.
           still **open**.  Re-verify an entry before acting on it; the
           code moves.
 
+.. note:: **Every entry below was checked against the tree on
+          2026-08-11**, and that pass removed two: one whose fix had
+          landed a month before this page first recorded it as open, and
+          one that had been fixed since.  It also corrected a claim that
+          was never true.  Treat that as the standing expectation rather
+          than a one-off — an entry here is a lead, not a finding, and
+          the two entries that cannot be checked by reading the tree
+          (the group-leave leaks, and the two "never validated" coverage
+          gaps) are the ones most likely to have gone stale unnoticed.
+
 Open decisions
 --------------
 
@@ -67,7 +77,7 @@ success path the handler is ``PMIX_EVENT_ONESHOT`` and removes itself
 when it fires; only the notification-failure return leaves it
 registered.  The obvious fix does not work: ``PMIx_Deregister_event_handler``
 gates on ``pmix_globals.initialized``, which ``PMIx_Init`` does not set
-until forty lines later, so the public API is a no-op from there and
+until well after that return, so the public API is a no-op from there and
 removing the handler means open-coding the thread-shift the entry point
 performs.  Weigh that against the reachability — the process must ignore
 a failed ``PMIx_Init``, keep running, and then be sent a
@@ -93,10 +103,14 @@ Two shared-state exposures that need a structural answer
   A tool that needs concurrent spawns formatted differently forces the
   stand-in to become per-request.
 * ``PMIx_Spawn_nb`` in a server role walks
-  ``pmix_server_globals.clients`` unlocked, on whatever thread the host
-  called it on, while the progress thread adds and removes clients.  The
-  cure is to thread-shift the whole entry point; the sibling call in
-  ``pmix_monitor.c`` has the same exposure.
+  ``pmix_server_globals.clients`` unlocked — through the ``static
+  inline`` ``pmix_get_peer_object()`` in ``pmix_server_ops.h`` — on
+  whatever thread the host called it on, while the progress thread adds
+  and removes clients.  The cure is to thread-shift the whole entry
+  point.  Note this is the *only* exposed caller: the other one, in
+  ``pmix_monitor.c``, sits inside ``pmix_monitor_processing()``, which is
+  reached by ``PMIX_THREADSHIFT`` and therefore already runs on the
+  progress thread.
 
 Smaller items carried forward
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,10 +121,6 @@ Smaller items carried forward
   if it is closed the screen belongs inside ``PMIx_Value_get_number``
   rather than at the call sites, since every caller in the tree is
   equally exposed.
-* ``req->flags = cd->flags`` in ``pmix_server_process_iof()`` aliases the
-  caddy's ``file``/``directory`` strings, which are freed when the caddy
-  is released — so the IOF request is left holding two dangling
-  pointers.  It is harmless only because nothing reads them today.
 * ``pmix_globals.init_called`` is set with ``__atomic_test_and_set`` and
   cleared with a plain assignment.  All three roles do this, and the
   only interleaving that reaches it is a concurrent
@@ -118,9 +128,12 @@ Smaller items carried forward
 * ``refcb()`` in ``src/client`` overwrites the store status with the next
   unpack's, so a store failure while absorbing a cache refresh is
   silently dropped.
-* ``resolve_peers()``'s pre-v3.2 compatibility branch is dead code — the
-  rank it sets is unconditionally reset two lines later.  Not removed
-  without a pre-v3.2 server to test against.
+* The rank ``resolve_peers()`` sets in its pre-v3.2 compatibility branch
+  is a dead store — it is unconditionally reset a few lines later, and
+  ``try_fetch()`` retries an ``UNDEF`` rank as ``WILDCARD``, which is why
+  the legacy path still resolves.  Only the store is dead; the ``key``
+  and ``ninfo`` that branch sets do take effect, so it cannot simply be
+  deleted.  Not touched without a pre-v3.2 server to test against.
 * The command-line parser drops a positional argument placed *before* an
   option, a consequence of ``getopt`` reordering.  Put options first.
 * The relay in ``src/tool`` assumes the downstream tool and the upstream

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -93,17 +93,6 @@ cleanup — ``_register_client``, ``harvest_envars``,
 entangled with a leak in the host's own group code, which is what makes
 attributing and fixing them delicate.  Left for separate, careful work.
 
-Hardening the spawn copy loop against allocation failure
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The ``strdup()``, ``PMIx_Argv_copy()`` and ``PMIx_Argv_prepend_nosize()``
-results in ``PMIx_Spawn_nb``'s copy loop are unchecked.  Doing half of
-this is worse than doing none of it, so the whole loop was left for a
-separate piece of work.  Note that the ``PMIX_NEW`` calls in that same
-function are an **open decision, not a considered one**: they were left
-on the strength of a claim that ``src/client`` never checks
-``PMIX_NEW``, and that claim was wrong.
-
 Two shared-state exposures that need a structural answer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -73,16 +73,6 @@ performs.  Weigh that against the reachability — the process must ignore
 a failed ``PMIx_Init``, keep running, and then be sent a
 ``PMIX_DEBUGGER_RELEASE`` it never asked for.
 
-A cached notification caddy still leaks on the cache-aging path
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-A cached notify caddy takes a reference that the event hotel owns.  The
-"all targets notified" checkout path was fixed to release it; pure
-cache-aging still leaks the working reference.  The fix needs
-"cached" and "posted upstairs" to be told apart — both currently set
-``holdcd = true`` — which is why it was deferred rather than attempted
-alongside the other leak fixes.
-
 Residual leaks on the group-leave path
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -83,16 +83,6 @@ cache-aging still leaks the working reference.  The fix needs
 ``holdcd = true`` — which is why it was deferred rather than attempted
 alongside the other leak fixes.
 
-An outstanding direct-modex request leaks its caddy at teardown
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``dmrqdes`` (``src/server/pmix_server_classes.c``) deletes the request's
-timer event and releases its tracker and key, but never releases
-``req->cbdata``.  A request still outstanding when the server finalizes
-or purges therefore leaks the server caddy behind it.  An earlier fix to
-the over-retain in ``create_local_tracker`` made this smaller — one
-caddy rather than two — but did not close it.
-
 Residual leaks on the group-leave path
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1736,17 +1736,11 @@ other.
   returns between the two actually free what the caddy already holds.
 
   This is the class the earlier sweeps have consistently closed
-  (`respeer()`, `construct_msg()`, `construct_cbfunc()`). The unchecked
-  `strdup()` / `PMIx_Argv_copy()` / `PMIx_Argv_prepend_nosize()` results
-  in the same loop are deliberately left: hardening this function against
-  allocation failure end-to-end is a separate piece of work, and doing
-  half of it is worse than none.
-
-  **This sweep also left `fcd = PMIX_NEW(pmix_setup_caddy_t)` and
-  `msg = PMIX_NEW(pmix_buffer_t)` unchecked on the strength of the ninth
-  sweep's claim that `PMIX_NEW` is never checked in this directory. That
-  claim was wrong** — see the corrected entry under the ninth sweep — so
-  treat this as an open decision rather than a considered one.
+  (`respeer()`, `construct_msg()`, `construct_cbfunc()`). The rest of the
+  loop was left at the time — the `strdup()`, `PMIx_Argv_copy()` and
+  `PMIx_Argv_prepend_nosize()` results, and the two `PMIX_NEW`s the whole
+  function hangs off — on the grounds that doing half of it is worse than
+  none. **That is now done; see the twelfth sweep below.**
 
 *Noted, not changed — do not re-open these without new evidence:*
 
@@ -1909,6 +1903,57 @@ the shift looks removable.
   the `direcv` fix closes, in the function that produces the answer when
   the client can compute it itself. Fixed in
   [`src/hwloc/pmix_hwloc.c`](../hwloc/pmix_hwloc.c).
+
+## The twelfth sweep — `PMIx_Spawn_nb` survives an allocation failure
+
+The tenth sweep closed the three `_CREATE` macros in the apps copy loop
+and deliberately left everything else, on the grounds that hardening this
+function against allocation failure end-to-end is one piece of work and
+half of it is worse than none. This is that piece of work. It changes no
+behavior on any path where nothing fails.
+
+Every allocation in `PMIx_Spawn_nb` is now checked: the two `PMIX_NEW`s
+the function hangs off (`fcd` and `msg`), `PMIx_Info_list_start()`, both
+`strdup()`s per app, both `pmix_basename()` results, both
+`PMIx_Argv_copy()` results, `PMIx_Argv_prepend_nosize()`, and
+`PMIx_Setenv()` in both harvest loops. Three things are worth carrying:
+
+- **The copy loop shares one exit** (`nomem:` at the foot of the
+  function), because `PMIX_RELEASE(fcd)` is the whole cleanup however far
+  the loop got. `fcd->copied` is set at construction and `PMIX_APP_CREATE`
+  constructs every element, so an app the loop never reached is an empty
+  one rather than garbage, and a half-filled one frees the members it did
+  get.
+- **`PMIx_Argv_copy()` answers NULL for a NULL source as well as for a
+  failure**, so the two are told apart by the *source*, not the result.
+  The `argv` copy is on a branch where `aptr->argv` is known non-NULL, so
+  a NULL back there is a failure; the `env` copy is not, so it is guarded
+  on `NULL != aptr->env` — an app that names no environment is the
+  ordinary case. (An argv whose first element is NULL still yields a
+  valid empty array, so that is not the ambiguous case it looks like.)
+- **`pmix_basename()` returns NULL for a NULL input and on failure**, and
+  both call sites in that branch pass something already known non-NULL —
+  our own copy of the cmd, and `aptr->argv[0]`, which the bozo check at
+  the top of the loop has already rejected as NULL. So a NULL there is an
+  allocation failure too.
+
+One behavior change came with it, and it is a consistency fix rather than
+hardening: **the per-app directive copy used `PMIX_INFO_XFER`, which
+discards its status by definition**, so a directive the copy could not
+carry was dropped in silence and the spawn went up with an empty slot
+where the caller had put something. The job-level directives twenty lines
+above have always failed the spawn in that case, through
+`PMIx_Info_list_xfer`. It now uses `PMIx_Info_xfer` and reports. Note
+`PMIX_UNDEF` transfers successfully, so a flag-only directive is
+unaffected.
+
+Coverage is in [`test/unit/spawn_api.c`](../../test/unit/spawn_api.c).
+**Nothing there tests the hardening directly** — a `make check` program
+cannot make an allocation fail — so what it holds down is the other half:
+that the argv-without-cmd, argv-not-starting-with-cmd and app-carrying-an-
+environment shapes still reach the host up-call, which is what a screen
+written the wrong way round would break. The `PMIX_INFO_XFER` change does
+have a real regression case, and it fails against the unfixed library.
 
 ## Coding conventions specific to this directory
 

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -249,8 +249,15 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         }
     }
 
-    // setup the caddy
+    /* Setup the caddy. Everything below is written to survive an
+     * allocation failure, so the two allocations the whole function hangs
+     * off - this one and the message near the foot - are checked too:
+     * leaving them out would be exactly the half-measure that kept this
+     * work parked. */
     fcd = PMIX_NEW(pmix_setup_caddy_t);
+    if (PMIX_UNLIKELY(NULL == fcd)) {
+        return PMIX_ERR_NOMEM;
+    }
     fcd->spcbfunc = cbfunc;
     fcd->cbdata = cbdata;
     /* everything we are about to put in the caddy's info and apps fields is
@@ -265,6 +272,10 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
      * one, which used to come back to the caller as the spawn's failure */
     if (NULL != job_info && 0 < ninfo) {
         xlist = PMIx_Info_list_start();
+        if (PMIX_UNLIKELY(NULL == xlist)) {
+            PMIX_RELEASE(fcd);
+            return PMIX_ERR_NOMEM;
+        }
         for (n = 0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&job_info[n], PMIX_SETUP_APP_ENVARS)) {
                 /* harvested and applied to our copy of the apps, below */
@@ -329,6 +340,9 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         } else {
             fcd->apps[n].cmd = strdup(aptr->cmd);
         }
+        if (PMIX_UNLIKELY(NULL == fcd->apps[n].cmd)) {
+            goto nomem;
+        }
 
         /* if they didn't give us a desired working directory, then
          * take the one we are in */
@@ -342,41 +356,74 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         } else {
             fcd->apps[n].cwd = strdup(aptr->cwd);
         }
+        if (PMIX_UNLIKELY(NULL == fcd->apps[n].cwd)) {
+            goto nomem;
+        }
 
         /* if they didn't give us the cmd as the first argv, fix it */
         if (NULL == aptr->argv) {
             tmp = pmix_basename(aptr->cmd);
+            if (PMIX_UNLIKELY(NULL == tmp)) {
+                goto nomem;
+            }
             fcd->apps[n].argv = (char **) malloc(2 * sizeof(char *));
             if (PMIX_UNLIKELY(NULL == fcd->apps[n].argv)) {
-                if (NULL != tmp) {
-                    free(tmp);
-                }
-                PMIX_RELEASE(fcd);
-                return PMIX_ERR_NOMEM;
+                free(tmp);
+                goto nomem;
             }
             fcd->apps[n].argv[0] = tmp;
             fcd->apps[n].argv[1] = NULL;
         } else {
+            /* aptr->argv is non-NULL on this branch, and a copy of a
+             * non-NULL argv is NULL only if an allocation failed - even an
+             * argv whose first element is NULL yields a valid empty one */
             fcd->apps[n].argv = PMIx_Argv_copy(aptr->argv);
+            if (PMIX_UNLIKELY(NULL == fcd->apps[n].argv)) {
+                goto nomem;
+            }
             /* take the basename from our own copy of the cmd, not from
              * aptr->cmd: the caller is allowed to supply argv without a cmd
              * (we filled it in from argv[0] above), and pmix_basename(NULL)
              * returns NULL, which the strcmp below would then dereference */
             tmp = pmix_basename(fcd->apps[n].cmd);
             t2 = pmix_basename(aptr->argv[0]);
+            if (PMIX_UNLIKELY(NULL == tmp || NULL == t2)) {
+                /* both inputs are non-NULL here, so a NULL back is an
+                 * allocation failure rather than the bozo case */
+                if (NULL != tmp) {
+                    free(tmp);
+                }
+                if (NULL != t2) {
+                    free(t2);
+                }
+                goto nomem;
+            }
             if (0 != strcmp(tmp, t2)) {
                 // assume that the user may have put the argv
                 // for their cmd in the argv array, but not
                 // started with the actual cmd - so add it
                 // to the front of the array
-                PMIx_Argv_prepend_nosize(&fcd->apps[n].argv, tmp);
+                rc = PMIx_Argv_prepend_nosize(&fcd->apps[n].argv, tmp);
+                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+                    free(tmp);
+                    free(t2);
+                    PMIX_RELEASE(fcd);
+                    return rc;
+                }
             }
             free(tmp);
             free(t2);
         }
 
-        // copy the env array
-        fcd->apps[n].env = PMIx_Argv_copy(aptr->env);
+        /* copy the env array - an app that names no environment is the
+         * ordinary case, and PMIx_Argv_copy answers NULL for that as well
+         * as for a failure, so only a non-NULL source can be told apart */
+        if (NULL != aptr->env) {
+            fcd->apps[n].env = PMIx_Argv_copy(aptr->env);
+            if (PMIX_UNLIKELY(NULL == fcd->apps[n].env)) {
+                goto nomem;
+            }
+        }
 
         // copy the #procs
         fcd->apps[n].maxprocs = aptr->maxprocs;
@@ -418,7 +465,16 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
                  * not leave the app claiming directives it does not have */
                 fcd->apps[n].ninfo = nappinfo;
                 for (m = 0; m < nappinfo; m++) {
-                    PMIX_INFO_XFER(&fcd->apps[n].info[m], &aptr->info[m]);
+                    /* PMIX_INFO_XFER discards the status by definition, so
+                     * a directive we could not copy used to be dropped in
+                     * silence - while the job-level ones a few lines above
+                     * fail the spawn through PMIx_Info_list_xfer. Both
+                     * halves of one message now report the same way */
+                    rc = PMIx_Info_xfer(&fcd->apps[n].info[m], &aptr->info[m]);
+                    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+                        PMIX_RELEASE(fcd);
+                        return rc;
+                    }
                 }
             }
         }
@@ -446,8 +502,14 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
                         return rc;
                     }
                     PMIX_LIST_FOREACH (kv, &ilist, pmix_kval_t) {
-                        PMIx_Setenv(kv->value->data.envar.envar, kv->value->data.envar.value, true,
-                                    &fcd->apps[n].env);
+                        rc = PMIx_Setenv(kv->value->data.envar.envar,
+                                         kv->value->data.envar.value, true,
+                                         &fcd->apps[n].env);
+                        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+                            PMIX_LIST_DESTRUCT(&ilist);
+                            PMIX_RELEASE(fcd);
+                            return rc;
+                        }
                     }
                     PMIX_LIST_DESTRUCT(&ilist);
                     break;
@@ -489,8 +551,14 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
         PMIX_LIST_FOREACH (kv, &ilist, pmix_kval_t) {
             /* cycle across all the apps and set this envar */
             for (n = 0; n < fcd->napps; n++) {
-                PMIx_Setenv(kv->value->data.envar.envar, kv->value->data.envar.value, true,
-                            &fcd->apps[n].env);
+                rc = PMIx_Setenv(kv->value->data.envar.envar,
+                                 kv->value->data.envar.value, true,
+                                 &fcd->apps[n].env);
+                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+                    PMIX_LIST_DESTRUCT(&ilist);
+                    PMIX_RELEASE(fcd);
+                    return rc;
+                }
             }
         }
         PMIX_LIST_DESTRUCT(&ilist);
@@ -570,6 +638,10 @@ envars_done:
     }
 
     msg = PMIX_NEW(pmix_buffer_t);
+    if (PMIX_UNLIKELY(NULL == msg)) {
+        PMIX_RELEASE(fcd);
+        return PMIX_ERR_NOMEM;
+    }
     /* pack the cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
@@ -628,6 +700,16 @@ envars_done:
     }
 
     return rc;
+
+    /* Shared exit for the copy loop above. Releasing the caddy is all that
+     * is required however far the loop got: fcd->copied was set at
+     * construction, so scaddes frees the apps array, and PMIX_APP_CREATE
+     * constructed every element - so an app we never reached is an empty
+     * one rather than garbage, and a half-filled one frees the members it
+     * did get. */
+nomem:
+    PMIX_RELEASE(fcd);
+    return PMIX_ERR_NOMEM;
 }
 
 /* callback for wait completion */

--- a/src/event/AGENTS.md
+++ b/src/event/AGENTS.md
@@ -386,6 +386,35 @@ Do not confuse them:
   ack destructs it. When adding an early return, recount who holds
   what on that path — most historical bugs here are a missed release or
   a missed completion callback on an error branch.
+
+  **`_notify_client_event` has exactly two references on its
+  `pmix_notify_caddy_t`, and `holdcd` and `cached` are what keep them
+  straight.** Write the two down before touching either flag, because
+  the variable used to carry both meanings and every bug in this
+  function has come from that:
+
+  - The **working** reference is the one `PMIX_NEW` made in
+    `pmix_server_notify_client_of_event` and thread-shifted in. This
+    routine owns it and gives it back at the foot — unless `holdcd` says
+    the host up-call accepted, in which case `local_cbfunc` gives it back
+    when the host calls. `holdcd` starts out holding the *caching*
+    decision and is reset to false before it takes on that second
+    meaning; the `PMIX_RANGE_RM` arm has to reset it too, since it jumps
+    over the reset, and not doing so leaked this reference and dropped
+    the caller's completion for every cached RM event. Covered by
+    `test_range_rm_completion` in `test/unit/event_chain.c`.
+  - The **hotel's** reference is the `PMIX_RETAIN` taken beside the
+    checkin. It comes back from exactly one of three places: the
+    eviction callback (`_notification_eviction_cbfunc`,
+    `src/runtime/pmix_init.c`), the replay checkout in
+    `check_cached_events`, or the "last custom target notified" checkout
+    in this routine. `cached` — not `holdcd` — is what says the hotel
+    holds it; the checkout arm here tested `holdcd` and was therefore
+    provably dead.
+
+  Both of those were fixed in July 2026 and both were still recorded as
+  open in `docs/todo.rst` a month later. Re-verify a leak claim against
+  the code before acting on it.
 - Every path that accepts user info arrays must keep the
   targets/affected distinction intact and must preserve the reserved
   two info slots (see the chain invariants above).

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -1174,6 +1174,23 @@ static void _notify_client_event(int sd, short args, void *cbdata)
         rc = pmix_notify_event_cache(cd);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            /* The hotel did not take it, so give back the reference we
+             * took on its behalf and stop calling it cached: the "last
+             * target notified" arm below would otherwise release a
+             * reference the hotel never held, and the chain would decline
+             * to re-cache an event that is not in the cache. This does not
+             * free cd - the working reference this routine runs on is
+             * still held, and PMIX_RELEASE clears the pointer only when it
+             * drops the last one.
+             *
+             * Nothing reaches here today: the cache fails only for a hotel
+             * with no rooms, and pmix_hotel_init refuses that, so a
+             * max_events of zero fails PMIx_Init rather than running. The
+             * two sibling cache sites - in pmix_notify_server_of_event and
+             * in the tool's _notify_complete - both release on this arm,
+             * and this is the one that had also taken a reference. */
+            PMIX_RELEASE(cd);
+            cached = false;
         }
     }
 
@@ -1181,7 +1198,10 @@ static void _notify_client_event(int sd, short args, void *cbdata)
      * against our registrations */
     chain = PMIX_NEW(pmix_event_chain_t);
     chain->status = cd->status;
-    if (holdcd) {
+    if (cached) {
+        /* "cached", not "holdcd" - the two agree here only when the
+         * checkin above succeeded, and this asks whether the event is in
+         * the cache, not whether we are holding a reference for anyone */
         chain->cached = true;
     }
     PMIX_LOAD_PROCID(&chain->source, cd->source.nspace, cd->source.rank);

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -925,6 +925,25 @@ callback with a status before discarding the tracker: those requesters are
 same reference-counting trap as the one below - the difference is only
 whether the waiters deserve to be told.
 
+**And that includes finalize, where a `PMIX_LIST_DESTRUCT` of
+`local_reqs` does nothing at all.** Destructing the list drops only each
+tracker's *creation* reference, and every request parked on it holds one
+of its own - so the tracker, its info array, each request, the server
+caddy each request carries and the peer that caddy retains all survive,
+now unreachable. Both roles that own the list (`PMIx_server_finalize` and
+`PMIx_tool_finalize`) therefore drain it with
+`pmix_server_fail_local_reqs` first, above the point where the peers are
+released. `PMIx_Progress_thread_stop` has already run by then, so
+`pmix_server_get_cbfunc` takes its `progress_thread_stopped` arm and
+simply releases the caddy rather than trying to reply to a client on a
+listener that is down. This is why `dmrqdes` does not release
+`req->cbdata` itself and carries a comment saying so: the single
+reference on that caddy travels with the request only until the request
+is answered, and the two paths that discard one unanswered
+(`discard_local_tracker`, which leaves it to the switchyard, and
+`pmix_server_fail_local_reqs`) own it explicitly. Covered by the last
+case in `test/unit/server_get.c`.
+
 **`remote_pnd` is the same trap pointing the other way.** It holds the
 *host's* `PMIx_server_dmodex_request` calls (`pmix_server_dmodex.c`),
 parked when the local client they name has not committed its data yet -

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1044,6 +1044,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     int i;
     pmix_peer_t *peer;
     pmix_namespace_t *ns;
+    pmix_dmdx_local_t *dlcd, *dnxt;
 
     if (!pmix_atomic_check_bool(&pmix_globals.initialized)) {
         return PMIX_ERR_INIT;
@@ -1091,6 +1092,18 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     PMIX_DESTRUCT(&pmix_client_globals.iof_stderr);
 
     pmix_ptl_base_stop_listening();
+
+    /* Retire every direct-modex tracker still parked on local_reqs before
+     * we start letting go of peers. A bare PMIX_LIST_DESTRUCT of that list
+     * cannot do it: each request parked on a tracker holds a reference of
+     * its own, so destructing the list drops only the creation reference
+     * and leaves the tracker - and the server caddy each request holds,
+     * and the peer that caddy retains - alive and unreachable. Draining
+     * with a status hands each caddy back through the requester's
+     * callback, which is where the single reference on it lives */
+    PMIX_LIST_FOREACH_SAFE (dlcd, dnxt, &pmix_server_globals.local_reqs, pmix_dmdx_local_t) {
+        pmix_server_fail_local_reqs(dlcd, PMIX_ERR_UNREACH);
+    }
 
     for (i = 0; i < pmix_server_globals.clients.size; i++) {
         peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, i);

--- a/src/server/pmix_server_classes.c
+++ b/src/server/pmix_server_classes.c
@@ -255,6 +255,16 @@ static void dmrqcon(pmix_dmdx_request_t *p)
     p->lcd = NULL;
     p->key = NULL;
 }
+/* Note what this does NOT free: cbdata, which is the switchyard's
+ * pmix_server_caddy_t. The single reference on that caddy travels with
+ * the request only until the request is answered - invoking cbfunc hands
+ * it to the reply path, which releases it - so releasing it here would be
+ * a double free on every ordinary completion. The two paths that discard
+ * a request without answering it own that caddy explicitly instead:
+ * discard_local_tracker leaves it to the switchyard, which is about to
+ * fail the very call that created it, and pmix_server_fail_local_reqs
+ * calls cbfunc with a status. Anything that tears down a tracker list
+ * must go through one of those two - see PMIx_server_finalize. */
 static void dmrqdes(pmix_dmdx_request_t *p)
 {
     if (p->event_active) {

--- a/src/tool/AGENTS.md
+++ b/src/tool/AGENTS.md
@@ -148,6 +148,11 @@ Three subtleties the current code documents inline and you must keep:
   pointer would silently ignore a changed `PMIX_SERVER_TMPDIR` on the
   next cycle. The many `PMIX_LIST_DESTRUCT`s exist for the same
   re-init-cleanliness reason (a tool may init→finalize→init).
+- `pmix_server_globals.local_reqs` is drained with
+  `pmix_server_fail_local_reqs` before the peers go, because a
+  `PMIX_LIST_DESTRUCT` of that list frees nothing — each parked request
+  holds a reference on its tracker. See the matching note in
+  [`src/server/AGENTS.md`](../server/AGENTS.md).
 - The keepalive-pipe teardown is guarded by a file-scope `keepalive_fd`
   rather than re-derived, because `PMIX_KEEPALIVE_PIPE` was a directive
   to *init* and finalize cannot see it. The stdin read event and its

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1650,6 +1650,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     int n, i;
     pmix_peer_t *peer;
     pmix_pfexec_child_t *child, *nxt;
+    pmix_dmdx_local_t *dlcd, *dnxt;
     pmix_lock_t lock;
     bool myserver_is_mypeer;
 
@@ -1788,6 +1789,13 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     PMIX_DESTRUCT(&pmix_client_globals.peers);
 
     pmix_ptl_base_stop_listening();
+
+    /* drain any parked direct-modex tracker before the peers go - see the
+     * matching comment in PMIx_server_finalize for why the list destruct
+     * below cannot free these */
+    PMIX_LIST_FOREACH_SAFE (dlcd, dnxt, &pmix_server_globals.local_reqs, pmix_dmdx_local_t) {
+        pmix_server_fail_local_reqs(dlcd, PMIX_ERR_UNREACH);
+    }
 
     for (n = 0; n < pmix_server_globals.clients.size; n++) {
         peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, n);

--- a/test/unit/server_get.c
+++ b/test/unit/server_get.c
@@ -61,8 +61,11 @@
  *   WILDCARD rank                  -> job-level data handed to the callback
  *   WILDCARD, missing reserved key -> PMIX_ERR_NOT_FOUND, callback untouched
  *   WILDCARD, missing plain key    -> unchanged: success, empty payload
+ *   local rank not yet connected   -> parked, and answered PMIX_ERR_UNREACH
+ *                                     by PMIx_server_finalize
  *
- * Every case additionally asserts that the request left local_reqs empty,
+ * Every case but the last additionally asserts that the request left
+ * local_reqs empty,
  * because a server that parks a request it can never answer hangs the
  * calling client rather than failing it.
  *
@@ -469,7 +472,30 @@ int main(int argc, char **argv)
     report("wildcard get of a missing non-reserved key parks nothing",
            nothing_parked());
 
+    /* --- a request still parked when the server finalizes ----------- */
+    /* Same target as the IMMEDIATE case above, but willing to wait: rank 0
+     * is registered and has not connected, so the request is parked on
+     * local_reqs to await its commit. No PMIX_TIMEOUT is given and this
+     * arm passes a zero timeval, so nothing is armed that could answer the
+     * request behind our back - it is still sitting there when finalize
+     * runs. This has to be the last case, since everything above asserts
+     * that local_reqs is empty. */
+    rc = do_get(GETUT_NSPACE, 0, "some.local.key", NULL, 0);
+    report("unconnected local rank defers the request", PMIX_SUCCESS == rc);
+    report("deferred request parks a tracker", !nothing_parked());
+    report("deferred request is not answered while it waits", !cb_fired);
+
     PMIx_server_finalize();
+
+    /* Finalize owes that requester an answer, and owes itself the caddy
+     * back. A bare list destruct gives neither: every request parked on a
+     * tracker holds a reference on it, so destructing local_reqs drops
+     * only the creation reference and leaves the tracker, the request, the
+     * server caddy it holds and the peer that caddy retains alive and
+     * unreachable. The callback firing is the visible half; the leak is
+     * the half you need valgrind to see. */
+    report("finalize answers a parked requester",
+           cb_fired && PMIX_ERR_UNREACH == cb_status);
 
     fprintf(stdout, "server_get: %d passed, %d failed\n", npass, nfail);
     return (0 == nfail) ? 0 : 1;

--- a/test/unit/spawn_api.c
+++ b/test/unit/spawn_api.c
@@ -35,6 +35,21 @@
  *      lives in a local. Note the sentinel has to sit past index 0 for
  *      this to be visible: a sentinel at index 0 counts zero, and writing
  *      zero over a zero proves nothing.
+ *
+ *   an app directive that cannot be copied
+ *      The apps copy transferred each directive with PMIX_INFO_XFER,
+ *      which discards its status by definition, so a directive the copy
+ *      could not carry was dropped in silence - while the job-level ones
+ *      have always failed the spawn, through PMIx_Info_list_xfer. Both
+ *      halves of one message now report the same way.
+ *
+ *   the argv / cmd / env shapes
+ *      These reach the strdup, PMIx_Argv_copy, pmix_basename and
+ *      PMIx_Argv_prepend_nosize results in the copy loop, all of which are
+ *      now checked for failure. Nothing here can *make* an allocation
+ *      fail, so these do not test the hardening directly; they hold the
+ *      ordinary paths down so a screen written the wrong way round cannot
+ *      turn a working spawn into an error.
  */
 
 #include "src/include/pmix_config.h"
@@ -148,6 +163,77 @@ int main(int argc, char **argv)
     app.ninfo = 0;
     PMIX_APP_DESTRUCT(&app);
     PMIX_INFO_FREE(appinfo, 2);
+
+    /* --- an app directive the copy cannot carry ---------------------- */
+    /* The apps copy used to transfer each app directive with
+     * PMIX_INFO_XFER, which discards its status by definition, so a
+     * directive that could not be copied was dropped in silence and the
+     * spawn went up carrying an empty slot where the caller had put
+     * something. The job-level directives a few lines above have always
+     * failed the spawn in that case, through PMIx_Info_list_xfer. This
+     * case holds the two halves of one message to the same answer.
+     *
+     * The library prints "PMIX-XFER-VALUE: UNSUPPORTED TYPE" on the way
+     * through, which is it declining rather than faulting - the same
+     * bargain test/unit/bfrops_null_object.c makes. */
+    PMIX_INFO_CREATE(appinfo, 1);
+    if (NULL == appinfo) {
+        fprintf(stderr, "test setup error: out of memory\n");
+        PMIx_server_finalize();
+        return 1;
+    }
+    PMIX_LOAD_KEY(appinfo[0].key, PMIX_PERSONALITY);
+    appinfo[0].value.type = (pmix_data_type_t) (PMIX_DATA_TYPE_MAX + 1);
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup("true");
+    app.maxprocs = 1;
+    app.info = appinfo;
+    app.ninfo = 1;
+    rc = PMIx_Spawn(NULL, 0, &app, 1, nspace);
+    report("an app directive that cannot be copied fails the spawn",
+           PMIX_ERR_NOT_SUPPORTED != rc && PMIX_SUCCESS != rc);
+    app.info = NULL;
+    app.ninfo = 0;
+    PMIX_APP_DESTRUCT(&app);
+    PMIX_INFO_FREE(appinfo, 1);
+
+    /* --- the argv/cmd/env paths through the copy loop ---------------- */
+    /* These three shapes are what the copy loop's strdup, PMIx_Argv_copy,
+     * pmix_basename and PMIx_Argv_prepend_nosize results are reached
+     * through, and every one of those is now checked. Nothing here can
+     * make an allocation fail - that is why the hardening has no direct
+     * regression test - but a screen written the wrong way round turns a
+     * working spawn into an error, and these catch that. */
+    PMIX_APP_CONSTRUCT(&app);
+    PMIx_Argv_append_nosize(&app.argv, "true");
+    app.maxprocs = 1;
+    rc = PMIx_Spawn(NULL, 0, &app, 1, nspace);
+    report("an app with argv and no cmd reaches the host up-call",
+           PMIX_ERR_NOT_SUPPORTED == rc);
+    PMIX_APP_DESTRUCT(&app);
+
+    /* argv[0] naming something other than the cmd is what drives the
+     * prepend, whose status the loop now reads */
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup("true");
+    PMIx_Argv_append_nosize(&app.argv, "-x");
+    app.maxprocs = 1;
+    rc = PMIx_Spawn(NULL, 0, &app, 1, nspace);
+    report("an app whose argv does not start with the cmd reaches the host up-call",
+           PMIX_ERR_NOT_SUPPORTED == rc);
+    PMIX_APP_DESTRUCT(&app);
+
+    /* an env array is copied only when the caller supplied one, since
+     * PMIx_Argv_copy answers NULL both for a NULL source and for a
+     * failure - so the guard has to be on the source, not the result */
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup("true");
+    PMIx_Argv_append_nosize(&app.env, "PMIX_SPAWNUT_VAR=1");
+    app.maxprocs = 1;
+    rc = PMIx_Spawn(NULL, 0, &app, 1, nspace);
+    report("an app carrying an environment reaches the host up-call",
+           PMIX_ERR_NOT_SUPPORTED == rc);
+    PMIX_APP_DESTRUCT(&app);
 
     PMIx_server_finalize();
 


### PR DESCRIPTION
Three items from [`docs/todo.rst`](https://github.com/openpmix/openpmix/blob/master/docs/todo.rst), taken in order. They are unrelated in subject, so they are three commits — but they all touch that page, which is why they ride together rather than as three PRs.

One of the three turned out to have been fixed a month before the page recorded it as open. That is worth knowing about the page generally: its own note says to re-verify an entry before acting on it, and that is load-bearing.

---

### 1. Drain the parked direct-modex requests at finalize

The entry pointed at `dmrqdes` not releasing `req->cbdata`. That framing was wrong — releasing it there would be a double free on every ordinary completion, since invoking `cbfunc` hands the caddy to the reply path.

The real defect is one level up. Both finalize paths that own `pmix_server_globals.local_reqs` — `PMIx_server_finalize` and `PMIx_tool_finalize` — tore the list down with a bare `PMIX_LIST_DESTRUCT`, **which frees none of it**: every parked request holds a reference on its tracker, so the destruct drops only the creation reference. What survives, alive and unreachable, is the tracker, its info array, each request, the server caddy the request holds, and the peer that caddy retains.

This is the same reference-counting trap `discard_local_tracker` and `pmix_server_fail_local_reqs` exist to avoid; finalize was simply the site nobody had applied them to. Both paths now drain with `pmix_server_fail_local_reqs`, above the point where the peers are released. It is safe that late because `PMIx_Progress_thread_stop` has already run, so `pmix_server_get_cbfunc` takes its `progress_thread_stopped` arm and releases the caddy rather than trying to queue a reply on a listener that is down.

`dmrqdes` is unchanged and now carries a comment saying why it does not release `cbdata`, naming the two paths that discard a request unanswered.

### 2. Let a failed allocation fail the spawn rather than the job

`PMIx_Spawn_nb` deep-copies the caller's apps array because it modifies the app structs, and almost nothing in that copy checked whether the copy had happened. A failed `strdup` left an app with no `cmd` or no `cwd`; a failed `PMIx_Argv_copy` left it with no `argv`, which the basename comparison two lines down then dereferenced; a failed prepend dropped the cmd out of the front of `argv`. The spawn went up anyway — so the outcome was a job that was not the one asked for, or a segfault in the library.

An earlier sweep closed the three `_CREATE` macros in the same loop and stopped, on the grounds that hardening this function end to end is one piece of work and half of it is worse than none. This is that piece of work: the two `PMIX_NEW`s the function hangs off, `PMIx_Info_list_start`, both `strdup`s per app, both `pmix_basename` results, both `PMIx_Argv_copy` results, `PMIx_Argv_prepend_nosize`, and `PMIx_Setenv` in each of the two envar harvests. Nothing changes on a path where nothing fails.

Two needed care rather than a NULL test. `PMIx_Argv_copy` answers NULL for a NULL source as readily as for a failure, so the two are told apart by the *source*: the argv copy sits on a branch where the caller's argv is known non-NULL, while the env copy does not, and an app that names no environment is the ordinary case. `pmix_basename` is the same shape, and both of its call sites pass something already known non-NULL.

**One behavior change came with it**, and it is a consistency fix rather than hardening: the per-app directive copy used `PMIX_INFO_XFER`, which discards its status by definition, so a directive the copy could not carry was dropped in silence — while the job-level directives twenty lines above have always failed the spawn in that case, through `PMIx_Info_list_xfer`. Both halves of one message now report the same way. `PMIX_UNDEF` transfers successfully, so a flag-only directive is unaffected.

### 3. Retire the notification-caddy leak the code already fixed

The entry said a cached notify caddy leaks its working reference on the cache-aging path, and that closing it needs "cached" and "posted upstairs" told apart because both set `holdcd`. Both halves landed in July; the page was written in August from a note that predated them.

- 843097a0 added the `cached` flag — exactly the disambiguation the entry asks for — and fixed what that conflation had broken: an eviction arm testing `holdcd` after `holdcd` had been reset, so the "last custom target notified" checkout was provably dead.
- 1c51fe55 fixed the leak itself the next day. The `PMIX_RANGE_RM` arm jumps straight to the local chain, *over* the reset, so `holdcd` still carried the caching decision when the foot of the routine tested it — and a cached RM event therefore never released the working reference and never completed its caller.

So the entry is retired rather than fixed. What the audit did turn up is one place the accounting is still written wrongly, on an arm nothing reaches: a failed `pmix_notify_event_cache` leaves the `PMIX_RETAIN` taken for the hotel unbalanced, and leaves `cached` claiming a hotel that declined the check-in. Nothing reaches it because the cache fails only for a hotel with no rooms, and `pmix_hotel_init` refuses that — a `max_events` of zero fails `PMIx_Init` rather than running with an unusable cache. The two sibling cache sites already release on this arm and this is the one that also holds a reference, so it now does both and says why it cannot fire.

---

### Testing

Two of the three carry a regression case that was **observed failing against the unfixed library** before the fix went in:

- `test/unit/server_get.c` — a get for a registered local rank that has not connected is parked (an arm that arms no timer, so nothing can answer it behind the test's back), and `PMIx_server_finalize` must hand that requester `PMIX_ERR_UNREACH`. Against the unfixed library the callback never fires. The leak itself needs valgrind to see.
- `test/unit/spawn_api.c` — an app directive that cannot be copied must fail the spawn. Three further cases hold the ordinary argv/cmd/env shapes down: nothing in `make check` can *make* an allocation fail, so what they catch is a screen written the wrong way round turning a working spawn into an error, which is the real risk in a change of this shape.

The third needed no new test — `test_range_rm_completion` in `test/unit/event_chain.c` already covers it, and was confirmed to have teeth by taking the `holdcd` reset back out (95/1 without it, 96/0 with).

Verified: clean build under `--enable-devel-check`; `make check` 21/21 in `test/`; `run_simptest.sh` clean; docs clean under `-W`.

### Documentation

`docs/todo.rst` loses all three entries. The reasoning behind each is recorded where it belongs — `src/server/AGENTS.md` (why a list destruct of `local_reqs` frees nothing), `src/tool/AGENTS.md`, `src/client/AGENTS.md` (a twelfth sweep entry for the spawn work), and `src/event/AGENTS.md` (the full reference accounting for the notify caddy: which two references exist, who gives each back, and which flag answers which question — re-deriving that from the code is what produced a month of believing item 3 was open).
