### PR TITLE
gds/shmem3: make building a modex segment cheaper

### DIFF
--- a/contrib/dockerswarm/run-gds-tests.sh
+++ b/contrib/dockerswarm/run-gds-tests.sh
@@ -356,7 +356,7 @@ test_linux() {
         -e PFX="$PMIX_PREFIX" \
         "$IMAGE" bash -euo pipefail -c '
             mkdir -p /opt/prte/tests-gds
-            for p in datatypes dmodex client modex_twice get_timing; do
+            for p in datatypes dmodex client modex_twice get_timing fence_timing; do
                 gcc -O0 -g -o /opt/prte/tests-gds/$p /pmix-src/examples/$p.c \
                     -I"$PFX/include" -I/pmix-src/examples \
                     -L"$PFX/lib" -lpmix -Wl,-rpath,"$PFX/lib"
@@ -368,10 +368,11 @@ test_linux() {
         return
     fi
     ok "built examples/datatypes, examples/dmodex, examples/client and examples/modex_twice"
-    # get_timing is a measurement tool, not a test - it is built here so it
-    # is to hand, but nothing below runs it. Timings do not belong in a
-    # pass/fail suite; run it directly, twice, with and without
-    # PMIX_MCA_pmix_client_fast_get=1.
+    # get_timing and fence_timing are measurement tools, not tests - they
+    # are built here so they are to hand, but nothing below runs them.
+    # Timings do not belong in a pass/fail suite. Run get_timing directly,
+    # twice, with and without PMIX_MCA_pmix_client_fast_get=1; run
+    # fence_timing twice, once as-is and once with --pmixmca gds hash.
 
     if ! RUN 'command -v prterun >/dev/null'; then
         skp "no prterun in the containers -- run ./build.sh first"

--- a/examples/fence_timing.c
+++ b/examples/fence_timing.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Time a *collecting* PMIx_Fence across separate PMIx servers.
+ *
+ * This is the write-side companion to examples/get_timing.c. That one
+ * scores the read path - a PMIx_Get answered out of a gds/shmem3
+ * segment; this one scores the path that builds the segment in the
+ * first place, which is where the server spends the fence.
+ *
+ * It exists for openpmix#4141: a collecting fence with no data costs
+ * about what a barrier costs, so the premium is entirely the modex, and
+ * the modex is mostly the datastore building its in-segment structures.
+ * Comparing gds modules is the point, so run it twice:
+ *
+ *   prterun ... ./fence_timing                       # whatever is default
+ *   prterun --pmixmca gds hash ... ./fence_timing    # forced onto hash
+ *
+ * The measurement is the FIRST collecting fence, deliberately. Under a
+ * cumulative commit every later fence re-ships the whole local store, so
+ * later rounds measure a growing payload rather than the same one twice
+ * - and one collecting fence is all most MPI jobs ever do.
+ *
+ * A barrier is timed first, on the same geometry and the same processes,
+ * as the baseline to subtract: what is left is what carrying the data
+ * cost.
+ *
+ * Run one rank per node (--map-by node with one slot each). With two
+ * ranks on a node half the traffic never leaves the server and the
+ * number means something else.
+ *
+ * Timings are printed, never asserted on - see the note in
+ * test/unit/util/hash_perf.c.
+ *
+ *   PMIX_PERF_KEYS    keys published per rank (default 32)
+ *   PMIX_PERF_VALSZ   bytes in each value     (default 1024)
+ */
+
+#include <pmix.h>
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+
+#include "examples.h"
+
+static pmix_proc_t myproc;
+
+static double now_usec(void)
+{
+    struct timeval tv;
+
+    gettimeofday(&tv, NULL);
+    return (double) tv.tv_sec * 1000000.0 + (double) tv.tv_usec;
+}
+
+static int env_int(const char *name, int dflt)
+{
+    const char *s = getenv(name);
+    int v;
+
+    if (NULL == s) {
+        return dflt;
+    }
+    v = atoi(s);
+    return (0 < v) ? v : dflt;
+}
+
+/* Fill with a cheap PRNG rather than a constant. A compressible payload
+ * is a different measurement: pcompress would collapse it on the wire and
+ * the segment would be built from a fraction of the bytes we think we
+ * are sending. */
+static void fill_incompressible(char *buf, size_t len, unsigned seed)
+{
+    uint32_t x = 0x9e3779b9u ^ seed;
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        buf[i] = (char) (x & 0xff);
+    }
+}
+
+/* A fence over the whole namespace, optionally collecting the data. */
+static pmix_status_t fence_all(bool collect, double *usec)
+{
+    pmix_proc_t wildcard;
+    pmix_info_t info;
+    pmix_status_t rc;
+    double t0;
+    bool flag = true;
+
+    PMIX_PROC_CONSTRUCT(&wildcard);
+    PMIX_LOAD_PROCID(&wildcard, myproc.nspace, PMIX_RANK_WILDCARD);
+
+    t0 = now_usec();
+    if (collect) {
+        PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+        rc = PMIx_Fence(&wildcard, 1, &info, 1);
+        PMIX_INFO_DESTRUCT(&info);
+    } else {
+        rc = PMIx_Fence(&wildcard, 1, NULL, 0);
+    }
+    if (NULL != usec) {
+        *usec = now_usec() - t0;
+    }
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t value;
+    pmix_value_t *val = NULL;
+    pmix_proc_t wildcard;
+    char key[PMIX_MAX_KEYLEN + 1];
+    char *payload = NULL;
+    double barrier_us = 0.0, modex_us = 0.0;
+    int nkeys, valsz, i;
+    uint32_t nprocs = 0;
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    nkeys = env_int("PMIX_PERF_KEYS", 32);
+    valsz = env_int("PMIX_PERF_VALSZ", 1024);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "fence_timing: PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    PMIX_PROC_CONSTRUCT(&wildcard);
+    PMIX_LOAD_PROCID(&wildcard, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS == PMIx_Get(&wildcard, PMIX_JOB_SIZE, NULL, 0, &val) && NULL != val) {
+        nprocs = val->data.uint32;
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    payload = (char *) malloc((size_t) valsz);
+    if (NULL == payload) {
+        fprintf(stderr, "fence_timing: out of memory\n");
+        goto done;
+    }
+
+    /* Line the ranks up so neither timed fence is really measuring the
+     * skew in how they got here. */
+    if (PMIX_SUCCESS != (rc = fence_all(false, NULL))) {
+        fprintf(stderr, "fence_timing: sync fence failed: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* Baseline: the same collective carrying nothing. */
+    if (PMIX_SUCCESS != (rc = fence_all(false, &barrier_us))) {
+        fprintf(stderr, "fence_timing: barrier failed: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* Publish. Untimed: PMIx_Put is a local store, and PMIx_Commit ships
+     * it to our own server - neither is the collective we are scoring. */
+    for (i = 0; i < nkeys; i++) {
+        snprintf(key, sizeof(key), "fence-timing-%u-%d", (unsigned) myproc.rank, i);
+        fill_incompressible(payload, (size_t) valsz,
+                            (unsigned) (myproc.rank * 1000003u + (unsigned) i));
+        PMIX_VALUE_CONSTRUCT(&value);
+        value.type = PMIX_BYTE_OBJECT;
+        value.data.bo.bytes = payload;
+        value.data.bo.size = (size_t) valsz;
+        rc = PMIx_Put(PMIX_GLOBAL, key, &value);
+        /* the value only borrows the payload buffer; PMIx_Put has copied
+         * what it needs by now, and destructing it would free ours */
+        value.data.bo.bytes = NULL;
+        value.data.bo.size = 0;
+        PMIX_VALUE_DESTRUCT(&value);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "fence_timing: PMIx_Put failed: %s\n", PMIx_Error_string(rc));
+            goto done;
+        }
+    }
+    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        fprintf(stderr, "fence_timing: PMIx_Commit failed: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* Re-align, then time the first collecting fence. */
+    if (PMIX_SUCCESS != (rc = fence_all(false, NULL))) {
+        fprintf(stderr, "fence_timing: sync fence failed: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    if (PMIX_SUCCESS != (rc = fence_all(true, &modex_us))) {
+        fprintf(stderr, "fence_timing: collecting fence failed: %s\n",
+                PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* Confirm we actually moved data before believing the number: a
+     * fence that quietly carried nothing is fast for the wrong reason. */
+    if (1 < nprocs) {
+        pmix_proc_t peer;
+        PMIX_PROC_CONSTRUCT(&peer);
+        PMIX_LOAD_PROCID(&peer, myproc.nspace,
+                         (myproc.rank + 1) % nprocs);
+        snprintf(key, sizeof(key), "fence-timing-%u-0", (unsigned) peer.rank);
+        val = NULL;
+        rc = PMIx_Get(&peer, key, NULL, 0, &val);
+        if (PMIX_SUCCESS != rc || NULL == val) {
+            fprintf(stderr, "fence_timing: rank %u could not read %s from rank %u: %s\n",
+                    (unsigned) myproc.rank, key, (unsigned) peer.rank,
+                    PMIx_Error_string(rc));
+            if (NULL != val) {
+                PMIX_VALUE_RELEASE(val);
+            }
+            goto done;
+        }
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    /* Only rank 0 reports, so the lines are not interleaved. */
+    if (0 == myproc.rank) {
+        fprintf(stdout,
+                "fence_timing: nprocs=%u keys=%d valsz=%d "
+                "barrier=%.1f us modex=%.1f us premium=%.1f us\n",
+                nprocs, nkeys, valsz, barrier_us, modex_us,
+                modex_us - barrier_us);
+        fflush(stdout);
+    }
+
+done:
+    if (NULL != payload) {
+        free(payload);
+    }
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}

--- a/src/class/pmix_hash_table.c
+++ b/src/class/pmix_hash_table.c
@@ -108,6 +108,12 @@ static void pmix_hash_table_destruct(pmix_hash_table_t *ht)
  * Init, etc
  */
 
+/* The density pmix_hash_table_init() applies to a requested element count.
+ * Shared with pmix_hash_table_sizeof_storage(), which has to reproduce the
+ * same arithmetic for a caller that must reserve the storage up front. */
+#define PMIX_HASH_TABLE_DENSITY_NUMER 1
+#define PMIX_HASH_TABLE_DENSITY_DENOM 2
+
 static size_t pmix_hash_round_capacity_up(size_t capacity)
 {
     /* round up to (1 mod 30) */
@@ -162,8 +168,12 @@ pmix_hash_table_init2(pmix_hash_table_t *ht, size_t estimated_max_size, int dens
 int /* PMIX_ return code */
 pmix_hash_table_init(pmix_hash_table_t *ht, size_t table_size)
 {
-    /* default to density of 1/2 and growth of 2/1 */
-    return pmix_hash_table_init2(ht, table_size, 1, 2, 2, 1);
+    /* default to density of 1/2 and growth of 2/1. The density is named
+     * because pmix_hash_table_sizeof_storage() has to apply the same ratio
+     * to answer how much this call will allocate. */
+    return pmix_hash_table_init2(ht, table_size,
+                                 PMIX_HASH_TABLE_DENSITY_NUMER,
+                                 PMIX_HASH_TABLE_DENSITY_DENOM, 2, 1);
 }
 
 int /* PMIX_ return code */
@@ -982,6 +992,20 @@ size_t
 pmix_hash_table_sizeof_hash_element(void)
 {
     return sizeof(pmix_hash_element_t);
+}
+
+size_t
+pmix_hash_table_sizeof_storage(size_t nelements)
+{
+    /* Mirror pmix_hash_table_init()/init2(): the request is scaled by the
+     * default density ratio and then rounded up. Keep the two in step -
+     * a caller reserving storage from this and then calling init() has no
+     * other way to learn the answer, and being short is not a slow path
+     * for the bump allocator in gds/shmem3, it is an abort. */
+    const size_t est_capacity = nelements * PMIX_HASH_TABLE_DENSITY_DENOM
+                                / PMIX_HASH_TABLE_DENSITY_NUMER;
+
+    return pmix_hash_round_capacity_up(est_capacity) * sizeof(pmix_hash_element_t);
 }
 
 /* there was/is no traversal for the ptr case; it would go here */

--- a/src/class/pmix_hash_table.h
+++ b/src/class/pmix_hash_table.h
@@ -360,6 +360,21 @@ PMIX_EXPORT size_t
 pmix_hash_table_sizeof_hash_element(void);
 
 /**
+ * Returns the bytes pmix_hash_table_init(ht, nelements) will allocate for
+ * the element array - the capacity it rounds that request up to, times the
+ * element size. A caller that has to reserve storage before the table is
+ * built (gds/shmem3 pre-sizes a shared-memory segment) needs this and
+ * cannot compute it: both the density ratio and the rounding are private
+ * to the implementation.
+ *
+ * Note this answers a question about *storage*. Do not feed the result
+ * back to pmix_hash_table_init(), which takes an element count and applies
+ * the density ratio itself.
+ */
+PMIX_EXPORT size_t
+pmix_hash_table_sizeof_storage(size_t nelements);
+
+/**
  * @brief Returns next power-of-two of the given value.
  *
  * @param value The integer value to return power of 2

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -211,6 +211,25 @@ static void keyindex_construct(pmix_keyindex_t *ki)
     ki->next_id = 0;
 }
 
+size_t pmix_keyindex_sizeof_fixed_storage(void)
+{
+    /* Mirror keyindex_construct() above: the object, its pointer array and
+     * that array's slots and free-bit map, its lookup table and that
+     * table's elements. Both children are built at a fixed capacity
+     * whatever the key count turns out to be, so this is the whole cost of
+     * an empty key index - and it is not small, which is exactly why a
+     * caller reserving space for one has to be told rather than guess. */
+    const size_t bits_per_word = 8 * sizeof(uint64_t);
+
+    return sizeof(pmix_keyindex_t)
+           + sizeof(pmix_pointer_array_t)
+           + PMIX_KEYINDEX_TABLE_SIZE * sizeof(void *)
+           + ((PMIX_KEYINDEX_TABLE_SIZE + bits_per_word - 1) / bits_per_word)
+                 * sizeof(uint64_t)
+           + sizeof(pmix_hash_table_t)
+           + pmix_hash_table_sizeof_storage(PMIX_KEYINDEX_LOOKUP_SIZE);
+}
+
 static void keyindex_destruct(pmix_keyindex_t *ki)
 {
     pmix_tma_t *const tma = pmix_obj_get_tma(&ki->super);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -849,12 +849,20 @@ typedef struct {
  * size has to be estimated *before* anything is allocated in it. The
  * allocator behind it is a bump allocator with nowhere to grow, so an
  * estimate that disagrees with these does not run slow, it aborts the
- * server. Keep the estimate in gds_shmem3.c in step with these. */
+ * server. Rather than restating them at the estimate, ask
+ * pmix_keyindex_sizeof_fixed_storage() below. */
 #define PMIX_KEYINDEX_TABLE_SIZE  1024
 #define PMIX_KEYINDEX_TABLE_BLOCK  128
 /* sized past the reserved dictionary so the common case never rehashes */
 #define PMIX_KEYINDEX_LOOKUP_SIZE 2048
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_keyindex_t);
+
+/** Bytes an *empty* pmix_keyindex_t occupies: the object plus the pointer
+ * array and lookup table its constructor builds, both at fixed capacity.
+ * Reported rather than restated so a caller reserving space for one cannot
+ * drift from keyindex_construct(). See pmix_hash_sizeof_key_entry() for
+ * what each registered key adds on top. */
+PMIX_EXPORT size_t pmix_keyindex_sizeof_fixed_storage(void);
 
 #define PMIX_KEYINDEX_STATIC_INIT                 \
 {                                                 \

--- a/src/mca/gds/shmem3/AGENTS.md
+++ b/src/mca/gds/shmem3/AGENTS.md
@@ -237,6 +237,42 @@ undo by accident:
   weakens, restore the `memset` in `tma_carve()` rather than at the call
   sites.
 
+### These hash tables are keyed by rank, not by key
+
+Both `job->smdata->local_hashtab` and `job->smmodex->hashtab` hold **one
+element per rank**. `pmix_hash_store()` looks up a single
+`pmix_proc_data_t` for the rank and hangs that rank's values off it in a
+pointer array; the values are not table elements. Job-level keys all
+share the one element belonging to `PMIX_RANK_WILDCARD`.
+
+That makes *two* numbers matter when pre-sizing a segment, and they are
+not interchangeable:
+
+| quantity | sizes | where it comes from |
+|---|---|---|
+| **elements** | the table itself, and the per-rank structures its elements point at | the modex: `job->nspace->nprocs`. The job segment: one per `PMIX_PROC_INFO_ARRAY`, plus one if there is any plain job-level key |
+| **key/value pairs** | the stored values, and the key index describing them | the modex: estimated from the blob. The job segment: the infos inside each proc array, plus each plain key |
+
+Both estimates used to feed the *pair* count into the table, so a 32-rank
+job built a table with tens of thousands of elements — each of which had
+to be zeroed into a fresh mapping before a single value could be stored.
+Keep the two apart when you touch `get_modex_sizing_data()` or
+`get_local_job_data_info()`; collapsing them is the original bug.
+
+Two smaller traps in the same arithmetic:
+
+- **`pmix_hash_table_init()` takes an element count, not a capacity.** It
+  applies the density ratio itself (`est_capacity = n * denom / numer`),
+  so passing it `get_actual_hashtab_capacity(n)` — as both paths did —
+  doubled the table a second time. Use the raw count for `init()` and
+  `get_actual_hashtab_capacity()` only to turn a count into *bytes* for
+  the segment estimate.
+- **An element costs more than a `pmix_hash_element_t`.** Each one points
+  at a `pmix_proc_data_t` with two pointer arrays of its own, and that
+  storage is in the segment too. `pmix_hash_sizeof_proc_storage()` in
+  `src/util/pmix_hash.c` reports it, because the type is private to that
+  file; keep it in step with `pdcon()` there.
+
 ### Every segment carries its own key index
 
 The hash tables in a segment store keys as **integers**, and those

--- a/src/mca/gds/shmem3/AGENTS.md
+++ b/src/mca/gds/shmem3/AGENTS.md
@@ -342,6 +342,33 @@ else leans on the client and server agreeing about global indices;
 until then it runs harmlessly at `store_job_info` time, before an
 application has threads.
 
+### The `/proc/self/maps` scan is not the expensive part — measured
+
+`pmix_vmem_find_hole()` reads and parses all of `/proc/self/maps` on
+every segment creation, which looks like an obvious thing to cache: one
+scan per job segment, per session segment, and per modex generation.
+It is not worth caching, and this is recorded so nobody re-derives the
+suspicion and pays for the fix.
+
+Measured cost is about **0.17 µs per VMA**, essentially linear:
+
+| VMAs | scan |
+|---|---|
+| 16 | 5 µs |
+| 516 | 91 µs |
+| 2016 | 345 µs |
+| 8016 | 1.3 ms |
+
+A PRRTE daemon in `contrib/dockerswarm` carries **72** VMAs, so the scan
+costs it roughly 15 µs — under 1% of the per-segment cost. Caching a
+hole would trade that for a stale-address failure mode on a path whose
+whole correctness rests on client and server agreeing about an address.
+
+Reconsider only where the VMA count is genuinely large — a DSO-heavy
+build with several fabric providers and a GPU runtime could plausibly
+reach the high hundreds, and the table above says what that would cost.
+Measure the daemon before assuming it.
+
 ### The fixed-address attach failure and GDS fallback
 
 A client may be unable to map the segment at the server's chosen address —

--- a/src/mca/gds/shmem3/AGENTS.md
+++ b/src/mca/gds/shmem3/AGENTS.md
@@ -294,6 +294,28 @@ rewrites on every put.
 (`pmix_hash_find_key()` and `pmix_hash_lookup_key()` with a known
 index). Registering would mean a reader writing into the segment.
 
+**Ask the code that spends the memory how much it spends.** The estimate
+is a shadow model of what storing will cost, and every time it has been
+wrong it was because it restated something it should have asked for.
+Four sizing entry points exist for exactly this, each living beside the
+code it describes so the two cannot drift:
+
+| ask | for | lives beside |
+|---|---|---|
+| `pmix_hash_table_sizeof_storage(n)` | the element array `init(ht, n)` allocates | `pmix_hash_table_init()` |
+| `pmix_hash_sizeof_proc_storage()` | one rank's per-proc object and its arrays | `pdcon()` |
+| `pmix_keyindex_sizeof_fixed_storage()` | an *empty* key index (~170 KB) | `keyindex_construct()` |
+| `pmix_hash_sizeof_key_entry(len)` | one newly registered key | `lookup_key()` |
+
+Do not open-code any of these here. The estimate previously reserved
+`3 * (PMIX_MAX_KEYLEN + 1)` per assumed key/value pair — three copies of
+a *511-byte* key — which came to roughly fifty times the payload and was
+single-handedly the largest term in the calculation. Real keys run tens
+of bytes, and their true bound is the data: every key that will be
+registered arrived in the buffer being packed or unpacked, so the key
+strings cannot total more than that buffer holds. Bound them by the
+payload, never by the maximum.
+
 **And whatever you put in a segment has to be in that segment's size
 estimate before it is put there.** A keyindex is not small — it
 constructs a 2048-slot lookup table and a 1024-slot pointer array

--- a/src/mca/gds/shmem3/AGENTS.md
+++ b/src/mca/gds/shmem3/AGENTS.md
@@ -192,7 +192,10 @@ The core mechanism is a **bump allocator over shared memory**, the
   address matches, every in-segment pointer resolves correctly with no
   fix-up. Clients never install the TMA function pointers — they only read.
 
-### The allocator keeps its bookkeeping in-band
+### The allocator keeps its bookkeeping in-band, and does not zero
+
+Two properties of `tma_malloc`/`tma_calloc`/`tma_strdup` that are easy to
+undo by accident:
 
 - **Every block carries a 16-byte header** (`pmix_gds_shmem3_tma_alloc_t`:
   the extent plus a magic) immediately ahead of the address handed out.
@@ -213,6 +216,26 @@ The core mechanism is a **bump allocator over shared memory**, the
   makes three to five allocations per key/value stored, so the tax landed
   on every byte of every modex. Do not reintroduce out-of-band
   bookkeeping here.
+
+- **Nothing zeroes a block, and nothing needs to.** A bump allocator only
+  ever hands out space no caller has touched, and
+  `pmix_shmem_segment_create()` opens its backing file `O_CREAT | O_TRUNC`
+  and `ftruncate`s it from empty — so every page of a fresh segment reads
+  as zero. `tma_calloc()` therefore returns zeroed storage without writing
+  a byte, and so, incidentally, does `tma_malloc()`. The `memset` that used
+  to be there only forced the whole segment resident up front instead of
+  letting demand paging bring in what is actually used, and the segment is
+  sized *far* larger than its contents (see `get_modex_sizing_data()`), so
+  that was the largest avoidable cost in building one.
+
+  **The `O_TRUNC` is load-bearing**, not tidiness. Segments are unlinked
+  when their last holder lets go, so a backing path collides only with a
+  file some earlier server left behind when it died — but the path is built
+  from the pid, and pids get reused. Without the truncate, `ftruncate()` to
+  the same or a smaller size leaves that corpse's bytes in place and only
+  the extension past the old end reads as zero. If that guarantee ever
+  weakens, restore the `memset` in `tma_carve()` rather than at the call
+  sites.
 
 ### Every segment carries its own key index
 

--- a/src/mca/gds/shmem3/AGENTS.md
+++ b/src/mca/gds/shmem3/AGENTS.md
@@ -192,6 +192,28 @@ The core mechanism is a **bump allocator over shared memory**, the
   address matches, every in-segment pointer resolves correctly with no
   fix-up. Clients never install the TMA function pointers — they only read.
 
+### The allocator keeps its bookkeeping in-band
+
+- **Every block carries a 16-byte header** (`pmix_gds_shmem3_tma_alloc_t`:
+  the extent plus a magic) immediately ahead of the address handed out.
+  The *only* consumer is `tma_realloc()`, which needs the old size to know
+  how much to copy — nothing else in the segment is reached by walking
+  allocations, so this is not part of the shared layout and does **not**
+  belong in `PMIX_GDS_SHMEM3_LAYOUT_ID`. Keep the header a multiple of 8:
+  `addr_align()` keeps the bump pointer 8-byte aligned and the payload
+  address is the header address plus its size, so an odd-sized header
+  misaligns every object in the segment.
+
+  This replaced a side hash table mapping address → extent, which the
+  allocator kept on the process heap. It cost **two heap allocations and a
+  ptr-keyed hash insert on every allocation**, grew monotonically (`free`
+  is a no-op, so nothing was ever removed), and had to be walked entry by
+  entry at teardown — all to answer a question `tma_realloc` is the sole
+  asker of. Worth knowing *why* that was so expensive: `pmix_hash_store()`
+  makes three to five allocations per key/value stored, so the tax landed
+  on every byte of every modex. Do not reintroduce out-of-band
+  bookkeeping here.
+
 ### Every segment carries its own key index
 
 The hash tables in a segment store keys as **integers**, and those

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -22,6 +22,7 @@
 
 #include "src/include/pmix_dictionary.h"
 
+#include "src/util/pmix_hash.h"
 #include "src/util/pmix_printf.h"
 #include "src/util/pmix_string_copy.h"
 #include "src/util/pmix_vmem.h"
@@ -70,8 +71,10 @@ typedef struct {
     uint32_t session_id;
     /** Size of packed data. */
     size_t packed_size;
-    /** Number of hash elements found. */
+    /** Number of elements the local hash table needs - one per rank. */
     size_t hash_table_size;
+    /** Number of key/value pairs those elements will hold between them. */
+    size_t nkvals;
 } pmix_gds_shmem3_packed_local_job_info_t;
 PMIX_CLASS_DECLARATION(pmix_gds_shmem3_packed_local_job_info_t);
 
@@ -98,6 +101,7 @@ packed_job_info_construct(
     pji->session_id = UINT32_MAX;
     pji->packed_size = 0;
     pji->hash_table_size = 0;
+    pji->nkvals = 0;
 }
 
 PMIX_CLASS_INSTANCE(
@@ -1490,6 +1494,25 @@ server_cache_job_info(
 }
 
 /**
+ * Internally the hash table can do some interesting sizing calculations, so we
+ * just construct a temporary one with the number of expected elements, then
+ * query it for its actual capacity.
+ */
+static inline size_t
+get_actual_hashtab_capacity(
+    size_t num_elements
+) {
+    pmix_hash_table_t tmp;
+    PMIX_CONSTRUCT(&tmp, pmix_hash_table_t);
+    pmix_hash_table_init(&tmp, num_elements);
+    // Grab the actual capacity.
+    const size_t result = tmp.ht_capacity;
+    PMIX_DESTRUCT(&tmp);
+
+    return result;
+}
+
+/**
  *
  */
 static pmix_status_t
@@ -1500,8 +1523,13 @@ prepare_shmem3_stores_for_local_job_data(
     pmix_status_t rc = PMIX_SUCCESS;
     static const float fluff = 3.0;
     const size_t kvsize = (sizeof(pmix_kval_t) + sizeof(pmix_value_t));
-    // Initial hash table size.
+    // Elements the table needs - one per rank it will hold.
     const size_t htsize = pji->hash_table_size;
+    // Key/value pairs those elements hold between them. The table is
+    // sized by the first number and its contents by this one; they are
+    // not interchangeable, and using htsize for both is what made the
+    // table thousands of times larger than it had to be.
+    const size_t nkvals = pji->nkvals;
     // Calculate a rough estimate on the amount of storage required to store the
     // values associated with the pmix_gds_shmem3_shared_job_data_t. Err on the
     // side of overestimation.
@@ -1509,16 +1537,19 @@ prepare_shmem3_stores_for_local_job_data(
     // We need to store a hash table in the shared-memory segment, so calculate
     // a rough estimate on the memory required for its storage.
     seg_size += sizeof(pmix_hash_table_t);
-    seg_size += htsize * pmix_hash_table_sizeof_hash_element();
+    seg_size += get_actual_hashtab_capacity(htsize)
+                * pmix_hash_table_sizeof_hash_element();
+    // Each element points at a per-rank structure with its own arrays.
+    seg_size += htsize * pmix_hash_sizeof_proc_storage();
     // Add a little extra to compensate for the value storage requirements. Here
-    // we add an additional storage space for each entry.
-    seg_size += htsize * kvsize;
+    // we add an additional storage space for each key/value pair.
+    seg_size += nkvals * kvsize;
     // The keyindex that translates the indices in that table lives in
     // this segment too, and it is not small: the object, its pointer
     // array, its own string -> entry hash table (which the keyindex
     // constructor sizes for the whole reserved dictionary), and one
     // entry per distinct key with two copies of the key string plus the
-    // copy the lookup table makes. Bound the entry count by htsize -
+    // copy the lookup table makes. Bound the entry count by nkvals -
     // the real number of distinct keys is normally far smaller.
     //
     // Leaving this out is not a slow leak, it is a hard failure: the
@@ -1534,7 +1565,7 @@ prepare_shmem3_stores_for_local_job_data(
     seg_size += PMIX_KEYINDEX_LOOKUP_SIZE
                 * pmix_hash_table_sizeof_hash_element();
     seg_size += PMIX_KEYINDEX_TABLE_SIZE * sizeof(void *);
-    seg_size += htsize * (sizeof(pmix_regattr_input_t)
+    seg_size += nkvals * (sizeof(pmix_regattr_input_t)
                           + sizeof(void *)
                           + 3 * (PMIX_MAX_KEYLEN + 1));
     // Finally add the data size contribution, plus a little extra.
@@ -1881,32 +1912,27 @@ fetch_local_job_data(
     return rc;
 }
 
-/**
- * Internally the hash table can do some interesting sizing calculations, so we
- * just construct a temporary one with the number of expected elements, then
- * query it for its actual capacity.
- */
-static inline size_t
-get_actual_hashtab_capacity(
-    size_t num_elements
-) {
-    pmix_hash_table_t tmp;
-    PMIX_CONSTRUCT(&tmp, pmix_hash_table_t);
-    pmix_hash_table_init(&tmp, num_elements);
-    // Grab the actual capacity.
-    const size_t result = tmp.ht_capacity;
-    PMIX_DESTRUCT(&tmp);
-
-    return result;
-}
-
 static inline pmix_status_t
 get_local_job_data_info(
     pmix_cb_t *job_cb,
     pmix_gds_shmem3_packed_local_job_info_t *pji
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
-    size_t nhtentries = 0;
+    /* Entries in job->smdata->local_hashtab. That table is keyed by RANK,
+     * so what goes in it is one element per rank a PMIX_PROC_INFO_ARRAY
+     * describes, plus a single element for PMIX_RANK_WILDCARD that every
+     * plain job-level key shares - see
+     * pmix_gds_shmem3_store_local_job_data_in_shmem3(). Counting the
+     * *infos* inside each array, and one per plain key, described a table
+     * that does not exist. */
+    size_t nprocarrays = 0;
+    bool have_job_level_kv = false;
+    /* How many key/value pairs go into that table between them. This is a
+     * different quantity from the element count, and the estimate below
+     * needs both: the elements size the table, the pairs size the values
+     * hanging off it and the key index describing them. Conflating the
+     * two is what made the element count wrong in the first place. */
+    size_t nkvals = 0;
     uint32_t sid = UINT32_MAX;
 
     pmix_buffer_t data;
@@ -1920,9 +1946,12 @@ get_local_job_data_info(
             NULL != kvi->value->data.darray &&
             NULL != kvi->value->data.darray->array &&
             0 != kvi->value->data.darray->size) {
-            // PMIX_PROC_INFO_ARRAY is stored in the hash table.
+            /* A PMIX_PROC_INFO_ARRAY becomes one hash-table entry: every
+             * info in it is stored against the single rank the array
+             * describes. */
             if (PMIX_CHECK_KEY(kvi, PMIX_PROC_INFO_ARRAY)) {
-                nhtentries += kvi->value->data.darray->size;
+                nprocarrays += 1;
+                nkvals += kvi->value->data.darray->size;
             }
             // See if this is the job's session ID. If so, capture it.
             pmix_info_t *info = (pmix_info_t *)kvi->value->data.darray->array;
@@ -1934,9 +1963,12 @@ get_local_job_data_info(
                 }
             }
         }
-        // Just a key/value pair, so they will likely go into the hash table.
+        /* Just a key/value pair. They all go into the hash table under
+         * PMIX_RANK_WILDCARD, so however many there are they share one
+         * entry between them. */
         else {
-            nhtentries += 1;
+            have_job_level_kv = true;
+            nkvals += 1;
         }
 
         PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &data, kvi, 1, PMIX_KVAL);
@@ -1947,7 +1979,10 @@ get_local_job_data_info(
     }
     pji->session_id = sid;
     pji->packed_size = data.bytes_used;
-    pji->hash_table_size = get_actual_hashtab_capacity(nhtentries);
+    /* Entries, not capacity: pmix_hash_table_init() applies the density
+     * ratio itself, so passing it a capacity double-applied it. */
+    pji->hash_table_size = nprocarrays + (have_job_level_kv ? 1 : 0);
+    pji->nkvals = nkvals;
 out:
     PMIX_DESTRUCT(&data);
     return rc;
@@ -2305,8 +2340,10 @@ store_job_info(
  * Returns size required to store modex data.
  */
 static pmix_gds_shmem3_modex_info_t
-get_modex_sizing_data(const pmix_buffer_t *buff)
-{
+get_modex_sizing_data(
+    const pmix_gds_shmem3_job_t *job,
+    const pmix_buffer_t *buff
+) {
     const size_t kval_size = sizeof(pmix_kval_t);
     // The default values if not provided with modex size info. More fluff than
     // in other places because this calculation is more imprecise. In many ways
@@ -2316,11 +2353,32 @@ get_modex_sizing_data(const pmix_buffer_t *buff)
     size_t segment_size = buff->bytes_used * 5;
     // Get an estimate on the number of kvals we need to store.
     const size_t nkvals = (segment_size / (float)kval_size) + kval_size;
-    // Get the required hash table size based on number of kvals.
-    const size_t nhtelems = get_actual_hashtab_capacity(nkvals);
-    // We also need storage space for the hash table and its elements.
+    /* The modex table is keyed by RANK, not by key: pmix_hash_store()
+     * looks up one pmix_proc_data_t per rank and hangs that rank's values
+     * off it in a pointer array. So the table needs one element per rank
+     * whose data lands in this segment - the procs of this namespace,
+     * since a blob for another namespace goes to that job's own segment -
+     * and not, as it used to compute, one per byte-group of payload. At
+     * 32 ranks that was the difference between 32 elements and tens of
+     * thousands, every one of which had to be zeroed into a fresh
+     * mapping before the first value could be stored.
+     *
+     * nprocs comes from the host's PMIX_JOB_SIZE and is not guaranteed to
+     * have arrived; the table grows itself if this is short, so a floor
+     * of one is a slow path rather than a wrong answer. */
+    size_t nranks = (size_t)job->nspace->nprocs;
+    if (0 == nranks) {
+        nranks = 1;
+    }
+    // Entries, not capacity: pmix_hash_table_init() applies the density
+    // ratio itself, so handing it a capacity would double-apply it.
+    const size_t nhtelems = nranks;
+    // We also need storage space for the hash table, its elements, and the
+    // per-rank structures those elements point at.
     segment_size += sizeof(pmix_hash_table_t);
-    segment_size += nhtelems * pmix_hash_table_sizeof_hash_element();
+    segment_size += get_actual_hashtab_capacity(nhtelems)
+                    * pmix_hash_table_sizeof_hash_element();
+    segment_size += nranks * pmix_hash_sizeof_proc_storage();
     // The keyindex that translates the indices in that hash table lives
     // in this segment too: the object, its pointer array, its own string
     // -> entry hash table, and one entry per distinct key with two
@@ -2422,7 +2480,7 @@ server_store_modex_cb(pmix_proc_t *proc,
         char segname[PMIX_PATH_MAX];
         snprintf(segname, sizeof(segname), "modexdata.%u", job->modex_generation);
         // Get the global packed buffer size from ctx.
-        pmix_gds_shmem3_modex_info_t minfo = get_modex_sizing_data(pbkt);
+        pmix_gds_shmem3_modex_info_t minfo = get_modex_sizing_data(job, pbkt);
         // Create and attach to the shared-memory
         // segment that will back these data.
         rc = shmem3_segment_create_and_attach(

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -181,19 +181,43 @@ strtost(
 
 /**
  * Stores TMA memory allocation information.
+ *
+ * One of these sits immediately ahead of every block the TMA hands out, so
+ * the block carries its own size. Two properties matter:
+ *
+ * - It must stay a multiple of 8 bytes. addr_align() keeps the bump pointer
+ *   8-byte aligned, and the payload address is the header address plus this
+ *   size, so a header that is not a multiple of 8 would misalign every
+ *   object in the segment.
+ * - It lives in the segment, but nothing outside this file reads it, so it
+ *   is not part of the shared *layout*: clients reach in-segment objects
+ *   through pointers, never by walking allocations. It therefore does not
+ *   belong in PMIX_GDS_SHMEM3_LAYOUT_ID and does not require a rename.
+ *
+ * This replaced a side hash table (addr -> extent) that the allocator
+ * maintained on the process heap. That table cost two heap allocations and
+ * a ptr-keyed hash insert on *every* allocation - and, because free is a
+ * no-op here, it only ever grew, then had to be walked entry by entry at
+ * teardown. All of it existed to answer one question, asked only by
+ * tma_realloc(): how big was this block? A header answers it for the price
+ * of 16 bytes of segment space, which is noise against the sizing fluff
+ * these segments already carry.
  */
 typedef struct {
     /** Size of allocation. */
     size_t extent;
+    /** Marks the header as one this allocator wrote; see tma_realloc(). */
+    uint64_t magic;
 } pmix_gds_shmem3_tma_alloc_t;
+
+/** Distinguishes our header from whatever else a bad pointer points at. */
+#define PMIX_GDS_SHMEM3_TMA_ALLOC_MAGIC 0x504d495833544d41ULL // "PMIX3TMA"
 
 /**
  * Holds allocation context information.
  */
 typedef struct {
     pmix_object_t super;
-    /** Address to allocation information table. */
-    pmix_hash_table_t addr2info;
     /** Handle to shared-memory backing store. */
     pmix_shmem_t *shmem3;
     /** Points to a value that maintains the next available address. */
@@ -205,9 +229,6 @@ static void
 shmem3_allocator_construct(
     pmix_gds_shmem3_alloc_ctx_t *a
 ) {
-    PMIX_CONSTRUCT(&a->addr2info, pmix_hash_table_t);
-    pmix_hash_table_init(&a->addr2info, 2048);
-
     a->shmem3 = NULL;
     a->data_ptr = NULL;
 }
@@ -216,12 +237,6 @@ static void
 shmem3_allocator_destruct(
     pmix_gds_shmem3_alloc_ctx_t *a
 ) {
-    pmix_gds_shmem3_tma_alloc_t *value;
-    void *key;
-
-    PMIX_HASH_TABLE_FOREACH_PTR(key, value, &a->addr2info, { free(value); });
-    PMIX_DESTRUCT(&a->addr2info);
-
     a->shmem3 = NULL;
     a->data_ptr = NULL;
 }
@@ -305,35 +320,45 @@ tma_alloc_request_will_overflow(
     return wo;
 }
 
-static inline void
-tma_register_alloc(
-    pmix_tma_t *tma,
-    void *base,
-    size_t extent
+/**
+ * Returns the bookkeeping header for a block this allocator handed out.
+ */
+static inline pmix_gds_shmem3_tma_alloc_t *
+tma_alloc_header(
+    void *ptr
 ) {
-    uintptr_t key = (uintptr_t)base;
-
-    pmix_gds_shmem3_tma_alloc_t *value = calloc(1, sizeof(*value));
-    value->extent = extent;
-
-    pmix_hash_table_set_value_ptr(
-        &tma_get_alloc_ctx(tma)->addr2info,
-        &key, sizeof(key), value
-    );
+    return (pmix_gds_shmem3_tma_alloc_t *)
+        ((char *)ptr - sizeof(pmix_gds_shmem3_tma_alloc_t));
 }
 
-static inline pmix_status_t
-tma_get_registered_alloc(
+/**
+ * Carves a block of the requested size out of the segment, stamping its
+ * header. The caller owns initializing the returned storage.
+ */
+static inline void *
+tma_carve(
     pmix_tma_t *tma,
-    void *addr,
-    pmix_gds_shmem3_tma_alloc_t **result
+    size_t size
 ) {
-    uintptr_t key = (uintptr_t)addr;
+    const size_t hdrsize = sizeof(pmix_gds_shmem3_tma_alloc_t);
+    // The header comes out of the segment too, so it is part of the request
+    // as far as the capacity check is concerned. Adding it must not be what
+    // wraps the sum.
+    if (PMIX_UNLIKELY(SIZE_MAX - hdrsize < size)) {
+        errno = ENOMEM;
+        perror(EMSG_SHMEM3_OOM);
+        abort();
+    }
+    if (PMIX_UNLIKELY(tma_alloc_request_will_overflow(tma, size + hdrsize))) {
+        return NULL;
+    }
+    pmix_gds_shmem3_tma_alloc_t *const hdr = tma_get_curraddr(tma);
+    hdr->extent = size;
+    hdr->magic = PMIX_GDS_SHMEM3_TMA_ALLOC_MAGIC;
 
-    return pmix_hash_table_get_value_ptr(
-        &tma_get_alloc_ctx(tma)->addr2info, &key,
-        sizeof(uintptr_t), (void **)result
-    );
+    void *const base = (char *)hdr + hdrsize;
+    tma_set_curraddr(tma, addr_align(base, size));
+    return base;
 }
 
 static inline void *
@@ -344,16 +369,13 @@ tma_malloc(
     if (0 == size) {
         return NULL;
     }
-    if (PMIX_UNLIKELY(tma_alloc_request_will_overflow(tma, size))) {
-        return NULL;
-    }
-    void *const current = tma_get_curraddr(tma);
-    tma_register_alloc(tma, current, size);
+    void *const base = tma_carve(tma, size);
 #if PMIX_ENABLE_DEBUG
-    memset(current, 0, size);
+    if (PMIX_LIKELY(NULL != base)) {
+        memset(base, 0, size);
+    }
 #endif
-    tma_set_curraddr(tma, addr_align(current, size));
-    return current;
+    return base;
 }
 
 static inline void *
@@ -373,14 +395,11 @@ tma_calloc(
     if (0 == real_size) {
         return NULL;
     }
-    if (PMIX_UNLIKELY(tma_alloc_request_will_overflow(tma, real_size))) {
-        return NULL;
+    void *const base = tma_carve(tma, real_size);
+    if (PMIX_LIKELY(NULL != base)) {
+        memset(base, 0, real_size);
     }
-    void *const current = tma_get_curraddr(tma);
-    tma_register_alloc(tma, current, real_size);
-    memset(current, 0, real_size);
-    tma_set_curraddr(tma, addr_align(current, real_size));
-    return current;
+    return base;
 }
 
 static inline void *
@@ -398,15 +417,17 @@ tma_realloc(
         pmix_tma_free(tma, ptr);
         return NULL;
     }
-    // Find the allocation info based on the provided address.
-    pmix_gds_shmem3_tma_alloc_t *alloc = NULL;
-    int rc = tma_get_registered_alloc(tma, ptr, &alloc);
-    if (PMIX_SUCCESS != rc) {
+    // Every block we hand out carries its size just ahead of it. A pointer
+    // that does not is one this allocator never produced, which means the
+    // caller has crossed a heap block with a segment block - keep saying so
+    // rather than copying from an extent we invented.
+    pmix_gds_shmem3_tma_alloc_t *const hdr = tma_alloc_header(ptr);
+    if (PMIX_UNLIKELY(PMIX_GDS_SHMEM3_TMA_ALLOC_MAGIC != hdr->magic)) {
         errno = EFAULT;
         perror(EMSG_SHMEM3_IS_BROKEN);
         abort();
     }
-    const size_t old_size = alloc->extent;
+    const size_t old_size = hdr->extent;
     if (new_size != old_size) {
         void *new_base = pmix_tma_malloc(tma, new_size);
         if (NULL == new_base) {
@@ -427,14 +448,11 @@ tma_strdup(
 ) {
     const size_t size = strlen(s) + 1;
 
-    if (PMIX_UNLIKELY(tma_alloc_request_will_overflow(tma, size))) {
+    void *const base = tma_carve(tma, size);
+    if (PMIX_UNLIKELY(NULL == base)) {
         return NULL;
     }
-
-    void *const current = tma_get_curraddr(tma);
-    tma_register_alloc(tma, current, size);
-    tma_set_curraddr(tma, addr_align(current, size));
-    return (char *)memmove(current, s, size);
+    return (char *)memmove(base, s, size);
 }
 
 static inline void

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -334,6 +334,14 @@ tma_alloc_header(
 /**
  * Carves a block of the requested size out of the segment, stamping its
  * header. The caller owns initializing the returned storage.
+ *
+ * Nothing zeroes the block, and nothing needs to: pmix_shmem_segment_create()
+ * truncates its backing file from empty, so every page of a fresh segment
+ * reads as zero and every block this hands out comes from space no caller has
+ * yet touched. Writing zeros over zeros only forced the whole segment
+ * resident up front - the largest avoidable cost in building one - instead of
+ * letting demand paging bring in what is actually used. If that guarantee
+ * ever weakens, restore the memset here rather than at the call sites.
  */
 static inline void *
 tma_carve(
@@ -369,13 +377,7 @@ tma_malloc(
     if (0 == size) {
         return NULL;
     }
-    void *const base = tma_carve(tma, size);
-#if PMIX_ENABLE_DEBUG
-    if (PMIX_LIKELY(NULL != base)) {
-        memset(base, 0, size);
-    }
-#endif
-    return base;
+    return tma_carve(tma, size);
 }
 
 static inline void *
@@ -395,11 +397,8 @@ tma_calloc(
     if (0 == real_size) {
         return NULL;
     }
-    void *const base = tma_carve(tma, real_size);
-    if (PMIX_LIKELY(NULL != base)) {
-        memset(base, 0, real_size);
-    }
-    return base;
+    // See tma_carve(): a fresh segment is already zero.
+    return tma_carve(tma, real_size);
 }
 
 static inline void *

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -1486,25 +1486,6 @@ server_cache_job_info(
 }
 
 /**
- * Internally the hash table can do some interesting sizing calculations, so we
- * just construct a temporary one with the number of expected elements, then
- * query it for its actual capacity.
- */
-static inline size_t
-get_actual_hashtab_capacity(
-    size_t num_elements
-) {
-    pmix_hash_table_t tmp;
-    PMIX_CONSTRUCT(&tmp, pmix_hash_table_t);
-    pmix_hash_table_init(&tmp, num_elements);
-    // Grab the actual capacity.
-    const size_t result = tmp.ht_capacity;
-    PMIX_DESTRUCT(&tmp);
-
-    return result;
-}
-
-/**
  *
  */
 static pmix_status_t
@@ -1529,37 +1510,33 @@ prepare_shmem3_stores_for_local_job_data(
     // We need to store a hash table in the shared-memory segment, so calculate
     // a rough estimate on the memory required for its storage.
     seg_size += sizeof(pmix_hash_table_t);
-    seg_size += get_actual_hashtab_capacity(htsize)
-                * pmix_hash_table_sizeof_hash_element();
+    seg_size += pmix_hash_table_sizeof_storage(htsize);
     // Each element points at a per-rank structure with its own arrays.
     seg_size += htsize * pmix_hash_sizeof_proc_storage();
     // Add a little extra to compensate for the value storage requirements. Here
     // we add an additional storage space for each key/value pair.
     seg_size += nkvals * kvsize;
-    // The keyindex that translates the indices in that table lives in
-    // this segment too, and it is not small: the object, its pointer
-    // array, its own string -> entry hash table (which the keyindex
-    // constructor sizes for the whole reserved dictionary), and one
-    // entry per distinct key with two copies of the key string plus the
-    // copy the lookup table makes. Bound the entry count by nkvals -
-    // the real number of distinct keys is normally far smaller.
-    //
-    // Leaving this out is not a slow leak, it is a hard failure: the
-    // TMA behind the segment is a bump allocator with nowhere to grow,
-    // so the server aborts partway through register_job_info() and
-    // every client sits waiting for job data that will never arrive.
-    seg_size += sizeof(pmix_keyindex_t);
-    seg_size += sizeof(pmix_pointer_array_t);
-    seg_size += sizeof(pmix_hash_table_t);
-    // Both children are constructed at a fixed capacity whatever the
-    // key count turns out to be, so count them at that size rather than
-    // scaling them with it.
-    seg_size += PMIX_KEYINDEX_LOOKUP_SIZE
-                * pmix_hash_table_sizeof_hash_element();
-    seg_size += PMIX_KEYINDEX_TABLE_SIZE * sizeof(void *);
-    seg_size += nkvals * (sizeof(pmix_regattr_input_t)
-                          + sizeof(void *)
-                          + 3 * (PMIX_MAX_KEYLEN + 1));
+    /* The keyindex that translates the indices in that table lives in
+     * this segment too, and an empty one is already ~170 KB. On top of
+     * that each distinct key costs a record and three copies of its own
+     * string. Bound the entry count by nkvals - the real number of
+     * distinct keys is normally far smaller.
+     *
+     * The key *lengths* are bounded by the data, not by PMIX_MAX_KEYLEN:
+     * every one of these keys arrived in the buffer we just packed, so
+     * their strings cannot total more than it holds. Reserving the
+     * 511-byte maximum for each instead made this term alone dwarf the
+     * payload it was protecting.
+     *
+     * Leaving this out is not a slow leak, it is a hard failure: the
+     * TMA behind the segment is a bump allocator with nowhere to grow,
+     * so the server aborts partway through register_job_info() and
+     * every client sits waiting for job data that will never arrive. */
+    seg_size += pmix_keyindex_sizeof_fixed_storage();
+    seg_size += nkvals * pmix_hash_sizeof_key_entry(0);
+    /* Three copies per registered key, plus the copy newkval() strdups
+     * for every value that lands on a list rather than in the table. */
+    seg_size += 4 * pji->packed_size;
     // Finally add the data size contribution, plus a little extra.
     seg_size += pji->packed_size;
     // Include some extra fluff that empirically seems reasonable.
@@ -2368,30 +2345,28 @@ get_modex_sizing_data(
     // We also need storage space for the hash table, its elements, and the
     // per-rank structures those elements point at.
     segment_size += sizeof(pmix_hash_table_t);
-    segment_size += get_actual_hashtab_capacity(nhtelems)
-                    * pmix_hash_table_sizeof_hash_element();
+    segment_size += pmix_hash_table_sizeof_storage(nhtelems);
     segment_size += nranks * pmix_hash_sizeof_proc_storage();
-    // The keyindex that translates the indices in that hash table lives
-    // in this segment too: the object, its pointer array, its own string
-    // -> entry hash table, and one entry per distinct key with two
-    // copies of the key string (the entry's name and string) plus the
-    // copy the lookup table makes of its key. We cannot know the number
-    // of distinct keys without unpacking, so bound it by nkvals - the
-    // real count is normally far smaller, and the fluff below covers the
-    // per-entry allocations.
-    segment_size += sizeof(pmix_keyindex_t);
-    segment_size += sizeof(pmix_pointer_array_t);
-    segment_size += sizeof(pmix_hash_table_t);
-    segment_size += nkvals * (sizeof(pmix_regattr_input_t)
-                              + sizeof(void *)
-                              + 3 * (PMIX_MAX_KEYLEN + 1));
-    segment_size += get_actual_hashtab_capacity(nkvals)
-                    * pmix_hash_table_sizeof_hash_element();
-    // The keyindex's two children are constructed at fixed capacities
-    // whatever nkvals says, so they have to be counted at those sizes.
-    segment_size += PMIX_KEYINDEX_LOOKUP_SIZE
-                    * pmix_hash_table_sizeof_hash_element();
-    segment_size += PMIX_KEYINDEX_TABLE_SIZE * sizeof(void *);
+    /* The keyindex that translates the indices in that hash table lives
+     * in this segment too. An empty one is already ~170 KB - both its
+     * children are built at a fixed capacity whatever the key count turns
+     * out to be - and each distinct key then costs a record plus three
+     * copies of its own string. We cannot know the number of distinct
+     * keys without unpacking, so bound it by nkvals; the real count is
+     * normally far smaller.
+     *
+     * The key *lengths* are bounded by the blob, not by PMIX_MAX_KEYLEN.
+     * Every key here arrived in the buffer being unpacked, so the key
+     * strings cannot total more than that buffer decompresses to.
+     * Reserving 511 bytes for each instead made this one term roughly
+     * fifty times the payload - by far the largest thing in this
+     * estimate, and the reason a 1.3 MB modex was getting an 80 MB
+     * segment. */
+    segment_size += pmix_keyindex_sizeof_fixed_storage();
+    segment_size += nkvals * pmix_hash_sizeof_key_entry(0);
+    // Three copies of every key string, against a payload already scaled
+    // by the compression factor above.
+    segment_size += 3 * (buff->bytes_used * 5);
     // Include some extra fluff that empirically seems reasonable.
     segment_size *= fluff;
     // Adjust (increase or decrease) segment size by the given parameter size.

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -86,14 +86,6 @@ typedef struct {
     size_t num_ht_elements;
 } pmix_gds_shmem3_modex_info_t;
 
-/**
- * Stores modex context information.
- */
-typedef struct {
-    size_t buff_size;
-    size_t nprocs;
-} pmix_gds_shmem3_modex_ctx_t;
-
 static void
 packed_job_info_construct(
     pmix_gds_shmem3_packed_local_job_info_t *pji

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -156,6 +156,24 @@ this file only *consumes* it) and the `a.b.c.d[/mask]` tuple parser
 `pmix_iftupletoaddr`, which returns masks in **host** order. Mind that
 byte-order difference if you ever mix the two.
 
+### `pmix_shmem` — a created segment reads as zero
+
+`pmix_shmem_segment_create()` opens its backing file `O_CREAT | O_TRUNC`
+and `ftruncate`s it to the full size, so a freshly created segment is a
+sparse file whose every page reads as zero. **That is a contract, not an
+incidental property**: `gds/shmem3`'s bump allocator relies on it to hand
+out zeroed storage without writing a byte (see `tma_carve()` and
+[`src/mca/gds/shmem3/AGENTS.md`](../mca/gds/shmem3/AGENTS.md)), which is
+what keeps building a segment from faulting in its whole — heavily
+over-estimated — extent up front.
+
+The `O_TRUNC` is the load-bearing half. Segments are unlinked when their
+last holder lets go, so a path collides only with a file left behind by a
+server that died; but the path carries a pid, and pids get reused, and
+`ftruncate()` to the same or a smaller size would leave that file's bytes
+in place. There is exactly one caller of this function and it always
+populates the segment from scratch, so the truncate costs nothing.
+
 ### `keyval/` — the flex lexer
 
 `keyval_lex.l` is the flex source; `keyval_lex.c` is a **generated build

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -963,6 +963,28 @@ pmix_regattr_input_t* pmix_hash_lookup_key(uint32_t inid,
     return lookup_key(inid, key, kidx, true);
 }
 
+size_t pmix_hash_sizeof_key_entry(size_t keylen)
+{
+    /* Mirror the registration branch of lookup_key() above: the attribute
+     * record, its two copies of the key string, the two-element
+     * description vector and the string it holds, the slot the pointer
+     * array takes, and the third copy of the key that the lookup table
+     * makes for itself.
+     *
+     * Three copies of the key string is the part worth knowing, because a
+     * caller reserving space for a key index will otherwise reach for
+     * PMIX_MAX_KEYLEN and be wrong by more than an order of magnitude:
+     * real keys run tens of bytes against a 511-byte maximum. */
+    static const size_t description_len = sizeof("USER DEFINED");
+
+    return sizeof(pmix_regattr_input_t)
+           + 2 * (keylen + 1)
+           + 2 * sizeof(char *)
+           + description_len
+           + sizeof(void *)
+           + keylen;
+}
+
 pmix_regattr_input_t* pmix_hash_find_key(uint32_t inid,
                                          const char *key,
                                          pmix_keyindex_t *kidx)

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -77,6 +77,17 @@ typedef struct {
  * as pmix_hash_proc_alloc. */
 int pmix_hash_proc_alloc = 128;
 
+/* How many qualifier slots to give a proc up front. Most procs publish no
+ * qualified values at all, so this stays far below pmix_hash_proc_alloc -
+ * but it must not be 1. pmix_pointer_array's grow_table() rounds the new
+ * size up to a multiple of the block size, so a block size of 1 grows the
+ * array by exactly one slot per addition: a proc publishing q qualified
+ * values did q reallocs. That is merely wasteful on the heap, and worse
+ * under the gds/shmem3 TMA, where free is a no-op - each of those reallocs
+ * copies the array and strands the old one in the shared segment, which is
+ * part of what the segment sizing fluff is paying for. */
+#define PMIX_HASH_QUAL_ALLOC 8
+
 static void pdcon(pmix_proc_data_t *p)
 {
     pmix_tma_t *const tma = pmix_obj_get_tma(&p->super);
@@ -88,7 +99,8 @@ static void pdcon(pmix_proc_data_t *p)
     p->data = PMIX_NEW(pmix_pointer_array_t, tma);
     pmix_pointer_array_init(p->data, nalloc, INT_MAX, nalloc);
     p->quals = PMIX_NEW(pmix_pointer_array_t, tma);
-    pmix_pointer_array_init(p->quals, 1, INT_MAX, 1);
+    pmix_pointer_array_init(p->quals, PMIX_HASH_QUAL_ALLOC, INT_MAX,
+                            PMIX_HASH_QUAL_ALLOC);
 }
 static void pddes(pmix_proc_data_t *p)
 {

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -102,6 +102,27 @@ static void pdcon(pmix_proc_data_t *p)
     pmix_pointer_array_init(p->quals, PMIX_HASH_QUAL_ALLOC, INT_MAX,
                             PMIX_HASH_QUAL_ALLOC);
 }
+size_t pmix_hash_sizeof_proc_storage(void)
+{
+    /* Mirror pdcon(): the object itself, plus the two pointer arrays it
+     * constructs and the storage each of those allocates (the slot array
+     * and its free-bit map). A caller pre-sizing a datastore before
+     * filling it - gds/shmem3 has to size a shared-memory segment up
+     * front - cannot see pmix_proc_data_t, so it has to ask. Keep this in
+     * step with pdcon(); it is the only reason the two can drift. */
+    const size_t nalloc = (0 < pmix_hash_proc_alloc)
+                          ? (size_t)pmix_hash_proc_alloc : 128;
+    const size_t bits_per_word = 8 * sizeof(uint64_t);
+
+    return sizeof(pmix_proc_data_t)
+           + 2 * sizeof(pmix_pointer_array_t)
+           + nalloc * sizeof(void *)
+           + ((nalloc + bits_per_word - 1) / bits_per_word) * sizeof(uint64_t)
+           + PMIX_HASH_QUAL_ALLOC * sizeof(void *)
+           + (((size_t)PMIX_HASH_QUAL_ALLOC + bits_per_word - 1) / bits_per_word)
+                 * sizeof(uint64_t);
+}
+
 static void pddes(pmix_proc_data_t *p)
 {
     int n;

--- a/src/util/pmix_hash.h
+++ b/src/util/pmix_hash.h
@@ -39,6 +39,12 @@ PMIX_EXPORT pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
  * in pmix_hash.c for what the trade actually is. */
 PMIX_EXPORT extern int pmix_hash_proc_alloc;
 
+/* Bytes one rank occupies in a table, over and above its hash-table
+ * element: the per-proc object plus the two pointer arrays it builds.
+ * A caller that must size a datastore before filling it - gds/shmem3
+ * pre-sizes a shared-memory segment - cannot see that type, so it asks. */
+PMIX_EXPORT size_t pmix_hash_sizeof_proc_storage(void);
+
 PMIX_EXPORT pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank,
                                           const char *key,
                                           pmix_info_t *qualifiers, size_t nquals,

--- a/src/util/pmix_hash.h
+++ b/src/util/pmix_hash.h
@@ -45,6 +45,13 @@ PMIX_EXPORT extern int pmix_hash_proc_alloc;
  * pre-sizes a shared-memory segment - cannot see that type, so it asks. */
 PMIX_EXPORT size_t pmix_hash_sizeof_proc_storage(void);
 
+/* Bytes registering one previously unseen key adds to a key index: the
+ * attribute record, the three copies made of the key string, and the
+ * description vector. Pair with pmix_keyindex_sizeof_fixed_storage() for
+ * the empty index itself. Reported rather than restated so a caller
+ * reserving the space cannot drift from the code that spends it. */
+PMIX_EXPORT size_t pmix_hash_sizeof_key_entry(size_t keylen);
+
 PMIX_EXPORT pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank,
                                           const char *key,
                                           pmix_info_t *qualifiers, size_t nquals,

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -185,7 +185,16 @@ pmix_shmem_segment_create(
     const size_t real_size = pmix_shmem_utils_pad_to_page(sizeof(pmix_shmem_header_t))
                              + pmix_shmem_utils_pad_to_page(size);
 
-    const int fd = open(backing_path, O_CREAT | O_RDWR, 0600);
+    /* O_TRUNC is what makes "a freshly created segment reads as zero" a
+     * guarantee rather than an assumption. Segments are unlinked when their
+     * last holder lets go, so a path collides only with a file some earlier
+     * server left behind when it died - but the path is built from the pid,
+     * and pids are reused. Without the truncate, ftruncate() to the same or a
+     * smaller size leaves that corpse's bytes in place, and only the extension
+     * past the old end reads as zero. gds/shmem3's allocator relies on the
+     * whole region being zero so it does not have to memset what it hands out;
+     * see tma_carve() there. */
+    const int fd = open(backing_path, O_CREAT | O_TRUNC | O_RDWR, 0600);
     if (fd == -1) {
         rc = PMIX_ERR_FILE_OPEN_FAILURE;
         goto out;


### PR DESCRIPTION
Addresses #4141.

`shmem3` buys a cheap post-fence `PMIx_Get` with an expensive fence, and #4141
measured the fence side to be the larger half for a realistically-sized modex.
This is the datastore half of that: the cost of building a segment at all.

The hash table underneath `shmem3` is the same one `hash` uses, so the
difference was never the table. It was everything around it — the allocator,
and the size estimate the allocator forces to exist.

### The allocator

The TMA kept a side hash table on the process heap mapping every address it
handed out to that allocation's extent. It was read from exactly one place —
`tma_realloc()`, which needs the old size to know how much to copy — but it
was *maintained* on every allocation, at two heap allocations plus a
ptr-keyed hash insert each time. `pmix_hash_store()` makes three to five
allocations per key/value stored, so that tax landed on every byte of every
modex. And since `free` is a no-op here, the table only ever grew, then had
to be walked entry by entry at teardown. The extent now lives in a 16-byte
header ahead of each block.

Separately, `tma_calloc()` memset every allocation (and `tma_malloc()` did
too under `--enable-debug`) over pages that a just-`ftruncate`d file already
guarantees are zero. That was the largest avoidable cost in building a
segment: it turned a deliberately generous size estimate into resident
memory up front. `pmix_shmem_segment_create()` now opens with `O_TRUNC` so
"a fresh segment reads as zero" is a guarantee rather than an assumption —
the backing path carries a pid, and pids get reused.

### The size estimate

A bump allocator over a fixed segment has to predict what storing will cost
before it stores anything. `hash` never predicts; it grows. That prediction
is a shadow model of `pmix_hash_store()`, and both defects here were the
model drifting from the thing it models:

* Both tables hold **one element per rank** — `pmix_hash_store()` finds one
  `pmix_proc_data_t` per rank and hangs that rank's values off it, and every
  job-level key shares `PMIX_RANK_WILDCARD`'s single element. Both estimates
  sized the table by the number of *values*. A 32-rank job asked for tens of
  thousands of elements where it needed 32.
* The key index reserved `3 * (PMIX_MAX_KEYLEN + 1)` per assumed pair —
  three copies of a *511-byte* key, when real keys run tens of bytes. That
  one term came to roughly fifty times the payload. The sound bound is the
  data: every key that gets registered arrived in the buffer being packed or
  unpacked.

Rather than restate any of this, the estimate now asks the code that spends
the memory. Four sizing entry points, each defined beside what it describes
so the two cannot drift: `pmix_hash_table_sizeof_storage()`,
`pmix_hash_sizeof_proc_storage()`, `pmix_keyindex_sizeof_fixed_storage()`,
`pmix_hash_sizeof_key_entry()`.

Reconciling the arithmetic turned up three more errors in the same block:
the key index's lookup table was counted at 2048 elements when `init` scales
it to 4111, its pointer array's free-bit map was not counted at all, and the
modex path counted a second lookup table that no code builds. Also retired
`get_actual_hashtab_capacity()`, which constructed a real hash table and
destructed it — walking every slot — to read back four lines of arithmetic.

### Measured

`contrib/scaling/cluster-sweep.sh --phases gds --nkeys 256 --reps 9` from
openpmix/prrte#2664, 256 KB/rank, median of 9 independent jobs:

| nodes | build | shmem3 | hash | premium | ratio |
|---|---|---|---|---|---|
| 4 | before | 7395 us | 3411 us | +3984 us | 2.17x |
| 4 | after | **4304 us** | 3535 us | **+769 us** | **1.22x** |
| 8 | before | 22755 us | 9674 us | +13082 us | 2.35x |
| 8 | after | **13115 us** | 9864 us | **+3252 us** | **1.33x** |

shmem3 data cost **-42%** at both sizes; the premium over `hash` down 81%
and 75%. `hash` is the control and barely moves (~2-4%).

Segment sizes fall with it — the second modex segment in
`examples/modex_twice` on four daemons goes from 84 MB to 31 MB for the same
1.3 MB of data, and the job segment sits at 27% utilized.

**Read the absolutes as directional only.** This is an `--enable-debug` build
on ten containers sharing one host, so it is the shmem3-vs-hash ratio within
each run that carries the signal, not the numbers. Worth repeating on real
hardware.

### Also here

* `examples/fence_timing.c`, the write-side companion to `get_timing.c`:
  times a barrier and then the first collecting fence and reports the
  difference. Built by `run-gds-tests.sh` but, like `get_timing`, not run by
  it — timings do not belong in a pass/fail suite.
* `util/hash`: the per-proc qualifier array had initial size **and block
  size** 1, so `grow_table()` reallocated on every single addition.
* A note in the `shmem3` AGENTS.md recording that the `/proc/self/maps` scan
  is **not** worth caching, with the measurements. It costs ~0.17 us/VMA and
  a daemon here carries 72 of them — under 1% of building a segment. Written
  down so the next reader can re-check rather than re-derive the suspicion
  and pay for the fix.

### Testing

Linux build warning-free (`shmem3` does not compile on macOS at all, so this
was built and run under `contrib/dockerswarm`). `run-gds-tests.sh` 29/29 —
collective modex at 2/4/8 servers, forced onto `hash`, second-fence
republish, no-fast-get, put scopes, direct modex, and the GDS fallback.
`run-class-tests.sh` 4/4 including the `--disable-debug` build.
`run-tests.sh` 12/12. Unit suite 110/110 on Linux, 131/131 on macOS.

No layout change: the per-allocation header is never reached by walking
allocations, so it is not part of `PMIX_GDS_SHMEM3_LAYOUT_ID` and needs no
rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
