### PR TITLE
Tell a waiter its target finalized, not that a connection was lost

### DIFF
--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -111,8 +111,10 @@ static void lost_connection(pmix_peer_t *peer)
             }
         }
 
-        /* purge any notifications cached for this client */
-        pmix_server_purge_events(peer, NULL);
+        /* purge any notifications cached for this client.  Here the
+         * connection really did drop, so that is what anyone parked on
+         * this peer's data is told. */
+        pmix_server_purge_events(peer, NULL, PMIX_ERR_LOST_CONNECTION);
 
         if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
             /* only connection I can lose is to my server, so mark it */

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -374,7 +374,17 @@ PMIX_EXPORT void pmix_server_message_handler(struct pmix_peer_t *pr, pmix_ptl_hd
 PMIX_EXPORT void pmix_server_iof_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
                                          pmix_buffer_t *buf, void *cbdata);
 
-PMIX_EXPORT void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc);
+/* Discard what a departed peer (or namespace) left behind: its event and
+ * IOF registrations, cached notifications naming it, and the direct-modex
+ * trackers waiting on data it will now never publish.
+ *
+ * "status" is what those waiters are told, and it is the caller's to say
+ * because only the caller knows what happened.  A peer that FINALIZED took
+ * its data with it and nothing was lost - the answer is that the key is not
+ * there.  A peer whose connection dropped is the case LOST_CONNECTION
+ * describes. */
+PMIX_EXPORT void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc,
+                                          pmix_status_t status);
 
 /* Record that the server itself has registered for the given event
  * codes. Only system (environmental) codes are tracked as those are the

--- a/src/server/pmix_server_registration.c
+++ b/src/server/pmix_server_registration.c
@@ -411,7 +411,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const pmix_nspace_t nspace
     return PMIX_SUCCESS;
 }
 
-void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc)
+void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc,
+                              pmix_status_t status)
 {
     pmix_regevents_info_t *reginfo, *regnext;
     pmix_peer_events_info_t *prev, *pnext;
@@ -476,13 +477,17 @@ void pmix_server_purge_events(pmix_peer_t *peer, pmix_proc_t *proc)
              * its own reference on the tracker and owns the server caddy of
              * the client behind it, so releasing the tracker alone left it
              * alive but unreachable and left those clients waiting on a
-             * reply nobody would ever send. */
-            pmix_server_fail_local_reqs(dlcd, PMIX_ERR_LOST_CONNECTION);
+             * reply nobody would ever send.
+             *
+             * What they are told is our caller's to decide - see the header.
+             * These are OTHER local procs, still running, and the status
+             * lands as the return of their PMIx_Get. */
+            pmix_server_fail_local_reqs(dlcd, status);
         }
     }
 
     /* and in any the host asked us for on a remote server's behalf */
-    pmix_server_fail_remote_pnd(peer, proc, PMIX_ERR_LOST_CONNECTION);
+    pmix_server_fail_remote_pnd(peer, proc, status);
 
     /* purge this client from any cached notifications */
     for (i = 0; i < pmix_globals.max_events; i++) {
@@ -717,7 +722,7 @@ static void _deregister_nspace(int sd, short args, void *cbdata)
 
     /* remove any event registrations, IOF registrations, and
      * cached notifications targeting procs from this nspace */
-    pmix_server_purge_events(NULL, &cd->proc);
+    pmix_server_purge_events(NULL, &cd->proc, PMIX_ERR_NOT_FOUND);
 
     // find the nspace object
     nptr = NULL;

--- a/src/server/pmix_server_switchyard.c
+++ b/src/server/pmix_server_switchyard.c
@@ -456,8 +456,11 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag, pmix_buf
 
     if (PMIX_FINALIZE_CMD == cmd) {
         peer->nptr->nfinalized++;
-        /* purge events */
-        pmix_server_purge_events(peer, NULL);
+        /* purge events.  This peer finalized - it did not vanish - so a
+         * request parked on data it never published is answered "not
+         * found", not "lost connection": the asker's own session is
+         * perfectly healthy and telling it otherwise reads as fatal. */
+        pmix_server_purge_events(peer, NULL, PMIX_ERR_NOT_FOUND);
         PMIX_GDS_CADDY(cd, peer, tag);
         /* Call the local server, if supported. A tool counts here just as a
          * client does: the host was told when the tool connected, and this


### PR DESCRIPTION
## The problem

A `PMIx_Get` for a peer's key that the local server does not hold is parked on `pmix_server_globals.local_reqs` to wait for that peer to commit it. When the peer instead departs, `pmix_server_purge_events()` fails everything parked on it — correctly, since the data is never coming — but it reports `PMIX_ERR_LOST_CONNECTION` however the peer departed, **including through an ordinary `PMIx_Finalize`**:

```c
/* see if this proc is involved in any direct modex requests */
PMIX_LIST_FOREACH_SAFE (dlcd, dnxt, &pmix_server_globals.local_reqs, pmix_dmdx_local_t) {
    if (... PMIX_CHECK_NAMES(&peer->info->pname, &dlcd->proc) ...) {
        pmix_server_fail_local_reqs(dlcd, PMIX_ERR_LOST_CONNECTION);
    }
}
```

`pmix_server_purge_events()` is reached from the switchyard's `PMIX_FINALIZE_CMD` as well as from the PTL's lost-connection handler, and only the second of those lost anything.

Nothing was lost in the first case. The asker's own connection is healthy, it is still running, and what it asked about is simply not there. Clients read `LOST_CONNECTION` as fatal — and they are not wrong to, since it is also what a client is told when its *server* dies — so handing it to a process whose only misfortune was to ask about a peer that finished first turns a routine outcome into an abort.

`PMIX_ERR_NOT_FOUND` is what actually happened, and is already what this file's sibling path (`pmix_pending_nspace_requests`) reports when it cannot obtain a value.

## The change

`pmix_server_purge_events()` takes the status as a parameter, since only the caller knows which departure this was:

- switchyard `PMIX_FINALIZE_CMD` → `PMIX_ERR_NOT_FOUND`
- namespace deregistration → `PMIX_ERR_NOT_FOUND`
- PTL lost-connection handler → `PMIX_ERR_LOST_CONNECTION`, which there is the literal truth

## How it was found, and how it is measured

PRRTE's `contrib/dockerswarm/peerinfo` does nothing but `PMIx_Init`, a sweep of `PMIx_Get` calls about its peers, and `PMIx_Finalize` — no put, no fence — so its ranks finish at different times and one routinely asks about a peer that has already finalized.

- **Before:** roughly one run in eight aborted with `PEERFAIL <r> <t> pmix.rank PMIX_ERR_LOST_CONNECTION`, both ranks on the *same node*.
- **After:** 16 of 16 runs clean, and the status does not appear at all.

`make check` passes (131 test binaries, 0 failures).