### PR TITLE
Three more from the deferred-work list, and one contract nobody had written down

### DIFF
--- a/docs/man/man5/pmix_server_module_t.5.rst
+++ b/docs/man/man5/pmix_server_module_t.5.rst
@@ -212,6 +212,17 @@ aggregated result through a ``pmix_modex_cbfunc_t``. A NULL ``data`` means the
 local processes had nothing to contribute. Directives in the ``info`` array
 steer the collective and are optional unless the mandatory flag is set.
 
+**Ownership of the** ``data`` **blob transfers to the host on this call**, and
+the host must ``free()`` it once it is done with it. This direction carries no
+release function with which the library could reclaim the blob, and it cannot
+free it when the call returns: the host is entitled to park the pointer and
+read it later from another thread, so freeing it here would be a use-after-free.
+Note that :ref:`PMIx_Data_embed(3) <man3-PMIx_Data_embed>` *copies* rather than
+consumes, so a host that embeds the blob into a message of its own still owns
+the original and must still free it. ``fence_nb`` is the only module function
+that hands the host a bare data blob this way; the other collectives carry
+their payloads in ``pmix_info_t`` arrays, which the library owns.
+
 The ``info`` array may include ``PMIX_LOCAL_COLLECTIVE_STATUS``
 (pmix_status_t), by which the PMIx server library reports to the host the status
 of the local portion of the collective |mdash| for example, an error detected

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -28,14 +28,15 @@ so that they are not repeatedly "rediscovered" and re-fixed.
           code moves.
 
 .. note:: **Every entry below was checked against the tree on
-          2026-08-11**, and that pass removed two: one whose fix had
-          landed a month before this page first recorded it as open, and
-          one that had been fixed since.  It also corrected a claim that
-          was never true.  Treat that as the standing expectation rather
-          than a one-off — an entry here is a lead, not a finding, and
-          the two entries that cannot be checked by reading the tree
-          (the group-leave leaks, and the two "never validated" coverage
-          gaps) are the ones most likely to have gone stale unnoticed.
+          2026-08-11.**  That pass retired three of them — one whose fix
+          had landed a month before this page first recorded it as open,
+          one that had been fixed since, and one that a fresh valgrind
+          run against a launcher could no longer reproduce — and
+          corrected a claim that was never true.  Treat that as the
+          standing expectation rather than a one-off: an entry here is a
+          lead, not a finding.  The two "never validated" coverage gaps
+          are the only remaining entries that cannot be checked by
+          reading the tree, so they are where the next stale one will be.
 
 Open decisions
 --------------
@@ -65,6 +66,31 @@ design and is the reason that component exists.  Any real fix has to
 answer the ``shmem3`` case first; the messaging half is not worth building
 on its own.
 
+Two concurrent spawns cannot be formatted differently
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``pmix_globals.spawn_iof_flags`` is a single process-wide slot holding
+the output-formatting directives of the spawn a tool has in flight.  It
+exists because forwarded output can arrive *before* the spawn reply names
+the namespace it belongs to, and until it existed that output was
+formatted with the process-wide defaults instead — so ``prun --output
+tag`` lost the tag on whichever rank happened to be quickest.  Two spawns
+in flight at once from one process means the second overwrites the
+first's flags.
+
+This cannot simply "become per-request", which is how it was recorded
+before.  The reader is ``spawn_or_global_flags()`` in
+``src/common/pmix_iof.c``, reached from ``pmix_iof_write_output()``
+precisely when the arriving output names a namespace we have no record
+of; the only things in scope there are that unknown namespace and the
+stream.  Nothing identifies *which* in-flight spawn the output came
+from, and nothing can until the reply arrives — which is the very thing
+the stand-in exists to cover for.  So the choices are: keep one slot and
+accept that concurrent spawns share it; let the reply establish the
+flags, which re-opens the window the stand-in was built to close; or
+carry something in the IOF message that names the spawn, which is a
+wire-format and Standard question rather than a bug fix.
+
 Deferred work
 -------------
 
@@ -82,25 +108,6 @@ removing the handler means open-coding the thread-shift the entry point
 performs.  Weigh that against the reachability — the process must ignore
 a failed ``PMIx_Init``, keep running, and then be sent a
 ``PMIX_DEBUGGER_RELEASE`` it never asked for.
-
-Two shared-state exposures that need a structural answer
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* The ``spawn_iof_flags`` stand-in is a single process-wide slot,
-  written from the caller's thread and read on the progress thread.  It
-  is safe for the case it was built for, but two spawns in flight at
-  once from one process means the second overwrites the first's flags.
-  A tool that needs concurrent spawns formatted differently forces the
-  stand-in to become per-request.
-* ``PMIx_Spawn_nb`` in a server role walks
-  ``pmix_server_globals.clients`` unlocked — through the ``static
-  inline`` ``pmix_get_peer_object()`` in ``pmix_server_ops.h`` — on
-  whatever thread the host called it on, while the progress thread adds
-  and removes clients.  The cure is to thread-shift the whole entry
-  point.  Note this is the *only* exposed caller: the other one, in
-  ``pmix_monitor.c``, sits inside ``pmix_monitor_processing()``, which is
-  reached by ``PMIX_THREADSHIFT`` and therefore already runs on the
-  progress thread.
 
 Smaller items carried forward
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -83,16 +83,6 @@ performs.  Weigh that against the reachability — the process must ignore
 a failed ``PMIx_Init``, keep running, and then be sent a
 ``PMIX_DEBUGGER_RELEASE`` it never asked for.
 
-Residual leaks on the group-leave path
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Valgrind runs against a server library embedded in a launcher show small
-*indirect* libpmix leaks rooted in the departed client's peer and block
-cleanup — ``_register_client``, ``harvest_envars``,
-``ptl_base_connection_handler``, and the tracker's children.  They are
-entangled with a leak in the host's own group code, which is what makes
-attributing and fixing them delicate.  Left for separate, careful work.
-
 Two shared-state exposures that need a structural answer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -183,6 +173,20 @@ Not defects — by design
 
 These look like bugs and are not.  They are recorded so that they are
 not "fixed" by a later reader.
+
+* **The fence modex bucket reported as a libpmix leak belongs to the
+  host.**  ``pmix_server_fence`` unloads the assembled bucket with
+  ``PMIX_UNLOAD_BUFFER`` and hands the bare pointer to
+  ``pmix_host_server.fence_nb``; ownership transfers on the call, and the
+  request direction carries no ``(release_fn, release_cbdata)`` pair the
+  way the reply direction does.  We cannot free it on return — the host
+  parks it and reads it from another thread — so a host that does not
+  free it leaks about 128 bytes per collecting fence.  In a valgrind run
+  against a launcher this looks exactly like a libpmix leak and nothing
+  else does: the allocation is ``pmix_server_collect_data``, the stack
+  bottoms out in ``progress_engine``, and there is no ``prte_`` frame
+  anywhere in it.  Both in-tree hosts (PRRTE and ``test/simple/simptest``)
+  currently leak it.  See ``src/server/AGENTS.md``.
 
 * **``pmix_srand()`` copies the seeded state into a file-static buffer**
   (``src/util/pmix_alfg.c``).  It looks like a footgun, but it is the

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -121,6 +121,15 @@ typedef pmix_status_t (*pmix_server_abort_fn_t)(const pmix_proc_t *proc, void *s
  * cbfunc. A _NULL_ data value indicates that the local procs had
  * no data to contribute.
  *
+ * OWNERSHIP OF THE DATA BLOB TRANSFERS TO THE HOST ON THIS CALL, and
+ * the host is responsible for freeing it. Unlike the reply direction,
+ * this call carries no release function with which the library could
+ * reclaim it: the host is free to park the pointer and read it later
+ * from another thread, so the library cannot free it when this call
+ * returns. Free it with free() once you no longer need it - note that
+ * PMIx_Data_embed() copies rather than consumes, so a host that embeds
+ * the blob in a message of its own still owns the original.
+ *
  * The array of info structs is used to pass user-requested options to the server.
  * This can include directives as to the algorithm to be used to execute the
  * fence operation. The directives are optional _unless_ the _mandatory_ flag

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1781,18 +1781,35 @@ other.
   request goes out, so the send path's peer lock publishes it. What it does
   **not** survive is two spawns in flight at once from one process — the
   second overwrites the first's flags. That is inherent to a single
-  process-wide slot, not a bug in this file; if a tool ever needs
-  concurrent spawns formatted differently, the stand-in has to become a
-  per-request one.
-- **The server branch reads `pmix_server_globals.clients` from the
+  process-wide slot, not a bug in this file, and **it cannot be closed by
+  making the slot per-request**, which is how this entry used to end.
+  `spawn_or_global_flags()` is reached exactly when the arriving output
+  names a namespace we have no record of, and the only things in scope
+  there are that unknown namespace and the stream — nothing says which
+  in-flight spawn the output came from, and nothing can until the reply
+  arrives, which is the very thing the stand-in covers for. See
+  `docs/todo.rst`, where it is now recorded as an open decision rather
+  than as work waiting to be done.
+- **FIXED — the server branch read `pmix_server_globals.clients` from the
   caller's thread.** `pmix_get_peer_object()` walks that pointer array
   unlocked to resolve a `PMIX_PARENT_ID`, and `PMIx_Spawn_nb` in a server
   role runs on whatever thread the host called it on, while the progress
-  thread adds and removes clients. Recorded rather than fixed because the
-  cure is to thread-shift the whole entry point — the sibling call in
-  `pmix_monitor.c` has exactly the same exposure — and because a host
-  spawning on behalf of a client it is concurrently losing is not a state
-  anything demonstrates.
+  thread adds and removes clients. Everything below the "can this host
+  spawn at all?" screen now runs in `_spawn_for_host` on the progress
+  thread, which is where the rest of the tree assumes that array is only
+  ever touched. **Know what the fix costs**: the parent-not-found and
+  host-refused failures are now reported through the caller's callback
+  rather than as the return of `PMIx_Spawn_nb`. That is what a
+  non-blocking form promises anyway, and `PMIx_Spawn` is unchanged
+  because its wrapper reads the status the callback delivers — but a
+  host driving the `_nb` form and checking only the return will no longer
+  see those two. Covered by `test/unit/spawn_api.c`.
+
+  Note this was the *only* exposed caller. The sibling in
+  `pmix_monitor.c`, which this entry used to name as having "exactly the
+  same exposure", does not: it sits inside `pmix_monitor_processing()`,
+  which is reached by `PMIX_THREADSHIFT` and so already runs on the
+  progress thread.
 - **`req->flags = cd->flags` in `pmix_server_process_iof()` aliases the
   caddy's `file`/`directory` strings**, which `scaddes` frees when
   `_lclcbfunc` releases the caddy — so the IOF request is left holding two

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -193,6 +193,83 @@ static void localcbfunc(pmix_status_t status,
     PMIX_THREADSHIFT(fcd, _lclcbfunc);
 }
 
+/* The server-role tail of PMIx_Spawn_nb, run on the progress thread.
+ *
+ * A host may call PMIx_Spawn_nb from whatever thread it likes, and
+ * resolving a PMIX_PARENT_ID means walking pmix_server_globals.clients -
+ * which the progress thread adds to and removes from, and which nothing
+ * in the tree locks, because everything else that touches it is already
+ * on that thread. Running the walk on the caller's thread was the one
+ * place that assumption was broken. The up-call below has to come with
+ * it: it needs the peer the walk found.
+ *
+ * The cost is that the two failures here are reported through the
+ * caller's callback rather than as the return of PMIx_Spawn_nb. That is
+ * what a non-blocking form promises anyway, and it does not change
+ * PMIx_Spawn - the blocking wrapper reads the status the callback
+ * delivers, so a host using that form sees exactly what it saw before.
+ */
+static void _spawn_for_host(int sd, short args, void *cbdata)
+{
+    pmix_setup_caddy_t *fcd = (pmix_setup_caddy_t *) cbdata;
+    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(fcd);
+
+    /* if I am spawning on behalf of someone else, then that peer is the
+     * "spawner" - PMIX_RANK_INVALID is how the entry point says nobody
+     * was named, since the caddy constructor zeroes proc and rank zero
+     * is a rank a parent can really have */
+    if (PMIX_RANK_INVALID != fcd->proc.rank) {
+        fcd->peer = pmix_get_peer_object(&fcd->proc);
+        if (PMIX_UNLIKELY(NULL == fcd->peer)) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+            fcd->status = PMIX_ERR_NOT_FOUND;
+            _lclcbfunc(0, 0, fcd);
+            return;
+        }
+    } else {
+        fcd->peer = pmix_globals.mypeer;
+    }
+    PMIX_RETAIN(fcd->peer);
+
+    /* run a quick check of the directives to see if any IOF
+     * requests were included so we can set that up now - helps
+     * to catch any early output - and a request for notification
+     * of job termination so we can setup the event registration */
+    pmix_server_spawn_parser(fcd->peer, &fcd->channels, &fcd->flags,
+                             fcd->info, fcd->ninfo);
+    /* a no-op on this branch - the stash is for tools, and the entry
+     * point has already excluded them. Kept so the two dispatch paths
+     * read the same way, and so relaxing that condition does not
+     * silently drop the stash */
+    stash_spawn_iof_flags(&fcd->flags);
+
+    /* call the local host */
+    rc = pmix_host_server.spawn(&pmix_globals.myid,
+                                fcd->info, fcd->ninfo,
+                                fcd->apps, fcd->napps,
+                                localcbfunc, fcd);
+    /* PMIX_OPERATION_SUCCEEDED is not a usable answer here. This
+     * up-call's entire product is the namespace of the job that was
+     * started, and it comes back through the callback - which we
+     * always supply, so a host has no reason to withhold it. Taking
+     * the status at face value would hand our caller a success and
+     * an empty namespace, which it cannot act on and cannot detect */
+    if (PMIX_UNLIKELY(PMIX_OPERATION_SUCCEEDED == rc)) {
+        pmix_show_help("help-pmix-server.txt", "atomic-completion-unsupported",
+                       true, "PMIx_Spawn");
+        rc = PMIX_ERR_NOT_SUPPORTED;
+    }
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+        /* a host that completed the request inline must return SUCCESS,
+         * so reaching here means nothing has answered the caller yet */
+        fcd->status = rc;
+        _lclcbfunc(0, 0, fcd);
+    }
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t ninfo,
                                         const pmix_app_t apps[], size_t napps,
                                         pmix_spawn_cbfunc_t cbfunc, void *cbdata)
@@ -570,58 +647,26 @@ envars_done:
         !PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer) &&
         !PMIX_PEER_IS_TOOL(pmix_globals.mypeer)) {
 
+        /* screened here rather than in the handler because it costs
+         * nothing to read - the host module table is established at init
+         * and never changes - so a host that cannot spawn at all still
+         * learns so from the return value */
         if (PMIX_UNLIKELY(NULL == pmix_host_server.spawn)) {
             PMIX_RELEASE(fcd);
             return PMIX_ERR_NOT_SUPPORTED;
         }
 
-        /* if I am spawning on behalf of someone else, then
-         * that peer is the "spawner" */
+        /* Everything left on this branch reads state that belongs to the
+         * progress thread, so hand it over rather than doing it here -
+         * see _spawn_for_host. Carry the parent on the caddy, using a
+         * rank no parent can have to mean "none was named". */
         if (proxy) {
-            /* find the parent's peer object */
-            fcd->peer = pmix_get_peer_object(&parent);
-            if (PMIX_UNLIKELY(NULL == fcd->peer)) {
-                PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
-                PMIX_RELEASE(fcd);
-                return PMIX_ERR_NOT_FOUND;
-            }
+            PMIX_XFER_PROCID(&fcd->proc, &parent);
         } else {
-            fcd->peer = pmix_globals.mypeer;
+            PMIX_LOAD_PROCID(&fcd->proc, NULL, PMIX_RANK_INVALID);
         }
-        PMIX_RETAIN(fcd->peer);
-
-        /* run a quick check of the directives to see if any IOF
-         * requests were included so we can set that up now - helps
-         * to catch any early output - and a request for notification
-         * of job termination so we can setup the event registration */
-        pmix_server_spawn_parser(fcd->peer, &fcd->channels, &fcd->flags,
-                                 fcd->info, fcd->ninfo);
-        /* a no-op on this branch - the stash is for tools, and this branch
-         * has already excluded them. Kept so the two dispatch paths read
-         * the same way, and so relaxing the condition above does not
-         * silently drop the stash */
-        stash_spawn_iof_flags(&fcd->flags);
-
-        /* call the local host */
-        rc = pmix_host_server.spawn(&pmix_globals.myid,
-                                    fcd->info, fcd->ninfo,
-                                    fcd->apps, fcd->napps,
-                                    localcbfunc, fcd);
-        /* PMIX_OPERATION_SUCCEEDED is not a usable answer here. This
-         * up-call's entire product is the namespace of the job that was
-         * started, and it comes back through the callback - which we
-         * always supply, so a host has no reason to withhold it. Taking
-         * the status at face value would hand our caller a success and
-         * an empty namespace, which it cannot act on and cannot detect */
-        if (PMIX_UNLIKELY(PMIX_OPERATION_SUCCEEDED == rc)) {
-            pmix_show_help("help-pmix-server.txt", "atomic-completion-unsupported",
-                           true, "PMIx_Spawn");
-            rc = PMIX_ERR_NOT_SUPPORTED;
-        }
-        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-            PMIX_RELEASE(fcd);
-        }
-        return rc;
+        PMIX_THREADSHIFT(fcd, _spawn_for_host);
+        return PMIX_SUCCESS;
     }
 
     /* if we are not connected, then just fork/exec

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -814,18 +814,25 @@ big-endian one, which multiplies every timeout by 2^32. Convert through a
 `uint32_t` of its own and assign. The fence, connect and get handlers all
 do this now; `pmix_server_group` always did.
 
-**The modex blob handed *up* to the host belongs to the host, and nothing
-says so in the header.** `pmix_server_fence` unloads the assembled bucket
-into a bare `char *data` and passes it to `pmix_host_server.fence_nb`; so
-does `pmix_server_execute_collective`. Neither frees it, and that is not
-an oversight to "fix": the request direction carries no
+**The modex blob handed *up* to the host belongs to the host.**
+`pmix_server_fence` unloads the assembled bucket into a bare `char *data`
+and passes it to `pmix_host_server.fence_nb`; so does
+`pmix_server_execute_collective`. Neither frees it, and that is not an
+oversight to "fix": the request direction carries no
 `(release_fn, release_cbdata)` pair the way the reply direction does, and
-the in-tree reference host parks the pointer on a caddy and reads it later
-from another thread (`fencenb_fn` in `test/simple/simptest.c`), so freeing
-it on return would be a use-after-free. Ownership transfers on the call.
-`simptest` then leaks it — that is a defect in the test host, not in the
-library, and it is the reason a naive valgrind run of the simple suite
-shows a per-fence leak here.
+a host is entitled to park the pointer and read it later from another
+thread — `fencenb_fn` in `test/simple/simptest.c` does exactly that — so
+freeing it on return would be a use-after-free. Ownership transfers on
+the call, and `pmix_server_fencenb_fn_t` in `include/pmix_server.h` now
+says so, as does the
+[`pmix_server_module_t(5)`](../../docs/man/man5/pmix_server_module_t.5.rst)
+man page. It did not until August 2026, and both in-tree hosts leaked it:
+PRRTE still does ([prrte#2649](https://github.com/openpmix/prrte/issues/2649)),
+and `simptest` was the reason a naive valgrind run of the simple suite
+showed a per-fence leak here. `simptest` now hands it back through the
+release function the modex callback takes — which is the point worth
+carrying: `pmix_server_modex_cbfunc` only thread-shifts, so a host cannot
+free the blob when that callback returns either.
 
 **`pmix_cb_t::copy` is advisory and no fetch honors it.** Several sites
 here set `cb.copy = false` with a comment about letting the GDS return a

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -839,6 +839,18 @@ static pmix_status_t abort_fn(const pmix_proc_t *proc, void *server_object, int 
     return PMIX_SUCCESS;
 }
 
+/* Give the modex blob back once the library has finished with it. The
+ * blob is ours: ownership of the data handed to fence_nb transfers to
+ * the host on the call (see pmix_server_module_t), and the one modex_resp
+ * builds is our own malloc. It cannot simply be freed after the callback
+ * returns - pmix_server_modex_cbfunc only thread-shifts, and packs the
+ * reply from this pointer later on the progress thread - so it goes back
+ * through the release function the callback takes for exactly this. */
+static void fence_relfn(void *cbdata)
+{
+    free(cbdata);
+}
+
 static void fencbfn(int sd, short args, void *cbdata)
 {
     pmix_shift_caddy_t *scd = (pmix_shift_caddy_t *) cbdata;
@@ -846,7 +858,11 @@ static void fencbfn(int sd, short args, void *cbdata)
 
     /* pass the provided data back to each participating proc */
     if (NULL != scd->cbfunc.modexcbfunc) {
-        scd->cbfunc.modexcbfunc(scd->status, scd->data, scd->ndata, scd->cbdata, NULL, NULL);
+        scd->cbfunc.modexcbfunc(scd->status, scd->data, scd->ndata, scd->cbdata,
+                                fence_relfn, (void *) scd->data);
+    } else if (NULL != scd->data) {
+        /* nobody to hand it to, so it is still ours to free */
+        free((void *) scd->data);
     }
     PMIX_RELEASE(scd);
 }

--- a/test/unit/spawn_api.c
+++ b/test/unit/spawn_api.c
@@ -59,6 +59,7 @@
 
 #include "src/include/pmix_globals.h"
 #include "src/server/pmix_server_ops.h"
+#include "src/threads/pmix_threads.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -76,6 +77,31 @@ static void report(const char *name, int passed)
         fprintf(stdout, "  FAIL: %s\n", name);
         ++nfail;
     }
+}
+
+/* A host module entry point, so the server-role branch gets past its
+ * "can this host spawn at all?" screen and reaches the thread-shifted
+ * tail. It is never actually called by the cases below - each of them
+ * fails at the parent lookup, which happens first. */
+static bool host_spawn_called = false;
+static pmix_status_t stub_spawn(const pmix_proc_t *proc, const pmix_info_t job_info[], size_t ninfo,
+                                const pmix_app_t apps[], size_t napps,
+                                pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+{
+    (void) proc; (void) job_info; (void) ninfo; (void) apps; (void) napps;
+    (void) cbfunc; (void) cbdata;
+    host_spawn_called = true;
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+/* completion recorder for the non-blocking form */
+static pmix_lock_t spawnlock;
+static pmix_status_t spawn_status = PMIX_SUCCESS;
+static void spawn_done(pmix_status_t status, char nspace[], void *cbdata)
+{
+    (void) nspace; (void) cbdata;
+    spawn_status = status;
+    PMIX_WAKEUP_THREAD(&spawnlock);
 }
 
 int main(int argc, char **argv)
@@ -234,6 +260,54 @@ int main(int argc, char **argv)
     report("an app carrying an environment reaches the host up-call",
            PMIX_ERR_NOT_SUPPORTED == rc);
     PMIX_APP_DESTRUCT(&app);
+
+    /* --- the server-role tail runs on the progress thread ------------ */
+    /* Resolving a PMIX_PARENT_ID means walking pmix_server_globals.clients,
+     * which belongs to the progress thread, so that walk and the host
+     * up-call that depends on it were moved off the caller's thread. Two
+     * things follow, and both are asserted below: the request is now
+     * *accepted* rather than refused synchronously, and the failure comes
+     * back through the callback instead of the return.
+     *
+     * Give the module a spawn entry point first, or the branch stops at
+     * the "can this host spawn?" screen above the shift and none of this
+     * is reached. The parent named is deliberately not one of our clients
+     * - there are none - so the lookup fails, which is the one error this
+     * handler produces without involving the host at all. */
+    pmix_host_server.spawn = stub_spawn;
+    host_spawn_called = false;
+
+    PMIX_INFO_LOAD(&jobinfo[0], PMIX_PARENT_ID, &pmix_globals.myid, PMIX_PROC);
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup("true");
+    app.maxprocs = 1;
+
+    PMIX_CONSTRUCT_LOCK(&spawnlock);
+    spawn_status = PMIX_SUCCESS;
+    rc = PMIx_Spawn_nb(jobinfo, 1, &app, 1, spawn_done, NULL);
+    report("a spawn naming a parent is accepted rather than refused",
+           PMIX_SUCCESS == rc);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_WAIT_THREAD(&spawnlock);
+        report("an unresolvable parent is reported through the callback",
+               PMIX_ERR_NOT_FOUND == spawn_status);
+        report("the host was not asked to spawn for a parent we could not find",
+               !host_spawn_called);
+    }
+    PMIX_DESTRUCT_LOCK(&spawnlock);
+    PMIX_APP_DESTRUCT(&app);
+
+    /* and the blocking form still reports it as its own return, because
+     * its wrapper reads the status the callback delivered */
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup("true");
+    app.maxprocs = 1;
+    rc = PMIx_Spawn(jobinfo, 1, &app, 1, nspace);
+    report("the blocking form still returns the parent failure itself",
+           PMIX_ERR_NOT_FOUND == rc);
+    PMIX_APP_DESTRUCT(&app);
+    PMIX_INFO_DESTRUCT(&jobinfo[0]);
+    pmix_host_server.spawn = NULL;
 
     PMIx_server_finalize();
 


### PR DESCRIPTION
A follow-on to #4129, working the same `docs/todo.rst` list. Two entries retired, one fixed, and one contract written down that had never been stated anywhere.

The theme, if there is one: an entry on that page is a lead, not a finding. Both entries retired here were verified rather than assumed, and one of them was wrong.

---

### 1. The group-leave leak entry was stale

This was the one entry left that could not be checked by reading the tree — it came from valgrind against a PMIx server embedded in a launcher — which made it the one most likely to have gone stale unnoticed. It had.

Re-ran it against current master: libpmix built from this tree and installed into the dockerswarm volume, valgrind wrapping `prterun` itself with `--trace-children=no` so only the launcher's embedded server is measured, in three shapes — one node with two ranks, two nodes with four, four nodes with eight. The four sites the entry named (`_register_client`, `harvest_envars`, `ptl_base_connection_handler`, and the tracker's children) appear **zero times** in any of the three logs.

The likely reason is that the entry was written immediately before the fix that closed it: its own note recorded the block/tracker refcount cycle as deferred, and that cycle was broken shortly after by making a tracker's back-pointer to its block non-owning. "The tracker's children" *was* the cycle.

What a run **does** still show is now recorded under "not defects", because that is what that section is for: every remaining record carries a `prte_` frame except one, and that one is the fence modex bucket described in (3). The PRRTE-side records are [openpmix/prrte#2649](https://github.com/openpmix/prrte/issues/2649).

### 2. The two shared-state exposures in spawn

**Fixed** — `PMIx_Spawn_nb` in a server role resolves a `PMIX_PARENT_ID` by walking `pmix_server_globals.clients`, on whatever thread the host called it on. Nothing in the tree locks that array, because everything else that touches it is already on the progress thread — which is meanwhile adding to and removing from it. Everything below the "can this host spawn at all?" screen now runs in `_spawn_for_host` on the progress thread: the parent lookup, the directive parse, and the host up-call, which has to come along because it needs the peer the lookup found. The screen itself stays synchronous — the host module table is established at init and never changes.

> **This is a behavior change to a released API and is the one thing here worth a second opinion.** The parent-not-found and host-refused failures now come back through the caller's callback rather than as the return of `PMIx_Spawn_nb`. That is what the non-blocking form promises anyway, and `PMIx_Spawn` is untouched — its wrapper returns the status the callback delivers, which is how a host normally reaches this code. But a host driving the `_nb` form and checking only the return will no longer see those two. Happy to drop this commit if that trade is not wanted.

The other exposure recorded alongside it **does not exist**: the sibling walk in `pmix_monitor.c` sits inside `pmix_monitor_processing()`, which is reached by `PMIX_THREADSHIFT` and so already runs on the progress thread.

**Not fixable as recorded** — the `spawn_iof_flags` stand-in was down as needing to "become per-request". Nobody can do that. Its reader, `spawn_or_global_flags()`, takes no arguments: it is reached precisely when the arriving output names a namespace we have no record of, and the only things in scope are that unknown namespace and the stream. Nothing says which in-flight spawn the output came from, and nothing can until the reply names the namespace — which is the very thing the stand-in covers for. Moved to the open decisions, stated as the choice it actually is.

### 3. Who owns the modex blob handed to `fence_nb`

`pmix_server_fence` assembles the bucket, `PMIX_UNLOAD_BUFFER`s it into a bare `char *data`, and hands that to `pmix_host_server.fence_nb`. Ownership transfers on the call — the library cannot free it on return, because a host is entitled to park the pointer and read it later from another thread — and **nothing in `pmix_server.h` said so.** Unlike the reply direction, this call carries no `(release_fn, release_cbdata)` pair to make it explicit either, so the only way for a host to learn the rule was to read the PMIx implementation.

Both in-tree hosts leaked it, which is fair evidence the rule was not discoverable. PRRTE still does (prrte#2649). Worth knowing what that looks like from the outside: the allocation is `pmix_server_collect_data`, the stack bottoms out in PMIx's own `progress_engine`, and there is no host frame anywhere in it — so a valgrind run against a launcher reports it as a *libpmix* leak, which is exactly the wrong place to go looking.

The typedef comment and the `pmix_server_module_t(5)` man page now state the transfer, that `free()` is how to give it back, and that `PMIx_Data_embed()` copies rather than consumes — so a host that embeds the blob into a message of its own still owns the original. That last part is the specific trap PRRTE fell into.

`simptest` is brought into line with the rule. **Be clear about what that hunk is worth: it is conformance with the documented contract, not a demonstrated fix.** The leak is only produced by a fence that actually collects, and two attempts to drive `simptest` into that branch under valgrind — once with its own client, once with `examples/client`, which does request `PMIX_COLLECT_DATA` — produced no `collect_data` allocation at all and therefore no before/after difference. The reasoning stands on the code, not on a measurement.

---

### Testing

`test/unit/spawn_api.c` gains four cases for the thread-shifted path, which the existing cases could not reach — they all stop at the screen above the shift. Giving the stub module a spawn entry point gets past it, and a parent that is not one of our clients then fails the lookup: the request must be *accepted* rather than refused, the failure must arrive through the callback, the host must not be asked to spawn, and the blocking form must still return the failure itself. The first of those was observed failing against the unfixed library.

(Noting a trap for anyone repeating that check: removing the fix alone leaves `_spawn_for_host` unused, which `-Werror=unused-function` turns into a build failure — so the test then runs against the *previous* library and passes. The handler has to come out too.)

Verified: clean build under `--enable-devel-check`; `make check` 21/21 in `test/`; `run_simptest.sh` clean; docs clean under `-W`.

### Documentation

`docs/todo.rst` loses two more entries and gains one open decision. Its verification note is refreshed: the group-leave entry is no longer among the things that cannot be checked by reading the tree, leaving the two "never validated" coverage gaps as the only ones in that position — which is where the next stale entry will be.
