### PR TITLE
Name the ownership asymmetry inside the fence upcall

### DIFF
--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -130,6 +130,13 @@ typedef pmix_status_t (*pmix_server_abort_fn_t)(const pmix_proc_t *proc, void *s
  * PMIx_Data_embed() copies rather than consumes, so a host that embeds
  * the blob in a message of its own still owns the original.
  *
+ * Note the asymmetry within this one call: procs and info belong to the
+ * library, are valid only until the operation is completed, and are
+ * freed by the library afterwards - while data is the host's from the
+ * moment the call is made. Every other array handed to a host callback
+ * follows the procs/info rule, so a correct instinct about the rest of
+ * this interface is exactly wrong for this one argument.
+ *
  * The array of info structs is used to pass user-requested options to the server.
  * This can include directives as to the algorithm to be used to execute the
  * fence operation. The directives are optional _unless_ the _mandatory_ flag


### PR DESCRIPTION
Comment only; no code change.

This is the one salvageable idea from #4132, which its author closed as
superseded and partly incorrect. Two of that PR's three hunks deserved
to go — the `include/pmix_server.h` paragraph duplicated the one
2eb40a00 had already added, and the `simptest.c` change freed the blob
immediately after the modex callback returned, which is a use-after-free
(`pmix_server_modex_cbfunc` only thread-shifts and packs the reply from
that pointer later, on the progress thread). The closing comment on
#4132 says both of those, and this PR does not revive either.

What is left is one observation that PR gestured at and that master's
text does not make.

2eb40a00 documents that ownership of the data blob transfers to the
host, and why. It does not say that **the same call hands the host two
arrays that follow the opposite rule**:

```c
rc = pmix_host_server.fence_nb(trk->pcs, trk->npcs, trk->info, trk->ninfo,
                               data, sz, ...);
```

`pcs` and `info` are the tracker's — `tdes()` frees both when the
tracker goes away — so they are valid only until the host completes the
operation, and freeing either is a double free. `data` is the host's
from the moment of the call. Three arguments, two ownership rules,
nothing in the signature to tell them apart.

That is worth stating because the procs/info rule is the one every
*other* array passed to a host callback follows. A host implementer who
has learned the interface has learned the wrong thing about this one
argument — the transfer does not read as an exception, it reads as the
fourth and fifth parameters of a function whose sixth behaves like them.
Which is most of why it was not discoverable before 2eb40a00, and why
both in-tree hosts leaked it.

Builds warning-free.