### PR TITLE
Give a spawned job its parent's output forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,6 +302,7 @@ test/unit/singleton_register
 test/unit/iof_pattern
 test/unit/iof_flow
 test/unit/iof_output
+test/unit/iof_inherit
 test/unit/proc_array_id
 test/unit/get_perf
 test/unit/ptl_uri

--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ examples/group_invite_decline
 examples/group_invite_abort
 examples/group_invite_others
 examples/spawn_reuse
+examples/spawn_iof
 examples/group_badinfo
 examples/group_invite_suppress
 examples/group_invite_nb

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -31,6 +31,7 @@ two disagree, the README wins, and please fix this file.
 | `run-runtime-tests.sh` | The `src/runtime` bring-up/tear-down suite in the optimized configuration and on Linux — where the progress thread's CPU-affinity path exists at all — plus that path driven through a real `PMIx_Init`, and node identity across real servers (README §18) |
 | `run-server-tests.sh` | `src/server` — the server-role half of libpmix — across separate servers: direct modex, cross-namespace get, group blocks spanning nodes, IOF pull/dereg against a persistent DVM, and a valgrind pass on the daemon (README §19) |
 | `run-tool-tests.sh` | `src/tool` — the tool-role half of libpmix — with the tool and its servers on different nodes: switching the primary between two independent DVMs, a remote server dying, IOF relayed to a tool from other nodes, and the only valgrind pass the tool library gets (README §20) |
+| `run-spawn-iof.sh` | Output forwarding for a job spawned by an ordinary client, with the spawning rank on a daemon other than the tool's — the reproducer for `docs/how-things-work/iof_inheritance.rst` (README §21) |
 | `swarm-common.sh` | **Sourced, never executed.** `$PMIX_SWARM` naming and the one copy of `cleanup_swarm` |
 
 ## Things that will bite you
@@ -173,6 +174,17 @@ two disagree, the README wins, and please fix this file.
   across runs and across checkouts, so a tree in it can be older than
   the source you are testing. When results make no sense, check what is
   actually in `/opt/prte` before doubting the code.
+
+- **The PRRTE clone baked into the image is not "PRRTE master" — it is
+  PRRTE master as of the day the image was built, and rebuilding the
+  image does not refresh it.** Docker caches the `git clone` RUN layer,
+  so `./build.sh image` hands back the identical commit. `build.sh` now
+  keeps the clone it actually builds in the volume
+  (`/opt/prte/prrte-src`), fetches it forward to the head of
+  `$PRRTE_REF` on every build, and prints the commit; the baked copy is
+  only the seed and the no-network fallback. This matters whenever the
+  behavior under test has a PRRTE half — you cannot conclude anything
+  about a launcher whose commit you cannot name.
 
 ## Adding a runner
 

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -1374,3 +1374,95 @@ servers — so the attach/switch/disconnect reference accounting runs for
 real. It runs `toolswitch -q` (queries skipped: a second DVM on the same
 host answers out of the same state as the first). Do not let it stand in
 for the linux mode.
+
+---
+
+## 21. Output forwarding for a spawned job (`run-spawn-iof.sh`)
+
+```sh
+./run-spawn-iof.sh linux      # the swarm; there is no macOS mode
+```
+
+A job spawned through `PMIx_Spawn` should be treated the way its parent
+is being treated: whoever receives the parent job's output should receive
+the child's. [`docs/how-things-work/iof_inheritance.rst`](../../docs/how-things-work/iof_inheritance.rst)
+is the design document; this runner is its reproducer.
+
+### Why one host cannot answer this
+
+Responsibility is split between the two projects, and the split is what
+makes the geometry matter:
+
+* **PMIx** decides who gets a copy, by walking the subscriptions
+  (`pmix_iof_req_t`) held by **one** PMIx server — the server inside the
+  daemon that the requesting tool attached to.
+* **PRRTE** decides which daemon a job's output is relayed to.
+
+So two daemons appear in the story and they need not be the same one:
+the daemon **the tool attached to**, which holds the subscription
+covering the parent job, and the daemon hosting **the rank that calls
+`PMIx_Spawn`**, which is where the spawn command lands and therefore
+where PMIx performs the inheritance.
+
+Put the spawning rank on the tool's own daemon and the two coincide. That
+is a real configuration — a single-node DVM, or `prterun` on one node —
+and it is also the configuration in which the test proves nearly nothing:
+a library that routes nothing at all still passes it.
+
+### The cases
+
+| # | Launch | Tool's daemon | Spawning rank | What it is for |
+|---|--------|---------------|---------------|----------------|
+| 1 | persistent DVM, `prun --host node1:1` | node1 (HNP) | node1 | **Control.** Says the example, the launcher and the capture all work. |
+| 2 | persistent DVM, `prun --host node2:1` | node1 (HNP) | node2 | **The reproducer.** Only the placement of one rank differs from case 1. |
+| 3 | `prterun`, node1 left out of `--host` | node1 (`prterun` itself) | node2 | What a user sees under `prterun`. Weaker evidence — see below. |
+
+The DVM spans six nodes and the parent job is one rank, because `--host`
+**is** the allocation: a parent that fills it leaves the spawn nowhere to
+land, and the job then blocks until the launch timeout — which reads
+exactly like a library hang and is not one.
+
+Case 3 is reported separately because `prterun` also writes output
+*locally*, which can carry a child's bytes to the terminal by a route
+that has nothing to do with the subscription being inherited. A pass
+there is not a substitute for a pass in case 2.
+
+### Reading a failure
+
+If the child's lines never come back, that alone does not say whether the
+forwarding dropped them or the child never ran — and those want opposite
+repairs. So the example is run as `spawn_iof --markers /tmp`, which makes
+every process also drop a file of the same content **on the node it ran
+on**, by a channel that has nothing to do with IOF. The runner gathers
+those from all ten nodes and prints them under every case, so each result
+comes with the layout that produced it. `judge` uses them: "the child job
+never ran" and "the child ran on node4 but none of its output reached the
+tool" are different verdicts.
+
+The parent's own output is checked first and separately. If the tool is
+not receiving *that*, the premise of the case is gone and the child's
+absence says nothing about inheritance; the runner says so rather than
+returning a confident wrong answer.
+
+Markers go to each node's own `/tmp` because the shared volume is mounted
+**read-only** in the node containers. The name deliberately does not
+match `pmix*` — that is the glob `cleanup_swarm` sweeps between cases,
+and these files have to survive until they are collected.
+
+### What it deliberately does not cover
+
+Two further cases from the design document are not built here:
+
+* the same spawn under a tool that attached to a **non-HNP** daemon;
+* a tool that attaches to a running DVM, pulls a job's output with
+  `PMIx_IOF_pull`, and then observes the output of a job that job spawns.
+
+Both need PRRTE to record a *set* of interested daemons for a job, which
+does not exist yet — `jdata->originator` is a single process. Until it
+does, both would only restate what case 2 already reports.
+
+### No macOS mode
+
+The subject is which daemon holds a subscription. One host has one
+daemon, so only the control case can be built there. The script says that
+and exits rather than running something that would look like coverage.

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -1411,21 +1411,33 @@ a library that routes nothing at all still passes it.
 
 ### The cases
 
-| # | Launch | Tool's daemon | Spawning rank | What it is for |
-|---|--------|---------------|---------------|----------------|
-| 1 | persistent DVM, `prun --host node1:1` | node1 (HNP) | node1 | **Control.** Says the example, the launcher and the capture all work. |
-| 2 | persistent DVM, `prun --host node2:1` | node1 (HNP) | node2 | **The reproducer.** Only the placement of one rank differs from case 1. |
-| 3 | `prterun`, node1 left out of `--host` | node1 (`prterun` itself) | node2 | What a user sees under `prterun`. Weaker evidence — see below. |
+| # | Launch | Tool's daemon | Spawning rank | Child | What it is for |
+|---|--------|---------------|---------------|-------|----------------|
+| 1 | persistent DVM, `prun --host node1:1` | node1 (HNP) | node1 | node2 | **Control.** Says the example, the launcher and the capture all work. |
+| 2 | persistent DVM, `prun --host node2:1` | node1 (HNP) | node2 | node1 | Only the placement of one rank differs from case 1. This is the case that failed before the delivery-time fallback landed. |
+| 3 | persistent DVM, `prun --host node2:1,node1:1 -np 2` | node1 (HNP) | node2 | node3 | **The strong one.** Three different daemons, so nothing about the answer can be read out of local state. |
+| 4 | `prterun`, node1 left out of `--host` | node1 (`prterun` itself) | node2 | node3 | What a user sees under `prterun`. Weaker evidence — see below. |
+
+Case 3 is worth understanding before changing the geometry. Case 2 leaves
+the child's placement to the mapper, which fills from the first free slot
+— node1, the tool's own node. The child's output therefore reaches the
+tool's server from a process that server hosts, and a delivery-time
+decision taken there could be reading local state rather than routed
+output. Listing node2 **first** puts rank 0 (the spawner) there and rank
+1 on node1, which consumes the slot the child would have taken and pushes
+it out to node3. The runner checks that three distinct nodes really
+appear and reports SKIP rather than PASS if the mapper placed things
+some other way.
 
 The DVM spans six nodes and the parent job is one rank, because `--host`
 **is** the allocation: a parent that fills it leaves the spawn nowhere to
 land, and the job then blocks until the launch timeout — which reads
 exactly like a library hang and is not one.
 
-Case 3 is reported separately because `prterun` also writes output
+Case 4 is reported separately because `prterun` also writes output
 *locally*, which can carry a child's bytes to the terminal by a route
 that has nothing to do with the subscription being inherited. A pass
-there is not a substitute for a pass in case 2.
+there is not a substitute for a pass in cases 2 and 3.
 
 ### Reading a failure
 
@@ -1451,15 +1463,20 @@ and these files have to survive until they are collected.
 
 ### What it deliberately does not cover
 
-Two further cases from the design document are not built here:
+Every case here attaches its tool to the HNP, which is what `prun` and
+`prterun` do. Two further cases from the design document are not built:
 
 * the same spawn under a tool that attached to a **non-HNP** daemon;
 * a tool that attaches to a running DVM, pulls a job's output with
   `PMIx_IOF_pull`, and then observes the output of a job that job spawns.
 
-Both need PRRTE to record a *set* of interested daemons for a job, which
-does not exist yet — `jdata->originator` is a single process. Until it
-does, both would only restate what case 2 already reports.
+Neither is a PMIx-side gap. The first daemon never receives another
+node's output at all — the HNP hands everything it receives to its *own*
+PMIx server and relays elsewhere only by `jdata->originator` — and the
+second request is not recorded against the job anywhere. Both need PRRTE
+to keep a *set* of interested daemons for a job, which does not exist yet
+(`jdata->originator` is a single process), and neither can be built here
+until it does.
 
 ### No macOS mode
 

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -14,9 +14,17 @@ is only the nickname.
 > This harness is adapted from PRRTE's `contrib/dockerswarm`, inverted to be
 > **PMIx-centric**: the code under test is *your live openpmix working tree*
 > (bind-mounted, built out-of-tree, never stale, no commit required). PRRTE is
-> just the launcher — its master branch is baked into the image as source and
+> just the launcher — its source lives in the shared volume, is fetched forward
+> to the head of `$PRRTE_REF` (default `master`) on every `build.sh`, and is
 > built **against your PMIx** at run time, so the launcher's PMIx *server*
 > library is the one you are testing.
+>
+> The image bakes a PRRTE clone too, but only as a seed and as the no-network
+> fallback. Do not rely on it for "this is master": it is exactly as old as the
+> image, and *rebuilding the image does not refresh it* — docker caches the
+> `git clone` layer and hands back the same commit. `build.sh` prints the
+> commit it is actually building, and `prte_info --version` in a node reports
+> what is installed.
 
 ---
 

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -11,9 +11,11 @@
 # test swarm (README.md) -- no commit required, never stale.
 #
 # This harness is PMIx-centric: the code under test is the openpmix tree this
-# script lives in.  PRRTE master is baked (as source) into the image and built
-# against your PMIx here, so the launcher's PMIx *server* library is the one you
-# are testing -- which is what makes it exercise server-side collective code.
+# script lives in.  PRRTE is only the launcher: its source is kept in the shared
+# volume at the HEAD of $PRRTE_REF (seeded from the copy baked into the image,
+# then fetched forward on every build) and is compiled against your PMIx here,
+# so the launcher's PMIx *server* library is the one you are testing -- which is
+# what makes it exercise server-side collective code.
 #
 # The PMIx tree is built OUT OF TREE (VPATH) so the source stays pristine:
 #
@@ -85,7 +87,14 @@ EVENT_EXAMPLES="group_invite group_invite_others group_invite_suppress group_inv
 # local, and the producer/consumer mismatch this catches made every process
 # report NO shared locality with its own node-mates.
 TOPO_EXAMPLES="topology"
-BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die group_leave $EVENT_EXAMPLES $TOPO_EXAMPLES"
+# The spawned-job output-forwarding exerciser, driven by run-spawn-iof.sh: a
+# client-issued PMIx_Spawn that names no output directives, so the child job
+# should be treated the way its parent is being treated. It has to run across
+# real nodes because the question is which daemon holds the subscription and
+# which one the output arrives at -- co-located, it passes against a library
+# that routes nothing. See docs/how-things-work/iof_inheritance.rst.
+IOF_EXAMPLES="spawn_iof"
+BUILD_EXAMPLES="$GROUP_EXAMPLES group_die connect_die group_leave $EVENT_EXAMPLES $TOPO_EXAMPLES $IOF_EXAMPLES"
 
 # The Python bindings are built with PMIx (--enable-python-bindings) and staged,
 # together with the maintained test scripts from test/python and the swarm's own
@@ -128,12 +137,14 @@ build_linux() {
     build_image
     docker volume create "$VOLUME" >/dev/null
 
-    echo ">>> building PMIx (your tree) + PRRTE (baked master) into volume $VOLUME"
+    echo ">>> building PMIx (your tree) + PRRTE ($PRRTE_REF) into volume $VOLUME"
     docker run --rm \
         -v "$root":/pmix-src:ro \
         -v "$VOLUME":/opt/prte \
         -e BUILD_EXAMPLES="$BUILD_EXAMPLES" \
         -e PYTHON_BINDINGS="$PYTHON_BINDINGS" \
+        -e PRRTE_REPO="$PRRTE_REPO" \
+        -e PRRTE_REF="$PRRTE_REF" \
         "$IMAGE" bash -euo pipefail -c '
             jobs=$(nproc)
 
@@ -184,20 +195,56 @@ build_linux() {
             make -j"$jobs"
             make install
 
-            echo ">>>> PRRTE (baked master) VPATH build -> /opt/prte/prte"
+            # ---- the launcher, at the HEAD of $PRRTE_REF --------------------
+            # The image bakes a PRRTE clone, and that clone is exactly as old
+            # as the image: "PRRTE master" stops being true the day after the
+            # image is built, and rebuilding the image does NOT fix it -- the
+            # `git clone` RUN layer is cached, so docker hands back the same
+            # commit. A test that depends on a PRRTE-side behavior would then
+            # be run against a launcher nobody can name.
+            #
+            # So the clone we actually build lives in the VOLUME, where it can
+            # be fetched forward between runs, and the baked copy is only the
+            # no-network fallback. autogen is re-run only when the commit
+            # actually moved -- it is the expensive half.
+            prte_src=/opt/prte/prrte-src
+            if [ ! -d "$prte_src/.git" ]; then
+                echo ">>>> cloning PRRTE $PRRTE_REF -> $prte_src"
+                rm -rf "$prte_src"
+                git clone --quiet --recursive -b "$PRRTE_REF" \
+                          "$PRRTE_REPO" "$prte_src" || {
+                    echo "   (clone failed -- using the baked copy in the image)"
+                    rm -rf "$prte_src"; cp -a /src/prrte "$prte_src"; }
+            fi
+            was=$(git -C "$prte_src" rev-parse HEAD 2>/dev/null || echo none)
+            if git -C "$prte_src" fetch --quiet origin "$PRRTE_REF" 2>/dev/null; then
+                git -C "$prte_src" checkout --quiet --detach FETCH_HEAD
+                git -C "$prte_src" submodule --quiet update --init --recursive
+            else
+                echo "   (cannot reach $PRRTE_REPO -- building the PRRTE already here)"
+            fi
+            now=$(git -C "$prte_src" rev-parse HEAD 2>/dev/null || echo none)
+            echo ">>>> PRRTE $PRRTE_REF at ${now:0:10}"
+            if [ ! -x "$prte_src/configure" ] || [ "$was" != "$now" ]; then
+                echo "   (source moved -- autogen)"
+                ( cd "$prte_src" && ./autogen.pl > /tmp/prte-autogen.log 2>&1 ) \
+                    || { tail -20 /tmp/prte-autogen.log; exit 1; }
+            fi
+
+            echo ">>>> PRRTE VPATH build -> /opt/prte/prte"
             mkdir -p /opt/prte/vpath-prte && cd /opt/prte/vpath-prte
-            # A rebuilt image re-clones PRRTE, so a build directory left by an
-            # older image is stale: its Makefiles carry the previous clone`s
-            # timestamps and maintainer mode then tries to regenerate the build
-            # system with whatever aclocal/automake version the image happens to
-            # have, which fails on the unexpanded OAC macros. Start over
-            # whenever the baked source is newer than this build directory.
-            if [ -f config.status ] && [ /src/prrte/configure -nt config.status ]; then
-                echo "   (baked PRRTE source is newer -- reconfiguring from scratch)"
+            # A moved PRRTE source leaves this build directory stale: its
+            # Makefiles carry the previous clone`s timestamps and maintainer
+            # mode then tries to regenerate the build system with whatever
+            # aclocal/automake version the image happens to have, which fails
+            # on the unexpanded OAC macros. Start over whenever the source is
+            # newer than this build directory.
+            if [ -f config.status ] && [ "$prte_src/configure" -nt config.status ]; then
+                echo "   (PRRTE source is newer -- reconfiguring from scratch)"
                 cd / && rm -rf /opt/prte/vpath-prte && mkdir -p /opt/prte/vpath-prte
                 cd /opt/prte/vpath-prte
             fi
-            [ -f config.status ] || /src/prrte/configure \
+            [ -f config.status ] || "$prte_src"/configure \
                 --prefix=/opt/prte/prte --with-pmix=/opt/prte/pmix --enable-debug
             make -j"$jobs"
             make install

--- a/contrib/dockerswarm/run-spawn-iof.sh
+++ b/contrib/dockerswarm/run-spawn-iof.sh
@@ -33,10 +33,16 @@
 # subscription to clone is right there, and the case passes.  That is a real
 # configuration -- a single-node DVM, or prterun on one node -- and it is
 # also the configuration in which this test proves almost nothing, because a
-# library that routes nothing at all still passes it.  The case that carries
-# the information is the one where the spawning rank sits on a DIFFERENT
-# daemon.  Both are run here, in that order, because the first is what says
-# the rig itself works when the second fails.
+# library that routes nothing at all still passes it.  The cases that carry
+# the information are the ones where the spawning rank sits on a DIFFERENT
+# daemon, and they are run after the co-located one because that one is what
+# says the rig itself works when a later case fails.
+#
+# The far end of the same question is where the child's output ARRIVES.  A
+# child placed on the tool's own node reaches the tool's server from a
+# process that server hosts, which a delivery-time decision could answer out
+# of local state; case 3 pushes tool, spawner and child onto three different
+# daemons so that nothing about the answer can be local.
 #
 # Nothing in `make check` reaches this: test/unit/iof_inherit.c drives the
 # parser and the registration directly and reads the subscription list back,
@@ -51,12 +57,15 @@
 # with IOF.  Each case reports both: what came back through the tool, and
 # what actually ran where.
 #
-# WHAT THIS DOES NOT COVER.  Two further cases from the design document are
-# not built here yet: the same spawn under a tool that attached to a NON-HNP
-# daemon, and a tool that attaches to a running DVM, pulls a job's output
-# with PMIx_IOF_pull, and then observes the output of a job that job spawns.
-# Both depend on PRRTE recording a set of interested daemons, which does not
-# exist yet; until it does they would only restate this runner's result.
+# WHAT THIS DOES NOT COVER.  Every case here attaches its tool to the HNP,
+# which is what prun and prterun do.  A tool attached to a NON-HNP daemon is
+# not reachable for another node's output at all -- the HNP hands everything
+# it receives to its OWN PMIx server, and relays elsewhere only by
+# jdata->originator -- and a tool that attaches to a running DVM and pulls a
+# job's output with PMIx_IOF_pull is not recorded against that job anywhere.
+# Both need PRRTE to keep a SET of interested daemons for a job, which does
+# not exist yet; neither is a PMIx-side gap and neither can be built here
+# until it does.
 #
 # Prints PASS/FAIL per case and a summary; exits non-zero if anything failed.
 
@@ -267,7 +276,39 @@ test_linux() {
     cleanup_swarm
 
     # ------------------------------------------------------------------
-    # Case 3: the same, under prterun rather than a persistent DVM.
+    # Case 3: three different daemons -- tool, spawner, child.
+    #
+    # Case 2 leaves the child's placement to the mapper, which fills from
+    # the first free slot -- node1, the tool's own node. So the output
+    # arrives at the tool's server from a process that server hosts, and
+    # a delivery-time decision made there could be reading local state
+    # rather than routed output. Listing node2 FIRST puts rank 0 (the
+    # spawner) there and rank 1 on node1, which consumes the free slot
+    # the child would have taken and pushes it out to node3.
+    #
+    # Tool on node1, spawner on node2, child on node3: no two of the
+    # three are the same daemon, and the child's bytes reach the tool
+    # only by being relayed to the HNP and matched there.
+    # ------------------------------------------------------------------
+    banner "case 3: tool, spawner and child on three different daemons"
+    clear_markers
+    OUT="$(RUN "prte --daemonize --host $DVM_HOSTS >/tmp/iof-dvm.log 2>&1; sleep 5;
+                prun --host node2:1,node1:1 -np 2 --timeout 90 $PROG --markers $MARKERS 2>&1;
+                echo '--- done ---';
+                pterm >/dev/null 2>&1")"
+    RAN="$(collect_markers)"
+    show_layout
+    if [ "$(echo "$RAN" | sed -n 's/.*host //p' | sort -u | wc -l)" -lt 3 ]; then
+        # The mapper placed things differently than the geometry above
+        # assumes, so whatever this run shows is not the case described.
+        skp "three-daemon: the ranks did not land on three distinct nodes"
+    else
+        judge "three-daemon" "the child's output crossed two daemons to reach the tool"
+    fi
+    cleanup_swarm
+
+    # ------------------------------------------------------------------
+    # Case 4: the same, under prterun rather than a persistent DVM.
     #
     # prterun brings up a DVM of its own and is the tool, so "the tool's
     # daemon" is the HNP by construction -- and the HNP is prterun itself,
@@ -282,7 +323,7 @@ test_linux() {
     # here is therefore weaker evidence than a pass in case 2 -- it is here
     # to show what a user sees, not to stand in for it.
     # ------------------------------------------------------------------
-    banner "case 3: the same under prterun"
+    banner "case 4: the same under prterun"
     clear_markers
     OUT="$(RUN "prterun --host node2:1,node3:1,node4:1,node5:1,node6:1 \
                     -np 1 --timeout 90 $PROG --markers $MARKERS 2>&1;

--- a/contrib/dockerswarm/run-spawn-iof.sh
+++ b/contrib/dockerswarm/run-spawn-iof.sh
@@ -1,0 +1,313 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Where does the output of a job spawned by an ordinary CLIENT go?
+#
+#   ./run-spawn-iof.sh linux   # in the 10-container swarm
+#                              #   (requires: ./build.sh && docker compose up -d)
+#
+# WHY THIS IS A MULTI-NODE TEST -- AND WHY THE GEOMETRY IS THE WHOLE POINT
+#
+# A job spawned through PMIx_Spawn should be treated the way its parent is
+# being treated: whoever is receiving the parent job's output should receive
+# the child's.  docs/how-things-work/iof_inheritance.rst is the design; the
+# short version of the mechanism is that PMIx decides who gets a copy by
+# walking the subscriptions (pmix_iof_req_t) held by ONE PMIx server -- the
+# server of the daemon the requesting tool attached to -- while PRRTE decides
+# which daemon a job's output is relayed to.
+#
+# So there are two daemons in this story and they need not be the same one:
+#
+#   * the daemon the TOOL attached to, which holds the subscription covering
+#     the parent job, and
+#   * the daemon hosting the RANK THAT CALLS PMIx_Spawn, which is where the
+#     spawn command lands and therefore where PMIx performs the inheritance.
+#
+# Put the spawning rank on the tool's own daemon and the two coincide: the
+# subscription to clone is right there, and the case passes.  That is a real
+# configuration -- a single-node DVM, or prterun on one node -- and it is
+# also the configuration in which this test proves almost nothing, because a
+# library that routes nothing at all still passes it.  The case that carries
+# the information is the one where the spawning rank sits on a DIFFERENT
+# daemon.  Both are run here, in that order, because the first is what says
+# the rig itself works when the second fails.
+#
+# Nothing in `make check` reaches this: test/unit/iof_inherit.c drives the
+# parser and the registration directly and reads the subscription list back,
+# which establishes WHICH subscriptions get created and for whom, but it
+# cannot say which daemon holds them or where the bytes arrive.  Neither can
+# test/simple/simptest, which cannot host a spawn at all.
+#
+# READING A FAILURE.  If the child's lines are missing, that alone does not
+# say whether the forwarding dropped them or the child never ran.  So the
+# example is run with --markers, which makes every process drop a file of the
+# same content on the node it ran on, by a channel that has nothing to do
+# with IOF.  Each case reports both: what came back through the tool, and
+# what actually ran where.
+#
+# WHAT THIS DOES NOT COVER.  Two further cases from the design document are
+# not built here yet: the same spawn under a tool that attached to a NON-HNP
+# daemon, and a tool that attaches to a running DVM, pulls a job's output
+# with PMIx_IOF_pull, and then observes the output of a job that job spawns.
+# Both depend on PRRTE recording a set of interested daemons, which does not
+# exist yet; until it does they would only restate this runner's result.
+#
+# Prints PASS/FAIL per case and a summary; exits non-zero if anything failed.
+
+set -uo pipefail
+
+mode="${1:-linux}"
+pass=0 fail=0 skip=0
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+# RUN/ON, cleanup_swarm, swarm_up_or_die and the swarm naming (PMIX_SWARM,
+# NODE, IMAGE, VOLUME) all live in swarm-common.sh.
+. "$(dirname "$0")/swarm-common.sh"
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+# See run-server-tests.sh: the example is COMPILED in a throwaway builder
+# container and RUN in the long-lived node containers, so it must link the
+# PMIx that build.sh installed into the shared volume -- the only tree that
+# is the same in both.
+PMIX_PREFIX=/opt/prte/pmix
+STAGE=/opt/prte/tests-iof
+PROG="$STAGE/spawn_iof"
+
+# The DVM spans six nodes; a parent job of one rank leaves five nodes' worth
+# of slots free.  --host IS the allocation, so a parent that fills it leaves
+# the spawn nowhere to land and the job blocks until the launch timeout --
+# which reads exactly like a library hang and is not one.
+DVM_HOSTS="node1:1,node2:1,node3:1,node4:1,node5:1,node6:1"
+
+# Markers go to each node's own /tmp: the shared volume is mounted READ-ONLY
+# in the node containers.  The name deliberately does not match pmix*, which
+# is the glob cleanup_swarm sweeps out of /tmp between cases -- we want to
+# clear these ourselves, at a moment we choose.
+MARKERS=/tmp
+clear_markers() {
+    local n
+    for n in $(seq 1 10); do
+        ON "$n" "rm -f $MARKERS/spawn_iof.* 2>/dev/null; true" >/dev/null 2>&1
+    done
+}
+# What actually ran, and where -- gathered from every node, IOF uninvolved.
+collect_markers() {
+    local n
+    for n in $(seq 1 10); do
+        ON "$n" "cat $MARKERS/spawn_iof.* 2>/dev/null" 2>/dev/null
+    done
+}
+
+OUT=""
+RAN=""
+
+# Judge one case.  $1 = label, $2 = what a pass means.
+#
+# The parent's own lines are checked first and separately.  If the tool is
+# not receiving the PARENT's output then the premise of the case is gone and
+# the child's absence says nothing about inheritance -- report that, rather
+# than a misleading verdict about the child.
+judge() {
+    local name="$1" what="$2"
+
+    if echo "$OUT" | grep -qiE 'time limit for job|timed out|DVM timeout'; then
+        bad "$name: HUNG (hit the launch timeout)"
+        return
+    fi
+    if echo "$OUT" | grep -qiE 'Segmentation|core dumped|: ERROR!'; then
+        bad "$name: $(echo "$OUT" | grep -iE 'Segmentation|core dumped|: ERROR!' | head -1)"
+        return
+    fi
+    if ! echo "$OUT" | grep -q 'SPAWN_IOF parent '; then
+        bad "$name: the tool never saw the PARENT's output -- the case cannot judge the child"
+        echo "     $(echo "$OUT" | tr '\n' ' ' | tail -c 200)" >&2
+        return
+    fi
+    if ! echo "$OUT" | grep -q 'SPAWN_IOF spawned '; then
+        bad "$name: PMIx_Spawn did not report a child namespace"
+        echo "     $(echo "$OUT" | tr '\n' ' ' | tail -c 200)" >&2
+        return
+    fi
+    if ! echo "$RAN" | grep -q 'SPAWN_IOF child '; then
+        bad "$name: the child job never ran (no marker on any node) -- not an IOF result"
+        return
+    fi
+
+    # The premise holds and the child ran.  Now the actual question.
+    if echo "$OUT" | grep -q 'SPAWN_IOF child ' && echo "$OUT" | grep -q 'SPAWN_IOF childerr '; then
+        ok "$name: $what"
+    elif echo "$OUT" | grep -qE 'SPAWN_IOF child|SPAWN_IOF childerr'; then
+        bad "$name: only one of the child's two channels came back"
+    else
+        bad "$name: the child ran ($(echo "$RAN" | grep 'SPAWN_IOF child ' | head -1 |
+             sed 's/.*host /on /')) but NONE of its output reached the tool"
+    fi
+}
+
+# Where each process ran, printed under every case: the whole subject is
+# which daemon is which, so a result nobody can place is not worth much.
+show_layout() {
+    echo "$RAN" | sed 's/^/     /'
+}
+
+########################################################################
+
+test_linux() {
+    local rc
+
+    swarm_up_or_die
+
+    banner "preflight"
+    if ! RUN 'command -v prterun prte prun pterm >/dev/null'; then
+        bad "prterun/prte/prun/pterm missing -- did ./build.sh run?"; return
+    fi
+    ok "prte tools on PATH"
+
+    if ! docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+        bad "build volume $VOLUME missing -- run ./build.sh first"; return
+    fi
+
+    # The nodes are long-lived containers while the install they read is
+    # replaced under them, so a node predating the current image runs a
+    # different PMIx than the builder container compiles against.
+    local imgid cimg n stalenodes=""
+    imgid=$(docker images --no-trunc --format '{{.ID}}' "$IMAGE" 2>/dev/null | head -1)
+    for n in $(seq 1 10); do
+        cimg=$(docker inspect "$NODE$n" --format '{{.Image}}' 2>/dev/null)
+        [ "$cimg" = "$imgid" ] || stalenodes="$stalenodes node$n"
+    done
+    if [ -n "$stalenodes" ]; then
+        bad "containers predate $IMAGE:$stalenodes"
+        echo "     Recreate them: ${SWARM_ENV}docker compose up -d --force-recreate" >&2
+        return
+    fi
+    ok "all 10 containers are on the current $IMAGE"
+
+    # Which PRRTE this is matters more here than in most of these runners:
+    # the routing half of the behavior under test is PRRTE's.
+    banner "the launcher under test"
+    RUN 'prte_info --version 2>/dev/null | head -2' | sed 's/^/     /'
+
+    banner "build the example"
+    docker run --rm \
+        -v "$root":/pmix-src:ro \
+        -v "$VOLUME":/opt/prte \
+        -e PFX="$PMIX_PREFIX" \
+        -e STAGE="$STAGE" \
+        "$IMAGE" bash -euo pipefail -c '
+            mkdir -p "$STAGE"
+            gcc -O0 -g -o "$STAGE/spawn_iof" /pmix-src/examples/spawn_iof.c \
+                -I"$PFX/include" -I/pmix-src/examples \
+                -L"$PFX/lib" -lpmix -Wl,-rpath,"$PFX/lib"
+        '
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        bad "could not build examples/spawn_iof.c (rc=$rc)"; return
+    fi
+    ok "built spawn_iof"
+
+    # ------------------------------------------------------------------
+    # Case 1: the spawning rank is on the tool's own daemon.
+    #
+    # prun runs on node1 and attaches to the DVM through node1's rendezvous
+    # file, so the subscription covering the parent job is held by the PMIx
+    # server inside node1's daemon -- and the parent's single rank is placed
+    # on node1 as well.  The spawn command therefore lands on the very
+    # server that holds the subscription, which is the co-located case the
+    # spawn-time inheritance already answers.
+    #
+    # This is the control.  It says the example, the launcher and the
+    # capture all work, so that a failure in case 2 is about routing.
+    # ------------------------------------------------------------------
+    banner "case 1: spawner on the tool's daemon (control)"
+    cleanup_swarm
+    clear_markers
+    OUT="$(RUN "prte --daemonize --host $DVM_HOSTS >/tmp/iof-dvm.log 2>&1; sleep 5;
+                prun --host node1:1 -np 1 --timeout 90 $PROG --markers $MARKERS 2>&1;
+                echo '--- done ---';
+                pterm >/dev/null 2>&1")"
+    RAN="$(collect_markers)"
+    show_layout
+    judge "co-located" "the child's output came back to the tool on both channels"
+    cleanup_swarm
+
+    # ------------------------------------------------------------------
+    # Case 2: the spawning rank is on a different daemon.  THE REPRODUCER.
+    #
+    # Identical to case 1 but for one thing: the parent's rank is placed on
+    # node2, so the spawn command lands on node2's PMIx server while the
+    # tool's subscription is still held by node1's.  Nothing else moves --
+    # same DVM, same tool, same tool attachment, same example.
+    #
+    # The parent's own output still comes back (every prted forwards to the
+    # HNP, and the HNP hands everything it receives to its own PMIx server,
+    # where prun's subscription for the parent namespace matches).  The
+    # child's is the question.
+    # ------------------------------------------------------------------
+    banner "case 2: spawner on another daemon (the reproducer)"
+    clear_markers
+    OUT="$(RUN "prte --daemonize --host $DVM_HOSTS >/tmp/iof-dvm.log 2>&1; sleep 5;
+                prun --host node2:1 -np 1 --timeout 90 $PROG --markers $MARKERS 2>&1;
+                echo '--- done ---';
+                pterm >/dev/null 2>&1")"
+    RAN="$(collect_markers)"
+    show_layout
+    judge "cross-daemon" "the child's output came back to the tool on both channels"
+    cleanup_swarm
+
+    # ------------------------------------------------------------------
+    # Case 3: the same, under prterun rather than a persistent DVM.
+    #
+    # prterun brings up a DVM of its own and is the tool, so "the tool's
+    # daemon" is the HNP by construction -- and the HNP is prterun itself,
+    # here on node1.  Leaving node1 OUT of the host list is what puts the
+    # spawning rank somewhere else: --host is the allocation, so with no
+    # slot on node1 the single rank lands on node2 while the tool stays
+    # where it is.
+    #
+    # This is reported separately because prterun ALSO writes output
+    # locally, which can carry a child's bytes to the terminal by a route
+    # that has nothing to do with the subscription being inherited.  A pass
+    # here is therefore weaker evidence than a pass in case 2 -- it is here
+    # to show what a user sees, not to stand in for it.
+    # ------------------------------------------------------------------
+    banner "case 3: the same under prterun"
+    clear_markers
+    OUT="$(RUN "prterun --host node2:1,node3:1,node4:1,node5:1,node6:1 \
+                    -np 1 --timeout 90 $PROG --markers $MARKERS 2>&1;
+                echo '--- done ---'")"
+    RAN="$(collect_markers)"
+    show_layout
+    judge "prterun" "the child's output reached the terminal"
+    clear_markers
+    cleanup_swarm
+}
+
+########################################################################
+
+case "$mode" in
+    linux) test_linux ;;
+    macos)
+        # One host means one daemon, so the two daemons in the story above
+        # are the same daemon and the only case that can be built is the
+        # control.  Saying so is more useful than running it.
+        echo "This runner has no macOS mode: the behavior it tests is about"
+        echo "WHICH daemon holds a subscription, and one host has only one."
+        exit 2 ;;
+    *) echo "usage: $0 [linux]" >&2; exit 2 ;;
+esac
+
+banner "summary"
+printf '  passed %d, failed %d, skipped %d\n' "$pass" "$fail" "$skip"
+[ "$fail" -eq 0 ]

--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -17,6 +17,7 @@ find information on that subject here.
    collectives/index.rst
    modex.rst
    inheritance/index.rst
+   iof_inheritance.rst
    resolve.rst
    adding_datatypes.rst
    pmix_log.rst

--- a/docs/how-things-work/iof_inheritance.rst
+++ b/docs/how-things-work/iof_inheritance.rst
@@ -67,29 +67,42 @@ The division follows the architectural split: PRRTE learns to route a job's outp
 
 4. Initialize a spawned child's set from its parent's, subject to the ``inherit`` rule. This is the routing half of the desired behavior, and it is what makes the property hold regardless of where the originating tool attached.
 
-**Planned - PMIx.**
+**PMIx - done.**
 
-5. Add a **delivery-time ancestry fallback**. When output for a namespace matches no subscription - the point at which the server currently falls through to caching it - walk that namespace's ``PMIX_PARENT_ID`` chain and re-test the subscriptions against each ancestor. Any daemon that receives a child's output and holds a subscription for one of its ancestors then delivers it, with no new wire protocol and no propagation of subscriptions between servers. This is what makes the PRRTE routing change sufficient, and it makes the "tool attaches later, then the job spawns" case fall out without further work.
+5. A **delivery-time ancestry fallback**. When output for a namespace matches no subscription - the point at which the server used to fall through to caching it - the server walks that namespace's ``PMIX_PARENT_ID`` chain and tests the subscriptions against each ancestor. A daemon that receives a child's output and holds a subscription for one of its ancestors delivers it, with no new wire protocol and no propagation of subscriptions between servers. See ``inherit_from_ancestry()`` in ``src/server/pmix_server_iof.c``.
 
-6. Provide a way for PRRTE's inheritance decision to reach PMIx. The timing is favorable: ``pmix_server_process_iof()`` runs from the spawn *completion*, after the host has processed the spawn, so the host has already decided by the time PMIx acts. The proposed mechanism is a new boolean attribute - absent meaning "inherit" - that PRRTE sets in the child namespace's job information; PMIx consults it when deciding whether to inherit. A server-wide default established at ``PMIx_server_init`` was considered and rejected because it cannot express a per-spawn override.
+   Two details of the implementation answered open questions that were on this page:
 
-The existing spawn-time inheritance (item 5's predecessor) is kept rather than replaced. It is what implements the precedence rule itself - the spawn request's own attributes against the parent's settings - and it answers the common co-located case without waiting for output to arrive.
+   * A match **clones** the ancestor's subscriptions onto the child's namespace rather than delivering that one chunk, so every later chunk takes the ordinary path and the datastore is consulted once per namespace instead of once per line. The clones are the same ones the spawn-time path creates, made by the same function, and have the same lifetime.
+
+   * The walk is **transitive**, bounded by ``PMIX_IOF_MAX_ANCESTRY``. "Treated the way its parent is treated" says nothing about depth, and the chain is host-supplied data, so the bound is what keeps a malformed or circular one from spinning the progress thread. It stops at the first ancestor anybody here is watching: once the clones exist, that generation's watchers are this namespace's watchers.
+
+   This turned out to close more than it was expected to. ``PMIX_PARENT_ID`` is per-process job data, so it is available on any server the namespace was registered with, and PRRTE funnels every daemon's output through the HNP, which hands everything it receives to its own PMIx server - which is where an ordinary ``prun`` or ``prterun`` tool's subscription lives. So for a tool attached to the HNP, the fallback alone is sufficient: ``run-spawn-iof.sh`` now passes with the tool, the spawning rank and the child job on three different daemons, against unmodified PRRTE.
+
+6. Provide a way for PRRTE's inheritance decision to reach PMIx. The timing is favorable: ``pmix_server_process_iof()`` runs from the spawn *completion*, after the host has processed the spawn, so the host has already decided by the time PMIx acts. The proposed mechanism is a new boolean attribute - absent meaning "inherit" - that PRRTE sets in the child namespace's job information; PMIx consults it when deciding whether to inherit. A server-wide default established at ``PMIx_server_init`` was considered and rejected because it cannot express a per-spawn override. **Still to do**, and note the fallback needs it as much as the spawn-time path does: it runs on a different daemon, so a decision that reaches only the spawner's daemon would be honored on one server and ignored on the other.
+
+The spawn-time inheritance is kept rather than replaced. It is what implements the precedence rule itself - the spawn request's own attributes against the parent's settings - and it answers the co-located case without waiting for output to arrive. The two are independent: neither needs the other to have happened, and where both apply the second finds the subscription the first created and does nothing.
+
+**What is left for PRRTE.** Items 1-4 are still the answer for a tool that is *not* attached to the HNP, and for a tool that attaches to a running DVM and pulls a job's output. Neither of those is reachable from the PMIx side: the first needs the output relayed to a daemon PRRTE does not currently send it to, and the second needs the request recorded against the job at all.
 
 Open questions
 --------------
 
-* Does ``PMIX_PARENT_ID`` reach a child namespace's registration on daemons that did not process the spawn? The delivery-time fallback depends on it. If it does not, PRRTE must include it.
+* Is a new attribute the right channel for the host's inheritance decision, and what should it be called? The alternative is for PRRTE to suppress inheritance by some other means and for PMIx to have no opinion. **Still open**, and it is now the only PMIx-side item left.
 
-* Is a new attribute the right channel for the host's inheritance decision, and what should it be called? The alternative is for PRRTE to suppress inheritance by some other means and for PMIx to have no opinion.
+Answered
+--------
 
-* Should the ancestry walk be transitive - a grandchild inheriting through a child that itself inherited - or only one level? Transitive is the more obviously correct reading of "treated the way its parent is treated", and costs nothing extra on the miss path.
+* *Does* ``PMIX_PARENT_ID`` *reach a child namespace's registration on daemons that did not process the spawn?* **Yes.** PRRTE adds it to the per-process job data in ``prte_pmix_server_register_nspace()``, which every daemon registering the namespace receives; ``pmix_pfexec`` records it for the job as a whole. The lookup tries the specific rank and then the wildcard, so both shapes answer. Demonstrated by ``run-spawn-iof.sh`` case 3, where the decision is taken on a daemon that hosts neither the spawner nor the child.
 
-* Should a match found through the ancestry walk register a real subscription for the child, so subsequent chunks take the fast path, or be re-tested per delivery? Registering is faster but adds a lifetime question; re-testing is simpler and only runs on output that would otherwise have been cached.
+* *Should the ancestry walk be transitive?* **Transitive**, bounded. See item 5.
+
+* *Should a match register a real subscription for the child, or be re-tested per delivery?* **Register.** Re-testing looked simpler until the cost was written down: it puts a datastore fetch in front of every line a watched job writes, where registering pays once per namespace. The lifetime question it seemed to add is not a new one - the clone is identical to the one the spawn-time path already creates, and is made by the same function.
 
 Sequencing and testing
 ----------------------
 
-The PMIx delivery-time fallback should land before the PRRTE routing change, because it is what makes the routing change pay off; until it is in place, relaying a child's output to a daemon holding only the parent's subscription still matches nothing.
+The PMIx delivery-time fallback landed first, and it turned out to be sufficient on its own for a tool attached to the HNP - which is every tool PRRTE's own launchers produce. The remaining PRRTE work is what a tool attached elsewhere needs.
 
 None of this is reachable from ``make check``. The spawn-time inheritance is covered by ``test/unit/iof_inherit.c``, which drives the parser and the registration directly and reads the subscription list back - it establishes which subscriptions are created and for whom, which needs no spawn, and no spawn is available in any case because ``test/simple/simptest`` cannot host one. Everything described above as planned is about *which daemon* holds a subscription and *where* bytes are relayed, so it can only be demonstrated across several daemons. The ten-container swarm under ``contrib/dockerswarm`` is the vehicle for that, and the cases worth building there are:
 

--- a/docs/how-things-work/iof_inheritance.rst
+++ b/docs/how-things-work/iof_inheritance.rst
@@ -46,6 +46,8 @@ This part is fixed. A spawn that names no output channel now clones the subscrip
 
 **The inheritance is performed on the wrong daemon for a multi-node DVM.** ``pmix_server_process_iof()`` runs on whichever PMIx server received the spawn command, which is the daemon hosting the *spawning process*. The tool's subscription for the parent job lives on the daemon the *tool* attached to. When those differ, the clone is built where the output does not arrive, and the server that does have the output has nothing to match it against.
 
+This is now demonstrated rather than argued: ``contrib/dockerswarm/run-spawn-iof.sh`` runs the same one-rank job twice against the same six-node DVM and the same tool, moving only the rank. With the rank on the tool's own daemon the child's output comes back on both channels; with the rank one node over, none of it does. The run also sharpens the diagnosis in a way worth keeping. In the failing case the child job happened to be placed on the *tool's own node*, so its output reached the very server that holds the tool's subscription - and was still dropped, because no subscription for the child's namespace was ever created anywhere. The two halves of the gap are therefore independent: this one is a PMIx bug about *where* the inheritance is performed, and it would still bite after PRRTE learns to route a child's output correctly.
+
 **PRRTE has no notion of a set of interested daemons.** ``jdata->originator`` is a single ``pmix_proc_t`` - "originator of a dynamic spawn" - and ``prte_iof_hnp_relay_to_tool()`` relays a job's output to exactly that one daemon. For a client-issued spawn the field is set to the requesting process and then overwritten at the HNP with the daemon that forwarded the launch request, so a child job's output is relayed toward the *spawner's* daemon rather than toward any tool.
 
 **A tool that pulls an existing job's output is not recorded anywhere.** The ``iof_pull`` upcall handler defines sinks on the daemon's own ``stdout``/``stderr`` and returns; it does not record which tool asked, or on which daemon it sits. Consequently a tool attached to a daemon that hosts none of a job's processes receives nothing from the other nodes - and this is true of the *parent* job, not merely of a child. The last of the desired properties above therefore cannot be layered on top of the current code; the parent case has to be built first.
@@ -95,4 +97,12 @@ None of this is reachable from ``make check``. The spawn-time inheritance is cov
 * the same under ``prterun`` rather than a persistent DVM;
 * a tool that attaches to a non-master daemon, pulls a running job's output, and then observes the output of a job that job spawns.
 
-The first of these is also the reproducer for the current gap, so it is worth building before any of the planned work, to hold the analysis above down.
+The first two are built, in ``contrib/dockerswarm/run-spawn-iof.sh``, driving ``examples/spawn_iof.c``; README §21 describes the geometry. The runner reports:
+
+* **spawner on the tool's daemon** - the child's output comes back on both channels. This is the control: it says the example, the launcher and the capture work, so that the next line means something.
+* **spawner one node over** - nothing of the child's output comes back. This is the reproducer, and it fails today.
+* **the same under prterun** - the output does reach the terminal. ``prterun`` also writes output locally, so its terminal is fed by a route that has nothing to do with the subscription being inherited; a pass here is not evidence that the inheritance worked, and the runner says so rather than counting it.
+
+Reading a negative result needs one more thing, because "the forwarding dropped it" and "the child never ran" look identical from the tool and want opposite repairs. ``spawn_iof --markers <dir>`` therefore has every process drop a file of its identity on the node it is running on, by a channel with nothing to do with IOF; the runner gathers those from all ten nodes and prints the layout under every case. That is how the failing case above can say *where* the child ran.
+
+The third case waits on the PRRTE work: it depends on a tool's ``iof_pull`` being recorded against a job at all, which is item 2 of the plan. Until then it would only restate the second case's result.

--- a/docs/how-things-work/iof_inheritance.rst
+++ b/docs/how-things-work/iof_inheritance.rst
@@ -1,7 +1,7 @@
 Output Forwarding for Spawned Jobs
 ==================================
 
-This page describes how the output of a *dynamically spawned* job is routed, what the current implementation does and does not do, and the plan for closing the gap. It is a working design document rather than a description of finished behavior: the sections marked **Planned** are not implemented yet.
+This page describes how the output of a *dynamically spawned* job is routed, what the current implementation does and does not do, and what is left. It is a working design document rather than a description of finished behavior. The PMIx side is implemented; the items still marked **Planned - PRRTE** are not, and the "What is missing" section below is kept as the description of the defect each fix closed rather than as a statement of current behavior.
 
 The behavior we want
 --------------------
@@ -67,7 +67,7 @@ The division follows the architectural split: PRRTE learns to route a job's outp
 
 4. Initialize a spawned child's set from its parent's, subject to the ``inherit`` rule. This is the routing half of the desired behavior, and it is what makes the property hold regardless of where the originating tool attached.
 
-**PMIx - done.**
+**PMIx - done.** Both items below are implemented.
 
 5. A **delivery-time ancestry fallback**. When output for a namespace matches no subscription - the point at which the server used to fall through to caching it - the server walks that namespace's ``PMIX_PARENT_ID`` chain and tests the subscriptions against each ancestor. A daemon that receives a child's output and holds a subscription for one of its ancestors delivers it, with no new wire protocol and no propagation of subscriptions between servers. See ``inherit_from_ancestry()`` in ``src/server/pmix_server_iof.c``.
 
@@ -79,19 +79,20 @@ The division follows the architectural split: PRRTE learns to route a job's outp
 
    This turned out to close more than it was expected to. ``PMIX_PARENT_ID`` is per-process job data, so it is available on any server the namespace was registered with, and PRRTE funnels every daemon's output through the HNP, which hands everything it receives to its own PMIx server - which is where an ordinary ``prun`` or ``prterun`` tool's subscription lives. So for a tool attached to the HNP, the fallback alone is sufficient: ``run-spawn-iof.sh`` now passes with the tool, the spawning rank and the child job on three different daemons, against unmodified PRRTE.
 
-6. Provide a way for PRRTE's inheritance decision to reach PMIx. The timing is favorable: ``pmix_server_process_iof()`` runs from the spawn *completion*, after the host has processed the spawn, so the host has already decided by the time PMIx acts. The proposed mechanism is a new boolean attribute - absent meaning "inherit" - that PRRTE sets in the child namespace's job information; PMIx consults it when deciding whether to inherit. A server-wide default established at ``PMIx_server_init`` was considered and rejected because it cannot express a per-spawn override. **Still to do**, and note the fallback needs it as much as the spawn-time path does: it runs on a different daemon, so a decision that reaches only the spawner's daemon would be honored on one server and ignored on the other.
+6. A channel for the host's inheritance decision: ``PMIX_IOF_INHERIT``, a boolean the host places in the job-level information of the spawned namespace. Absent means "inherit", so a host says nothing unless it is turning inheritance off. Both decision points consult it through ``iof_inherit_allowed()``.
+
+   Job information is the channel rather than anything carried with the spawn request, and that follows from the two decision points being on *different daemons*: the flag has to be readable by the server the output arrives at, which may have had nothing to do with the spawn. Job info is exactly the thing PRRTE already ships to every daemon that registers the namespace - it is how ``PMIX_PARENT_ID`` gets there. Nothing about it is read by the spawned processes; it is server-side state that happens to be keyed by their namespace. A server-wide default at ``PMIx_server_init`` was rejected because it cannot express a per-job answer, and PRRTE's inherit setting is per-job.
+
+   The spawn-time site needs one more rule, because it is the only place where "the host said nothing" and "we cannot ask yet" are distinguishable. It runs from the spawn *completion*, and whether the child's namespace has been registered with that server by then is the host's business - a daemon hosting none of the child's processes may never register it at all. A fetch that found nothing there would read as "inherit", which is the wrong way to be wrong: it would clone against the host's wishes and nothing would take the clone back. So an unregistered namespace defers to the delivery-time half, which cannot run before the namespace exists and therefore always has a real answer. Deferring is never *behaviorally* wrong - it only postpones a decision that the other half will make correctly.
 
 The spawn-time inheritance is kept rather than replaced. It is what implements the precedence rule itself - the spawn request's own attributes against the parent's settings - and it answers the co-located case without waiting for output to arrive. The two are independent: neither needs the other to have happened, and where both apply the second finds the subscription the first created and does nothing.
 
 **What is left for PRRTE.** Items 1-4 are still the answer for a tool that is *not* attached to the HNP, and for a tool that attaches to a running DVM and pulls a job's output. Neither of those is reachable from the PMIx side: the first needs the output relayed to a daemon PRRTE does not currently send it to, and the second needs the request recorded against the job at all.
 
-Open questions
---------------
-
-* Is a new attribute the right channel for the host's inheritance decision, and what should it be called? The alternative is for PRRTE to suppress inheritance by some other means and for PMIx to have no opinion. **Still open**, and it is now the only PMIx-side item left.
-
 Answered
 --------
+
+* *Is a new attribute the right channel for the host's inheritance decision?* **Yes**, and it is ``PMIX_IOF_INHERIT`` in the spawned namespace's job information. The alternative considered - PMIx having no opinion, and a spawn controlling its own output through the ``PMIX_FWD_*`` directives it already has - would have left a launcher's ``inherit`` setting silently not covering output forwarding. See item 6.
 
 * *Does* ``PMIX_PARENT_ID`` *reach a child namespace's registration on daemons that did not process the spawn?* **Yes.** PRRTE adds it to the per-process job data in ``prte_pmix_server_register_nspace()``, which every daemon registering the namespace receives; ``pmix_pfexec`` records it for the job as a whole. The lookup tries the specific rank and then the wildcard, so both shapes answer. Demonstrated by ``run-spawn-iof.sh`` case 3, where the decision is taken on a daemon that hosts neither the spawner nor the child.
 

--- a/docs/how-things-work/iof_inheritance.rst
+++ b/docs/how-things-work/iof_inheritance.rst
@@ -1,0 +1,98 @@
+Output Forwarding for Spawned Jobs
+==================================
+
+This page describes how the output of a *dynamically spawned* job is routed, what the current implementation does and does not do, and the plan for closing the gap. It is a working design document rather than a description of finished behavior: the sections marked **Planned** are not implemented yet.
+
+The behavior we want
+--------------------
+
+A job spawned through ``PMIx_Spawn`` should have its output forwarded according to the following precedence, highest first:
+
+1. **The output attributes the spawn request carried.** If the request named any of ``PMIX_FWD_STDOUT``, ``PMIX_FWD_STDERR`` or ``PMIX_FWD_STDDIAG``, that request is honored exactly as written - including a channel explicitly set to ``false``, which is how a spawn asks for silence from a job whose parent is being watched. A partial request is not merged into anything else; naming one channel settles the matter for all of them.
+
+2. **Otherwise, the child inherits its parent's output forwarding** - unless the PRRTE ``inherit`` MCA parameter was explicitly *set* to false. "Inherits" means the child is treated the way the parent is being treated: whoever is receiving the parent job's output also receives the child's, on the same channels and with the same formatting.
+
+Two properties of that second rule matter as much as the rule itself, and they are what make this more than a local bookkeeping change:
+
+* It must hold **regardless of which daemon the originating tool attached to** when it launched the parent job, and it must hold under ``prterun`` as well as under a persistent DVM.
+
+* It must also hold for a tool that connects to a DVM daemon *after* a job is running and asks (through ``PMIx_IOF_pull``) for that job's output to be forwarded to it. If that job subsequently spawns a child, the tool's request carries over to the child, so the tool receives a copy of the child's output too.
+
+Finally, one thing that must **not** happen: output is never forwarded to an application process. Doing so is a loopback rather than a fallback - the output would simply be emitted again on the receiving process's own ``stdout``, for the runtime to collect and forward a second time. So where there is nothing to inherit, no forwarding is set up at all.
+
+How output forwarding works today
+---------------------------------
+
+Responsibility is split cleanly between the two projects, and keeping the split straight is the key to reading any of this code:
+
+* **PRRTE gets the bytes to the right daemon.** A ``prted`` captures its local processes' output and forwards it to the HNP; the HNP fans it back out. There is no daemon-to-daemon traffic - everything funnels through the HNP. PRRTE's own write machinery (sinks, write handlers) is used almost entirely for the ``stdin`` direction.
+
+* **PMIx decides who gets a copy, and emits it.** Every daemon hands the output it has to ``PMIx_server_IOF_deliver()``. The PMIx server writes it locally if it is meant to, then walks ``pmix_globals.iof_requests`` - the list of ``pmix_iof_req_t`` subscriptions - and sends a copy to every registered requestor whose channel and source filters match. Output that matches nothing is cached in ``pmix_server_globals.iof`` until it ages out of that bounded cache.
+
+A tool's subscription is therefore held by **the PMIx server of the daemon that tool attached to**, and only that server can deliver to it. For output produced elsewhere to reach that tool, PRRTE must relay a copy to that daemon. That is what ``prte_iof_hnp_relay_to_tool()`` does, and it selects the destination from ``jdata->originator``.
+
+Two details of the current implementation are easy to miss and change the analysis:
+
+* **The HNP hands everything it receives to its own PMIx server**, not merely what it relays onward. So a tool attached to the HNP - the ordinary ``prun --dvm-uri`` case - is reachable for any job's output, whether or not the relay would have selected the HNP.
+
+* **PRRTE already inherits the parent's output** *formatting* **directives** onto a spawned child, gated on the same ``inherit`` flag as mapping, ranking and binding: tagging, timestamping and stderr/stdout merging are copied from parent to child. What is not inherited is anything about *who receives* the output.
+
+What is missing
+---------------
+
+**PMIx did not give a spawned job any subscription at all.** The spawn parser defaulted the output channels on only when the spawn came from a *tool*, so a spawn issued by an ordinary application process - an ``MPI_Comm_spawn`` - subscribed to nothing, and the child's output matched no request and aged out of the cache unseen. Asking explicitly did not help either: ``PMIX_FWD_STDOUT`` is documented as forwarding the output "to this process", and the request was registered and the bytes shipped, but every place that would arm local writing for the spawned namespace is gated on the peer being a tool. There was no combination of directives a client could pass that worked.
+
+This part is fixed. A spawn that names no output channel now clones the subscriptions covering the spawning process's own job onto the child's namespace, keeping the requestor, channels, formatting and handler id, so the child's output goes where the parent's goes. See ``inherit_parent_iof()`` in ``src/server/pmix_server_iof.c``. **It is only sufficient when the spawn is processed on the same server that holds the parent's subscription** - a single-node DVM, ``prterun`` on one node, or any layout where the spawner's daemon is also the tool's daemon.
+
+**The inheritance is performed on the wrong daemon for a multi-node DVM.** ``pmix_server_process_iof()`` runs on whichever PMIx server received the spawn command, which is the daemon hosting the *spawning process*. The tool's subscription for the parent job lives on the daemon the *tool* attached to. When those differ, the clone is built where the output does not arrive, and the server that does have the output has nothing to match it against.
+
+**PRRTE has no notion of a set of interested daemons.** ``jdata->originator`` is a single ``pmix_proc_t`` - "originator of a dynamic spawn" - and ``prte_iof_hnp_relay_to_tool()`` relays a job's output to exactly that one daemon. For a client-issued spawn the field is set to the requesting process and then overwritten at the HNP with the daemon that forwarded the launch request, so a child job's output is relayed toward the *spawner's* daemon rather than toward any tool.
+
+**A tool that pulls an existing job's output is not recorded anywhere.** The ``iof_pull`` upcall handler defines sinks on the daemon's own ``stdout``/``stderr`` and returns; it does not record which tool asked, or on which daemon it sits. Consequently a tool attached to a daemon that hosts none of a job's processes receives nothing from the other nodes - and this is true of the *parent* job, not merely of a child. The last of the desired properties above therefore cannot be layered on top of the current code; the parent case has to be built first.
+
+The plan
+--------
+
+The division follows the architectural split: PRRTE learns to route a job's output to every daemon that has an interested tool, and PMIx learns to recognize that a subscription covering a parent job also covers its children.
+
+**Planned - PRRTE.**
+
+1. Give a job a **set of interested daemons** for output-routing purposes, rather than deriving a single destination from ``jdata->originator``. Seed it with the daemon hosting the tool that launched the job, which is what ``originator`` supplies today.
+
+2. Record the requesting tool's daemon into that set in the ``iof_pull`` upcall, for each job the request names. This is what makes a tool that attaches later and pulls an existing job's output work across nodes at all, and it is a prerequisite for the child case rather than part of it.
+
+3. Fan out in ``prte_iof_hnp_relay_to_tool()`` to the whole set instead of to a single daemon.
+
+4. Initialize a spawned child's set from its parent's, subject to the ``inherit`` rule. This is the routing half of the desired behavior, and it is what makes the property hold regardless of where the originating tool attached.
+
+**Planned - PMIx.**
+
+5. Add a **delivery-time ancestry fallback**. When output for a namespace matches no subscription - the point at which the server currently falls through to caching it - walk that namespace's ``PMIX_PARENT_ID`` chain and re-test the subscriptions against each ancestor. Any daemon that receives a child's output and holds a subscription for one of its ancestors then delivers it, with no new wire protocol and no propagation of subscriptions between servers. This is what makes the PRRTE routing change sufficient, and it makes the "tool attaches later, then the job spawns" case fall out without further work.
+
+6. Provide a way for PRRTE's inheritance decision to reach PMIx. The timing is favorable: ``pmix_server_process_iof()`` runs from the spawn *completion*, after the host has processed the spawn, so the host has already decided by the time PMIx acts. The proposed mechanism is a new boolean attribute - absent meaning "inherit" - that PRRTE sets in the child namespace's job information; PMIx consults it when deciding whether to inherit. A server-wide default established at ``PMIx_server_init`` was considered and rejected because it cannot express a per-spawn override.
+
+The existing spawn-time inheritance (item 5's predecessor) is kept rather than replaced. It is what implements the precedence rule itself - the spawn request's own attributes against the parent's settings - and it answers the common co-located case without waiting for output to arrive.
+
+Open questions
+--------------
+
+* Does ``PMIX_PARENT_ID`` reach a child namespace's registration on daemons that did not process the spawn? The delivery-time fallback depends on it. If it does not, PRRTE must include it.
+
+* Is a new attribute the right channel for the host's inheritance decision, and what should it be called? The alternative is for PRRTE to suppress inheritance by some other means and for PMIx to have no opinion.
+
+* Should the ancestry walk be transitive - a grandchild inheriting through a child that itself inherited - or only one level? Transitive is the more obviously correct reading of "treated the way its parent is treated", and costs nothing extra on the miss path.
+
+* Should a match found through the ancestry walk register a real subscription for the child, so subsequent chunks take the fast path, or be re-tested per delivery? Registering is faster but adds a lifetime question; re-testing is simpler and only runs on output that would otherwise have been cached.
+
+Sequencing and testing
+----------------------
+
+The PMIx delivery-time fallback should land before the PRRTE routing change, because it is what makes the routing change pay off; until it is in place, relaying a child's output to a daemon holding only the parent's subscription still matches nothing.
+
+None of this is reachable from ``make check``. The spawn-time inheritance is covered by ``test/unit/iof_inherit.c``, which drives the parser and the registration directly and reads the subscription list back - it establishes which subscriptions are created and for whom, which needs no spawn, and no spawn is available in any case because ``test/simple/simptest`` cannot host one. Everything described above as planned is about *which daemon* holds a subscription and *where* bytes are relayed, so it can only be demonstrated across several daemons. The ten-container swarm under ``contrib/dockerswarm`` is the vehicle for that, and the cases worth building there are:
+
+* a client-issued spawn where the spawning rank is hosted by a daemon other than the one the launching tool attached to;
+* the same under ``prterun`` rather than a persistent DVM;
+* a tool that attaches to a non-master daemon, pulls a running job's output, and then observes the output of a job that job spawns.
+
+The first of these is also the reproducer for the current gap, so it is worth building before any of the planned work, to hold the analysis above down.

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -368,6 +368,15 @@ process that spawned it: output is never forwarded to an application process,
 which would only emit it again on its own ``stdout`` for the runtime to
 collect and forward a second time.
 
+The host environment has the final say. A host that does not want a spawned
+job to inherit |mdash| because the user asked its launcher not to, for example
+|mdash| sets ``PMIX_IOF_INHERIT`` to ``false`` in the job-level information it
+supplies for the spawned namespace, and no forwarding is inherited for that
+job. Absence of the attribute means inheritance is allowed, so a host that has
+no opinion sends nothing. This does not override a request that named a channel
+of its own; naming a channel has already settled the matter before the host's
+preference is consulted.
+
 * ``PMIX_FWD_STDIN`` (bool) |mdash| forward this process's ``stdin`` to the target
   processes. This is the opposite direction and has no bearing on the output
   inheritance described above.

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -344,8 +344,33 @@ non-``IOF`` output attributes (see the note below).
 
 Selecting which streams to forward:
 
+If the request names none of the three output attributes below, the spawned job
+**inherits its parent's output forwarding**: whoever is receiving the output of
+the job that issued the spawn also receives the output of the job it spawned, on
+the same channels and with the same formatting. This is what makes a child
+launched by an ordinary application process |mdash| an ``MPI_Comm_spawn``, for
+example |mdash| appear where its parent's output appears, without the parent
+having to describe a destination it has no way to know.
+
+Naming *any* one of them turns inheritance off and the request is taken exactly
+as written, including a channel explicitly set to ``false`` (which is how a
+spawn asks for silence from a job whose parent is being watched). Partial
+requests are not merged into the inherited set.
+
+A tool is not a member of a job and so has no parent to inherit from; a spawn
+issued by a tool that names no output attribute continues to default to
+forwarding all three output channels to that tool.
+
+When there is nothing to inherit |mdash| the request named no channel *and*
+nobody is watching the spawning job's output |mdash| no forwarding is set up.
+There is deliberately no fallback to forwarding the child's output to the
+process that spawned it: output is never forwarded to an application process,
+which would only emit it again on its own ``stdout`` for the runtime to
+collect and forward a second time.
+
 * ``PMIX_FWD_STDIN`` (bool) |mdash| forward this process's ``stdin`` to the target
-  processes.
+  processes. This is the opposite direction and has no bearing on the output
+  inheritance described above.
 * ``PMIX_FWD_STDOUT`` (bool) |mdash| forward the spawned processes' ``stdout`` to
   this process (typically used by a tool).
 * ``PMIX_FWD_STDERR`` (bool) |mdash| forward the spawned processes' ``stderr`` to

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -89,7 +89,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   simple simple_server abort group_die connect_die group_leave \
                   group_destruct_die group_invite group_invite_timeout group_invite_decline \
                   group_invite_abort group_invite_others group_invite_suppress group_invite_nb topology \
-                  spawn_reuse group_badinfo datatypes toolswitch
+                  spawn_reuse spawn_iof group_badinfo datatypes toolswitch
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -188,6 +188,10 @@ group_badinfo_LDADD = $(top_builddir)/src/libpmix.la
 spawn_reuse_SOURCES = spawn_reuse.c examples.h
 spawn_reuse_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 spawn_reuse_LDADD = $(top_builddir)/src/libpmix.la
+
+spawn_iof_SOURCES = spawn_iof.c examples.h
+spawn_iof_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+spawn_iof_LDADD = $(top_builddir)/src/libpmix.la
 
 group_invite_suppress_SOURCES = group_invite_suppress.c examples.h
 group_invite_suppress_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)

--- a/examples/spawn_iof.c
+++ b/examples/spawn_iof.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/* spawn_iof - does the output of a spawned job reach whoever is watching
+ * the job that spawned it?
+ *
+ * The parent job is launched by a tool (prun, prterun) and so its output is
+ * already being forwarded to that tool. Rank 0 then calls PMIx_Spawn naming
+ * NONE of PMIX_FWD_STDOUT/STDERR/STDDIAG, which is the request to be treated
+ * the way the parent is being treated: the child's output should come out of
+ * the same terminal the parent's does. See
+ * docs/how-things-work/iof_inheritance.rst.
+ *
+ * Every line this program writes is prefixed so a harness can tell the two
+ * jobs apart without knowing either namespace in advance:
+ *
+ *    SPAWN_IOF parent <nspace>:<rank> host <host>   (parent, stdout)
+ *    SPAWN_IOF spawned <child-nspace>               (rank 0, stdout)
+ *    SPAWN_IOF child <nspace>:<rank> host <host>    (child, stdout)
+ *    SPAWN_IOF childerr <nspace>:<rank> host <host> (child, stderr)
+ *
+ * The interesting question is a routing one, so WHERE each line was written
+ * is part of the answer and every line carries its host. A run in which the
+ * spawning rank sits on the same daemon as the tool proves much less than one
+ * in which it does not; contrib/dockerswarm/run-spawn-iof.sh drives both.
+ *
+ * Rank 0 waits for the child job to terminate before it finalizes, because
+ * the parent job going away first would tear down the very forwarding under
+ * test. The wait is bounded: a missing termination event is a failure to
+ * report, not a reason to hang a suite.
+ *
+ * One more thing is needed to read a NEGATIVE result. If the child's lines
+ * never appear, the run alone cannot say whether the forwarding dropped them
+ * or the child never ran at all - and those want opposite repairs. So with
+ *
+ *    spawn_iof --markers <dir>
+ *
+ * each process also drops a file of the same content into <dir> on the node
+ * it is running on, by a channel that has nothing to do with IOF, and rank 0
+ * passes the option down to the child. Without it - the ordinary way to run
+ * this - no files are written. The directory travels in argv rather than in
+ * the environment because argv is what a spawn is guaranteed to carry: what
+ * a launcher forwards of its own environment is its business, and the child
+ * job does not inherit it in any case.
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+static char hostname[1024];
+static char *markerdir = NULL;
+static volatile bool child_done = false;
+
+/* the child job ended - stop waiting */
+static void tercbfunc(size_t evhdlr_registration_id, pmix_status_t status,
+                      const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                      pmix_info_t results[], size_t nresults,
+                      pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source,
+                                info, ninfo, results, nresults);
+
+    child_done = true;
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* Say the same thing again, out of band, so that a run in which no output
+ * arrives can still be told apart from a run in which nothing happened. */
+static void drop_marker(const char *what)
+{
+    char path[1024];
+    FILE *fp;
+
+    if (NULL == markerdir) {
+        return;
+    }
+    snprintf(path, sizeof(path), "%s/spawn_iof.%s.%s.%u",
+             markerdir, what, myproc.nspace, myproc.rank);
+    fp = fopen(path, "w");
+    if (NULL == fp) {
+        fprintf(stderr, "SPAWN_IOF %s:%u cannot write %s\n",
+                myproc.nspace, myproc.rank, path);
+        return;
+    }
+    fprintf(fp, "SPAWN_IOF %s %s:%u host %s\n", what, myproc.nspace, myproc.rank, hostname);
+    fclose(fp);
+}
+
+static void regcbfunc(pmix_status_t status, size_t evhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(evhandler_ref);
+
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+/* the child job: say who and where we are, on both channels */
+static int be_the_child(void)
+{
+    pmix_status_t rc;
+
+    printf("SPAWN_IOF child %s:%u host %s\n", myproc.nspace, myproc.rank, hostname);
+    fflush(stdout);
+    fprintf(stderr, "SPAWN_IOF childerr %s:%u host %s\n",
+            myproc.nspace, myproc.rank, hostname);
+    fflush(stderr);
+    drop_marker("child");
+
+    rc = PMIx_Finalize(NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "SPAWN_IOF child %s:%u PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        return 1;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc, code = PMIX_ERR_JOB_TERMINATED;
+    pmix_app_t *app;
+    pmix_info_t jinfo[1];
+    pmix_nspace_t child;
+    mylock_t mylock;
+    bool am_child = false;
+    int i, secs;
+
+    for (i = 1; i < argc; i++) {
+        if (0 == strcmp(argv[i], "child")) {
+            am_child = true;
+        } else if (0 == strcmp(argv[i], "--markers")) {
+            if (argc == ++i) {
+                fprintf(stderr, "--markers requires a directory\n");
+                exit(1);
+            }
+            markerdir = argv[i];
+        } else {
+            fprintf(stderr, "usage: %s [child] [--markers <dir>]\n", argv[0]);
+            exit(1);
+        }
+    }
+
+    if (0 > gethostname(hostname, sizeof(hostname))) {
+        strcpy(hostname, "unknown");
+    }
+    hostname[sizeof(hostname) - 1] = '\0';
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "SPAWN_IOF PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    if (am_child) {
+        return be_the_child();
+    }
+
+    /* the parent job - our own output is what the tool is already watching */
+    printf("SPAWN_IOF parent %s:%u host %s\n", myproc.nspace, myproc.rank, hostname);
+    fflush(stdout);
+    drop_marker("parent");
+
+    if (0 != myproc.rank) {
+        /* only rank 0 spawns; the rest are here to be somewhere else */
+        goto done;
+    }
+
+    /* ask to be told when the child job ends, and be ready to hear it
+     * BEFORE the spawn - a short-lived child can finish first */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, tercbfunc, regcbfunc, (void *) &mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "SPAWN_IOF %s:%u could not register for job termination: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    PMIX_APP_CREATE(app, 1);
+    app->cmd = strdup(argv[0]);
+    app->maxprocs = 1;
+    PMIx_Argv_append_nosize(&app->argv, argv[0]);
+    PMIx_Argv_append_nosize(&app->argv, "child");
+    if (NULL != markerdir) {
+        PMIx_Argv_append_nosize(&app->argv, "--markers");
+        PMIx_Argv_append_nosize(&app->argv, markerdir);
+    }
+
+    /* NOTHING about output forwarding is named here - that is the point.
+     * PMIX_NOTIFY_COMPLETION is not an output directive and so does not
+     * turn inheritance off. */
+    PMIX_INFO_LOAD(&jinfo[0], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL);
+
+    rc = PMIx_Spawn(jinfo, 1, app, 1, child);
+    PMIX_INFO_DESTRUCT(&jinfo[0]);
+    PMIX_APP_FREE(app, 1);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "SPAWN_IOF %s:%u PMIx_Spawn failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    printf("SPAWN_IOF spawned %s\n", child);
+    fflush(stdout);
+
+    /* Stay alive until the child is done: the parent job ending is what
+     * tears down the forwarding we are asking about. Bounded, so a lost
+     * notification shows up as a stated timeout instead of a hung suite. */
+    for (secs = 0; !child_done && secs < 30; ++secs) {
+        sleep(1);
+    }
+    if (!child_done) {
+        fprintf(stderr, "SPAWN_IOF %s:%u timed out waiting for %s to end\n",
+                myproc.nspace, myproc.rank, child);
+    }
+
+done:
+    rc = PMIx_Finalize(NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "SPAWN_IOF parent %s:%u PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        return 1;
+    }
+    return 0;
+}

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1332,6 +1332,15 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_IOF_LOCAL_OUTPUT               "pmix.iof.local"        // (bool) Write output streams to local stdout/err
 #define PMIX_IOF_OUTPUT_RAW                 "pmix.iof.raw"          // (bool) Do not buffer output to be written as complete lines - output
                                                                     //        characters as the stream delivers them
+#define PMIX_IOF_INHERIT                    "pmix.iof.inhrt"        // (bool) Provided by the host in the job-level information of a
+                                                                    //        dynamically spawned job: whether that job is to inherit the
+                                                                    //        output forwarding of the job that spawned it - i.e., whether
+                                                                    //        whoever is receiving the parent job's output is to receive
+                                                                    //        this job's output as well. Absence of the attribute means
+                                                                    //        "true", so a host says nothing unless it is turning
+                                                                    //        inheritance off. Directives on the spawn request itself take
+                                                                    //        precedence: naming any of PMIX_FWD_STDOUT/STDERR/STDDIAG
+                                                                    //        settles the matter and this attribute is not consulted.
 
 /* Attributes for controlling contents of application setup data */
 #define PMIX_SETUP_APP_ENVARS               "pmix.setup.env"        // (bool) harvest and include relevant envars

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -239,6 +239,7 @@ static void _spawn_for_host(int sd, short args, void *cbdata)
      * to catch any early output - and a request for notification
      * of job termination so we can setup the event registration */
     pmix_server_spawn_parser(fcd->peer, &fcd->channels, &fcd->flags,
+                             &fcd->inherit_iof,
                              fcd->info, fcd->ninfo);
     /* a no-op on this branch - the stash is for tools, and the entry
      * point has already excluded them. Kept so the two dispatch paths
@@ -734,6 +735,7 @@ envars_done:
 
     /* check for IOF flags */
     pmix_server_spawn_parser(fcd->peer, &fcd->channels, &fcd->flags,
+                             &fcd->inherit_iof,
                              fcd->info, fcd->ninfo);
     stash_spawn_iof_flags(&fcd->flags);
 

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -136,7 +136,13 @@ pmix_status_t pmix_gds_base_store_modex(pmix_buffer_t *buff,
     pmix_proc_t proc;
     pmix_buffer_t pbkt;
     bool compressed, decompressed, found;
-    pmix_collect_t last_blob_info_byte, blob_info_byte;
+    pmix_collect_t last_blob_info_byte;
+    /* PMIX_BYTE writes exactly one byte through this pointer, and
+     * pmix_collect_t is an enum carrying a negative member - so the
+     * compiler makes it int-sized and an unpack into it leaves three
+     * bytes of the comparisons below reading whatever was on the stack.
+     * pmix_server_collect_data packs a uint8_t; read one back. */
+    uint8_t blob_info_byte;
     pmix_list_t nspaces;
     pmix_proclist_t *plist;
 
@@ -220,8 +226,8 @@ pmix_status_t pmix_gds_base_store_modex(pmix_buffer_t *buff,
                 goto exit;
             }
             if (PMIX_COLLECT_INVALID == last_blob_info_byte) {
-                last_blob_info_byte = blob_info_byte;
-            } else if (last_blob_info_byte != blob_info_byte) {
+                last_blob_info_byte = (pmix_collect_t) blob_info_byte;
+            } else if (last_blob_info_byte != (pmix_collect_t) blob_info_byte) {
                 // we have a mismatch - report the error
                 pmix_show_help("help-pmix-server.txt", "collection-mismatch", true);
                 rc = PMIX_ERR_BAD_PARAM;

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -1182,6 +1182,74 @@ the client-driven pull/registration commands. Note `pmix_server_process_iof`
 drains the cache into a newly registered request so a late subscriber
 still sees recently produced output.
 
+**A spawned job inherits its parent's forwarding, and the reason it has
+to is worth understanding before touching `pmix_server_spawn_parser`.**
+That parser used to default the output channels on only for a **tool**,
+so a spawn issued by an ordinary client subscribed to nothing and the
+child's output matched no request, was cached, and aged out unseen
+([openpmix#4120][i4120]). The fix is *not* to forward the child's output
+to the spawning client: a client has nowhere to put it — every place
+that would arm local writing is deliberately tool-only, and
+`pmix_globals.iof_flags.local_output` is false for a non-singleton
+client — so that merely moves the drop one hop later.
+
+What the child gets instead is whatever the *parent job* has.
+"The parent's settings" are not stored anywhere as settings; what exists
+is the set of live subscriptions covering the spawning process's job,
+which is the same thing seen from the other end — **whoever receives the
+parent's output should receive the child's**. `inherit_parent_iof()`
+clones each such request onto the child's namespace, keeping the
+requestor, channels, formatting *and `remote_id`*, so the child's output
+lands at the requestor under the handler id the parent's already uses.
+
+The ordering is: a channel named on the spawn wins, else the parent's
+subscriptions. **There is deliberately no third level.** If nothing is
+watching the parent there is nowhere for the child's output to go, and
+falling back to forwarding it to the spawner would be a loopback rather
+than a fallback — output is never forwarded to an application process,
+which would only emit it again on its own stdout for the runtime to
+collect and forward a second time. (An `iof_spawn_default` MCA parameter
+was written for that slot and removed before merge for this reason;
+PRRTE's existing `prte_rmaps_default_inherit` is the place to control
+inheritance from, and layering a second one would only confuse users.)
+`pmix_server_spawn_parser` reports the first of those through its
+`inherit` out-parameter — **naming any one
+output channel turns inheritance off for all of them**, including naming
+one `false`, which is how a spawn asks for silence from a job whose
+parent is being watched. A tool is not a member of a job, so it has no
+parent and keeps its own "forward everything to me" default; `prun`
+depends on that.
+
+Two things fall out that are easy to get wrong:
+
+- **`drain_cache()` is driven by namespace, not by request.** A job can
+  inherit more than one watcher, and a cache entry is consumed the moment
+  it is forwarded — so draining per-request would hand the cached head of
+  the stream to whichever watcher was cloned first and the rest of the
+  stream to all of them.
+- **The clone is subject to the same screens `pmix_iof_process_iof`
+  applies before forwarding** (non-NULL requestor, non-NULL
+  `requestor->info`, not finalized). A request it would refuse is not
+  worth inheriting, and the `info` read is load-bearing rather than
+  defensive because the verbose line dereferences it.
+
+**Known limit — this fixes the case where the spawn is processed on the
+server that holds the parent's subscription**, which covers a single-node
+DVM, `prterun`, and any layout where the spawner's daemon is also the
+tool's daemon. On a multi-node DVM it is not sufficient by itself: PRRTE
+registers a tool's IOF request with *the daemon that tool attached to*
+and routes a job's output there using `jdata->originator`, which for a
+client-issued spawn is set to the daemon hosting the spawner rather than
+the one hosting the tool. So the cloned request is created on a server
+the HNP will indeed relay the child's output to, but the parent's
+subscription that it would clone lives on a different daemon and is not
+visible there. Closing that needs the PRRTE side; see
+`src/mca/iof/AGENTS.md` in PRRTE for the relay path.
+
+Coverage: [`test/unit/iof_inherit.c`](../../test/unit/iof_inherit.c).
+
+[i4120]: https://github.com/openpmix/openpmix/issues/4120
+
 **The three client-driven commands own the arrays they unpack, and the
 `pmix_setup_caddy_t` will not believe it without being told.** They are
 the mirror image of the two public push APIs, which park the *caller's*

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -1271,6 +1271,35 @@ subscription is. Four things about it are load-bearing:
   run, and where both apply the second finds the subscription the first
   created and does nothing.
 
+**The host gets the final say through `PMIX_IOF_INHERIT`, and where it is
+read follows from the two halves being on different daemons.** The
+attribute is a boolean the host places in the *job-level information of
+the spawned namespace*; absent means "inherit", so a host sends it only
+to say no. Nothing about it is read by the spawned processes — it is
+server-side state that happens to be keyed by their namespace, read out
+of the local datastore by `iof_inherit_allowed()` exactly as
+`PMIX_PARENT_ID` is. That channel is what makes it reach the server the
+output arrives at, which may have had nothing to do with the spawn; a
+directive carried with the spawn request, or a server-wide default at
+`PMIx_server_init`, would reach one of the two sites and not the other
+(and the latter cannot express a per-job answer at all, while PRRTE's
+`inherit` is per-job).
+
+**At the spawn-time site, "the host said nothing" and "we cannot ask yet"
+must not be conflated** — it is the one place they are distinguishable.
+That site runs from the spawn *completion*, and whether the child's
+namespace has been registered with this server by then is the host's
+business: a daemon hosting none of the child's processes may never
+register it. A fetch that found nothing would read as "inherit", which is
+the wrong way to be wrong — it would clone against the host's wishes and
+nothing takes a clone back. So `inherit_parent_iof()` looks the namespace
+up in `pmix_globals.nspaces` first and returns without cloning when it is
+absent, leaving the decision to the delivery-time half, which cannot run
+before the namespace exists. Deferring is never behaviorally wrong; it
+only postpones. That is also why `test/unit/iof_inherit.c` registers its
+child namespace before driving the spawn-time cases — without that they
+exercise the deferral rather than the inheritance.
+
 What is still PRRTE's is a tool attached to a **non-HNP** daemon, and a
 tool that attaches to a running DVM and `PMIx_IOF_pull`s a job's output:
 the first never receives another node's output at all (the HNP relays

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -1233,20 +1233,62 @@ Two things fall out that are easy to get wrong:
   worth inheriting, and the `info` read is load-bearing rather than
   defensive because the verbose line dereferences it.
 
-**Known limit — this fixes the case where the spawn is processed on the
-server that holds the parent's subscription**, which covers a single-node
-DVM, `prterun`, and any layout where the spawner's daemon is also the
-tool's daemon. On a multi-node DVM it is not sufficient by itself: PRRTE
-registers a tool's IOF request with *the daemon that tool attached to*
-and routes a job's output there using `jdata->originator`, which for a
-client-issued spawn is set to the daemon hosting the spawner rather than
-the one hosting the tool. So the cloned request is created on a server
-the HNP will indeed relay the child's output to, but the parent's
-subscription that it would clone lives on a different daemon and is not
-visible there. Closing that needs the PRRTE side; see
-`src/mca/iof/AGENTS.md` in PRRTE for the relay path.
+**Inheritance is decided in two places, and the second is the one that
+works on a multi-node DVM.** `pmix_server_process_iof()` runs on the
+server that *processed the spawn* — the one hosting the spawning
+process. The watching tool's subscription lives on the server the *tool*
+attached to. On a single-node DVM or under `prterun` those are the same
+server and the spawn-time clone is the whole story; on a multi-node DVM
+they are not, and the clone gets built where the output never arrives.
 
-Coverage: [`test/unit/iof_inherit.c`](../../test/unit/iof_inherit.c).
+So `_iofdeliver` carries the other half: when a chunk of output matches
+no subscription — the point at which it would otherwise go into the
+cache to age out — `inherit_from_ancestry()` walks the source
+namespace's `PMIX_PARENT_ID` chain and clones the subscriptions covering
+the first ancestor anybody here is watching. That decision is taken on
+the server the output *reaches*, which for every PRRTE launcher is the
+HNP: every prted forwards to the HNP, and the HNP hands everything it
+receives to its own PMIx server, where a `prun`/`prterun` tool's
+subscription is. Four things about it are load-bearing:
+
+- **It clones rather than delivering the one chunk.** Every later chunk
+  from that namespace then takes the ordinary walk above, so the
+  datastore is consulted once per namespace instead of once per line of
+  a watched job's output. The clone is made by the same
+  `clone_iof_reqs()` the spawn-time path uses and has the same lifetime,
+  so this adds no lifetime question that was not already there.
+- **`PMIX_PARENT_ID` is per-process job data**, which is why the lookup
+  works on a server that had nothing to do with the spawn: PRRTE adds it
+  in `prte_pmix_server_register_nspace()` for every daemon that
+  registers the namespace. `pmix_pfexec` records it for the job as a
+  whole instead, so `get_parent_id()` tries the specific rank and then
+  the wildcard.
+- **The walk is transitive and bounded** (`PMIX_IOF_MAX_ANCESTRY`). A
+  grandchild of a watched job is watched; the chain is host-supplied
+  data, so the bound is what stops a malformed or circular one from
+  spinning the progress thread.
+- **The two halves are independent.** Neither needs the other to have
+  run, and where both apply the second finds the subscription the first
+  created and does nothing.
+
+What is still PRRTE's is a tool attached to a **non-HNP** daemon, and a
+tool that attaches to a running DVM and `PMIx_IOF_pull`s a job's output:
+the first never receives another node's output at all (the HNP relays
+elsewhere only by `jdata->originator`), and the second is not recorded
+against the job anywhere. Both need PRRTE to keep a *set* of interested
+daemons; see `src/mca/iof/AGENTS.md` in PRRTE for the relay path, and
+[`docs/how-things-work/iof_inheritance.rst`](../../docs/how-things-work/iof_inheritance.rst)
+for the whole design.
+
+Coverage: [`test/unit/iof_inherit.c`](../../test/unit/iof_inherit.c) for
+both halves — note its delivery cases deliberately use a channel the
+watcher did not subscribe to, so `pmix_iof_process_iof()` returns at its
+channel test and the identity-only peer stubs never reach a pack. The
+multi-daemon half is
+[`contrib/dockerswarm/run-spawn-iof.sh`](../../contrib/dockerswarm/run-spawn-iof.sh),
+whose case 3 puts the tool, the spawning rank and the child job on three
+different daemons — the geometry in which nothing about the answer can
+be local.
 
 [i4120]: https://github.com/openpmix/openpmix/issues/4120
 

--- a/src/server/pmix_server_classes.c
+++ b/src/server/pmix_server_classes.c
@@ -180,6 +180,7 @@ static void scadcon(pmix_setup_caddy_t *p)
     p->keys = NULL;
     p->channels = PMIX_FWD_NO_CHANNELS;
     pmix_iof_init_flags(&p->flags);
+    p->inherit_iof = false;
     p->xoff = false;
     p->bo = NULL;
     p->nbo = 0;

--- a/src/server/pmix_server_iof.c
+++ b/src/server/pmix_server_iof.c
@@ -416,12 +416,172 @@ pmix_status_t PMIx_server_IOF_flow_control(const pmix_proc_t *source,
     return PMIX_SUCCESS;
 }
 
+/* Hand the output already in the cache to the subscriptions just built
+ * for a job. A job's first bytes routinely beat its own spawn reply back
+ * to us, so without this the opening lines of every spawned job are lost.
+ *
+ * This is driven by namespace rather than by one request because a job
+ * can inherit more than one watcher, and a cache entry is consumed the
+ * moment it is forwarded: draining per-request would give the cached
+ * head of the stream to whichever watcher happened to be cloned first
+ * and the rest of it to all of them. Every request naming the job is
+ * offered each entry, and the entry is dropped once anyone took it. */
+static void drain_cache(const char *nspace)
+{
+    pmix_iof_cache_t *iof, *ionext;
+    pmix_iof_req_t *req;
+    pmix_status_t rc;
+    bool taken;
+    int i;
+
+    PMIX_LIST_FOREACH_SAFE (iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
+        taken = false;
+        for (i = 0; i < pmix_globals.iof_requests.size; i++) {
+            req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests, i);
+            if (NULL == req || 0 == req->nprocs) {
+                continue;
+            }
+            if (!PMIX_CHECK_NSPACE(req->procs[0].nspace, nspace)) {
+                continue;
+            }
+            /* the source still has to match, so an entry from some other
+             * job is simply declined here */
+            rc = pmix_iof_process_iof(iof->channel, &iof->source, iof->bo,
+                                      iof->info, iof->ninfo, req);
+            if (PMIX_OPERATION_SUCCEEDED == rc) {
+                taken = true;
+            }
+        }
+        if (taken) {
+            /* remove it from the list since it has now been forwarded */
+            pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
+            PMIX_RELEASE(iof);
+        }
+    }
+}
+
+/* Give the child job the output-forwarding its parent has.
+ *
+ * "The parent's settings" are not recorded anywhere as settings - what
+ * exists is the set of live subscriptions covering the spawning process's
+ * own job, which is the same thing seen from the other end: whoever is
+ * receiving the parent job's output is who should receive the child's.
+ * So each matching request is cloned onto the child's namespace with the
+ * same requestor, channels and formatting.
+ *
+ * The clone keeps the original's remote_id deliberately, so the child's
+ * output arrives at the requestor under the same handler id the parent's
+ * does and is treated identically there.
+ *
+ * Returns the number of subscriptions inherited - zero means the parent
+ * has nobody watching it either, and the caller falls back to the MCA
+ * parameter.
+ */
+static size_t inherit_parent_iof(pmix_setup_caddy_t *cd, char nspace[])
+{
+    pmix_iof_req_t *req, *nreq;
+    pmix_proc_t parent;
+    size_t m, ninherited = 0;
+    int i, limit;
+
+    if (NULL == cd->peer || NULL == cd->peer->info) {
+        return 0;
+    }
+    PMIX_LOAD_PROCID(&parent, cd->peer->info->pname.nspace,
+                     cd->peer->info->pname.rank);
+
+    /* the array grows as we add to it, so bound the walk to what was
+     * there when we started - a clone can never be its own parent */
+    limit = pmix_globals.iof_requests.size;
+    for (i = 0; i < limit; i++) {
+        req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests, i);
+        if (NULL == req) {
+            continue;
+        }
+        /* a request with no requestor peer was registered by this process
+         * for itself and is delivered through its own callback; there is
+         * nothing about it to give the child. The same screens
+         * pmix_iof_process_iof applies before forwarding apply here
+         * before cloning - a request it would refuse is not worth
+         * inheriting - and the info read is load-bearing rather than
+         * defensive, because the verbose line below dereferences it */
+        if (NULL == req->requestor || NULL == req->requestor->info ||
+            req->requestor->finalized) {
+            continue;
+        }
+        if (PMIX_FWD_NO_CHANNELS == req->channels) {
+            continue;
+        }
+        /* does it cover the job the spawning process belongs to? A
+         * request registered for the job as a whole carries
+         * PMIX_RANK_WILDCARD, which PMIX_CHECK_PROCID matches */
+        for (m = 0; m < req->nprocs; m++) {
+            if (PMIX_CHECK_PROCID(&parent, &req->procs[m])) {
+                break;
+            }
+        }
+        if (m >= req->nprocs) {
+            continue;
+        }
+
+        nreq = PMIX_NEW(pmix_iof_req_t);
+        if (NULL == nreq) {
+            return ninherited;
+        }
+        PMIX_PROC_CREATE(nreq->procs, 1);
+        if (NULL == nreq->procs) {
+            PMIX_RELEASE(nreq);
+            return ninherited;
+        }
+        nreq->nprocs = 1;
+        PMIX_LOAD_PROCID(&nreq->procs[0], nspace, PMIX_RANK_WILDCARD);
+        PMIX_RETAIN(req->requestor);
+        nreq->requestor = req->requestor;
+        nreq->channels = req->channels;
+        nreq->remote_id = req->remote_id;
+        /* a shallow copy of the flags owns nothing - see the note in
+         * pmix_server_process_iof below */
+        nreq->flags = req->flags;
+        nreq->flags.file = NULL;
+        nreq->flags.directory = NULL;
+        nreq->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, nreq);
+        ++ninherited;
+
+        pmix_output_verbose(2, pmix_server_globals.iof_output,
+                            "PMIx:SERVER job %s inheriting %s forwarding to %s from %s",
+                            nspace, PMIx_IOF_channel_string(nreq->channels),
+                            PMIX_PNAME_PRINT(&req->requestor->info->pname),
+                            PMIX_NAME_PRINT(&parent));
+    }
+    /* every clone exists now, so the cached head of the stream can be
+     * shared out among all of them */
+    if (0 < ninherited) {
+        drain_cache(nspace);
+    }
+    return ninherited;
+}
+
 pmix_status_t pmix_server_process_iof(pmix_setup_caddy_t *cd,
                                       char nspace[])
 {
     pmix_iof_req_t *req;
-    pmix_status_t rc;
-    pmix_iof_cache_t *iof, *ionext;
+
+    /* Nothing in the spawn request said which channels to forward, so
+     * the child job takes its parent's - and if the parent has nobody
+     * watching it, there is nowhere for the child's output to go
+     * either. We deliberately do NOT fall back to forwarding it to the
+     * spawner: output is never forwarded to an application process,
+     * which would only emit it on its own stdout for the runtime to
+     * pick up and forward again. */
+    if (cd->inherit_iof) {
+        if (0 == inherit_parent_iof(cd, nspace)) {
+            pmix_output_verbose(2, pmix_server_globals.iof_output,
+                                "PMIx:SERVER job %s has nothing to inherit - "
+                                "its parent's output is not being forwarded",
+                                nspace);
+        }
+        return PMIX_SUCCESS;
+    }
 
     // if no channels to forward, just return success
     if (PMIX_FWD_NO_CHANNELS == cd->channels) {
@@ -455,15 +615,7 @@ pmix_status_t pmix_server_process_iof(pmix_setup_caddy_t *cd,
     req->flags.directory = NULL;
     req->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
     /* process any cached IO */
-    PMIX_LIST_FOREACH_SAFE (iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
-        rc = pmix_iof_process_iof(iof->channel, &iof->source, iof->bo,
-                                  iof->info, iof->ninfo, req);
-        if (PMIX_OPERATION_SUCCEEDED == rc) {
-            /* remove it from the list since it has now been forwarded */
-            pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
-            PMIX_RELEASE(iof);
-        }
-    }
+    drain_cache(nspace);
     return PMIX_SUCCESS;
 }
 

--- a/src/server/pmix_server_iof.c
+++ b/src/server/pmix_server_iof.c
@@ -579,19 +579,96 @@ static size_t clone_iof_reqs(const pmix_proc_t *parent, const char *nspace)
     return ninherited;
 }
 
+/* Does the host allow this job to inherit? PMIX_IOF_INHERIT is job-level
+ * information the host supplies with the spawned namespace, so it reaches
+ * every server the namespace is registered with - which matters, because
+ * the two places that ask are on different daemons. Absent means yes: a
+ * host says nothing unless it is turning inheritance off.
+ *
+ * "Absent" and "we have never heard of this namespace" are the same
+ * answer here, and deliberately so at the only site where they can
+ * differ - see inherit_parent_iof() below.
+ */
+static bool iof_inherit_allowed(const char *nspace)
+{
+    pmix_cb_t cb;
+    pmix_info_t optional;
+    pmix_kval_t *kv;
+    pmix_proc_t wild;
+    pmix_status_t rc;
+    bool allowed = true;
+
+    PMIX_INFO_LOAD(&optional, PMIX_OPTIONAL, NULL, PMIX_BOOL);
+    PMIX_LOAD_PROCID(&wild, nspace, PMIX_RANK_WILDCARD);
+
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    cb.proc = &wild;
+    cb.key = PMIX_IOF_INHERIT;
+    cb.info = &optional;
+    cb.ninfo = 1;
+    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+    if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
+        kv = (pmix_kval_t *) pmix_list_remove_first(&cb.kvs);
+        /* the union must not be read until the type says which member is
+         * live - this is host-supplied data */
+        if (NULL != kv && NULL != kv->value && PMIX_BOOL == kv->value->type) {
+            allowed = kv->value->data.flag;
+        }
+        if (NULL != kv) {
+            PMIX_RELEASE(kv);
+        }
+    }
+    PMIX_DESTRUCT(&cb);
+    PMIX_INFO_DESTRUCT(&optional);
+
+    return allowed;
+}
+
 /* Give the child job the output forwarding its parent has, at the moment
  * the spawn completes. The spawning process is the parent, and it is a
  * local client of ours - so this only ever finds anything on the server
  * that processed the spawn. See inherit_from_ancestry() for the other
  * half, which runs where the output arrives.
+ *
+ * This is the one site where "the host said nothing" and "we cannot ask
+ * yet" are distinguishable and must not be conflated. We run from the
+ * spawn COMPLETION, and whether the child's namespace has been
+ * registered with this server by now is up to the host - a daemon
+ * hosting none of the child's processes may never register it at all. A
+ * fetch that finds nothing there would read as "inherit", which is the
+ * wrong way to be wrong: it would clone against the host's wishes and
+ * nothing would take the clone back. So an unknown namespace defers to
+ * the delivery-time half, which cannot run before the namespace exists
+ * and therefore always has a real answer.
  */
 static size_t inherit_parent_iof(pmix_setup_caddy_t *cd, char nspace[])
 {
     pmix_proc_t parent;
+    pmix_namespace_t *ns, *nptr = NULL;
 
     if (NULL == cd->peer || NULL == cd->peer->info) {
         return 0;
     }
+
+    PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
+        if (PMIX_CHECK_NSPACE(ns->nspace, nspace)) {
+            nptr = ns;
+            break;
+        }
+    }
+    if (NULL == nptr) {
+        pmix_output_verbose(2, pmix_server_globals.iof_output,
+                            "PMIx:SERVER job %s not registered here yet - "
+                            "leaving inheritance to delivery", nspace);
+        return 0;
+    }
+    if (!iof_inherit_allowed(nspace)) {
+        pmix_output_verbose(2, pmix_server_globals.iof_output,
+                            "PMIx:SERVER job %s: host declined output inheritance",
+                            nspace);
+        return 0;
+    }
+
     PMIX_LOAD_PROCID(&parent, cd->peer->info->pname.nspace,
                      cd->peer->info->pname.rank);
 
@@ -687,6 +764,16 @@ static size_t inherit_from_ancestry(const pmix_proc_t *source)
     pmix_proc_t anc, parent;
     size_t ninherited;
     int depth;
+
+    /* The host's decision, read where it is reliable: output cannot
+     * arrive for a namespace this server has not been told about, so
+     * unlike the spawn-time site there is no "cannot ask yet" here. */
+    if (!iof_inherit_allowed(source->nspace)) {
+        pmix_output_verbose(2, pmix_server_globals.iof_output,
+                            "PMIx:SERVER job %s: host declined output inheritance",
+                            source->nspace);
+        return 0;
+    }
 
     PMIX_LOAD_PROCID(&anc, source->nspace, source->rank);
 

--- a/src/server/pmix_server_iof.c
+++ b/src/server/pmix_server_iof.c
@@ -49,6 +49,10 @@
 
 #include "pmix_server_ops.h"
 
+/* defined below, beside the spawn-time inheritance it is the other half
+ * of - _iofdeliver reaches for it on its miss path */
+static size_t inherit_from_ancestry(const pmix_proc_t *source);
+
 void pmix_server_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
                             pmix_buffer_t *buf, void *cbdata)
 {
@@ -206,6 +210,28 @@ static void _iofdeliver(int sd, short args, void *cbdata)
              * so there is no need to cache it */
             found = true;
             rc = PMIX_SUCCESS;
+        }
+    }
+
+    /* Nobody here is subscribed to this namespace - but it may be the
+     * child of one they are. Ask before the bytes go into the cache to
+     * age out: this is the only point at which the server that RECEIVES
+     * a spawned job's output gets to make the inheritance decision, and
+     * on a multi-node DVM it is not the server that processed the spawn.
+     * A match leaves clones behind, so the walk above answers every
+     * later chunk and this runs once per namespace rather than once per
+     * chunk. */
+    if (!found && 0 < inherit_from_ancestry(cd->procs)) {
+        for (i = 0; i < pmix_globals.iof_requests.size; i++) {
+            req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests, i);
+            if (NULL == req) {
+                continue;
+            }
+            rc = pmix_iof_process_iof(cd->channels, cd->procs, cd->bo, cd->info, cd->ninfo, req);
+            if (PMIX_OPERATION_SUCCEEDED == rc) {
+                found = true;
+                rc = PMIX_SUCCESS;
+            }
         }
     }
 
@@ -460,7 +486,7 @@ static void drain_cache(const char *nspace)
     }
 }
 
-/* Give the child job the output-forwarding its parent has.
+/* Clone every subscription covering "parent" onto "nspace".
  *
  * "The parent's settings" are not recorded anywhere as settings - what
  * exists is the set of live subscriptions covering the spawning process's
@@ -473,22 +499,14 @@ static void drain_cache(const char *nspace)
  * output arrives at the requestor under the same handler id the parent's
  * does and is treated identically there.
  *
- * Returns the number of subscriptions inherited - zero means the parent
- * has nobody watching it either, and the caller falls back to the MCA
- * parameter.
+ * Returns the number of subscriptions cloned - zero means nobody is
+ * watching that parent here.
  */
-static size_t inherit_parent_iof(pmix_setup_caddy_t *cd, char nspace[])
+static size_t clone_iof_reqs(const pmix_proc_t *parent, const char *nspace)
 {
     pmix_iof_req_t *req, *nreq;
-    pmix_proc_t parent;
     size_t m, ninherited = 0;
     int i, limit;
-
-    if (NULL == cd->peer || NULL == cd->peer->info) {
-        return 0;
-    }
-    PMIX_LOAD_PROCID(&parent, cd->peer->info->pname.nspace,
-                     cd->peer->info->pname.rank);
 
     /* the array grows as we add to it, so bound the walk to what was
      * there when we started - a clone can never be its own parent */
@@ -516,7 +534,7 @@ static size_t inherit_parent_iof(pmix_setup_caddy_t *cd, char nspace[])
          * request registered for the job as a whole carries
          * PMIX_RANK_WILDCARD, which PMIX_CHECK_PROCID matches */
         for (m = 0; m < req->nprocs; m++) {
-            if (PMIX_CHECK_PROCID(&parent, &req->procs[m])) {
+            if (PMIX_CHECK_PROCID(parent, &req->procs[m])) {
                 break;
             }
         }
@@ -551,7 +569,7 @@ static size_t inherit_parent_iof(pmix_setup_caddy_t *cd, char nspace[])
                             "PMIx:SERVER job %s inheriting %s forwarding to %s from %s",
                             nspace, PMIx_IOF_channel_string(nreq->channels),
                             PMIX_PNAME_PRINT(&req->requestor->info->pname),
-                            PMIX_NAME_PRINT(&parent));
+                            PMIX_NAME_PRINT(parent));
     }
     /* every clone exists now, so the cached head of the stream can be
      * shared out among all of them */
@@ -559,6 +577,139 @@ static size_t inherit_parent_iof(pmix_setup_caddy_t *cd, char nspace[])
         drain_cache(nspace);
     }
     return ninherited;
+}
+
+/* Give the child job the output forwarding its parent has, at the moment
+ * the spawn completes. The spawning process is the parent, and it is a
+ * local client of ours - so this only ever finds anything on the server
+ * that processed the spawn. See inherit_from_ancestry() for the other
+ * half, which runs where the output arrives.
+ */
+static size_t inherit_parent_iof(pmix_setup_caddy_t *cd, char nspace[])
+{
+    pmix_proc_t parent;
+
+    if (NULL == cd->peer || NULL == cd->peer->info) {
+        return 0;
+    }
+    PMIX_LOAD_PROCID(&parent, cd->peer->info->pname.nspace,
+                     cd->peer->info->pname.rank);
+
+    return clone_iof_reqs(&parent, nspace);
+}
+
+/* How far the ancestry walk below will climb. The chain is data - each
+ * link is a PMIX_PARENT_ID the host stored - so a bound is what keeps a
+ * malformed or circular one from spinning the progress thread. Nothing
+ * legitimate is anywhere near this deep.
+ */
+#define PMIX_IOF_MAX_ANCESTRY 16
+
+/* Who spawned the job this process belongs to?
+ *
+ * PMIX_PARENT_ID is per-process job data supplied by the host, so it is
+ * available on any server the namespace was registered with - including
+ * ones that had nothing to do with the spawn, which is the entire point
+ * of the caller. A host that records it for the job as a whole rather
+ * than per rank (pmix_pfexec does) is answered by the second fetch.
+ */
+static bool get_parent_id(const pmix_proc_t *proc, pmix_proc_t *parent)
+{
+    pmix_cb_t cb;
+    pmix_info_t optional;
+    pmix_kval_t *kv;
+    pmix_proc_t wild;
+    pmix_status_t rc;
+    bool found = false;
+    int pass;
+
+    PMIX_INFO_LOAD(&optional, PMIX_OPTIONAL, NULL, PMIX_BOOL);
+    PMIX_LOAD_PROCID(&wild, proc->nspace, PMIX_RANK_WILDCARD);
+
+    for (pass = 0; pass < 2 && !found; pass++) {
+        if (1 == pass && PMIX_RANK_WILDCARD == proc->rank) {
+            break;      // the second fetch would repeat the first
+        }
+        PMIX_CONSTRUCT(&cb, pmix_cb_t);
+        cb.proc = (0 == pass) ? (pmix_proc_t *) proc : &wild;
+        cb.key = PMIX_PARENT_ID;
+        cb.info = &optional;
+        cb.ninfo = 1;
+        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+        if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
+            kv = (pmix_kval_t *) pmix_list_remove_first(&cb.kvs);
+            /* the union must not be read until the type says which member
+             * is live, and PMIX_PROC carries a pointer that a mistyped or
+             * truncated store can leave NULL */
+            if (NULL != kv && NULL != kv->value && PMIX_PROC == kv->value->type &&
+                NULL != kv->value->data.proc) {
+                PMIX_LOAD_PROCID(parent, kv->value->data.proc->nspace,
+                                 kv->value->data.proc->rank);
+                found = true;
+            }
+            if (NULL != kv) {
+                PMIX_RELEASE(kv);
+            }
+        }
+        PMIX_DESTRUCT(&cb);
+    }
+    PMIX_INFO_DESTRUCT(&optional);
+
+    return found;
+}
+
+/* The delivery-time half of inheritance: output has arrived for a
+ * namespace nobody here is subscribed to. Before it is cached and lost,
+ * ask whether it belongs to a job that was SPAWNED by one somebody here
+ * IS subscribed to - a subscription covering a parent job covers its
+ * children.
+ *
+ * This is what makes inheritance work when the spawn was processed
+ * somewhere else. pmix_server_process_iof() runs on the server hosting
+ * the spawning process, which on a multi-node DVM is not the server
+ * holding the watching tool's subscription; this runs on the server the
+ * output actually reaches, which is that one. Neither needs the other to
+ * have happened, and no subscription crosses the wire.
+ *
+ * The walk is transitive because "treated the way its parent is treated"
+ * says nothing about depth - a grandchild of a watched job is watched.
+ * It stops at the first ancestor anybody here is subscribed to: once the
+ * clones exist, that generation's watchers are this namespace's watchers.
+ *
+ * A match CLONES rather than delivering once, so every later chunk from
+ * this namespace takes the ordinary path above. That costs one entry per
+ * watcher and gives the fallback the same lifetime the spawn-time clones
+ * have; re-deriving it per chunk would put a datastore fetch in front of
+ * every line of a watched job's output.
+ */
+static size_t inherit_from_ancestry(const pmix_proc_t *source)
+{
+    pmix_proc_t anc, parent;
+    size_t ninherited;
+    int depth;
+
+    PMIX_LOAD_PROCID(&anc, source->nspace, source->rank);
+
+    for (depth = 0; depth < PMIX_IOF_MAX_ANCESTRY; depth++) {
+        if (!get_parent_id(&anc, &parent)) {
+            return 0;       // no parent recorded - this job is a root
+        }
+        if (PMIX_CHECK_NSPACE(parent.nspace, anc.nspace)) {
+            return 0;       // a job cannot have spawned itself
+        }
+        ninherited = clone_iof_reqs(&parent, source->nspace);
+        if (0 < ninherited) {
+            pmix_output_verbose(2, pmix_server_globals.iof_output,
+                                "PMIx:SERVER job %s inherited %d subscription(s) "
+                                "from ancestor %s at delivery",
+                                source->nspace, (int) ninherited,
+                                PMIX_NAME_PRINT(&parent));
+            return ninherited;
+        }
+        PMIX_LOAD_PROCID(&anc, parent.nspace, parent.rank);
+    }
+
+    return 0;
 }
 
 pmix_status_t pmix_server_process_iof(pmix_setup_caddy_t *cd,

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -598,6 +598,7 @@ void pmix_server_spcbfunc(pmix_status_t status, char nspace[], void *cbdata)
 void pmix_server_spawn_parser(pmix_peer_t *peer,
                               pmix_iof_channel_t *channels,
                               pmix_iof_flags_t *flags,
+                              bool *inherit,
                               pmix_info_t *info,
                               size_t ninfo)
 {
@@ -636,9 +637,18 @@ void pmix_server_spawn_parser(pmix_peer_t *peer,
     /* we will construct any required iof request tracker upon completion of the spawn
      * as we need the nspace of the spawned application! */
 
+    /* Naming ANY output channel decides the matter for all of them: the
+     * request is taken verbatim, including a channel the requestor
+     * explicitly turned off. Merging a partial request into an inherited
+     * set would make "forward stdout" quietly mean something different
+     * depending on what the parent job happened to be doing. */
+    *inherit = !(stdout_found || stderr_found || stddiag_found);
+
     if (PMIX_PEER_IS_TOOL(peer)) {
         /* if the requestor is a tool, we default to forwarding all
-         * output IO channels */
+         * output IO channels. A tool is not a member of a job, so it has
+         * no parent whose settings it could inherit - this default IS its
+         * setting, and it is what a launcher such as prun relies on. */
         if (!stdout_found) {
             *channels |= PMIX_FWD_STDOUT_CHANNEL;
         }
@@ -648,6 +658,7 @@ void pmix_server_spawn_parser(pmix_peer_t *peer,
         if (!stddiag_found) {
             *channels |= PMIX_FWD_STDDIAG_CHANNEL;
         }
+        *inherit = false;
     }
 }
 
@@ -732,7 +743,7 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer, pmix_buffer_t *buf,
          * to catch any early output - and a request for notification
          * of job termination so we can setup the event registration */
         pmix_server_spawn_parser(peer, &cd->channels, &cd->flags,
-                                 cd->info, cd->ninfo);
+                                 &cd->inherit_iof, cd->info, cd->ninfo);
     }
 
     /* unpack the number of apps */

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -70,6 +70,10 @@ typedef struct {
     size_t napps;
     pmix_iof_channel_t channels;
     pmix_iof_flags_t flags;
+    /* nothing in the spawn request decided which output channels the child
+     * job should have forwarded, so the child inherits its parent's - see
+     * pmix_server_spawn_parser() and pmix_server_process_iof() */
+    bool inherit_iof;
     bool xoff;      // IOF flow control: suspend (true) or resume (false)
     pmix_byte_object_t *bo;
     size_t nbo;
@@ -284,9 +288,14 @@ PMIX_EXPORT pmix_status_t pmix_server_unpublish(pmix_peer_t *peer, pmix_buffer_t
 
 PMIX_EXPORT pmix_status_t pmix_server_spawn(pmix_peer_t *peer, pmix_buffer_t *buf,
                                             pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+/* Parse a spawn request's output-forwarding directives. On return,
+ * *inherit is true when nothing in the request decided which channels to
+ * forward, which is the caller's signal to give the child job its
+ * parent's settings instead - see pmix_server_process_iof(). */
 PMIX_EXPORT void pmix_server_spawn_parser(pmix_peer_t *peer,
                                           pmix_iof_channel_t *channels,
                                           pmix_iof_flags_t *flags,
+                                          bool *inherit,
                                           pmix_info_t *info,
                                           size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_server_process_iof(pmix_setup_caddy_t *cd,

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -69,10 +69,25 @@ They fall into three groups.
 These run anywhere and are the bulk of the suite: `compress`, `preg`,
 `bfrops_regex2`, `bfrops_alloc_inherit`, `bfrops_darray`,
 `bfrops_malformed`, `bfrops_get_number`, `bfrops_null_object`,
-`bfrops_helpers`, `info_support`, `iof_pattern`,
+`bfrops_helpers`, `info_support`, `iof_pattern`, `iof_inherit`,
 `hwloc_datatype`, `tracker_match`, `trk_complete`, `collective_status`,
 `collect_job_info`, `progress_threads`, `runtime_init`, `pmix_log`,
 `server_get`, `resolve_api`, `spawn_api`.
+
+`iof_inherit` covers the rule that a spawned job takes its parent's
+output forwarding when the spawn request names no channel of its own
+(see [`src/server/AGENTS.md`](../../src/server/AGENTS.md) and
+[openpmix#4120](https://github.com/openpmix/openpmix/issues/4120)). It
+drives `pmix_server_spawn_parser` and `pmix_server_process_iof` directly
+and reads `pmix_globals.iof_requests` back rather than moving real
+output: what is under test is which subscriptions get created and for
+whom, and no spawn is needed to establish that — nor could one be used,
+since `test/simple/simptest` cannot host a spawn. Its two inheritance
+cases fail against an unfixed library, which was checked by neutering
+the inheritance branch and re-running. Note the deliberate absence of a
+"nothing to inherit" fallback: the case asserting that **no**
+subscription is created there is load-bearing, because forwarding a
+child's output to the process that spawned it is a loopback.
 
 **Singleton client tests** — call the real public API in a process that
 comes up with no server. `client_cycle` (init/finalize cycling),

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_inherit proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_inherit proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup
 
 client_api_SOURCES = \
         client_api.c
@@ -272,8 +272,14 @@ iof_output_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 iof_output_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+iof_inherit_SOURCES = \
+        iof_inherit.c
+iof_inherit_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+iof_inherit_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
-	rm -f compress compress_block preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output proc_array_id get_perf
+	rm -f compress compress_block preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_inherit proc_array_id get_perf
 
 ptl_uri_SOURCES = \
         ptl_uri.c

--- a/test/unit/iof_inherit.c
+++ b/test/unit/iof_inherit.c
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * A spawned job inherits its parent's output forwarding.
+ *
+ * Until this existed, pmix_server_spawn_parser() defaulted the output
+ * channels on only when the spawn came from a TOOL. A spawn issued by an
+ * ordinary client - an MPI application calling MPI_Comm_spawn is the case
+ * that matters - therefore subscribed to nothing, and the child job's
+ * output arrived at the server, matched no request, and was cached until
+ * it aged out of the cache. Nobody ever saw it. See openpmix#4120.
+ *
+ * The fix is not to forward the child's output to the spawning client -
+ * a client has nowhere to put it - but to give the child whatever the
+ * parent job already has. "The parent's settings" are not stored
+ * anywhere as settings; what exists is the set of live subscriptions
+ * covering the spawning process's job, which is the same thing seen from
+ * the other end: whoever receives the parent's output should receive the
+ * child's. So the requests are cloned onto the child's namespace.
+ *
+ * The ordering under test is: a channel named on the spawn request wins,
+ * otherwise the parent's subscriptions are inherited. There is no third
+ * level: if nothing is watching the parent there is nowhere for the
+ * child's output to go, and forwarding it to the spawner would be a
+ * loopback rather than a fallback.
+ *
+ * This drives pmix_server_process_iof() and pmix_server_spawn_parser()
+ * directly and reads pmix_globals.iof_requests back, rather than moving
+ * real output - what is under test is which subscriptions get created
+ * and for whom, and no spawn is needed to establish that. (Nor could one
+ * be: test/simple/simptest cannot host a spawn - see src/server/AGENTS.md.)
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+
+#include "src/common/pmix_iof.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/ptl/ptl_types.h"
+#include "src/server/pmix_server_ops.h"
+
+static int failures = 0;
+
+static void report(const char *what, bool pass)
+{
+    printf("%-64s : %s\n", what, pass ? "PASS" : "FAIL");
+    fflush(stdout);
+    if (!pass) {
+        ++failures;
+    }
+}
+
+/* Build a peer standing in for a process in the given namespace. Only
+ * the identity and the role matter here - nothing in this test packs a
+ * message, so no bfrops module is needed. */
+static pmix_peer_t *mkpeer(const char *nspace, pmix_rank_t rank, bool tool)
+{
+    pmix_peer_t *p;
+
+    p = PMIX_NEW(pmix_peer_t);
+    p->info = PMIX_NEW(pmix_rank_info_t);
+    p->info->pname.nspace = strdup(nspace);
+    p->info->pname.rank = rank;
+    if (tool) {
+        p->proc_type.type |= PMIX_PROC_TOOL;
+    }
+    return p;
+}
+
+/* Register a subscription covering an entire job, as a tool's spawn
+ * does, and hand back the index so it can be removed again. */
+static int watch_job(pmix_peer_t *requestor, const char *nspace,
+                     pmix_iof_channel_t channels, size_t remote_id)
+{
+    pmix_iof_req_t *req;
+
+    req = PMIX_NEW(pmix_iof_req_t);
+    PMIX_RETAIN(requestor);
+    req->requestor = requestor;
+    req->nprocs = 1;
+    PMIX_PROC_CREATE(req->procs, 1);
+    PMIX_LOAD_PROCID(&req->procs[0], nspace, PMIX_RANK_WILDCARD);
+    req->channels = channels;
+    req->remote_id = remote_id;
+    req->local_id = pmix_pointer_array_add(&pmix_globals.iof_requests, req);
+    return (int) req->local_id;
+}
+
+/* Find the one subscription covering the given namespace. Returns NULL
+ * if there is none, and sets *count to how many there were, so a test
+ * can tell "none" from "more than we expected". */
+static pmix_iof_req_t *find_watch(const char *nspace, int *count)
+{
+    pmix_iof_req_t *req, *found = NULL;
+    int i;
+
+    *count = 0;
+    for (i = 0; i < pmix_globals.iof_requests.size; i++) {
+        req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests, i);
+        if (NULL == req || 0 == req->nprocs) {
+            continue;
+        }
+        if (PMIX_CHECK_NSPACE(req->procs[0].nspace, nspace)) {
+            ++(*count);
+            if (NULL == found) {
+                found = req;
+            }
+        }
+    }
+    return found;
+}
+
+/* Drop every subscription naming a namespace, so each case starts clean */
+static void drop_watches(const char *nspace)
+{
+    pmix_iof_req_t *req;
+    int i;
+
+    for (i = 0; i < pmix_globals.iof_requests.size; i++) {
+        req = (pmix_iof_req_t *) pmix_pointer_array_get_item(&pmix_globals.iof_requests, i);
+        if (NULL == req || 0 == req->nprocs) {
+            continue;
+        }
+        if (PMIX_CHECK_NSPACE(req->procs[0].nspace, nspace)) {
+            pmix_pointer_array_set_item(&pmix_globals.iof_requests, i, NULL);
+            PMIX_RELEASE(req);
+        }
+    }
+}
+
+/* Run a spawn's IOF setup the way _spcbfunc does */
+static pmix_status_t run_spawn_iof(pmix_peer_t *spawner, bool inherit,
+                                   pmix_iof_channel_t channels,
+                                   const char *child)
+{
+    pmix_setup_caddy_t *cd;
+    pmix_status_t rc;
+
+    cd = PMIX_NEW(pmix_setup_caddy_t);
+    PMIX_RETAIN(spawner);
+    cd->peer = spawner;
+    cd->inherit_iof = inherit;
+    cd->channels = channels;
+    rc = pmix_server_process_iof(cd, (char *) child);
+    PMIX_RELEASE(cd);
+    return rc;
+}
+
+static void test_spawn_parser(void)
+{
+    pmix_peer_t *client, *tool;
+    pmix_iof_channel_t ch;
+    pmix_iof_flags_t flags;
+    pmix_info_t info;
+    bool inherit;
+    bool flag = false;
+
+    client = mkpeer("parentjob", 0, false);
+    tool = mkpeer("toolns", 0, true);
+
+    /* a client that says nothing wants to inherit */
+    pmix_iof_init_flags(&flags);
+    inherit = false;
+    pmix_server_spawn_parser(client, &ch, &flags, &inherit, NULL, 0);
+    report("spawn_parser: silent client inherits",
+           inherit && PMIX_FWD_NO_CHANNELS == ch);
+
+    /* a tool that says nothing keeps its own default - it is not a member
+     * of a job, so it has no parent to inherit from, and prun relies on
+     * this being all channels */
+    pmix_iof_init_flags(&flags);
+    inherit = true;
+    pmix_server_spawn_parser(tool, &ch, &flags, &inherit, NULL, 0);
+    report("spawn_parser: silent tool defaults to all, does not inherit",
+           !inherit
+           && (PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL
+               | PMIX_FWD_STDDIAG_CHANNEL) == ch);
+
+    /* naming a channel decides the matter - including naming it FALSE,
+     * which is a request for silence and must not be overridden by an
+     * inherited subscription */
+    PMIX_INFO_LOAD(&info, PMIX_FWD_STDOUT, &flag, PMIX_BOOL);
+    pmix_iof_init_flags(&flags);
+    inherit = true;
+    pmix_server_spawn_parser(client, &ch, &flags, &inherit, &info, 1);
+    report("spawn_parser: an explicit 'false' suppresses inheritance",
+           !inherit && PMIX_FWD_NO_CHANNELS == ch);
+    PMIX_INFO_DESTRUCT(&info);
+
+    flag = true;
+    PMIX_INFO_LOAD(&info, PMIX_FWD_STDERR, &flag, PMIX_BOOL);
+    pmix_iof_init_flags(&flags);
+    inherit = true;
+    pmix_server_spawn_parser(client, &ch, &flags, &inherit, &info, 1);
+    report("spawn_parser: a named channel suppresses inheritance",
+           !inherit && PMIX_FWD_STDERR_CHANNEL == ch);
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* stdin is the other direction and says nothing about output */
+    flag = true;
+    PMIX_INFO_LOAD(&info, PMIX_FWD_STDIN, &flag, PMIX_BOOL);
+    pmix_iof_init_flags(&flags);
+    inherit = false;
+    pmix_server_spawn_parser(client, &ch, &flags, &inherit, &info, 1);
+    report("spawn_parser: FWD_STDIN alone still inherits output",
+           inherit && PMIX_FWD_STDIN_CHANNEL == ch);
+    PMIX_INFO_DESTRUCT(&info);
+
+    PMIX_RELEASE(client);
+    PMIX_RELEASE(tool);
+}
+
+static void test_inheritance(void)
+{
+    pmix_peer_t *watcher, *client;
+    pmix_iof_req_t *req;
+    int count;
+
+    watcher = mkpeer("toolns", 0, true);
+    client = mkpeer("parentjob", 0, false);
+
+    /* the parent job is being watched by a tool, as it would be after
+     * prun spawned it */
+    watch_job(watcher, "parentjob",
+              PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL, 7);
+
+    /* ---- the child inherits it ---- */
+    run_spawn_iof(client, true, PMIX_FWD_NO_CHANNELS, "childjob");
+    req = find_watch("childjob", &count);
+    report("inherit: child job gets a subscription", NULL != req && 1 == count);
+    if (NULL != req) {
+        report("inherit: it goes to the parent's watcher, not the spawner",
+               req->requestor == watcher);
+        report("inherit: it carries the parent's channels",
+               (PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL) == req->channels);
+        report("inherit: it keeps the watcher's handler id",
+               7 == req->remote_id);
+        report("inherit: it names the whole child job",
+               PMIX_RANK_WILDCARD == req->procs[0].rank);
+    }
+    drop_watches("childjob");
+
+    /* ---- an explicit request is not overridden ---- */
+    run_spawn_iof(client, false, PMIX_FWD_STDDIAG_CHANNEL, "childjob");
+    req = find_watch("childjob", &count);
+    report("explicit: exactly one subscription", NULL != req && 1 == count);
+    if (NULL != req) {
+        report("explicit: it goes to the spawner that asked",
+               req->requestor == client);
+        report("explicit: it carries only what was asked for",
+               PMIX_FWD_STDDIAG_CHANNEL == req->channels);
+    }
+    drop_watches("childjob");
+
+    /* ---- nothing to inherit: nobody watches, and nobody may ----
+     *
+     * This is the case that must NOT fall back to forwarding the child's
+     * output to the spawner. Output is never forwarded to an application
+     * process: it would only come back out of that process's own stdout
+     * for the runtime to pick up and forward again. */
+    {
+        pmix_peer_t *orphan = mkpeer("unwatchedjob", 0, false);
+
+        run_spawn_iof(orphan, true, PMIX_FWD_NO_CHANNELS, "childjob");
+        find_watch("childjob", &count);
+        report("no parent: no subscription is created at all", 0 == count);
+        drop_watches("childjob");
+        PMIX_RELEASE(orphan);
+    }
+
+    /* ---- two watchers on the parent are both inherited ---- */
+    {
+        pmix_peer_t *watcher2 = mkpeer("toolns2", 0, true);
+
+        watch_job(watcher2, "parentjob", PMIX_FWD_STDDIAG_CHANNEL, 3);
+        run_spawn_iof(client, true, PMIX_FWD_NO_CHANNELS, "childjob");
+        find_watch("childjob", &count);
+        report("inherit: every watcher of the parent is carried over", 2 == count);
+        drop_watches("childjob");
+        PMIX_RELEASE(watcher2);
+    }
+
+    drop_watches("parentjob");
+    PMIX_RELEASE(watcher);
+    PMIX_RELEASE(client);
+}
+
+static pmix_server_module_t mymodule = {0};
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    rc = PMIx_server_init(&mymodule, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    test_spawn_parser();
+    test_inheritance();
+
+    PMIx_server_finalize();
+
+    printf("\n%s: %d failure(s)\n", 0 == failures ? "SUCCESS" : "FAILURE", failures);
+    return (0 == failures) ? 0 : 1;
+}

--- a/test/unit/iof_inherit.c
+++ b/test/unit/iof_inherit.c
@@ -159,6 +159,57 @@ static pmix_status_t run_spawn_iof(pmix_peer_t *spawner, bool inherit,
     return rc;
 }
 
+/* Register a namespace whose job data records who spawned it, which is
+ * what a host supplies to every server the namespace is registered with
+ * - including servers that had nothing to do with the spawn. */
+static pmix_status_t register_child(const char *nspace, const char *parent_ns,
+                                    pmix_rank_t parent_rank)
+{
+    pmix_info_t info[2];
+    pmix_proc_t parent;
+    pmix_status_t rc;
+    uint32_t one = 1;
+
+    PMIX_LOAD_PROCID(&parent, parent_ns, parent_rank);
+    PMIX_INFO_LOAD(&info[0], PMIX_PARENT_ID, &parent, PMIX_PROC);
+    PMIX_INFO_LOAD(&info[1], PMIX_JOB_SIZE, &one, PMIX_UINT32);
+
+    rc = PMIx_server_register_nspace((char *) nspace, 0, info, 2, NULL, NULL);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    return rc;
+}
+
+/* The same, plus the host's PMIX_IOF_INHERIT decision. Absence of that
+ * attribute means "inherit", so a host only sends it to say no. */
+static pmix_status_t register_child_noinherit(const char *nspace,
+                                              const char *parent_ns,
+                                              pmix_rank_t parent_rank)
+{
+    pmix_info_t info[3];
+    pmix_proc_t parent;
+    pmix_status_t rc;
+    uint32_t one = 1;
+    bool no = false;
+
+    PMIX_LOAD_PROCID(&parent, parent_ns, parent_rank);
+    PMIX_INFO_LOAD(&info[0], PMIX_PARENT_ID, &parent, PMIX_PROC);
+    PMIX_INFO_LOAD(&info[1], PMIX_JOB_SIZE, &one, PMIX_UINT32);
+    PMIX_INFO_LOAD(&info[2], PMIX_IOF_INHERIT, &no, PMIX_BOOL);
+
+    rc = PMIx_server_register_nspace((char *) nspace, 0, info, 3, NULL, NULL);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_INFO_DESTRUCT(&info[2]);
+    return rc;
+}
+
 static void test_spawn_parser(void)
 {
     pmix_peer_t *client, *tool;
@@ -237,6 +288,15 @@ static void test_inheritance(void)
     watch_job(watcher, "parentjob",
               PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL, 7);
 
+    /* The host registers the spawned namespace with us; the spawn-time
+     * path will not clone onto a namespace it has never been told about
+     * (see below), so registering it is what makes these the ordinary
+     * case rather than the deferral one. */
+    if (PMIX_SUCCESS != register_child("childjob", "parentjob", 0)) {
+        report("inherit: could not register the child namespace", false);
+        goto done;
+    }
+
     /* ---- the child inherits it ---- */
     run_spawn_iof(client, true, PMIX_FWD_NO_CHANNELS, "childjob");
     req = find_watch("childjob", &count);
@@ -293,33 +353,24 @@ static void test_inheritance(void)
         PMIX_RELEASE(watcher2);
     }
 
+    /* ---- a namespace we have not been told about is left alone ----
+     *
+     * The spawn completion can reach us before - or without - the host
+     * registering the spawned namespace here: a daemon hosting none of
+     * the child's processes may never register it at all. The host's
+     * PMIX_IOF_INHERIT decision travels with that registration, so
+     * cloning now would be deciding on the host's behalf with its answer
+     * unread. The delivery-time path cannot run before the namespace
+     * exists, so it always has a real answer; leave it to that. */
+    run_spawn_iof(client, true, PMIX_FWD_NO_CHANNELS, "unregisteredjob");
+    find_watch("unregisteredjob", &count);
+    report("inherit: an unregistered namespace defers to delivery", 0 == count);
+    drop_watches("unregisteredjob");
+
+done:
     drop_watches("parentjob");
     PMIX_RELEASE(watcher);
     PMIX_RELEASE(client);
-}
-
-/* Register a namespace whose job data records who spawned it, which is
- * what a host supplies to every server the namespace is registered with
- * - including servers that had nothing to do with the spawn. */
-static pmix_status_t register_child(const char *nspace, const char *parent_ns,
-                                    pmix_rank_t parent_rank)
-{
-    pmix_info_t info[2];
-    pmix_proc_t parent;
-    pmix_status_t rc;
-    uint32_t one = 1;
-
-    PMIX_LOAD_PROCID(&parent, parent_ns, parent_rank);
-    PMIX_INFO_LOAD(&info[0], PMIX_PARENT_ID, &parent, PMIX_PROC);
-    PMIX_INFO_LOAD(&info[1], PMIX_JOB_SIZE, &one, PMIX_UINT32);
-
-    rc = PMIx_server_register_nspace((char *) nspace, 0, info, 2, NULL, NULL);
-    if (PMIX_OPERATION_SUCCEEDED == rc) {
-        rc = PMIX_SUCCESS;
-    }
-    PMIX_INFO_DESTRUCT(&info[0]);
-    PMIX_INFO_DESTRUCT(&info[1]);
-    return rc;
 }
 
 /* Hand the server a chunk of output from a namespace, as a host does.
@@ -424,7 +475,23 @@ static void test_delivery_ancestry(void)
     find_watch("orphanjob", &count);
     report("ancestry: an unwatched ancestry creates no subscription", 0 == count);
 
+    /* ---- the host can turn inheritance off ----
+     *
+     * PMIX_IOF_INHERIT=false in the job data is how a host says a
+     * spawned job is not to be treated the way its parent is - PRRTE's
+     * "inherit" setting reaching us. The ancestry is intact and the
+     * parent is watched, so only the attribute stands between this job
+     * and a subscription. */
+    if (PMIX_SUCCESS != register_child_noinherit("quietjob", "parentjob", 0)) {
+        report("ancestry: could not register the quiet namespace", false);
+        goto cleanup;
+    }
+    deliver_from("quietjob", 0);
+    find_watch("quietjob", &count);
+    report("ancestry: PMIX_IOF_INHERIT=false suppresses inheritance", 0 == count);
+
 cleanup:
+    drop_watches("quietjob");
     drop_watches("childjob");
     drop_watches("grandchild");
     drop_watches("orphanjob");

--- a/test/unit/iof_inherit.c
+++ b/test/unit/iof_inherit.c
@@ -167,14 +167,19 @@ static pmix_status_t register_child(const char *nspace, const char *parent_ns,
 {
     pmix_info_t info[2];
     pmix_proc_t parent;
+    pmix_nspace_t ns;
     pmix_status_t rc;
     uint32_t one = 1;
 
+    /* a pmix_nspace_t, not the caller's string: this API takes a
+     * fixed-size array, and gcc rejects a shorter literal outright under
+     * -Werror=stringop-overread. Same reason as test/unit/resolve_api.c */
+    PMIX_LOAD_NSPACE(ns, nspace);
     PMIX_LOAD_PROCID(&parent, parent_ns, parent_rank);
     PMIX_INFO_LOAD(&info[0], PMIX_PARENT_ID, &parent, PMIX_PROC);
     PMIX_INFO_LOAD(&info[1], PMIX_JOB_SIZE, &one, PMIX_UINT32);
 
-    rc = PMIx_server_register_nspace((char *) nspace, 0, info, 2, NULL, NULL);
+    rc = PMIx_server_register_nspace(ns, 0, info, 2, NULL, NULL);
     if (PMIX_OPERATION_SUCCEEDED == rc) {
         rc = PMIX_SUCCESS;
     }
@@ -191,16 +196,19 @@ static pmix_status_t register_child_noinherit(const char *nspace,
 {
     pmix_info_t info[3];
     pmix_proc_t parent;
+    pmix_nspace_t ns;
     pmix_status_t rc;
     uint32_t one = 1;
     bool no = false;
 
+    /* see register_child() above for why this is not the caller's string */
+    PMIX_LOAD_NSPACE(ns, nspace);
     PMIX_LOAD_PROCID(&parent, parent_ns, parent_rank);
     PMIX_INFO_LOAD(&info[0], PMIX_PARENT_ID, &parent, PMIX_PROC);
     PMIX_INFO_LOAD(&info[1], PMIX_JOB_SIZE, &one, PMIX_UINT32);
     PMIX_INFO_LOAD(&info[2], PMIX_IOF_INHERIT, &no, PMIX_BOOL);
 
-    rc = PMIx_server_register_nspace((char *) nspace, 0, info, 3, NULL, NULL);
+    rc = PMIx_server_register_nspace(ns, 0, info, 3, NULL, NULL);
     if (PMIX_OPERATION_SUCCEEDED == rc) {
         rc = PMIX_SUCCESS;
     }

--- a/test/unit/iof_inherit.c
+++ b/test/unit/iof_inherit.c
@@ -298,6 +298,140 @@ static void test_inheritance(void)
     PMIX_RELEASE(client);
 }
 
+/* Register a namespace whose job data records who spawned it, which is
+ * what a host supplies to every server the namespace is registered with
+ * - including servers that had nothing to do with the spawn. */
+static pmix_status_t register_child(const char *nspace, const char *parent_ns,
+                                    pmix_rank_t parent_rank)
+{
+    pmix_info_t info[2];
+    pmix_proc_t parent;
+    pmix_status_t rc;
+    uint32_t one = 1;
+
+    PMIX_LOAD_PROCID(&parent, parent_ns, parent_rank);
+    PMIX_INFO_LOAD(&info[0], PMIX_PARENT_ID, &parent, PMIX_PROC);
+    PMIX_INFO_LOAD(&info[1], PMIX_JOB_SIZE, &one, PMIX_UINT32);
+
+    rc = PMIx_server_register_nspace((char *) nspace, 0, info, 2, NULL, NULL);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    return rc;
+}
+
+/* Hand the server a chunk of output from a namespace, as a host does.
+ *
+ * The channel is deliberately one the watcher did NOT subscribe to. What
+ * is under test is the ANCESTRY decision - whether a subscription gets
+ * cloned onto this namespace at all - and stopping short of the actual
+ * forwarding is what lets these peers stay the identity-only stubs the
+ * rest of this file builds: pmix_iof_process_iof() returns at its
+ * channel test, before it reaches the pack that would need a bfrops
+ * module and a socket. Do not "fix" the mismatch.
+ */
+static void deliver_from(const char *nspace, pmix_rank_t rank)
+{
+    pmix_proc_t source;
+    pmix_byte_object_t bo;
+    pmix_info_t local;
+    char text[] = "output\n";
+    bool flag = false;
+
+    PMIX_LOAD_PROCID(&source, nspace, rank);
+    bo.bytes = text;
+    bo.size = strlen(text);
+    /* not ours to emit - keeps the test's own stdout clean */
+    PMIX_INFO_LOAD(&local, PMIX_IOF_LOCAL_OUTPUT, &flag, PMIX_BOOL);
+
+    PMIx_server_IOF_deliver(&source, PMIX_FWD_STDOUT_CHANNEL, &bo, &local, 1, NULL, NULL);
+
+    PMIX_INFO_DESTRUCT(&local);
+}
+
+/* The delivery-time half of inheritance.
+ *
+ * The spawn-time clone above is made by the server that PROCESSED the
+ * spawn - the one hosting the spawning process. On a multi-node DVM that
+ * is not the server holding the watching tool's subscription, so the
+ * clone is built where the output does not arrive and the server that
+ * does receive it has nothing to match against. This is the other end:
+ * output arrives for a namespace nobody here watches, and before it is
+ * cached and lost the server asks whether it is the child of a job that
+ * someone here does watch.
+ */
+static void test_delivery_ancestry(void)
+{
+    pmix_peer_t *watcher;
+    pmix_iof_req_t *req;
+    int count;
+
+    watcher = mkpeer("toolns", 0, true);
+
+    /* somebody here watches the parent job's stderr, and nothing at all
+     * names the child. The drop is not tidying: a childjob subscription
+     * left behind by the spawn-time cases above would let every case
+     * here pass without the delivery-time path running at all. */
+    drop_watches("childjob");
+    watch_job(watcher, "parentjob", PMIX_FWD_STDERR_CHANNEL, 9);
+
+    if (PMIX_SUCCESS != register_child("childjob", "parentjob", 0)) {
+        report("ancestry: could not register the child namespace", false);
+        goto cleanup;
+    }
+
+    /* ---- output from an unwatched child finds its parent's watcher ---- */
+    deliver_from("childjob", 0);
+    req = find_watch("childjob", &count);
+    report("ancestry: delivery creates the child's subscription",
+           NULL != req && 1 == count);
+    if (NULL != req) {
+        report("ancestry: it goes to the ancestor's watcher",
+               req->requestor == watcher);
+        report("ancestry: it carries the ancestor's channels",
+               PMIX_FWD_STDERR_CHANNEL == req->channels);
+        report("ancestry: it keeps the watcher's handler id", 9 == req->remote_id);
+    }
+
+    /* ---- the walk is transitive ----
+     *
+     * A grandchild is watched too: "treated the way its parent is
+     * treated" says nothing about depth. Note the child's own clone is
+     * dropped first, so the grandchild's answer has to come from two
+     * levels up rather than from the entry the case above created. */
+    if (PMIX_SUCCESS != register_child("grandchild", "childjob", 0)) {
+        report("ancestry: could not register the grandchild namespace", false);
+        goto cleanup;
+    }
+    drop_watches("childjob");
+    deliver_from("grandchild", 0);
+    req = find_watch("grandchild", &count);
+    report("ancestry: a grandchild inherits through an unwatched parent",
+           NULL != req && 1 == count && (NULL == req || req->requestor == watcher));
+    drop_watches("grandchild");
+
+    /* ---- a job with no ancestry gets nothing ----
+     *
+     * There is nowhere for its output to go, and inventing a
+     * subscription would be worse than caching it. */
+    if (PMIX_SUCCESS != register_child("orphanjob", "unwatchedjob", 0)) {
+        report("ancestry: could not register the orphan namespace", false);
+        goto cleanup;
+    }
+    deliver_from("orphanjob", 0);
+    find_watch("orphanjob", &count);
+    report("ancestry: an unwatched ancestry creates no subscription", 0 == count);
+
+cleanup:
+    drop_watches("childjob");
+    drop_watches("grandchild");
+    drop_watches("orphanjob");
+    drop_watches("parentjob");
+    PMIX_RELEASE(watcher);
+}
+
 static pmix_server_module_t mymodule = {0};
 
 int main(int argc, char **argv)
@@ -313,6 +447,7 @@ int main(int argc, char **argv)
 
     test_spawn_parser();
     test_inheritance();
+    test_delivery_ancestry();
 
     PMIx_server_finalize();
 


### PR DESCRIPTION
Addresses the PMIx half of #4120. `docs/how-things-work/iof_inheritance.rst`
carries the whole design, including what is left for PRRTE.

## The defect

Output from a job spawned by an ordinary client never reached anyone.
`pmix_server_spawn_parser()` defaulted the output channels on only for a
**tool**, so a spawn issued by an application process — an
`MPI_Comm_spawn` — subscribed to nothing: the child's output arrived at
the server, matched no request, and sat in the cache until it aged out.

Asking explicitly did not help either, and that is the sharper form of
it. `PMIX_FWD_STDOUT` is documented as forwarding the child's output "to
this process", and a request *was* registered and the bytes shipped —
but every place that would arm local writing for the spawned namespace
is gated on the peer being a tool, so a client dropped them on arrival.
There was **no combination of directives that worked**.

## What a child inherits, and from where

Forwarding to the spawning client is the wrong repair regardless: output
is never forwarded to an application process, which would only emit it
again on its own stdout for the runtime to collect and forward a second
time. What the child wants is to be treated the way its parent is being
treated — so the live subscriptions covering the spawning process's job
are cloned onto the child's namespace, keeping the requestor, channels,
formatting and handler id.

Naming any one output channel takes the request verbatim and turns
inheritance off for all of them, including naming one `false` — that is
how a spawn asks for silence from a job whose parent is watched.

## Deciding it twice, because there are two daemons

The first commit decided this once, in `pmix_server_process_iof()` —
which runs on the server that **processed the spawn**, i.e. the one
hosting the spawning process. The watching tool's subscription lives on
the server the **tool** attached to. On a single-node DVM or under
`prterun` those are the same server; on a multi-node DVM they are not,
and the clone gets built where the output never arrives.

So `_iofdeliver` now carries the other half. When a chunk matches no
subscription — the point at which it would otherwise be cached and lost
— `inherit_from_ancestry()` walks the source namespace's
`PMIX_PARENT_ID` chain and clones the subscriptions covering the first
ancestor anybody here is watching. That decision is taken on the server
the output *reaches*, which for every PRRTE launcher is the HNP: each
prted forwards there, and the HNP hands everything it receives to its
own PMIx server.

**No PRRTE change was needed for that**, which was not the expectation
going in. The reproducer passes with the tool, the spawning rank and the
child job on three different daemons, against unmodified PRRTE master.

Four things about it are deliberate:

* A match **clones** rather than delivering the one chunk, so every
  later chunk takes the ordinary path — one datastore lookup per
  namespace instead of one per line of output. The clone is made by the
  same function the spawn-time path uses.
* `PMIX_PARENT_ID` is per-process job data, which is why the lookup
  works on a server that had nothing to do with the spawn. `pmix_pfexec`
  records it for the job as a whole, so the lookup tries the specific
  rank and then the wildcard.
* The walk is **transitive** and bounded (`PMIX_IOF_MAX_ANCESTRY`): a
  grandchild of a watched job is watched, and the chain is host-supplied
  data.
* The two halves are independent — neither needs the other, and where
  both apply the second finds the first's subscription and does nothing.

## The host's say: `PMIX_IOF_INHERIT`

New boolean the host places in the job-level information of the spawned
namespace; **absent means inherit**, so a host sends it only to say no.
This is what lets PRRTE's existing `inherit` setting govern who receives
a spawned job's output, as it already governs mapping, ranking, binding
and output *formatting*.

Job information is the channel — rather than anything carried with the
spawn request — because the two decision points are on different
daemons and the flag has to be readable by both. It is exactly what
PRRTE already ships to every daemon that registers the namespace. It is
**not** read by the spawned processes; it is server-side state keyed by
their namespace.

The spawn-time site carries one extra rule, because it is the only place
where "the host said nothing" and "we cannot ask yet" are
distinguishable: an unregistered namespace defers to the delivery-time
half rather than guessing. Deferring is never behaviorally wrong — the
other half cannot run before the namespace exists, so it always has a
real answer.

**PRRTE must set this attribute for the knob to do anything**; until
then absence means inherit and behavior is unchanged.

## Also here

* **A drive-by fix**, its own commit: `pmix_gds_base_store_modex()`
  unpacked the one-byte modex collect flag into a `pmix_collect_t`,
  which is int-sized because of `PMIX_COLLECT_INVALID = -1` — so three
  bytes of both comparisons read the stack. A fence whose servers all
  agree could be failed with the `collection-mismatch` message. Found by
  valgrind against a prted, and confirmed fixed the same way.
* **The swarm's launcher is now kept at the head of PRRTE master.** The
  image bakes a clone that is as old as the image, and rebuilding the
  image does not refresh it (docker caches the `git clone` layer). The
  clone that gets built now lives in the volume and is fetched forward
  on every build. The swarm here had been 21 commits behind.

## Testing

* `test/unit/iof_inherit.c` — 23 cases across the parser, the spawn-time
  clone, the delivery-time ancestry walk (including transitivity and the
  deferral rule), and `PMIX_IOF_INHERIT`. The delivery cases were
  verified to fail against the library without the walk.
* `contrib/dockerswarm/run-spawn-iof.sh` (README §21) — the multi-daemon
  half, which nothing in `make check` can reach: control (spawner on the
  tool's daemon), the cross-daemon case, tool/spawner/child on **three**
  different daemons, and the same under `prterun`. It ran red on the
  cross-daemon case before the delivery-time half and is green now.
* `make check` green; `run-tool-tests.sh` 10/10, including its cross-node
  IOF case.

`run-server-tests.sh` reports 4 failures in `dynamic`/`resolve` — a
double free in PRRTE's fence caddy, unrelated to this and present with
these commits reverted. Fixed separately in openpmix/prrte.

## What is left, and it is PRRTE's

A tool attached to a **non-HNP** daemon never receives another node's
output at all (the HNP relays elsewhere only by `jdata->originator`), and
a tool that attaches to a running DVM and `PMIx_IOF_pull`s a job's output
is not recorded against that job anywhere. Both need PRRTE to keep a
*set* of interested daemons for a job. Neither is reachable from this
side.
