### PR TITLE
hwloc: find a device by any of the names it answers to

### DIFF
--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -1671,18 +1671,46 @@ static pmix_status_t build_device_uuid(hwloc_obj_t osdev, char **uuid)
     return PMIX_SUCCESS;
 }
 
+/* Does this OS device answer to the caller's name?  Either spelling counts:
+ * the OS name hwloc gave it, or the uuid PMIx reports for it. */
+static bool osdev_named(hwloc_obj_t osdev, const char *devid)
+{
+    char *uuid = NULL;
+    bool found;
+
+    if (NULL == devid || NULL == osdev->name) {
+        return false;
+    }
+    if (0 == strcasecmp(devid, osdev->name)) {
+        return true;
+    }
+    if (PMIX_SUCCESS != build_device_uuid(osdev, &uuid)) {
+        return false;
+    }
+    found = (0 == strcasecmp(devid, uuid));
+    free(uuid);
+    return found;
+}
+
 /* one candidate device while we are still collecting */
 typedef struct {
     pmix_list_item_t super;
     hwloc_obj_t osdev;     /* the OS device that names the function */
     hwloc_obj_t pci;       /* the function, or NULL */
     pmix_device_type_t type;
+    /* the caller asked for this device by name or uuid.  Recorded per
+     * candidate because the name they used may belong to an OS device other
+     * than the one chosen to name the function - a fabric device and its
+     * network device commonly share a function, and only one of the two can
+     * be the name we report. */
+    bool named;
 } pmix_devcand_t;
 static void cndcon(pmix_devcand_t *p)
 {
     p->osdev = NULL;
     p->pci = NULL;
     p->type = PMIX_DEVTYPE_UNKNOWN;
+    p->named = false;
 }
 static PMIX_CLASS_INSTANCE(pmix_devcand_t, pmix_list_item_t, cndcon, NULL);
 
@@ -1773,7 +1801,13 @@ pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
             }
         }
         if (NULL != match) {
-            if (osdev_preferred(osdev, match->osdev)) {
+            /* the name the caller used wins the right to name the function -
+             * asking for mlx5_0 and being told about ib0 is not an answer */
+            if (osdev_named(osdev, devid)) {
+                match->osdev = osdev;
+                match->type = dtype;
+                match->named = true;
+            } else if (!match->named && osdev_preferred(osdev, match->osdev)) {
                 match->osdev = osdev;
                 match->type = dtype;
             }
@@ -1787,6 +1821,7 @@ pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
         c->osdev = osdev;
         c->pci = pci;
         c->type = dtype;
+        c->named = osdev_named(osdev, devid);
         pmix_list_append(&cands, &c->super);
 
     next:
@@ -1803,9 +1838,7 @@ pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
             PMIX_RELEASE(c);
             continue;
         }
-        if (NULL != devid
-            && 0 != strcasecmp(devid, c->osdev->name)
-            && 0 != strcasecmp(devid, uuid)) {
+        if (NULL != devid && !c->named) {
             free(uuid);
             pmix_list_remove_item(&cands, &c->super);
             PMIX_RELEASE(c);

--- a/test/unit/hwloc_devices.c
+++ b/test/unit/hwloc_devices.c
@@ -164,6 +164,27 @@ static void test_topo2(const char *dir)
     devs = NULL;
     ndevs = 0;
 
+    /* Naming a device that shares its PCI function with another: mlx5_0 and
+     * ib0 are one device, and only one of the two names it.  Asking for
+     * either has to find it, or "--map-by device=mlx5_0" - the whole reason
+     * a caller names a device - finds nothing on a machine where the
+     * network device happened to sort first. */
+    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_UNKNOWN, "mlx5_0", &devs, &ndevs);
+    ok(PMIX_SUCCESS == rc && 1 == ndevs, "topo2: the fabric device is found by its own name");
+    if (1 == ndevs) {
+        ok(NULL != devs[0].dev.osname && 0 == strcmp(devs[0].dev.osname, "mlx5_0"),
+           "topo2: and it is reported under the name that was asked for");
+    }
+    pmix_hwloc_release_devices(devs, ndevs);
+    devs = NULL;
+    ndevs = 0;
+
+    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_UNKNOWN, "ib0", &devs, &ndevs);
+    ok(PMIX_SUCCESS == rc && 1 == ndevs, "topo2: the network device on that same function too");
+    pmix_hwloc_release_devices(devs, ndevs);
+    devs = NULL;
+    ndevs = 0;
+
     /* the fabric and network devices sit on different functions */
     rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_OPENFABRICS, NULL, &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 1 == ndevs, "topo2: one openfabrics device");


### PR DESCRIPTION
Follow-up to #4143, fixing a defect in it.

`pmix_hwloc_get_devices()` groups a PCI function's OS devices into one device
and picks one of them to name it. The lookup by device id then compared the
caller's name against **that one chosen name** — so a device was findable only
under whichever of its names happened to win the selection.

A fabric device and its network device commonly share a function: on a
Mellanox card, `mlx5_0` and `ib0`. Only one of them can name the device, and
the other was then unfindable — which defeats the point of being able to name
a device at all.

Found while wiring `--map-by device=<name>` in PRRTE: asking for `mlx5_4`
reported that the node had no such device, because `ib1x` sits on the same
function and had been chosen to name it.

### Fix

Test every OS device on the function against the caller's name as the
candidates are collected, rather than testing only the survivor afterwards.
A name the caller actually used also claims the naming of the function —
being told about `ib0` when you asked for `mlx5_0` is not an answer either.
Both spellings count, the OS name and the uuid.

### Testing

`test/unit/hwloc_devices.c` gains the case, now 33 checks: `mlx5_0` and `ib0`
share a function in `test-topo2`, and asking for either has to find it, with
the answer reported under the name that was asked for. `make check` 136/136.

Also rebuilt PRRTE against it and re-ran the device-mapping cases that
exposed this: `--map-by device=mlx5_4` now places every process on the NUMA
domain that device is local to.