### PR TITLE
pif/linux_ipv6: get device flags from the kernel

### DIFF
--- a/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
+++ b/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
@@ -69,6 +69,40 @@ pmix_pif_base_component_t pmix_mca_pif_linux_ipv6_component = {
 };
 PMIX_MCA_BASE_COMPONENT_INIT(pmix, pif, linux_ipv6)
 
+/* Ask the kernel for a device's flags.
+ *
+ * /proc/net/if_inet6 has no flags column, and pmix_if_list cannot answer
+ * either: it is the list we are building, so a device whose IPv4 address
+ * has not been discovered yet is simply absent. Falling back to a bare
+ * IFF_UP loses IFF_LOOPBACK, which makes ::1 look like an ordinary
+ * routable interface to everything downstream, including the code that
+ * chooses which of our addresses to advertise to other hosts.
+ */
+static bool if_linux_ipv6_flags(const char *ifname, uint32_t *flags)
+{
+    struct ifreq ifr;
+    int sd;
+
+    sd = socket(AF_INET6, SOCK_DGRAM, 0);
+    if (sd < 0) {
+        sd = socket(AF_INET, SOCK_DGRAM, 0);
+        if (sd < 0) {
+            return false;
+        }
+    }
+
+    memset(&ifr, 0, sizeof(ifr));
+    pmix_strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name) - 1);
+    if (ioctl(sd, SIOCGIFFLAGS, &ifr) < 0) {
+        close(sd);
+        return false;
+    }
+    close(sd);
+
+    *flags = (uint32_t)(unsigned short) ifr.ifr_flags;
+    return true;
+}
+
 /* configure using getifaddrs(3) */
 static int if_linux_ipv6_open(void)
 {
@@ -136,7 +170,9 @@ static int if_linux_ipv6_open(void)
             ((struct sockaddr_in6 *) &intf->if_addr)->sin6_family = AF_INET6;
             ((struct sockaddr_in6 *) &intf->if_addr)->sin6_scope_id = scope;
             intf->if_mask = pfxlen;
-            if (PMIX_SUCCESS == pmix_ifindextoflags(pmix_ifnametoindex(ifname), &flag)) {
+            if (if_linux_ipv6_flags(ifname, &flag)) {
+                intf->if_flags = flag;
+            } else if (PMIX_SUCCESS == pmix_ifindextoflags(pmix_ifnametoindex(ifname), &flag)) {
                 intf->if_flags = flag;
             } else {
                 intf->if_flags = IFF_UP;


### PR DESCRIPTION
/proc/net/if_inet6 has no flags column, so this component looked the flags up with pmix_ifindextoflags (pmix_ifnametoindex(name)). Both of those search pmix_if_list, which is the list we are in the middle of building. If the device has not been added yet (its IPv4 address is discovered by a different component), the lookup fails and we fall back to a bare IFF_UP.

That silently drops IFF_LOOPBACK from the ::1 entry, so every consumer downstream sees the IPv6 loopback as an ordinary routable interface. pmix_ifisloopback() returns false for it, and code that skips loopback interfaces when deciding which addresses to advertise to other hosts does not skip it. Such code often carries an explicit "127.0.0.1" string check with no ::1 equivalent, precisely because the IPv4 path gets correct flags and this one does not.

Ask the kernel via SIOCGIFFLAGS instead, which is what the IPv4 component already does, and keep the old lookup as a fallback.