### PR TITLE
Close the deferred-work list in docs/todo.rst

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -471,6 +471,12 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         [[#include <stdatomic.h>]],
         [[_Bool flag = 0; (void) __atomic_test_and_set(&flag, __ATOMIC_SEQ_CST);]])
 
+    # the required partner of the above: a flag set with a test-and-set has to
+    # be cleared with this, not with a plain store
+    PMIX_REQUIRE_ATOMIC([__atomic_clear],
+        [[#include <stdatomic.h>]],
+        [[_Bool flag = 0; __atomic_clear(&flag, __ATOMIC_SEQ_CST);]])
+
     ##################################
     # Header files
     ##################################

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -98,11 +98,44 @@ flags, which re-opens the window the stand-in was built to close; or
 carry something in the IOF message that names the spawn, which is a
 wire-format and Standard question rather than a bug fix.
 
+A tool caches an event nobody handled; a client discards it
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a local event chain in a tool ends with nothing having handled the
+event, ``_notify_complete`` in ``src/tool/pmix_tool.c`` parks a copy in
+the notification hotel so that a handler registered *later* can still be
+given it.  A client in the same position simply releases the chain — the
+equivalent branch does not exist in ``src/client/pmix_client.c``.
+
+Only one of those can be right, and choosing is a statement about
+event-delivery behavior in a released library rather than a bug fix.
+Either the tool's branch is unreachable and should go, or it is correct
+and the client is losing events a late registrant was entitled to see.
+
+Nothing has been found that reaches it.  A server forwards an event to a
+tool only if that tool registered for the code, and it applies the
+tool's affected-proc filter before forwarding, so a tool does not
+normally receive an event it has no handler for.  The one shape that
+might — an event already on the wire when the handler is deregistered —
+**has not been confirmed**, and should not be treated as evidence until
+somebody checks whether the server stops forwarding before or after the
+deregistration round-trips.
+
+What is *not* at issue is the branch's correctness if it is entered:
+its two unchecked allocations and its caddy-leaking failure arms are
+fixed, as are the same two in the event layer's copy of the block
+(``_notify_client_event``).  Tracked as
+`openpmix#4101 <https://github.com/openpmix/openpmix/issues/4101>`_.
+
 Deferred work
 -------------
 
 Smaller items carried forward
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The items that stood under this heading were closed on 2026-08-13; what
+is left of them is recorded here, because in two cases the fix does not
+cover the whole of what the entry described.
 
 * **The pre-v3.2 branch of** ``resolve_peers()`` **no longer carries a
   dead store**, but what it *meant* to do is still not done.  The branch
@@ -114,9 +147,11 @@ Smaller items carried forward
   directly, as the branch intended, is still untried** — that is a
   behavior change on a path only a pre-v3.2 server exercises, and there
   is none to test against.
-* The event-caching branch in the tool's ``_notify_complete`` appears to
-  be unreachable, and ``src/client`` has no equivalent branch at all.
-  Tracked as `openpmix#4101 <https://github.com/openpmix/openpmix/issues/4101>`_.
+* **A malformed** ``PMIX_QUALIFIED_VALUE`` **or a NULL key arriving in a
+  cache refresh now fails the enclosing** ``PMIx_Get``.  See the
+  ``refcb()`` entry in ``src/client/AGENTS.md`` for why all-or-nothing is
+  the only answer an application can act on.  Recorded here because it is
+  the one behavior change in that group of fixes.
 
 Coverage gaps
 -------------
@@ -176,6 +211,16 @@ not "fixed" by a later reader.
   anywhere in it.  Both in-tree hosts (PRRTE and ``test/simple/simptest``)
   currently leak it.  See ``src/server/AGENTS.md``.
 
+* **The event-caching blocks assign ``cd->nondefault`` inside their**
+  ``0 < chain->ninfo`` **guard**, which reads as though a non-default
+  event carrying no info would be parked as a default one and then
+  delivered to default handlers that should not see it.  It cannot
+  happen: every path that sets ``chain->nondefault`` reads it out of a
+  ``PMIX_EVENT_NON_DEFAULT`` directive in the info array, so the flag is
+  only ever true when there is info to have carried it.  Hoisting the
+  assignment out of the guard is equivalent, not a fix.  Both copies —
+  ``_notify_complete`` in ``src/tool`` and ``_notify_client_event`` in
+  ``src/event`` — are left as they are.
 * **``pmix_srand()`` copies the seeded state into a file-static buffer**
   (``src/util/pmix_alfg.c``).  It looks like a footgun, but it is the
   only way to seed the global that ``pmix_random()`` reads, and the unit

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -97,12 +97,6 @@ Deferred work
 Smaller items carried forward
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``PMIx_Value_get_number()`` is called without a ``NULL`` check on
-  ``kv->value`` at three fetches in ``src/client``'s ``get_data()``.
-  Nothing demonstrates a local datastore fetch producing such a kval, and
-  if it is closed the screen belongs inside ``PMIx_Value_get_number``
-  rather than at the call sites, since every caller in the tree is
-  equally exposed.
 * ``pmix_globals.init_called`` is set with ``__atomic_test_and_set`` and
   cleared with a plain assignment.  All three roles do this, and the
   only interleaving that reaches it is a concurrent

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -104,12 +104,16 @@ Deferred work
 Smaller items carried forward
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* The rank ``resolve_peers()`` sets in its pre-v3.2 compatibility branch
-  is a dead store — it is unconditionally reset a few lines later, and
-  ``try_fetch()`` retries an ``UNDEF`` rank as ``WILDCARD``, which is why
-  the legacy path still resolves.  Only the store is dead; the ``key``
-  and ``ninfo`` that branch sets do take effect, so it cannot simply be
-  deleted.  Not touched without a pre-v3.2 server to test against.
+* **The pre-v3.2 branch of** ``resolve_peers()`` **no longer carries a
+  dead store**, but what it *meant* to do is still not done.  The branch
+  assigned ``PMIX_RANK_WILDCARD`` and was then overwritten with
+  ``PMIX_RANK_UNDEF`` before anything read it; the assignment is gone and
+  the branch now varies only the ``key`` and ``ninfo``, which is what it
+  always really did.  The legacy path resolves because ``try_fetch()``
+  retries an ``UNDEF`` rank as ``WILDCARD``.  **Fetching at ``WILDCARD``
+  directly, as the branch intended, is still untried** — that is a
+  behavior change on a path only a pre-v3.2 server exercises, and there
+  is none to test against.
 * The command-line parser drops a positional argument placed *before* an
   option, a consequence of ``getopt`` reordering.  Put options first.
 * The relay in ``src/tool`` assumes the downstream tool and the upstream

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -114,10 +114,6 @@ Smaller items carried forward
   directly, as the branch intended, is still untried** — that is a
   behavior change on a path only a pre-v3.2 server exercises, and there
   is none to test against.
-* The relay in ``src/tool`` assumes the downstream tool and the upstream
-  server negotiated the same ``bfrops`` module and buffer type.  A tool
-  forces the same modules on itself and its server, so this holds today,
-  but the code does not check it.
 * The event-caching branch in the tool's ``_notify_complete`` appears to
   be unreachable, and ``src/client`` has no equivalent branch at all.
   Tracked as `openpmix#4101 <https://github.com/openpmix/openpmix/issues/4101>`_.

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -101,9 +101,6 @@ Smaller items carried forward
   cleared with a plain assignment.  All three roles do this, and the
   only interleaving that reaches it is a concurrent
   ``PMIx_Init``/``PMIx_Finalize``, which is already unsupported.
-* ``refcb()`` in ``src/client`` overwrites the store status with the next
-  unpack's, so a store failure while absorbing a cache refresh is
-  silently dropped.
 * The rank ``resolve_peers()`` sets in its pre-v3.2 compatibility branch
   is a dead store — it is unconditionally reset a few lines later, and
   ``try_fetch()`` retries an ``UNDEF`` rank as ``WILDCARD``, which is why

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -114,8 +114,6 @@ Smaller items carried forward
   directly, as the branch intended, is still untried** — that is a
   behavior change on a path only a pre-v3.2 server exercises, and there
   is none to test against.
-* The command-line parser drops a positional argument placed *before* an
-  option, a consequence of ``getopt`` reordering.  Put options first.
 * The relay in ``src/tool`` assumes the downstream tool and the upstream
   server negotiated the same ``bfrops`` module and buffer type.  A tool
   forces the same modules on itself and its server, so this holds today,

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -38,6 +38,13 @@ so that they are not repeatedly "rediscovered" and re-fixed.
           are the only remaining entries that cannot be checked by
           reading the tree, so they are where the next stale one will be.
 
+          Three of the "smaller items carried forward" were closed on
+          2026-08-13 — the ``PMIx_Value_get_number`` screen (now in the
+          function itself, where every caller in the tree gets it), the
+          ``init_called`` clear (now ``pmix_atomic_clear``, the required
+          partner of the ``__atomic_test_and_set`` that sets it), and
+          ``refcb()``'s dropped store status.
+
 Open decisions
 --------------
 
@@ -97,10 +104,6 @@ Deferred work
 Smaller items carried forward
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``pmix_globals.init_called`` is set with ``__atomic_test_and_set`` and
-  cleared with a plain assignment.  All three roles do this, and the
-  only interleaving that reaches it is a concurrent
-  ``PMIx_Init``/``PMIx_Finalize``, which is already unsupported.
 * The rank ``resolve_peers()`` sets in its pre-v3.2 compatibility branch
   is a dead store — it is unconditionally reset a few lines later, and
   ``try_fetch()`` retries an ``UNDEF`` rank as ``WILDCARD``, which is why

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -881,16 +881,34 @@ inspection against the code that consumes them.
   logged and reported, and the unpack still ends the loop.
 
   **The behavior decision this entry used to defer is worth stating
-  rather than re-deferring.** Reporting the store failure does fail a
-  `PMIx_Get` that would previously have succeeded — `refresh_cache()`'s
-  return aborts the enclosing get — and that is the point: the caller
-  asked explicitly for fresh data, and the alternative is to hand them
-  the stale copy without a word. A store failure here is never a
-  legitimate outcome (the hash module replaces a duplicate rather than
-  refusing it), which is what distinguishes it from the status the
-  *server* sent. That one is still discarded, deliberately: a "nothing
-  to refresh" `PMIX_ERR_NOT_FOUND` must not fail gets that succeed
-  today. See the matching note in
+  rather than re-deferring, and so is the reason for it.** Reporting the
+  store failure does fail a `PMIx_Get` that would previously have
+  succeeded — `refresh_cache()`'s return aborts the enclosing get. The
+  reason to accept that is not that a partial refresh is rare; it is
+  that **the caller cannot recover from one**. This data is the
+  library's, not theirs: they asked through `PMIX_GET_REFRESH_CACHE` for
+  what the server holds now, and if only some of it landed there is
+  nothing they can inspect to tell which keys are current and which are
+  stale. An error over the whole operation is the only answer they can
+  act on.
+
+  **Know what such a failure can and cannot be**, because the obvious
+  guess is wrong. It is never a duplicate: `pmix_hash_store()` ignores a
+  repeat whose value is unchanged and *replaces* one whose value
+  differs, reporting success either way, so nothing about re-delivering
+  a key can fail. What is left is an allocation failure — the job
+  tracker, the proc entry, the key registration, the value copy — or a
+  kval we cannot make sense of, meaning a NULL key or a
+  `PMIX_QUALIFIED_VALUE` whose payload is not a non-empty data array.
+  The array-expansion arms of `pmix_gds_hash_store()` (including the
+  duplicate node/proc-map detection, which *does* refuse) are not
+  reachable from here: `pmix_server_refresh_cache` fetches
+  `PMIX_REMOTE` scope for one rank, so what comes back is per-proc put
+  data rather than job-level arrays.
+
+  The status the *server* sent is still discarded, deliberately: a
+  "nothing to refresh" `PMIX_ERR_NOT_FOUND` must not fail gets that
+  succeed today. See the matching note in
   [`src/server/AGENTS.md`](../server/AGENTS.md).
 - `pmix_client_convert_group_procs()` holds `grouplock` across a
   `PMIX_GDS_FETCH_KV` for `PMIX_JOB_SIZE`. That is safe only because

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -575,11 +575,15 @@ regression coverage in `test/unit/client_api.c`.
 
 *Known, left alone (deliberately):*
 
-- `resolve_peers()` sets `proc.rank = PMIX_RANK_WILDCARD` for a pre-v3.2
-  server and then unconditionally resets it to `PMIX_RANK_UNDEF` two
-  lines later, so the legacy branch is dead. `try_fetch()` retries an
-  UNDEF rank as WILDCARD, which is why the path still works. Not changed
-  without a pre-v3.2 server to test against; see the comment in the code.
+- `resolve_peers()` set `proc.rank = PMIX_RANK_WILDCARD` for a pre-v3.2
+  server and then unconditionally reset it to `PMIX_RANK_UNDEF` two
+  lines later. **The dead store is gone**; the legacy branch now varies
+  only the `key` and `ninfo`, which is all it ever really did, and the
+  path resolves because `try_fetch()` retries an UNDEF rank as WILDCARD.
+  What is still untried is the branch's *intent* — fetching at WILDCARD
+  directly rather than by way of the retry — because that is a behavior
+  change on a path only a pre-v3.2 server exercises and there is none to
+  test against. The comment in the code says so.
 - **The library's own event handlers could be silently suppressed by the
   application — [openpmix#4059][i4059]. Mostly fixed; read this before
   touching the group event code.** Both registrations here
@@ -1749,11 +1753,12 @@ alone:
   `str` is safe: `pmix_bfrops_base_value_load()` zeroes the union for a
   NULL source rather than reaching `strdup`. A NULL nspace is the
   documented "all namespaces" request and reaches both host queries.
-- The dead `PMIX_ERR_DATA_VALUE_NOT_FOUND` arm in both functions, and the
-  dead `proc.rank = PMIX_RANK_WILDCARD` store in the pre-v3.2 branch, are
-  unchanged and still carry their explaining comments. `try_fetch()`
+- The dead `PMIX_ERR_DATA_VALUE_NOT_FOUND` arm in both functions is
+  unchanged and still carries its explaining comment. `try_fetch()`
   returns only `PMIX_SUCCESS`, `PMIX_ERR_INVALID_NAMESPACE` and
-  `PMIX_ERR_NOT_FOUND`.
+  `PMIX_ERR_NOT_FOUND`. (The `proc.rank = PMIX_RANK_WILDCARD` store this
+  entry used to name beside it has since been deleted — see the first
+  sweep's entry for what that did and did not close.)
 
 ## Defects found in the August 2026 review (tenth sweep — `pmix_client_spawn.c`)
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -873,12 +873,25 @@ inspection against the code that consumes them.
   No test drives it, so this has never been noticed. Fixing it means
   making that path asynchronous; until then, do not add a `run_*.pl`
   that spawns.
-- `refcb()` overwrites the `PMIX_GDS_STORE_KV` status with the next
-  unpack's before anyone reads it, so a store failure while absorbing a
-  cache refresh is silently dropped. The loop is driven by the unpack,
-  which is the right termination condition; reporting the store error
-  would change what `PMIx_Get` returns for a refresh that partially
-  succeeded, and that is a behavior decision, not a bug fix.
+- **FIXED — `refcb()` overwrote the `PMIX_GDS_STORE_KV` status with the
+  next unpack's** before anyone read it, so a store failure while
+  absorbing a cache refresh was silently dropped. The loop is driven by
+  the unpack, which is the right termination condition, so the store
+  status now lives in a variable of its own: the first failure is
+  logged and reported, and the unpack still ends the loop.
+
+  **The behavior decision this entry used to defer is worth stating
+  rather than re-deferring.** Reporting the store failure does fail a
+  `PMIx_Get` that would previously have succeeded — `refresh_cache()`'s
+  return aborts the enclosing get — and that is the point: the caller
+  asked explicitly for fresh data, and the alternative is to hand them
+  the stale copy without a word. A store failure here is never a
+  legitimate outcome (the hash module replaces a duplicate rather than
+  refusing it), which is what distinguishes it from the status the
+  *server* sent. That one is still discarded, deliberately: a "nothing
+  to refresh" `PMIX_ERR_NOT_FOUND` must not fail gets that succeed
+  today. See the matching note in
+  [`src/server/AGENTS.md`](../server/AGENTS.md).
 - `pmix_client_convert_group_procs()` holds `grouplock` across a
   `PMIX_GDS_FETCH_KV` for `PMIX_JOB_SIZE`. That is safe only because
   the hash module answers locally and never up-calls the server. If a
@@ -1274,17 +1287,25 @@ without new evidence.
   discards its argument entirely, so the operand is never evaluated.
   Reordered here for readability, but do not go looking for a bug behind
   the same shape elsewhere in the tree.
-- **`PMIx_Value_get_number(kv->value, …)` is called without a NULL check
-  on `kv->value`** at the nodeid, appnum and sessionid fetches in
-  `get_data()`, and that function dereferences `value->type` as its
-  first act. The hostname fetch beside them *does* check. Left alone
-  because nothing demonstrates a local GDS fetch producing a kval with a
-  NULL value — `pmix_kval_t.value` is documented as legitimately
-  NULL-able by [`src/mca/bfrops/AGENTS.md`](../mca/bfrops/AGENTS.md),
-  but that is about what arrives off the wire through `pack_kval`, and
-  these three read the local datastore. If you decide to close it, the
-  screen belongs in `PMIx_Value_get_number` rather than at three call
-  sites here, since every other caller in the tree is equally exposed.
+- **FIXED — `PMIx_Value_get_number(kv->value, …)` was called without a
+  NULL check on `kv->value`** at the nodeid, appnum and sessionid
+  fetches in `get_data()`, and that function dereferences `value->type`
+  as its first act. The hostname fetch beside them always checked. It
+  sat open for several sweeps on the grounds that nothing demonstrates a
+  local GDS fetch producing a kval with a NULL value —
+  `pmix_kval_t.value` is documented as legitimately NULL-able by
+  [`src/mca/bfrops/AGENTS.md`](../mca/bfrops/AGENTS.md), but that is
+  about what arrives off the wire through `pack_kval`, and these three
+  read the local datastore.
+
+  **The screen went into `PMIx_Value_get_number` itself, not here**, and
+  that is the part worth carrying: there are thirty-odd callers in the
+  tree and every one of them was equally exposed, so three checks in
+  this file would have been the least useful place to put it. A NULL
+  value or a NULL destination is now `PMIX_ERR_BAD_PARAM`. Regression:
+  `test_null_arguments_are_refused()` in
+  [`test/unit/bfrops_get_number.c`](../../test/unit/bfrops_get_number.c),
+  which segfaults rather than fails against the unfixed library.
 - **`strdup(pmix_globals.hostname)` in `get_data()`'s invalid-rank
   branch is unguarded** where the branch above it tests
   `NULL != pmix_globals.hostname` first. It is safe:
@@ -1370,14 +1391,23 @@ without new evidence.
   released. That is safe because nothing in the teardown reads
   `cbobject` — `relfn` is NULL for an ordinary handler, only observers
   set one.
-- **`pmix_globals.init_called` is set with `__atomic_test_and_set` and
-  cleared with a plain `= false`.** It is a bare `bool`, not an
-  `atomic_bool` like `initialized` beside it, so the clear is a
-  non-atomic store racing an atomic RMW. Left alone because it is not a
-  `src/client` decision: `pmix_client.c`, `pmix_server.c` and
-  `pmix_tool.c` all do exactly this, and the only interleaving that
-  reaches it is a concurrent `PMIx_Init`/`PMIx_Finalize`, which the
-  comment at the top of `PMIx_Init` already declines to support.
+- **FIXED — `pmix_globals.init_called` was set with
+  `__atomic_test_and_set` and cleared with a plain `= false`.** It is a
+  bare `bool`, not an `atomic_bool` like `initialized` beside it, so the
+  clear was a non-atomic store racing an atomic RMW. It was left alone
+  for several sweeps because it is not a `src/client` decision —
+  `pmix_client.c`, `pmix_server.c` and `pmix_tool.c` all did exactly
+  this, and the only interleaving that reaches it is a concurrent
+  `PMIx_Init`/`PMIx_Finalize`, which the comment at the top of
+  `PMIx_Init` already declines to support.
+
+  It is closed the way it had to be closed — in all three roles at once,
+  with `pmix_atomic_clear()`, the required partner of the builtin that
+  sets it (see [`src/include/AGENTS.md`](../include/AGENTS.md)). Note
+  the type is deliberately unchanged: `__atomic_test_and_set` and
+  `__atomic_clear` both take a pointer to an ordinary object, and
+  `_Atomic`-qualifying the flag would mean doing the same to the three
+  init counters beside it.
 - **The re-entrant `PMIx_Init` returns `PMIX_SUCCESS` where the first
   call returned `PMIX_ERR_UNREACH`.** A second library in the same
   process therefore reads "connected" from a singleton that is not, and

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1320,7 +1320,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
 
     // mark we are no longer initialized
     pmix_atomic_unset_bool(&pmix_globals.initialized);
-    pmix_globals.init_called = false;
+    pmix_atomic_clear(&pmix_globals.init_called);
 
     pmix_output_verbose(2, pmix_client_globals.base_output,
                         "%s:%d pmix:client finalize called",

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -1505,7 +1505,7 @@ static void refcb(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
 {
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
     int32_t cnt;
-    pmix_status_t rc, ret;
+    pmix_status_t rc, ret, strc, store_rc = PMIX_SUCCESS;
     pmix_kval_t kv;
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
@@ -1534,19 +1534,33 @@ static void refcb(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
         goto done;
     }
 
-    // unpack and store any returned data
+    /* unpack and store any returned data. The unpack is what terminates the
+     * loop, so the store cannot be allowed to overwrite its status - but a
+     * store failure must not be dropped either. The caller asked explicitly
+     * for fresh data, and the alternative to reporting it is to hand them the
+     * stale copy without a word. Record the first one and report it below.
+     * Note this deliberately does not resurrect the status the *server* sent:
+     * refresh_cache() is called for its side effect and its return aborts the
+     * enclosing PMIx_Get, so a "nothing to refresh" answer must not fail gets
+     * that succeed today - see the note in src/server/AGENTS.md */
     PMIX_CONSTRUCT(&kv, pmix_kval_t);
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &kv, &cnt, PMIX_KVAL);
     while (PMIX_SUCCESS == rc) {
-        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, cb->proc, PMIX_INTERNAL, &kv);
+        PMIX_GDS_STORE_KV(strc, pmix_globals.mypeer, cb->proc, PMIX_INTERNAL, &kv);
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != strc && PMIX_SUCCESS == store_rc)) {
+            PMIX_ERROR_LOG(strc);
+            store_rc = strc;
+        }
         PMIX_DESTRUCT(&kv);
         PMIX_CONSTRUCT(&kv, pmix_kval_t);
         cnt = 1;
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &kv, &cnt, PMIX_KVAL);
     }
     PMIX_DESTRUCT(&kv);
-    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+    if (PMIX_SUCCESS != store_rc) {
+        ret = store_rc;
+    } else if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
         ret = PMIX_SUCCESS;
     } else {
         ret = rc;

--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -175,22 +175,26 @@ static void resolve_peers(int sd, short args, void *cbdata)
     // avoids a threadlock situation
     PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, NULL, PMIX_BOOL);
 
-    /* if I am a client and my server is earlier than v3.2.x, then
-     * I need to look for this data under rank=PMIX_RANK_WILDCARD
-     * with a key equal to the nodename */
+    /* if I am a client and my server is earlier than v3.2.x, then I need to
+     * look for this data keyed by the nodename rather than under
+     * PMIX_LOCAL_PEERS with node-info qualifiers.
+     *
+     * NOTE: what the legacy branch varies is the key and the number of
+     * directives - not the rank. Both branches look the data up at
+     * PMIX_RANK_UNDEF, set once below, because try_fetch() retries an UNDEF
+     * rank as WILDCARD and that is what reaches a pre-v3.2 server's
+     * wildcard-filed entry. This branch used to assign PMIX_RANK_WILDCARD
+     * here as well, which read as the thing that made the legacy path work
+     * and was in fact a dead store - the assignment below overwrote it
+     * before anyone looked. Removing it changes nothing; *restoring the
+     * intent* - fetching at WILDCARD directly rather than by way of the
+     * retry - is the part that wants a pre-v3.2 server to test against, and
+     * there is none. See docs/todo.rst. */
     if (PMIX_PEER_IS_CLIENT(pmix_globals.mypeer) &&
         PMIX_PEER_IS_EARLIER(pmix_client_globals.myserver, 3, 1, 100)) {
-        /* NOTE: pre-v3.2 servers filed this under the wildcard rank keyed by
-         * the node name, but the reset below puts the rank back to UNDEF for
-         * both branches, so this assignment has no effect. try_fetch() retries
-         * an UNDEF rank as WILDCARD, which is why the legacy path still
-         * resolves; the dead store is left as-is rather than "fixed" blind,
-         * since no pre-v3.2 server is available to test the difference. */
-        proc.rank = PMIX_RANK_WILDCARD;
         key = cd->nodename;
         ninfo = 1;
     } else {
-        proc.rank = PMIX_RANK_UNDEF;
         key = PMIX_LOCAL_PEERS;
         PMIX_INFO_LOAD(&info[1], PMIX_NODE_INFO, NULL, PMIX_BOOL);
         PMIX_INFO_LOAD(&info[2], PMIX_HOSTNAME, cd->nodename, PMIX_STRING);

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -317,6 +317,12 @@ pmix_status_t pmix_notify_server_of_event(pmix_status_t status, const pmix_proc_
             if (0 < chain->ninfo) {
                 cd->ninfo = chain->ninfo;
                 PMIX_INFO_CREATE(cd->info, cd->ninfo);
+                if (NULL == cd->info) {
+                    cd->ninfo = 0;
+                    rc = PMIX_ERR_NOMEM;
+                    PMIX_RELEASE(cd);
+                    goto cleanup;
+                }
                 cd->nondefault = chain->nondefault;
                 /* need to copy the info */
                 for (n = 0; n < cd->ninfo; n++) {
@@ -326,6 +332,12 @@ pmix_status_t pmix_notify_server_of_event(pmix_status_t status, const pmix_proc_
             if (NULL != chain->targets) {
                 cd->ntargets = chain->ntargets;
                 PMIX_PROC_CREATE(cd->targets, cd->ntargets);
+                if (NULL == cd->targets) {
+                    cd->ntargets = 0;
+                    rc = PMIX_ERR_NOMEM;
+                    PMIX_RELEASE(cd);
+                    goto cleanup;
+                }
                 memcpy(cd->targets, chain->targets, cd->ntargets * sizeof(pmix_proc_t));
             }
             if (NULL != chain->affected) {

--- a/src/include/AGENTS.md
+++ b/src/include/AGENTS.md
@@ -269,9 +269,10 @@ or macro signature ripples across the tree.
   `pmix_shmem.c`). Includes `pmix_stdatomic.h`.
 
 **Design note — the `__atomic_*` builtins in `pmix_stdatomic.h` are
-deliberate, not a bug, and are equally required.** Four of its convenience
+deliberate, not a bug, and are equally required.** Five of its convenience
 macros (`pmix_atomic_store_int`, `pmix_atomic_load_int`,
-`pmix_atomic_fetch_add`, `pmix_atomic_test_and_set`) use the GCC/Clang
+`pmix_atomic_fetch_add`, and the `pmix_atomic_test_and_set` /
+`pmix_atomic_clear` pair) use the GCC/Clang
 `__atomic_*` builtins rather than the C11 generic functions — this is the
 *only* place in the tree that does. The reason: their callers operate
 atomically on **ordinary, non-`_Atomic`-qualified** globals
@@ -287,6 +288,14 @@ compromise. Note the memory ordering differs on purpose:
 `pmix_atomic_fetch_add` here is `SEQ_CST` (init/finalize counters),
 whereas the differently-named `pmix_atomic_fetch_add_32` in
 `pmix_atomic.h` is relaxed (shared-memory refcounts in `pmix_shmem.c`).
+
+**`pmix_atomic_test_and_set` and `pmix_atomic_clear` are a pair — use
+the second to clear what the first set.** A plain `= false` is a
+non-atomic store racing an atomic read-modify-write, which is what all
+three roles did to `pmix_globals.init_called` until August 2026. This is
+also why the flag stays a plain `bool` rather than becoming
+`pmix_atomic_bool_t`: `__atomic_clear` takes an ordinary object, and
+qualifying the flag would drag in the three init counters beside it.
 
 **Inconsistency to be aware of:** `pmix_globals_t` declares its flags as
 bare C11 `atomic_bool` (`initialized`, `util_initialized`, `connected`,

--- a/src/include/pmix_stdatomic.h
+++ b/src/include/pmix_stdatomic.h
@@ -56,4 +56,14 @@ typedef _Atomic uintptr_t pmix_atomic_uintptr_t;
 
 #define pmix_atomic_test_and_set(addr) __atomic_test_and_set(addr, __ATOMIC_SEQ_CST)
 
+/* the required partner of pmix_atomic_test_and_set - a flag that was set with
+ * a test-and-set must be cleared with this, not with a plain assignment, or
+ * the clear is a non-atomic store racing an atomic read-modify-write. Both
+ * take a pointer to an ordinary (non-_Atomic) object - pmix_globals.init_called
+ * is a plain bool - which is why this pair spells itself with the compiler's
+ * __atomic_* builtins rather than the C11 generic functions beside them:
+ * atomic_store/atomic_load require an _Atomic-qualified operand. See the
+ * design note in src/include/AGENTS.md */
+#define pmix_atomic_clear(addr) __atomic_clear(addr, __ATOMIC_SEQ_CST)
+
 #endif

--- a/src/mca/bfrops/base/AGENTS.md
+++ b/src/mca/bfrops/base/AGENTS.md
@@ -226,6 +226,17 @@ on review:
 - **`PMIX_PID` was not a source type at all.** There was no
   `check_pid()`, and the dispatcher's `PMIX_PID` branch had no `else`,
   so every conversion out of a pid returned `PMIX_ERR_BAD_PARAM`.
+- **Neither argument was screened.** The dispatcher reads `value->type`
+  as its first act and every arm that matches writes through `dest`, so
+  a NULL for either was a segfault — and the NULL that actually arrives
+  is the value: callers pass the `value` member of a `pmix_kval_t`,
+  which is a pointer that is legitimately NULL off the wire. Three call
+  sites in `src/client`'s `get_data()` carried this as a known gap for
+  four sweeps before it was closed **here**, which is the point worth
+  keeping: there are thirty-odd callers in the tree and every one was
+  equally exposed, so a screen at any of them was the wrong place for
+  it. This is the same rule as "put the screen in the `_tma_` inline,
+  not in the `PMIx_` wrapper" below.
 - **Range constants.** `check_int64()` bounded `PMIX_PID` and
   `PMIX_STATUS` — both *signed* 32-bit — by `UINT32_MAX` and did not
   check the negative side at all. `check_float()` bounded `PMIX_UINT`

--- a/src/mca/bfrops/base/bfrop_base_get_number.c
+++ b/src/mca/bfrops/base/bfrop_base_get_number.c
@@ -92,6 +92,17 @@ static pmix_status_t check_pid(const pmix_value_t *value,
 pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
                                     void *dest, pmix_data_type_t type)
 {
+    /* the type tag is the first thing every branch below reads, and the
+     * destination is written by every one that matches, so both have to be
+     * screened here. Callers reach this with the "value" member of a
+     * pmix_kval_t - which is a pointer that is legitimately NULL for a kval
+     * that arrived off the wire (see src/mca/bfrops/AGENTS.md) - so the
+     * screen belongs here rather than at the call sites, all of which are
+     * equally exposed */
+    if (NULL == value || NULL == dest) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     if (PMIX_SIZE == value->type) {
         if (PMIX_SIZE == type) {
             size_t *sz;

--- a/src/runtime/help-pmix-runtime.txt
+++ b/src/runtime/help-pmix-runtime.txt
@@ -170,3 +170,25 @@ returned PMIX_ERR_WOULD_BLOCK without performing the operation. An API
 that reports no status has instead completed the operation
 asynchronously, which is indistinguishable to the caller except that it
 did not wait.
+#
+[relay-encoding-mismatch]
+A PMIx tool cannot relay a request on behalf of a tool that connected to
+it, because the two connections do not use the same encoding.
+
+  Requesting tool:  %s
+    its bfrops module:  %s   (buffer type %d)
+  Our own server:
+    its bfrops module:  %s   (buffer type %d)
+
+A relayed request is passed along exactly as it arrived - the bytes are
+copied onward without being unpacked, and the answer is copied back the
+same way. That is only sound while both ends agree on how those bytes are
+encoded. They disagree here, so relaying the request would hand the far
+end a message it would misread rather than reject.
+
+This is not expected: a tool imposes its own bfrops module and buffer
+type on itself and on the server it attaches to, so the two normally
+match by construction. Reaching this message most likely means a peer was
+given its modules by some other path - please report it.
+
+The request has been refused rather than relayed.

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -1859,6 +1859,10 @@ misbehave by design).
   "nothing to refresh" `PMIX_ERR_NOT_FOUND` would fail gets that
   currently succeed. Pack the honest status (it is the right thing on the
   wire), but do not build anything here on the client acting on it.
+
+  What the client *does* report is a failure to **store** what arrived,
+  which is a different thing and is not a legitimate outcome the way a
+  not-found answer is. Do not read the two as one rule.
 - **`pmix_server_job_ctrl` creating a namespace for an unknown target is
   deliberate.** A job-control request may name a job this server has not
   been told about yet, and the epilog directives need somewhere to hang;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1056,7 +1056,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
 
     // mark we are no longer initialized
     pmix_atomic_unset_bool(&pmix_globals.initialized);
-    pmix_globals.init_called = false;
+    pmix_atomic_clear(&pmix_globals.init_called);
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "pmix:server finalize called");

--- a/src/tool/AGENTS.md
+++ b/src/tool/AGENTS.md
@@ -494,12 +494,37 @@ named are the ones that fail against the unfixed library.
 - **The tool's event cache in `_notify_complete` looks unreachable, and
   `src/client` has no equivalent branch at all.** See item 14 and
   [openpmix#4101](https://github.com/openpmix/openpmix/issues/4101).
-- **The relay assumes both peers negotiated the same bfrops module and
-  buffer type.** (Unchanged by the spawn-fallback work above.) `pmix_tool_relay_op` copies the downstream tool's raw
-  payload into a fresh buffer and sends it to `myserver` unchanged, and
-  `tool_switchyard` does the reverse. A tool forces the same modules on
-  itself and its server, so this holds today — but it is an assumption,
-  not something the code checks.
+  What is *no longer* open is the branch itself: it indexed an unchecked
+  `PMIX_INFO_CREATE` and an unchecked `PMIX_PROC_CREATE`, and its
+  allocation-failure arms fell straight into the chain release, leaking
+  the caddy with everything already copied into it. Those are fixed, and
+  the same two allocations were fixed in the event layer's copy of this
+  block (`_notify_client_event` in
+  [`pmix_event_notification.c`](../event/pmix_event_notification.c) —
+  the two are copy-paste siblings, so check both when you touch either).
+  Note the `cd->nondefault` assignment sitting inside the
+  `0 < chain->ninfo` guard is **not** a defect: `nondefault` is only
+  ever set from a `PMIX_EVENT_NON_DEFAULT` directive in the info array,
+  so it cannot be true when there is no info. What remains open is the
+  question the issue is about — whether a server-forwarded event can
+  reach a tool with no handler for it, and whether a client should cache
+  one when it does — which is an event-delivery semantics decision.
+- **FIXED — the relay assumed both peers negotiated the same bfrops
+  module and buffer type.** `pmix_tool_relay_op` copies the downstream
+  tool's raw payload into a fresh buffer and sends it to `myserver`
+  unchanged, and `tool_switchyard` does the reverse, so a relay that
+  crossed an encoding boundary would be *misread* at the far end rather
+  than refused. A tool forces the same modules on itself and its server,
+  so this still holds by construction — the point is that the code now
+  says so instead of assuming it, and reports
+  `relay-encoding-mismatch` plus `PMIX_ERR_PACK_MISMATCH` if it ever
+  stops holding.
+
+  **The status matters as much as the check.** `server_switchyard`
+  falls through to its logic tree on `PMIX_ERR_NOT_SUPPORTED` and
+  `PMIX_ERR_UNREACH`, so returning either of those would have made an
+  encoding mismatch fork/exec the spawn locally instead of reporting
+  it. Any new refusal added here needs a status outside that pair.
 
 ## Testing
 

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1667,7 +1667,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     /* reset the one-time-init latch so a subsequent PMIx_tool_init in this
      * process starts a fresh library instance rather than short-circuiting
      * on the still-set flag and returning PMIX_ERR_INIT */
-    pmix_globals.init_called = false;
+    pmix_atomic_clear(&pmix_globals.init_called);
     pmix_globals.mypeer->finalized = true;
 
     pmix_output_verbose(2, pmix_globals.debug_output,

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -128,12 +128,19 @@ static void _notify_complete(pmix_status_t status, void *cbdata)
      * be registered later */
     if (PMIX_ERR_NOT_FOUND == status && !chain->cached) {
         cd = PMIX_NEW(pmix_notify_caddy_t);
+        if (NULL == cd) {
+            goto cleanup;
+        }
         cd->status = chain->status;
         PMIX_LOAD_PROCID(&cd->source, chain->source.nspace, chain->source.rank);
         cd->range = chain->range;
         if (0 < chain->ninfo) {
             cd->ninfo = chain->ninfo;
             PMIX_INFO_CREATE(cd->info, cd->ninfo);
+            if (NULL == cd->info) {
+                cd->ninfo = 0;
+                goto relcd;
+            }
             cd->nondefault = chain->nondefault;
             /* need to copy the info */
             for (n = 0; n < cd->ninfo; n++) {
@@ -143,6 +150,10 @@ static void _notify_complete(pmix_status_t status, void *cbdata)
         if (NULL != chain->targets) {
             cd->ntargets = chain->ntargets;
             PMIX_PROC_CREATE(cd->targets, cd->ntargets);
+            if (NULL == cd->targets) {
+                cd->ntargets = 0;
+                goto relcd;
+            }
             memcpy(cd->targets, chain->targets, cd->ntargets * sizeof(pmix_proc_t));
         }
         if (NULL != chain->affected) {
@@ -150,7 +161,7 @@ static void _notify_complete(pmix_status_t status, void *cbdata)
             PMIX_PROC_CREATE(cd->affected, cd->naffected);
             if (NULL == cd->affected) {
                 cd->naffected = 0;
-                goto cleanup;
+                goto relcd;
             }
             memcpy(cd->affected, chain->affected, cd->naffected * sizeof(pmix_proc_t));
         }
@@ -163,6 +174,14 @@ static void _notify_complete(pmix_status_t status, void *cbdata)
         }
         chain->cached = true;
     }
+    PMIX_RELEASE(chain);
+    return;
+
+relcd:
+    /* the caddy never reached the cache, so nothing else will free it -
+     * the affected-array arm used to fall straight into the chain release
+     * below and leak everything the caddy had already been given */
+    PMIX_RELEASE(cd);
 
 cleanup:
     PMIX_RELEASE(chain);

--- a/src/tool/pmix_tool_ops.c
+++ b/src/tool/pmix_tool_ops.c
@@ -24,6 +24,7 @@
 #include "src/mca/ptl/ptl.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/util/pmix_show_help.h"
 
 #include "pmix_tool_ops.h"
 
@@ -83,6 +84,34 @@ pmix_status_t pmix_tool_relay_op(pmix_cmd_t cmd, pmix_peer_t *peer,
 
     if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
         return PMIX_ERR_UNREACH;
+    }
+
+    /* Both directions of this relay move the payload verbatim - we copy the
+     * downstream tool's bytes onward without unpacking them, and
+     * tool_switchyard copies the server's answer back the same way - so the
+     * two ends have to have negotiated the same encoding. That holds today
+     * because a tool forces its own bfrops module and buffer type on both
+     * itself and its server, but nothing here has ever checked it, and a
+     * relayed message that crossed an encoding boundary would be silently
+     * misread at the far end rather than refused. Say so instead.
+     *
+     * PMIX_ERR_PACK_MISMATCH is deliberately not one of the two statuses
+     * server_switchyard falls through on: this is not "a command we do not
+     * relay" (PMIX_ERR_NOT_SUPPORTED) and not "no server to relay it to"
+     * (PMIX_ERR_UNREACH), and fork/exec'ing the spawn ourselves would not
+     * answer it either. The requester gets the status back as the result of
+     * its command. */
+    if (peer->nptr->compat.bfrops != pmix_client_globals.myserver->nptr->compat.bfrops ||
+        peer->nptr->compat.type != pmix_client_globals.myserver->nptr->compat.type) {
+        pmix_show_help("help-pmix-runtime.txt", "relay-encoding-mismatch", true,
+                       PMIX_PNAME_PRINT(&peer->info->pname),
+                       (NULL == peer->nptr->compat.bfrops)
+                           ? "unknown" : peer->nptr->compat.bfrops->version,
+                       (int) peer->nptr->compat.type,
+                       (NULL == pmix_client_globals.myserver->nptr->compat.bfrops)
+                           ? "unknown" : pmix_client_globals.myserver->nptr->compat.bfrops->version,
+                       (int) pmix_client_globals.myserver->nptr->compat.type);
+        return PMIX_ERR_PACK_MISMATCH;
     }
 
     s = PMIX_NEW(pmix_shift_caddy_t);

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -98,10 +98,15 @@ matching `PMIX_OPTION_SHORT_DEFINE` (or vice-versa) is a latent parse bug.
 >   `pmix_cmd_line_parse` (the `argc == 1` early-out now returns with
 >   `tail == NULL` instead of falling through the `done:` copy); a bare
 >   `pevent`/`plookup`/`pquery` now correctly prints its usage/guard.
-> - A **positional placed before an option** (`pquery key --uri x`) is
->   still dropped by the parser's option/positional reordering — put
->   options first (`pquery --uri x key`). This is a `pmix_cmd_line`
->   limitation, not a per-tool bug.
+> - A **positional placed before an option** (`pquery key --uri x`) used
+>   to be dropped outright by getopt's option/positional reordering,
+>   while the option beyond it was still parsed as the tool's. It is not
+>   dropped now: the first non-option ends the option list, so that
+>   invocation yields a tail of `["key", "--uri", "x"]` and no `--uri`.
+>   Options still have to come first to be *seen* (`pquery --uri x key`),
+>   which is the intended reading — the tokens after the first
+>   non-option belong to it, not to the tool. See the `pmix_cmd_line`
+>   section of [`src/util/AGENTS.md`](../util/AGENTS.md).
 >
 > `pmix_info` additionally compares `join(results.tail)` against `argv[0]`
 > as belt-and-suspenders; new tools need only null-check `results.tail`.

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -108,12 +108,30 @@ function of its own.
 
 The parser is intricate and
 carries several special cases (`-v` repeat counting, `--` separator,
-MCA-param option pairs, the `-np` shortcut, optional `-h` argument). Two
-parser quirks that bit `src/tools` and are worth remembering: a bare
-invocation (`argc == 1`) returns early with `tail == NULL` (it must *not*
-fall through the `done:` copy, which would leave the program name in the
-tail), and a positional placed *before* an option is dropped by getopt's
-reordering — put options first.
+MCA-param option pairs, the `-np` shortcut, optional `-h` argument). One
+quirk that bit `src/tools` is worth remembering: a bare invocation
+(`argc == 1`) returns early with `tail == NULL` (it must *not* fall
+through the `done:` copy, which would leave the program name in the
+tail).
+
+**The first token that is not an option ends the option list**, and the
+short-option string is prefixed with `'+'` to make getopt agree with
+that. Without it getopt permutes non-options to the end of argv as it
+goes, so by the time the loop looked at `argv[optind]` to decide it had
+reached one, they had already been moved past it: the tail began *after*
+the token it should have begun with, and a lone positional was dropped
+altogether while the option beyond it was parsed as though it were the
+tool's. Two things depend on the `'+'`, so do not remove it — the tail
+boundary, and the option-name recovery that reads `argv[optind-1]` to
+see which spelling the user typed, which is only meaningful while argv
+is still in the order they typed it in.
+
+The cost is deliberate: an option placed *after* the first non-option is
+no longer the tool's, it goes to the tail. That is what a launcher
+needs, since the tokens after the executable are the *application's*
+flags and must not be eaten. Regression cases are
+`test_parse_positional_first` / `test_parse_positional_after_options` in
+[`test/unit/util/util_cmd_line.c`](../../test/unit/util/util_cmd_line.c).
 
 ### `pmix_hash` — the TMA-aware datastore helper
 

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -230,7 +230,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
     int option_index = 0;   /* getopt_long stores the option index here. */
     int n, m, opt, argc, argind;
     bool found;
-    char *ptr, *str, **argv;
+    char *ptr, *str, **argv, *shortopts;
     const char *optname;
     pmix_cmd_line_store_fn_t mystore;
 
@@ -238,6 +238,26 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
      * we have to protect it here */
     argv = PMIx_Argv_copy(pargv);
     argc = PMIx_Argv_count(argv);
+
+    /* Prefix the short-option string with '+' so getopt stops at the first
+     * non-option token instead of permuting non-options to the end of argv.
+     *
+     * Two things depend on this. The loop below means to stop at the first
+     * thing that is not an option - that token is the executable, and
+     * everything from there on belongs to *it*, not to us - and it decides
+     * that by looking at argv[optind]. With permutation, getopt has already
+     * moved the non-options past optind by the time we look, so the loop
+     * broke too late and the tail started after the very argument it was
+     * supposed to start with: "prog positional --verbose" parsed the option
+     * and dropped the positional entirely. And the option-name recovery
+     * below reads argv[optind-1] to see which spelling the user typed,
+     * which is only meaningful while argv is still in the order they typed
+     * it in.
+     *
+     * The cost is that an option placed *after* the first non-option is no
+     * longer ours - it goes to the tail. That is the intent: a launcher
+     * must not eat the flags belonging to the application it launches. */
+    pmix_asprintf(&shortopts, "+%s", (NULL == shorts) ? "" : shorts);
     // assign a default store_fn if one isn't provided
     if (NULL == storefn) {
         mystore = check_store;
@@ -260,6 +280,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
         // every caller to mistake the program name for a positional
         // argument.
         PMIx_Argv_free(argv);
+        free(shortopts);
         return PMIX_SUCCESS;
     }
 
@@ -277,7 +298,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
             // Don't process any further.
             break;
         }
-        opt = getopt_long(argc, argv, shorts, myoptions, &option_index);
+        opt = getopt_long(argc, argv, shortopts, myoptions, &option_index);
         switch (opt) {
             case 0:
                 /* if this is an MCA param of some type, store it */
@@ -299,6 +320,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             free(str);
                         }
                         PMIx_Argv_free(argv);
+                        free(shortopts);
                         return PMIX_ERR_SILENT;
                     }
                     pmix_asprintf(&str, "%s=%s", argv[optind-1], argv[optind]);
@@ -375,6 +397,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             free(str);
                         }
                         PMIx_Argv_free(argv);
+                        free(shortopts);
                         return PMIX_OPERATION_SUCCEEDED;
                     }
                     if (0 == strcmp(ptr, "verbose") || 0 == strcmp(ptr, "v")) {
@@ -385,6 +408,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             free(str);
                         }
                         PMIx_Argv_free(argv);
+                        free(shortopts);
                         return PMIX_OPERATION_SUCCEEDED;
                     }
                     if (0 == strcmp(ptr, "help") || 0 == strcmp(ptr, "h")) {
@@ -400,6 +424,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             free(str);
                         }
                         PMIx_Argv_free(argv);
+                        free(shortopts);
                         return PMIX_OPERATION_SUCCEEDED;
                     }
                     /* see if we have help on that subject */
@@ -419,6 +444,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         free(str);
                     }
                     PMIx_Argv_free(argv);
+                    free(shortopts);
                     return PMIX_OPERATION_SUCCEEDED;
                 } else if (NULL == optarg) {
                     // high-level help request
@@ -433,6 +459,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         free(str);
                     }
                     PMIx_Argv_free(argv);
+                    free(shortopts);
                     return PMIX_OPERATION_SUCCEEDED;
                 } else {  // unrecognized option
                     str = pmix_show_help_string("help-cli.txt", "unrecognized-option", true,
@@ -444,6 +471,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                     }
                 }
                 PMIx_Argv_free(argv);
+                free(shortopts);
                 return PMIX_ERR_SILENT;
             case 'V':
                 str = pmix_show_help_string(helpfile, "version", false,
@@ -457,6 +485,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                 }
                 // if they ask for the version, that is all we do
                 PMIx_Argv_free(argv);
+                free(shortopts);
                 return PMIX_OPERATION_SUCCEEDED;
             case 'v':
                 /* Name the option from the character getopt handed back, not
@@ -550,6 +579,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                                             free(str);
                                         }
                                         PMIx_Argv_free(argv);
+                                        free(shortopts);
                                         return PMIX_ERR_SILENT;
                                     }
                                     ptr = NULL;
@@ -578,6 +608,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             // directives and the application
                             results->tail = PMIx_Argv_copy(&argv[optind]);
                             PMIx_Argv_free(argv);
+                            free(shortopts);
                             return PMIX_SUCCESS;
                         }
                         str = pmix_show_help_string("help-cli.txt", "short-no-long", true,
@@ -588,6 +619,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             free(str);
                         }
                         PMIx_Argv_free(argv);
+                        free(shortopts);
                         return PMIX_ERR_SILENT;
                     }
                 }
@@ -612,6 +644,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                             free(str);
                         }
                         PMIx_Argv_free(argv);
+                        free(shortopts);
                         return PMIX_ERR_SILENT;
                     }
                 }
@@ -632,6 +665,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                     free(str);
                 }
                 PMIx_Argv_free(argv);
+                free(shortopts);
                 return PMIX_ERR_SILENT;
         }
     }
@@ -645,6 +679,7 @@ done:
         }
     }
     PMIx_Argv_free(argv);
+    free(shortopts);
     return PMIX_SUCCESS;
 }
 

--- a/test/unit/bfrops_get_number.c
+++ b/test/unit/bfrops_get_number.c
@@ -378,6 +378,34 @@ static void test_negative_into_unsigned_is_refused(void)
     report("a negative value is refused by every unsigned destination", ok);
 }
 
+/* Neither argument was screened, and both are dereferenced unconditionally:
+ * the value for its type tag, the destination by whichever arm matches. A
+ * NULL value is the one that actually arrives - callers pass the "value"
+ * member of a pmix_kval_t, which is a pointer that can legitimately be NULL.
+ * Against the unfixed library this case segfaults rather than failing. */
+static void test_null_arguments_are_refused(void)
+{
+    pmix_value_t v;
+    int64_t out = 0;
+    int ok = 1;
+
+    setval(&v, PMIX_INT32, 42);
+
+    if (PMIX_ERR_BAD_PARAM != PMIx_Value_get_number(NULL, &out, PMIX_INT64)) {
+        fprintf(stdout, "    a NULL value was not refused\n");
+        ok = 0;
+    }
+    if (PMIX_ERR_BAD_PARAM != PMIx_Value_get_number(&v, NULL, PMIX_INT64)) {
+        fprintf(stdout, "    a NULL destination was not refused\n");
+        ok = 0;
+    }
+    if (PMIX_ERR_BAD_PARAM != PMIx_Value_get_number(NULL, NULL, PMIX_INT64)) {
+        fprintf(stdout, "    two NULLs were not refused\n");
+        ok = 0;
+    }
+    report("a NULL value or destination is refused", ok);
+}
+
 /* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
@@ -395,6 +423,7 @@ int main(int argc, char **argv)
 
     fprintf(stdout, "\n=== PMIx_Value_get_number unit tests ===\n\n");
 
+    test_null_arguments_are_refused();
     test_every_source_type_is_handled();
     test_success_means_exact();
     test_refusal_means_unrepresentable();

--- a/test/unit/util/util_cmd_line.c
+++ b/test/unit/util/util_cmd_line.c
@@ -152,6 +152,57 @@ static void test_parse_not_taken(void)
     PMIX_DESTRUCT(&res);
 }
 
+/* The first token that is not an option ends the option list: it is the
+ * executable, and it plus everything after it is the tail.
+ *
+ * getopt permutes non-options to the end of argv as it goes, which used to
+ * defeat that: by the time the parse loop looked at argv[optind] to decide
+ * it had reached a non-option, getopt had already moved the non-options
+ * past optind. The tail then began *after* the token it should have begun
+ * with - and where the positional was the only one, as in the first case
+ * here, it was dropped altogether while the option beyond it was parsed as
+ * though it were ours. A launcher must not eat the flags of the
+ * application it launches. */
+static void test_parse_positional_first(void)
+{
+    char *argv[] = {"prog", "positional", "--verbose", NULL};
+    pmix_cli_result_t res;
+    int rc;
+
+    PMIX_CONSTRUCT(&res, pmix_cli_result_t);
+    rc = pmix_cmd_line_parse(argv, "", myopts, NULL, &res, NULL);
+    report("positional_first: returns SUCCESS", PMIX_SUCCESS == rc);
+    report("positional_first: tail is not empty", NULL != res.tail);
+    report("positional_first: tail begins with the positional",
+           NULL != res.tail && NULL != res.tail[0]
+               && 0 == strcmp(res.tail[0], "positional"));
+    report("positional_first: option beyond it is the tail's, not ours",
+           !pmix_cmd_line_is_taken(&res, PMIX_CLI_VERBOSE)
+               && NULL != res.tail && NULL != res.tail[1]
+               && 0 == strcmp(res.tail[1], "--verbose"));
+    PMIX_DESTRUCT(&res);
+}
+
+/* The ordinary shape - options first - is unchanged: they are parsed, and
+ * the tail is everything from the first non-option on. */
+static void test_parse_positional_after_options(void)
+{
+    char *argv[] = {"prog", "--verbose", "positional", "extra", NULL};
+    pmix_cli_result_t res;
+    int rc;
+
+    PMIX_CONSTRUCT(&res, pmix_cli_result_t);
+    rc = pmix_cmd_line_parse(argv, "", myopts, NULL, &res, NULL);
+    report("positional_after: returns SUCCESS", PMIX_SUCCESS == rc);
+    report("positional_after: verbose taken",
+           pmix_cmd_line_is_taken(&res, PMIX_CLI_VERBOSE));
+    report("positional_after: tail is the two trailing tokens",
+           NULL != res.tail && 2 == PMIx_Argv_count(res.tail)
+               && 0 == strcmp(res.tail[0], "positional")
+               && 0 == strcmp(res.tail[1], "extra"));
+    PMIX_DESTRUCT(&res);
+}
+
 /* ================================================================== */
 /* The table                                                          */
 /* ================================================================== */
@@ -802,6 +853,8 @@ int main(int argc, char **argv)
     test_parse_required_arg();
     test_parse_multiple_options();
     test_parse_not_taken();
+    test_parse_positional_first();
+    test_parse_positional_after_options();
 
     fprintf(stdout, "\n--- command-line table ---\n");
     run_table();


### PR DESCRIPTION
Closes the "smaller items carried forward" list in `docs/todo.rst` — the
deferred-work entries that successive reviews recorded as real defects but
left unfixed. Seven commits, one per item, each independently reviewable.

### Fixes

| Commit | What |
|---|---|
| `a0a858f9` | `PMIx_Value_get_number()` screens both arguments. Callers pass the `value` member of a `pmix_kval_t`, which is legitimately NULL off the wire, and the function dereferences it as its first act. The screen went into the function rather than the three `src/client` call sites that had it recorded as a gap — there are thirty-odd callers and every one was equally exposed. |
| `bfeba74f` | `refcb()` no longer drops a store failure while absorbing a cache refresh. It handed the store's status to the next unpack before anything read it. |
| `1bd5801b` | `pmix_globals.init_called` is cleared with the new `pmix_atomic_clear()` — the required partner of the `__atomic_test_and_set` that sets it — in all three roles, instead of a plain assignment racing an atomic RMW. |
| `f717e284` | The dead `PMIX_RANK_WILDCARD` store in `resolve_peers()`'s pre-v3.2 branch is deleted. It was overwritten before anything read it. |
| `e2117e9a` | The command-line parser no longer drops a positional argument placed before an option. |
| `4dd5b276` | The tool relay checks that its two ends negotiated the same `bfrops` module and buffer type instead of assuming it. |
| `fb603ffb` | The event-caching branch in the tool's `_notify_complete` no longer indexes two unchecked allocations, and its failure arms no longer leak the caddy they were filling. Same two allocations fixed in the event layer's copy-paste sibling. |

### Two behavior changes worth a reviewer's attention

**A failed cache refresh now fails the `PMIx_Get`** (`bfeba74f`). Previously a
store failure was silently dropped and the get was answered out of whatever was
already in the datastore. The caller cannot recover from a partial refresh: the
data is the library's, so if only some of it landed there is nothing they can
inspect to tell which keys are current and which are stale. All-or-nothing is
the only answer an application can act on. Note this is never a duplicate —
`pmix_hash_store()` ignores an unchanged repeat and replaces a differing value,
success either way — it is an allocation failure or a kval we cannot parse.

**The first non-option token now ends the option list** (`e2117e9a`). The parse
loop always meant to stop there, but getopt permutes non-options to the end of
argv, so by the time the loop looked they had been moved past `optind`: the tail
began after the token it should have begun with, and a lone positional was
dropped entirely while the option beyond it was parsed as the tool's. Prefixing
the short-option string with `'+'` makes getopt agree with what the loop already
says. The consequence is that an option placed after the first non-option goes
to the tail rather than to the tool — which is the intent, since a launcher must
not eat the flags of the application it launches.

### Not closed here

`docs/todo.rst` is updated throughout. Two items are recorded as remaining rather
than fixed:

- **openpmix#4101 is promoted to an open decision.** A tool caches an event
  nothing handled so a late registrant can still receive it; a client discards
  it. Only one can be right, and choosing is a statement about event delivery in
  a released library. The branch itself is now correct if entered; what is
  undecided is whether it should exist and whether the client should match. The
  entry marks as *unconfirmed* the one shape that might reach it, so the next
  reader does not mistake a hypothesis for evidence.
- **The pre-v3.2 branch's intent is still untried.** Deleting the dead store
  changes nothing; fetching at `WILDCARD` directly, as the branch meant to,
  is a behavior change on a path only a pre-v3.2 server exercises, and there
  is none to test against.

One finding is recorded under *Not defects — by design*: both event-caching
blocks assign `cd->nondefault` inside their `0 < chain->ninfo` guard, which
looks like it could park a non-default event as a default one. It cannot —
`nondefault` is only ever set from a `PMIX_EVENT_NON_DEFAULT` directive in the
info array.

### Testing

Warning-free build under `--enable-devel-check`; `make check` 131/131 on
macOS/clang. `config/pmix.m4` gains a required-atomics probe for
`__atomic_clear`, so this needs `autogen.pl` + `configure` rather than a plain
`make`. Sphinx docs build clean.

New regression coverage:

- `test/unit/bfrops_get_number.c` — NULL value / NULL destination. **Segfaults**
  (exit 139) against the unfixed library rather than failing; verified by
  neutering the screen and re-running.
- `test/unit/util/util_cmd_line.c` — a positional before an option, and the
  ordinary options-first shape, so the new semantics are pinned in both
  directions. The existing 76-case table passes unchanged.

The relay-encoding check has no automated coverage: a tool imposes its own
modules on itself and its server, so the mismatch cannot be arranged in-tree.
A new `relay-encoding-mismatch` `show_help` topic names both ends if it ever
fires, and the generated `show_help` content was regenerated per the golden rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
