### PR TITLE
Say how long the host owns the fence upcall's data buffer

### DIFF
--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -130,6 +130,14 @@ typedef pmix_status_t (*pmix_server_abort_fn_t)(const pmix_proc_t *proc, void *s
  * PMIx_Data_embed() copies rather than consumes, so a host that embeds
  * the blob in a message of its own still owns the original.
  *
+ * "Once you no longer need it" is not necessarily before this function
+ * returns: a host that carries the pointer across a thread shift, or
+ * holds it until a collective it is driving completes, owns it for that
+ * whole time. Note also that this is the opposite of every other array
+ * passed to a host callback - those the library keeps valid until the
+ * host completes the operation and then frees itself - so a correct
+ * instinct about the rest of this interface is exactly wrong here.
+ *
  * The array of info structs is used to pass user-requested options to the server.
  * This can include directives as to the algorithm to be used to execute the
  * fence operation. The directives are optional _unless_ the _mandatory_ flag


### PR DESCRIPTION
**Reduced.** This PR originally documented the ownership of the buffer
handed to `pmix_server_fencenb_fn_t` from scratch, but 2eb40a00 landed
that same change while this branch was open — header paragraph, man
page, `src/server/AGENTS.md` entry and the `simptest` fix. That is what
the conflict was.

Rebased onto master and cut down to the part that is not already there:
two things about the rule that are worth saying in the header and were
not.

* **"Once you no longer need it" is not necessarily before the call
  returns.** A host that carries the pointer across a thread shift, or
  holds it until a collective it is driving completes, owns it for that
  whole time.
* **This is the opposite of every other array passed to a host
  callback** — those the library keeps valid until the host completes
  the operation and then frees itself. So a host implementer's correct
  instinct about the rest of this interface is exactly wrong here, which
  is most of why the rule was not discoverable in the first place.

Comment-only; no code change.

Two things from the original branch are deliberately dropped. The
`include/pmix_server.h` paragraph was a duplicate of the one 2eb40a00
already added. And the `test/simple/simptest.c` change freed the blob
immediately after invoking the modex callback with a NULL release
function — that is a use-after-free: `pmix_server_modex_cbfunc` only
thread-shifts and packs the reply from that pointer later, on the
progress thread. 2eb40a00 handles it correctly by passing a
`fence_relfn`, and that is what stays.