### PR TITLE
Take back the debugger-wait handler when nobody is listening

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -94,21 +94,6 @@ wire-format and Standard question rather than a bug fix.
 Deferred work
 -------------
 
-The ``PMIx_Init`` debugger-wait handler can outlive its return object
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``PMIX_EVENT_RETURN_OBJECT`` is stored as a bare ``cbobject`` pointer,
-and here it points at a lock on ``PMIx_Init``'s own stack frame.  On the
-success path the handler is ``PMIX_EVENT_ONESHOT`` and removes itself
-when it fires; only the notification-failure return leaves it
-registered.  The obvious fix does not work: ``PMIx_Deregister_event_handler``
-gates on ``pmix_globals.initialized``, which ``PMIx_Init`` does not set
-until well after that return, so the public API is a no-op from there and
-removing the handler means open-coding the thread-shift the entry point
-performs.  Weigh that against the reachability — the process must ignore
-a failed ``PMIx_Init``, keep running, and then be sent a
-``PMIX_DEBUGGER_RELEASE`` it never asked for.
-
 Smaller items carried forward
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -168,6 +153,10 @@ Coverage gaps
   handler for forwarded stdin needs a tty, and the late-finalize-reply
   guard needs a server that answers the finalize handshake more than
   five seconds late.
+* **The debugger-wait teardown in ``PMIx_Init`` is not exercised.**
+  Reaching it needs the debugger-stop key set on the namespace *and* the
+  ``PMIX_READY_FOR_DEBUG`` notification to then fail, which no test
+  environment can arrange without fault injection.
 * **The process-set and resolve examples have never been leak-validated.**
   Both hang in the test environments used so far, so valgrind is killed
   before ``PMIx_Finalize`` runs and the report is inconclusive.

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1326,21 +1326,50 @@ without new evidence.
   process is leaving), and `PMIx_Finalize` returning anything but
   `PMIX_SUCCESS` would newly fail applications that check it. Changing
   it is a behavior decision about a universally-called API, not a fix.
-- **`PMIx_Init`'s debugger-wait handler is left registered, holding a
-  pointer into a stack frame that is about to die, if the
-  `PMIX_READY_FOR_DEBUG` notification fails.** `PMIX_EVENT_RETURN_OBJECT`
-  is stored as a bare `cbobject` pointer (see the parser in
+- **FIXED — `PMIx_Init`'s debugger-wait handler was left registered,
+  holding a pointer into a stack frame that was about to die, if the
+  `PMIX_READY_FOR_DEBUG` notification failed.**
+  `PMIX_EVENT_RETURN_OBJECT` is stored as a bare `cbobject` pointer (see
+  the parser in
   [`pmix_event_registration.c`](../event/pmix_event_registration.c)), and
   it points at `releaselock` on `PMIx_Init`'s stack. On the success path
   the handler is `PMIX_EVENT_ONESHOT` and removes itself when it fires,
-  so only the notify-failure return leaves it behind. It is not fixed
-  because the obvious fix does not work: `PMIx_Deregister_event_handler`
-  gates on `pmix_globals.initialized`, which `PMIx_Init` does not set
-  until forty lines later, so the public API is a no-op from there and
-  removing the handler means open-coding the threadshift the public
-  entry point performs. Weigh that against the reachability — the
-  process must ignore a failed `PMIx_Init`, keep running, and then be
-  sent a `PMIX_DEBUGGER_RELEASE` it never asked for.
+  so only the notify-failure return left it behind.
+
+  The reason this sat open for several sweeps is worth keeping, because
+  it is the same trap for anything else this function has to undo:
+  **`PMIx_Init` runs before `pmix_globals.initialized` is set, so every
+  public entry point is a no-op from inside it.**
+  `PMIx_Deregister_event_handler` gates on exactly that. The way out is
+  the one the *registration* already uses forty lines above — threadshift
+  straight to the internal handler — so `dereg_event_hdlr` is now
+  exported as `pmix_internal_dereg_event_hdlr`, the mirror of the
+  `pmix_internal_reg_event_hdlr` beside it, and `dereg_debugger_wait()`
+  posts to it and blocks. Blocking is the point: the registration holds a
+  pointer into the frame we are leaving, so the removal has to land
+  before we return.
+
+  Two things fall out that are easy to get wrong if you touch this.
+  **The handler index arrives as a status** — `mycbfn` assigns the
+  `refid` into `cd->status` on success, which is why the registration is
+  checked with `0 > rc` — so it has to be saved into `evref` before `rc`
+  is reused by the notify below it. And the internal handler **releases
+  its own caddy** after invoking `cbfunc.opcbfn`, so the poster must not.
+
+  The reachability the earlier entry weighed this against is unchanged
+  and still narrow: the process must ignore a failed `PMIx_Init`, keep
+  running, and then be sent a `PMIX_DEBUGGER_RELEASE` it never asked
+  for. There is no `make check` coverage — reaching it needs the
+  debugger-stop key set on the namespace *and* the ready-for-debug
+  notification to fail.
+
+  Note what is **not** a problem here, so it is not "fixed" later: on the
+  success path the oneshot deregistration happens on the progress thread
+  *after* `notification_fn` has already woken `releaselock`, so
+  `PMIx_Init` can return and the frame die before the handler object is
+  released. That is safe because nothing in the teardown reads
+  `cbobject` — `relfn` is NULL for an ordinary handler, only observers
+  set one.
 - **`pmix_globals.init_called` is set with `__atomic_test_and_set` and
   cleared with a plain `= false`.** It is a bare `bool`, not an
   `atomic_bool` like `initialized` beside it, so the clear is a

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -442,6 +442,18 @@ static void mycbfn(pmix_status_t status, size_t refid, void *cbdata)
     PMIX_WAKEUP_THREAD(&cd->lock);
 }
 
+/* wake the caller of a deregistration we had to open-code because the
+ * public entry point is not yet available to us - see the debugger-wait
+ * teardown in PMIx_Init */
+static void deregopcb(pmix_status_t status, void *cbdata)
+{
+    pmix_lock_t *lock = (pmix_lock_t *) cbdata;
+
+    PMIX_ACQUIRE_OBJECT(lock);
+    lock->status = status;
+    PMIX_WAKEUP_THREAD(lock);
+}
+
 static void notification_fn(size_t evhdlr_registration_id, pmix_status_t status,
                             const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
                             pmix_info_t results[], size_t nresults,
@@ -642,6 +654,36 @@ cleanup:
     PMIX_BYTE_OBJECT_DESTRUCT(&bo);
 }
 
+/* Remove the debugger-wait handler PMIx_Init registered.
+ *
+ * This has to be open-coded because PMIx_Deregister_event_handler gates on
+ * pmix_globals.initialized, which PMIx_Init does not set until it is nearly
+ * done - so the public entry point is a no-op from here. Registration has
+ * the same problem and solves it the same way, by threadshifting straight
+ * to the internal handler, and this is that call's mirror image.
+ *
+ * It blocks: the registration holds a pointer into our caller's stack
+ * frame, and the point of removing it is that the frame is about to die. */
+static void dereg_debugger_wait(size_t evref)
+{
+    pmix_shift_caddy_t *cd;
+    pmix_lock_t lock;
+
+    cd = PMIX_NEW(pmix_shift_caddy_t);
+    if (PMIX_UNLIKELY(NULL == cd)) {
+        /* nothing else we can do - the handler stays registered */
+        return;
+    }
+    PMIX_CONSTRUCT_LOCK(&lock);
+    cd->ref = evref;
+    cd->cbfunc.opcbfn = deregopcb;
+    cd->cbdata = &lock;
+    /* the handler releases the caddy after invoking our callback */
+    PMIX_THREADSHIFT(cd, pmix_internal_dereg_event_hdlr);
+    PMIX_WAIT_THREAD(&lock);
+    PMIX_DESTRUCT_LOCK(&lock);
+}
+
 static int client_init_cntr = 0;
 
 pmix_status_t PMIx_Init(pmix_proc_t *proc,
@@ -655,7 +697,7 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     pmix_proc_t wildcard, srvr;
     pmix_info_t ginfo, evinfo[4];
     pmix_lock_t releaselock;
-    size_t n;
+    size_t n, evref = 0;
     bool found;
     pmix_ptl_posted_recv_t *rcv;
     pid_t pid;
@@ -1123,6 +1165,10 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
                 PMIX_DESTRUCT_LOCK(&releaselock);
                 return rc;
             }
+            /* a successful registration reports the handler's index as its
+             * status - hold onto it, as rc is about to be reused, and it is
+             * the only way to take the registration back */
+            evref = (size_t) rc;
 
             /* notify the host that we are waiting. The announcement is aimed
              * solely at our local server, which upcalls it to the host - the
@@ -1156,8 +1202,13 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
             PMIX_INFO_DESTRUCT(&evinfo[2]);
             PMIX_INFO_DESTRUCT(&evinfo[3]);
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-                // failed to notify ready-for-debug
+                // failed to notify ready-for-debug. Nobody knows we are
+                // waiting, so nothing will release us - but the handler we
+                // just registered holds a pointer to releaselock, which is
+                // on this stack frame and is about to go away. Take the
+                // registration back before we leave.
                 PMIX_ERROR_LOG(rc);
+                dereg_debugger_wait(evref);
                 PMIX_DESTRUCT_LOCK(&releaselock);
                 return rc;
             }

--- a/src/event/AGENTS.md
+++ b/src/event/AGENTS.md
@@ -290,6 +290,18 @@ whose last local registration just disappeared (the caller then sends
 that buffer as a `PMIX_DEREGEVENTS_CMD`). A default-handler
 deregistration packs the `PMIX_MAX_ERR_CONSTANT` wildcard instead.
 
+**Both halves of the pipeline are reachable without the public entry
+points, and that is deliberate.** `pmix_internal_reg_event_hdlr` and
+`pmix_internal_dereg_event_hdlr` are the threadshift targets
+`PMIx_Register_event_handler` / `PMIx_Deregister_event_handler` post to,
+and they are exported because the public calls gate on
+`pmix_globals.initialized` — so code that runs *before* a role finishes
+initializing cannot use them. `PMIx_Init`'s debugger-wait handler is the
+case that needs both: it registers one, and on the notify-failure return
+it has to take it back while `initialized` is still unset. Post a
+`pmix_shift_caddy_t` whose `ref` is the handler index; the handler
+invokes `cbfunc.opcbfn` and then releases the caddy itself.
+
 ## Notification flow
 
 `PMIx_Notify_event` thread-shifts to `pmix_internal_notify_event`, then

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -339,6 +339,16 @@ PMIX_EXPORT void pmix_internal_notify_event(int sd, short args, void *cbdata);
 
 PMIX_EXPORT void pmix_internal_reg_event_hdlr(int sd, short args, void *cbdata);
 
+/* The deregistration counterpart, exposed for the same reason its sibling
+ * is: PMIx_Init registers the debugger-wait handler by threadshifting to
+ * pmix_internal_reg_event_hdlr directly, because it runs before
+ * pmix_globals.initialized is set and the public entry points gate on it.
+ * Anything that has to take such a registration back before init completes
+ * must threadshift to this the same way. The caddy is a
+ * pmix_shift_caddy_t whose ref carries the handler index; this releases it
+ * after invoking cbfunc.opcbfn, so the poster must not. */
+PMIX_EXPORT void pmix_internal_dereg_event_hdlr(int sd, short args, void *cbdata);
+
 #define PMIX_REPORT_EVENT(e, p, r, f)                                                          \
     do {                                                                                       \
         pmix_event_chain_t *ch, *cp;                                                           \

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -1325,7 +1325,7 @@ pmix_status_t pmix_deregister_event_hdlr(size_t event_hdlr_ref,
     return PMIX_SUCCESS;
 }
 
-static void dereg_event_hdlr(int sd, short args, void *cbdata)
+void pmix_internal_dereg_event_hdlr(int sd, short args, void *cbdata)
 {
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t *) cbdata;
     pmix_buffer_t *msg = NULL;
@@ -1392,7 +1392,7 @@ pmix_status_t pmix_event_deregister_observer(size_t obsid,
 
     pmix_output_verbose(2, pmix_client_globals.event_output,
                         "pmix_event_deregister_observer shifting to progress thread");
-    PMIX_THREADSHIFT(cd, dereg_event_hdlr);
+    PMIX_THREADSHIFT(cd, pmix_internal_dereg_event_hdlr);
 
     return PMIX_SUCCESS;
 }
@@ -1441,7 +1441,7 @@ PMIX_EXPORT pmix_status_t PMIx_Deregister_event_handler(size_t event_hdlr_ref,
 
     pmix_output_verbose(2, pmix_client_globals.event_output,
                         "pmix_deregister_event_hdlr shifting to progress thread");
-    PMIX_THREADSHIFT(cd, dereg_event_hdlr);
+    PMIX_THREADSHIFT(cd, pmix_internal_dereg_event_hdlr);
 
     if (NULL == cbfunc) {
         PMIX_WAIT_THREAD(&cd->lock);

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -128,7 +128,8 @@ against this list before "fixing" one:
 - **`PMIX_DEREGEVENTS_CMD` answers nothing, deliberately.** It is the one
   arm that returns `PMIX_SUCCESS` without queuing a reply and without an
   async owner to queue one later. The client sends that command through
-  `PMIX_PTL_SEND_RECV` with a **NULL** callback (`dereg_event_hdlr` in
+  `PMIX_PTL_SEND_RECV` with a **NULL** callback
+  (`pmix_internal_dereg_event_hdlr` in
   `src/event/pmix_event_registration.c`), so nothing is waiting on a tag.
 - **`PMIX_GDS_CADDY` and `PMIX_SERVER_QUEUE_REPLY` both dereference an
   unchecked `PMIX_NEW`.** Making the macros NULL-safe does not help: the


### PR DESCRIPTION
`PMIx_Init` registers a `PMIX_DEBUGGER_RELEASE` handler whose
`PMIX_EVENT_RETURN_OBJECT` is `releaselock`, a lock on its own stack
frame, then tells the host it is ready for debug and waits. If that
notification fails, the function returns — and leaves the handler
registered, holding a pointer into a frame that is about to die. A
process that ignores the failed init, keeps running, and is later sent a
release it never asked for wakes a lock that no longer exists.

The success path was never exposed: the handler is `PMIX_EVENT_ONESHOT`
and removes itself when it fires. Only the notify-failure return left it
behind.

### Why this sat open, and what changed

It has been recorded as deferred work in `docs/todo.rst` because the
obvious fix does not work: every public entry point gates on
`pmix_globals.initialized`, which `PMIx_Init` does not set until it is
nearly done, so `PMIx_Deregister_event_handler` is a no-op from in
there.

But the *registration* forty lines above has exactly the same problem
and already solves it, by threadshifting straight to
`pmix_internal_reg_event_hdlr`. The mirror image simply was not
exported. So `dereg_event_hdlr` becomes
`pmix_internal_dereg_event_hdlr`, declared next to its sibling in
`src/event/pmix_event.h`, and `dereg_debugger_wait()` posts to it. The
two existing `PMIX_THREADSHIFT` sites are unchanged in behavior.

The removal blocks, because the whole point is that it must land before
the frame goes away.

Two details worth a reviewer's eye:

* the handler index arrives *as the callback's status* — `mycbfn`
  assigns `refid` into `cd->status`, which is why the registration is
  checked with `0 > rc` — so it has to be saved into `evref` before `rc`
  is reused by the notify below it;
* `pmix_internal_dereg_event_hdlr` releases its own caddy after invoking
  `cbfunc.opcbfn`, so the poster must not.

### Testing

Warning-free build under `--enable-devel-check`; `make check` 130/130
pass under a clean `TMPDIR`; `make -C docs` succeeds.

**The fixed path itself has no test coverage, and cannot easily get
any**: reaching it needs the debugger-stop key set on the namespace
*and* the ready-for-debug notification to then fail. That is recorded as
a coverage gap in `docs/todo.rst` rather than left unsaid.

No news entry: this is a latent internal lifetime fix with no
user-visible behavior change.

### Also

Retires the corresponding `docs/todo.rst` entry, updates the
seventh-sweep entry in `src/client/AGENTS.md` to FIXED (keeping the
"public entry points are no-ops inside `PMIx_Init`" trap, since it
applies to anything else that function has to undo), documents the
exported pair in `src/event/AGENTS.md`, and fixes the now-stale
`dereg_event_hdlr` reference in `src/server/AGENTS.md`.