### PR TITLE
Say what PMIX_DEVICE_ID holds when it reports an assignment

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1549,6 +1549,10 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_DEVICE_TYPE                    "pmix.dev.type"        // (pmix_device_type_t) Bitmask specifying the type(s) of device(s) whose
                                                                    //         information is being requested. Only used as a directive/qualifier.
 #define PMIX_DEVICE_ID                      "pmix.dev.id"          // (char*) System-wide UUID or node-local OS name of a particular device.
+                                                                   //         When used to report the device(s) a process has been
+                                                                   //         assigned - e.g. in that process's own proc info - the
+                                                                   //         value is instead a pmix_data_array_t of pmix_device_t,
+                                                                   //         and is an array even when it holds one device.
 
 
 /* Descriptive Attributes */


### PR DESCRIPTION
`PMIX_DEVICE_ID` is documented as `(char*)` naming "a particular device",
which is what it is when passed *in* as a directive selecting one.

A runtime reporting the device(s) it has **assigned** to a process has a
different answer to give. There may be several, and PRRTE's `--map-by
device=gpu:ndev=N` makes that ordinary rather than exotic. Nothing in the
key's description says how the plural case is spelled, so a producer has to
invent an encoding and a consumer has to guess it. PRRTE invented a
comma-delimited list of UUIDs, which works only because no UUID grammar in
use today contains a comma — a property nothing enforces of a hostname or an
OS device name.

This records the answer instead of leaving it to be invented: when the value
reports an assignment it is a `pmix_data_array_t` of `pmix_device_t`, and it
is an array **even when it holds a single device**. Making one device and
several devices the same kind of answer at different lengths means a reader
needs one path rather than two — and avoids the situation where the
single-device path, being the one almost everybody hits, is the only one that
ever gets exercised. The array also carries each device's OS name and type
rather than the UUID alone.

Comment-only; no code or ABI change. The PRRTE side that produces this shape
is openpmix/prrte#2671.