### PR TITLE
pcompress: add an lz4 component, and build the swarm against the right compressor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,6 +286,7 @@ test/unit/client_cycle
 test/unit/tool_cycle
 test/unit/event_chain
 test/unit/hwloc_datatype
+test/unit/hwloc_devices
 test/unit/progress_threads
 test/unit/runtime_init
 test/unit/resolve_api

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,7 +378,7 @@ Many components only build when a piece of hardware, a fabric, or an
 optional third-party library is present — the GPU vendor components
 (`pgpu/{amd,intel,nvd}`), some transports (`pnet/nvd` and the opt-in
 `pnet/{simptest,tcp}`), the test components (`pgpu/test`), and the library
-wrappers (`pcompress/{zlib,zlibng}`, `plog/smtp`, `psec/munge`). On a
+wrappers (`pcompress/{zlib,zlibng,zstd,lz4}`, `plog/smtp`, `psec/munge`). On a
 machine that lacks those dependencies, that code is silently left out of
 the build and never gets compiler coverage.
 
@@ -404,7 +404,7 @@ tree, and do not run `make check` / the functional test suite against
 one.** The shims return placeholder values rather than doing real work, so
 any test that exercises a shimmed component *will* misbehave — and it is
 **expected**, not a bug to chase. A concrete example that has burned us
-before: with the `pcompress/{zlib,zlibng}` shims in place, `deflate`
+before: with the `pcompress/{zlib,zlibng,zstd,lz4}` shims in place, `deflate`
 becomes a no-op, so compression produces an empty payload and a
 compression round-trip yields an empty string. That makes
 `test/unit/preg` fail its "large list" case and the `test/unit/compress`

--- a/contrib/dockerswarm/Dockerfile
+++ b/contrib/dockerswarm/Dockerfile
@@ -29,11 +29,27 @@ ENV DEBIAN_FRONTEND=noninteractive
 # and setup.py needs setuptools plus Python.h.  The distro packages are used
 # deliberately rather than pip -- Ubuntu 24.04 marks its Python environment
 # "externally managed" (PEP 668), so a plain `pip install` refuses to run.
+# The compression dev packages are load-bearing, not incidental. A pcompress
+# component is compiled only if its configure.m4 finds the library's HEADERS,
+# and the runtime .so alone is not enough - so an image carrying libzstd.so.1
+# but not libzstd-dev silently builds zlib only, and every measurement taken
+# in the swarm is then made against the framework's lowest-priority, slowest
+# component rather than the one a real deployment selects. That was the state
+# of this image until Aug 2026, which is how a fence profile came to show 83%
+# of its instructions in zlib. Keep zlib/zstd/lz4 dev packages here so the
+# harness measures what production runs, and add the dev package with any new
+# pcompress component.
+#
+# valgrind and time are here for the same reason: profiling the daemons needed
+# them, and installing them by hand into a running container does not survive
+# the next `docker compose up`.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential gcc g++ make \
         autoconf automake libtool m4 flex \
         perl python3 python3-dev python3-setuptools cython3 git \
-        libevent-dev libhwloc-dev zlib1g-dev \
+        libevent-dev libhwloc-dev \
+        zlib1g-dev libzstd-dev liblz4-dev \
+        valgrind time \
         openssh-server openssh-client \
         iproute2 iputils-ping procps less vim ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/installing-pmix/configure-cli-options/optional-support-libraries.rst
+++ b/docs/installing-pmix/configure-cli-options/optional-support-libraries.rst
@@ -13,16 +13,25 @@ Compression
 
 * ``--with-zstd[=VALUE]``:
 * ``--with-zlibng[=VALUE]``:
+* ``--with-lz4[=VALUE]``:
 * ``--with-zlib[=VALUE]``:
 
   These options specify where to find the headers and libraries for
   `Zstandard <https://facebook.github.io/zstd/>`_, `zlib-ng
-  <https://github.com/zlib-ng/zlib-ng>`_ and `zlib <https://zlib.net/>`_
-  respectively. Each builds the matching ``pcompress`` component.
+  <https://github.com/zlib-ng/zlib-ng>`_, `LZ4 <https://lz4.org/>`_ and
+  `zlib <https://zlib.net/>`_ respectively. Each builds the matching
+  ``pcompress`` component.
+
+  Note that each needs the library's **development** package |mdash| the
+  headers, not just the shared object. A system with ``libzstd.so`` but
+  no ``zstd.h`` builds no ``zstd`` component and quietly falls back to
+  whatever else has headers installed.
 
   Only one component is active at run time |mdash| the highest priority
-  one built (``zstd``, then ``zlibng``, then ``zlib``) |mdash| so there
-  is no need to provide more than one, and no harm in providing several.
+  one built (``zstd``, then ``zlibng``, then ``lz4``, then ``zlib``)
+  |mdash| so there is no need to provide more than one, and no harm in
+  providing several. Any of them can be forced at run time with
+  ``--pmixmca pcompress <name>``.
 
   A build with none of them works, but compresses nothing: expect longer
   start-up times and larger memory footprints at scale, and a warning to
@@ -69,6 +78,7 @@ Permitted values, and one important behavior
 
 * ``--with-zstd-libdir=LIBDIR``:
 * ``--with-zlibng-libdir=LIBDIR``:
+* ``--with-lz4-libdir=LIBDIR``:
 * ``--with-zlib-libdir=LIBDIR``:
 * ``--with-munge-libdir=LIBDIR``:
 * ``--with-smtp-libdir=LIBDIR``:

--- a/docs/installing-pmix/optional-support-libraries.rst
+++ b/docs/installing-pmix/optional-support-libraries.rst
@@ -44,6 +44,12 @@ worthwhile on any system that runs jobs at scale.
      - ``--with-zlibng``
      - Builds the ``pcompress/zlibng`` component |mdash| a faster
        implementation of the same DEFLATE format ``zlib`` produces.
+   * - `LZ4 <https://lz4.org/>`_
+     - ``--with-lz4``
+     - Builds the ``pcompress/lz4`` component. The fastest of the four
+       and the least dense, so it is not preferred over ``zstd`` by
+       default; it is the one to select where daemon CPU matters more
+       than bytes on the wire.
    * - `zlib <https://zlib.net/>`_
      - ``--with-zlib``
      - Builds the ``pcompress/zlib`` component. Almost universally
@@ -59,18 +65,35 @@ can be silenced with ``pcompress_base_silence_warning=1`` if the trade is
 deliberate.
 
 **You do not need more than one.** Exactly one component is active,
-chosen by priority: ``zstd`` (90), then ``zlibng`` (75), then ``zlib``
-(50). Building several is harmless |mdash| the highest-priority one wins
-and the others are simply never selected.
+chosen by priority: ``zstd`` (90), then ``zlibng`` (75), then ``lz4``
+(60), then ``zlib`` (50). Building several is harmless |mdash| the
+highest-priority one wins and the others are simply never selected, and
+any of them can be forced at run time with ``--pmixmca pcompress
+<name>``.
+
+.. important:: **You need the development package, not just the runtime
+   library.** A ``pcompress`` component is compiled only if ``configure``
+   finds the library's **headers** |mdash| ``zstd.h``, ``lz4frame.h``,
+   ``zlib.h``. A system carrying ``libzstd.so`` but not ``libzstd-dev``
+   builds no ``zstd`` component at all, and silently falls back to
+   whichever lower-priority library *does* have headers installed. The
+   distribution packages are typically ``libzstd-dev``, ``liblz4-dev``
+   and ``zlib1g-dev`` (Debian/Ubuntu), or ``libzstd-devel``,
+   ``lz4-devel`` and ``zlib-devel`` (RHEL/SUSE). Check the ``External
+   Packages`` lines of the ``configure`` summary to see what was actually
+   found.
 
 .. warning:: **All processes in a job must use the same component.**
    ``zlib`` and ``zlib-ng`` both emit standard DEFLATE and are freely
    interchangeable, so a build that picks one on one node and the other
-   elsewhere is fine. A ``zstd`` blob is **not** DEFLATE, and compressed
-   data does cross nodes, so a mix of ``zstd`` and zlib-based
-   installations within one job will not interoperate. In practice this
-   follows from a shared installation; it is worth knowing during a
-   rolling upgrade.
+   elsewhere is fine. A ``zstd`` or ``lz4`` blob is **not** DEFLATE, and
+   compressed data does cross nodes, so mixing either of those with each
+   other or with a zlib-based installation within one job will not
+   interoperate. Both refuse a blob that does not carry their own frame
+   magic, so the mismatch surfaces as a clean error rather than as
+   corrupted data |mdash| but it does not work. In practice this follows
+   from a shared installation; it is worth knowing during a rolling
+   upgrade.
 
 Optional features
 -----------------

--- a/examples/fence_timing.c
+++ b/examples/fence_timing.c
@@ -39,6 +39,14 @@
  *
  *   PMIX_PERF_KEYS    keys published per rank (default 32)
  *   PMIX_PERF_VALSZ   bytes in each value     (default 1024)
+ *   PMIX_PERF_COMPRESSIBLE  1 to fill values with repetitive data instead
+ *                     of random (default 0)
+ *
+ * That last one exists because whether compressing the modex pays is the
+ * question, not a detail: pcompress decides on size alone and never looks
+ * at the data, so an incompressible payload costs the full compression and
+ * returns nothing. Measure both ends before concluding anything about a
+ * codec.
  */
 
 #include <pmix.h>
@@ -90,6 +98,19 @@ static void fill_incompressible(char *buf, size_t len, unsigned seed)
     }
 }
 
+/* The other end of the range: a short repeating pattern, which any of the
+ * codecs collapses. Real modex values sit somewhere between this and the
+ * PRNG above - repetitive key names wrapped around opaque endpoint bytes. */
+static void fill_compressible(char *buf, size_t len, unsigned seed)
+{
+    static const char pattern[] = "pmix.endpoint.fabric.device.coordinates=0123456789 ";
+    size_t i, n = sizeof(pattern) - 1;
+
+    for (i = 0; i < len; i++) {
+        buf[i] = pattern[(i + seed) % n];
+    }
+}
+
 /* A fence over the whole namespace, optionally collecting the data. */
 static pmix_status_t fence_all(bool collect, double *usec)
 {
@@ -126,12 +147,15 @@ int main(int argc, char **argv)
     char *payload = NULL;
     double barrier_us = 0.0, modex_us = 0.0;
     int nkeys, valsz, i;
+    bool compressible;
     uint32_t nprocs = 0;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
     nkeys = env_int("PMIX_PERF_KEYS", 32);
     valsz = env_int("PMIX_PERF_VALSZ", 1024);
+    compressible = (NULL != getenv("PMIX_PERF_COMPRESSIBLE")
+                    && 0 != strcmp("0", getenv("PMIX_PERF_COMPRESSIBLE")));
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
         fprintf(stderr, "fence_timing: PMIx_Init failed: %s\n", PMIx_Error_string(rc));
@@ -168,8 +192,13 @@ int main(int argc, char **argv)
      * it to our own server - neither is the collective we are scoring. */
     for (i = 0; i < nkeys; i++) {
         snprintf(key, sizeof(key), "fence-timing-%u-%d", (unsigned) myproc.rank, i);
-        fill_incompressible(payload, (size_t) valsz,
-                            (unsigned) (myproc.rank * 1000003u + (unsigned) i));
+        if (compressible) {
+            fill_compressible(payload, (size_t) valsz,
+                              (unsigned) (myproc.rank * 1000003u + (unsigned) i));
+        } else {
+            fill_incompressible(payload, (size_t) valsz,
+                                (unsigned) (myproc.rank * 1000003u + (unsigned) i));
+        }
         PMIX_VALUE_CONSTRUCT(&value);
         value.type = PMIX_BYTE_OBJECT;
         value.data.bo.bytes = payload;
@@ -226,10 +255,10 @@ int main(int argc, char **argv)
     /* Only rank 0 reports, so the lines are not interleaved. */
     if (0 == myproc.rank) {
         fprintf(stdout,
-                "fence_timing: nprocs=%u keys=%d valsz=%d "
+                "fence_timing: nprocs=%u keys=%d valsz=%d payload=%s "
                 "barrier=%.1f us modex=%.1f us premium=%.1f us\n",
-                nprocs, nkeys, valsz, barrier_us, modex_us,
-                modex_us - barrier_us);
+                nprocs, nkeys, valsz, compressible ? "compressible" : "random",
+                barrier_us, modex_us, modex_us - barrier_us);
         fflush(stdout);
     }
 

--- a/src/mca/pcompress/AGENTS.md
+++ b/src/mca/pcompress/AGENTS.md
@@ -18,7 +18,7 @@ described there all apply here and are not repeated. This file covers
 what is specific to `pcompress`: what the framework is for, the way its
 one active component is chosen (entirely at build time), the shared
 compressed-blob format its components must agree on, and the contract a
-component must honor. Each component subdirectory (`zlib/`, `zlibng/`, `zstd/`)
+component must honor. Each component subdirectory (`zlib/`, `zlibng/`, `zstd/`, `lz4/`)
 carries its own `AGENTS.md` with component-specific detail. There is no
 `docs/how-things-work/` page for this framework.
 
@@ -76,7 +76,7 @@ time**, not run time:
 
 - No component's `component_query` gates on anything — each
   unconditionally returns its module and a fixed priority (`zstd` = 90,
-  `zlibng` = 75, `zlib` = 50). So on a host where several libraries were
+  `zlibng` = 75, `lz4` = 60, `zlib` = 50). So on a host where several libraries were
   found at configure time the highest wins; where only one was found, it
   wins. `zstd` is ranked first because it is both faster and smaller than
   the zlib components on the payloads this framework actually sees — see
@@ -92,7 +92,7 @@ time**, not run time:
   entry points do nothing but return `false`.
 
 So "which compressor am I getting?" is answered by the configure summary
-line (`External Packages: ZLIB` / `ZLIBNG` / `ZSTD`), not by any MCA
+line (`External Packages: ZLIB` / `ZLIBNG` / `ZSTD` / `LZ4`), not by any MCA
 parameter — though `--pmixmca pcompress <name>` can still force one of the
 built components at run time.
 
@@ -192,6 +192,7 @@ library can see.
 | `pcompress_zlib_level` | int, **1** | level passed to `deflateInit` |
 | `pcompress_zlibng_level` | int, **2** | level passed to `zng_deflateInit` |
 | `pcompress_zstd_level` | int, **3** | level passed to `ZSTD_compress` |
+| `pcompress_lz4_level` | int, **0** | level passed to `LZ4F_compressFrame`; 0 is the plain LZ4 codec, any positive value switches to the slower, denser LZ4HC |
 
 The zlib defaults were a hard-coded **9** until these parameters were added.
 On a 25.6 MB aggregated modex, level 9 costs roughly twice the CPU of level 1
@@ -237,15 +238,15 @@ this is a contract, not an implementation detail:
   both use this identical 4-byte framing, a blob produced by one is
   readable by the other, which is what makes it safe for the build to pick
   `zlibng` on one node and `zlib` on another.
-  **`zstd` breaks that symmetry**: it keeps the 4-byte prefix (so every
-  size query still works) but its payload is a zstd frame, which a
-  zlib-only peer cannot read. Compressed blobs *do* cross nodes — the
+  **`zstd` and `lz4` break that symmetry**: each keeps the 4-byte prefix
+  (so every size query still works) but its payload is a zstd or an LZ4
+  frame, which a peer running any of the other components cannot read. Compressed blobs *do* cross nodes — the
   server compresses each daemon's fence bucket and the receivers inflate
   it — so **every node in a job must run the same component**. In practice
-  that follows from a shared installation. `zstd`'s decompress checks the
-  zstd frame magic and refuses anything else, which converts the mixed-build
-  failure from a corrupted modex into a clean error; it does not make the
-  mixed build work. If heterogeneous deployments ever have to be
+  that follows from a shared installation. Both check their own frame magic on the
+  way in and refuse anything else, which converts the mixed-build failure
+  from a corrupted modex into a clean error; it does not make the mixed
+  build work. If heterogeneous deployments ever have to be
   supported, the fix is to make the blob self-describing across the whole
   framework — a scheme byte, or that sniff generalized into the base — not
   a per-component workaround.

--- a/src/mca/pcompress/lz4/AGENTS.md
+++ b/src/mca/pcompress/lz4/AGENTS.md
@@ -1,0 +1,143 @@
+<!--
+  Copyright (c) 2026      Nanook Consulting  All rights reserved.
+
+  $COPYRIGHT$
+
+  Additional copyrights may follow
+
+  $HEADER$
+-->
+
+# AGENTS.md: The `lz4` PCOMPRESS Component
+
+Orientation for the `pcompress/lz4` component. Read the framework's
+[`../AGENTS.md`](../AGENTS.md) first — the module contract, the selection
+model, and the shared blob format are described there and are not repeated
+here. The top-level [`AGENTS.md`](../../../../AGENTS.md) governs everything
+else.
+
+## Why this component exists
+
+The other three components sit close together on the speed/size curve:
+`zlib` and `zlibng` emit DEFLATE, and `zstd` is both faster and denser
+than either. None of them offers the *fast* end of the curve, where the
+compressor costs so little that attempting it is nearly free even when it
+does not pay off.
+
+That end matters here for a specific reason. `pcompress` is called on the
+progress thread of a daemon while a whole DVM waits on the collective, and
+the decision to compress is made on **size alone** — no component looks at
+the data. For a payload that does not compress (opaque endpoint blobs,
+already-compressed application data) the whole cost is spent and nothing is
+returned. The cheaper the codec, the less that mistake costs.
+
+LZ4 is that codec. It gives up ratio for throughput, so it is not the right
+default where bandwidth is the scarce resource — which is why it is **not**
+ranked first. See "Priority" below.
+
+## Priority: 60, deliberately below `zstd`
+
+| component | priority |
+|---|---|
+| `zstd` | 90 |
+| `zlibng` | 75 |
+| **`lz4`** | **60** |
+| `zlib` | 50 |
+
+Above `zlib`, because it beats `zlib` on both terms. Below `zstd`, because
+which of those two should win is a **bandwidth-against-CPU judgement that
+depends on the link the payload will cross**, and nothing in the library
+can see that link. Ranking `lz4` first would silently change the trade for
+every existing build.
+
+Select it explicitly to measure or to use it:
+
+```sh
+prterun --pmixmca pcompress lz4 ...
+```
+
+Re-rank it here if measurement on a real fabric says it should win by
+default — that is a policy decision backed by numbers, not a default to
+drift into.
+
+## The level parameter means something different here
+
+`pcompress_lz4_level` defaults to **0**, and 0 is not "the lowest setting of
+one algorithm" the way it is for the zlib components. In the LZ4 library a
+level of 0 selects the plain LZ4 codec, and any positive value switches the
+same call to **LZ4HC** — a different, much slower, denser algorithm.
+
+LZ4HC is not a useful place for this framework to be: it is slower than
+`zstd` at a comparable ratio, so if density is what you want, use `zstd`.
+The parameter exists because the framework's convention is that a level is
+tunable rather than baked in, not because a positive value is expected to
+be a good idea.
+
+## It uses the FRAME api, not the block api
+
+`LZ4F_compressFrame` / `LZ4F_decompress` from `<lz4frame.h>`, not
+`LZ4_compress_default` / `LZ4_decompress_safe` from `<lz4.h>`. The block
+API would be marginally faster and the framework's 4-byte length prefix
+already supplies the uncompressed size the block decoder needs — so the
+choice needs a reason, and the reason is the **mixed-build failure mode**.
+
+A blob carries no indication of which component produced it (see the
+framework's blob-format section). The LZ4 block format has no header at
+all, so a DEFLATE blob handed to the block decoder is decoded as far as it
+happens to parse. A **frame** starts with a magic number, so it can be
+refused at the first byte — which is what `is_lz4_frame()` does, exactly as
+`zstd` does with its own magic.
+
+That does not make a mixed build work; nothing here can. Every node in a
+job must run the same component. It converts the failure from a corrupted
+modex into a clean refusal, which is the difference between a diagnosable
+configuration error and a wrong answer.
+
+The frame also carries `contentSize` in its header. This component does not
+need it — it has the prefix — but it costs 8 bytes and makes a captured
+blob readable by anything that speaks LZ4.
+
+## Decompression is strict on purpose
+
+`doit()` rejects the result unless **all** of these hold: the decoder
+returned 0 (frame complete, no more input wanted), it produced exactly the
+length the prefix promised, and it consumed exactly the bytes it was given.
+A frame that decodes partially, or that leaves trailing bytes, is not one
+this component wrote. Loosening any of the three turns a truncated or
+foreign blob into a partial answer the caller cannot tell from a real one.
+
+## Building
+
+`configure.m4` probes for `lz4frame.h` and the **`LZ4F_compressFrame`**
+symbol. Probe the frame symbol, not `LZ4_compress` — that name is the
+long-deprecated block entry point and has been removed from current lz4
+releases, so probing it would fail on exactly the systems where the library
+is newest.
+
+Like the other components, this one is compiled only if `configure` found
+the library, so its `component_query` gates on nothing. The dev package
+(`liblz4-dev` on Debian/Ubuntu) is what decides this — the runtime `.so`
+alone is not enough, and an image carrying one without the other silently
+drops the component. `contrib/dockerswarm/Dockerfile` installs the dev
+packages for all of `zlib`/`zstd`/`lz4` for that reason.
+
+`testbuild_lz4.h` is the non-functional shim `--enable-test-build` compiles
+against where the real headers are absent. It is not a working compressor;
+never run the functional suite against a test build.
+
+## Testing
+
+`test/unit/compress` and `test/unit/compress_block` exercise whichever
+component is selected, so run them once per component:
+
+```sh
+cd test/unit
+for c in lz4 zstd zlibng zlib; do
+    (. ../pmix_test_env.sh; PMIX_MCA_pcompress=$c ./compress_block)
+done
+```
+
+Sourcing `pmix_test_env.sh` is what points the loader at the components in
+the **build tree**; without it the binary finds whatever is installed under
+`$prefix/lib/pmix`, which is how a component that was never built appears
+to "work" by silently being a different one.

--- a/src/mca/pcompress/lz4/CLAUDE.md
+++ b/src/mca/pcompress/lz4/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/pcompress/lz4/Makefile.am
+++ b/src/mca/pcompress/lz4/Makefile.am
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(pcompress_lz4_CPPFLAGS)
+
+# Non-functional shim used only under --enable-test-build; always shipped
+EXTRA_DIST = testbuild_lz4.h
+
+sources = \
+        compress_lz4.h \
+        compress_lz4_component.c \
+        compress_lz4.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pcompress_lz4_DSO
+component_noinst =
+component_install = pmix_mca_pcompress_lz4.la
+else
+component_noinst = libpmix_mca_pcompress_lz4.la
+component_install =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+pmix_mca_pcompress_lz4_la_SOURCES = $(sources)
+pmix_mca_pcompress_lz4_la_LDFLAGS = -module -avoid-version $(pcompress_lz4_LDFLAGS)
+pmix_mca_pcompress_lz4_la_LIBADD = $(pcompress_lz4_LIBS)
+if NEED_LIBPMIX
+pmix_mca_pcompress_lz4_la_LIBADD += $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(component_noinst)
+libpmix_mca_pcompress_lz4_la_SOURCES = $(sources)
+libpmix_mca_pcompress_lz4_la_LDFLAGS = -module -avoid-version $(pcompress_lz4_LDFLAGS)
+libpmix_mca_pcompress_lz4_la_LIBADD = $(pcompress_lz4_LIBS)

--- a/src/mca/pcompress/lz4/compress_lz4.c
+++ b/src/mca/pcompress/lz4/compress_lz4.c
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+
+#include <string.h>
+
+#if PMIX_TESTBUILD
+#    include "testbuild_lz4.h"
+#else
+#    include <lz4frame.h>
+#endif
+
+#include "src/include/pmix_stdint.h"
+#include "src/util/pmix_output.h"
+
+#include "pmix_common.h"
+
+#include "src/mca/pcompress/base/base.h"
+
+#include "compress_lz4.h"
+
+static bool lz4_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbytes, size_t *outlen);
+
+static bool lz4_decompress(uint8_t **outbytes, size_t *outlen, const uint8_t *inbytes, size_t inlen);
+
+static bool compress_string(char *instring, uint8_t **outbytes, size_t *nbytes);
+
+static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len);
+
+static size_t get_decompressed_size(const pmix_byte_object_t *bo);
+
+static size_t get_decompressed_strlen(const pmix_byte_object_t *bo);
+
+pmix_compress_base_module_t pmix_pcompress_lz4_module = {
+    .compress = lz4_compress,
+    .decompress = lz4_decompress,
+    .get_decompressed_size = get_decompressed_size,
+    .compress_string = compress_string,
+    .decompress_string = decompress_string,
+    .get_decompressed_strlen = get_decompressed_strlen,
+};
+
+/* The LZ4 frame magic, as it appears on the wire: 0x184D2204 is defined to be
+ * serialized little-endian, so the first four bytes of any frame are this
+ * sequence regardless of host byte order.
+ *
+ * Same reasoning as zstd's equivalent, and the same limitation.  The
+ * framework's blob format puts a 4-byte raw length in front of a payload it
+ * does not describe, so a blob this component produced is unreadable by a peer
+ * whose PMIx selected any of the other three.  Sniffing the magic cannot make
+ * that work; it turns "silently inflate garbage" into a clean refusal.  See
+ * ../AGENTS.md - every node in a job must run the same component.
+ *
+ * This is also why the component uses the FRAME api rather than the raw block
+ * api.  The block format has no header at all, so a DEFLATE blob handed to it
+ * would be decoded as far as it happened to parse; a frame refuses at the
+ * first byte. */
+static const uint8_t lz4_magic[4] = {0x04, 0x22, 0x4D, 0x18};
+
+static bool is_lz4_frame(const uint8_t *p, size_t len)
+{
+    return (sizeof(lz4_magic) <= len) && (0 == memcmp(p, lz4_magic, sizeof(lz4_magic)));
+}
+
+static bool lz4_compress(const uint8_t *inbytes, size_t inlen, uint8_t **outbytes, size_t *outlen)
+{
+    LZ4F_preferences_t prefs;
+    size_t bound, produced, total;
+    uint8_t *tmp, *ptr;
+    uint32_t rawlen;
+
+    /* set default output */
+    *outbytes = NULL;
+    *outlen = 0;
+
+    /* the same two economy rules every component in this framework applies:
+     * too small to be worth it, or too big for the 4-byte length prefix */
+    if (inlen < pmix_compress_base.compress_limit || inlen >= UINT32_MAX) {
+        return false;
+    }
+    rawlen = inlen;
+
+    memset(&prefs, 0, sizeof(prefs));
+    prefs.compressionLevel = pmix_pcompress_lz4_level;
+    /* Tell the frame header how much is coming.  It costs 8 bytes and lets a
+     * reader size its output buffer from the frame alone - which this
+     * component does not need, having the prefix, but a third party reading a
+     * captured blob does. */
+    prefs.frameInfo.contentSize = inlen;
+
+    /* an upper bound on the compressed size, so the compress call cannot
+     * fail for want of room */
+    bound = LZ4F_compressFrameBound(inlen, &prefs);
+    if (LZ4F_isError(bound)) {
+        return false;
+    }
+    /* allocate the 4-byte uncompressed-length prefix up front, so the payload
+     * lands in its final position and no second copy is needed */
+    if (NULL == (tmp = (uint8_t *) malloc(bound + sizeof(uint32_t)))) {
+        return false;
+    }
+    memcpy(tmp, &rawlen, sizeof(uint32_t));
+
+    produced = LZ4F_compressFrame(tmp + sizeof(uint32_t), bound, inbytes, inlen, &prefs);
+    if (LZ4F_isError(produced)) {
+        free(tmp);
+        return false;
+    }
+    total = produced + sizeof(uint32_t);
+
+    /* if this isn't going to result in a smaller footprint, then don't do it.
+     * A caller can therefore always read a true return as "space was saved". */
+    if (total >= inlen) {
+        free(tmp);
+        return false;
+    }
+
+    /* hand back a buffer sized to what was actually produced rather than to
+     * the bound, which for an incompressible input is larger than the input */
+    ptr = (uint8_t *) realloc(tmp, total);
+    if (NULL == ptr) {
+        /* the oversized buffer is still perfectly valid; only the trim failed */
+        ptr = tmp;
+    }
+    *outbytes = ptr;
+    *outlen = total;
+
+    pmix_output_verbose(2, pmix_pcompress_base_framework.framework_output,
+                        "COMPRESS INPUT BLOCK OF LEN %" PRIsize_t " OUTPUT SIZE %" PRIsize_t "",
+                        inlen, produced);
+    return true; // we did the compression
+}
+
+static bool compress_string(char *instring, uint8_t **outbytes, size_t *nbytes)
+{
+    /* the stored length is the string's length WITHOUT its NUL, matching the
+     * other components; decompress_string adds the terminator back */
+    return lz4_compress((uint8_t *) instring, strlen(instring), outbytes, nbytes);
+}
+
+/* Inflate `inlen` bytes of frame into a freshly allocated buffer.
+ *
+ * `capacity` and `expected` are separate on purpose and are NOT always equal:
+ * the string path allocates one byte more than the blob's stored length so it
+ * has room to append the NUL that length deliberately does not count.  Folding
+ * them into one argument makes the strict length check below reject every
+ * string it ever compressed. */
+static bool doit(uint8_t **outbytes, size_t capacity, size_t expected,
+                 const uint8_t *inbytes, size_t inlen)
+{
+    LZ4F_dctx *dctx = NULL;
+    uint8_t *dest;
+    size_t rc, dstsize, srcsize;
+
+    /* set the default error answer */
+    *outbytes = NULL;
+
+    if (!is_lz4_frame(inbytes, inlen)) {
+        /* Not ours.  Produced by a peer whose PMIx selected a different
+         * pcompress component - which this one cannot read, and must not
+         * pretend to. */
+        pmix_output_verbose(2, pmix_pcompress_base_framework.framework_output,
+                            "DECOMPRESS: blob is not an lz4 frame - it was produced "
+                            "by a peer using a different pcompress component");
+        return false;
+    }
+
+    dest = (uint8_t *) malloc(capacity);
+    if (NULL == dest) {
+        return false;
+    }
+
+    if (LZ4F_isError(LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION))) {
+        free(dest);
+        return false;
+    }
+
+    /* The whole frame is in hand and the destination is big enough for all of
+     * it, so this decodes in one call.  A non-zero return means the decoder
+     * wants more input, which for a complete frame means the blob is
+     * truncated - refuse it rather than hand back a partial answer. */
+    dstsize = capacity;
+    srcsize = inlen;
+    rc = LZ4F_decompress(dctx, dest, &dstsize, inbytes, &srcsize, NULL);
+    LZ4F_freeDecompressionContext(dctx);
+
+    if (LZ4F_isError(rc) || 0 != rc || dstsize != expected || srcsize != inlen) {
+        free(dest);
+        return false;
+    }
+
+    *outbytes = dest;
+    return true;
+}
+
+static bool lz4_decompress(uint8_t **outbytes, size_t *outlen, const uint8_t *inbytes, size_t inlen)
+{
+    uint32_t len2;
+
+    /* set the default error answer */
+    *outlen = 0;
+
+    if (NULL == inbytes || inlen < sizeof(uint32_t)) {
+        return false;
+    }
+
+    /* the first 4 bytes contains the uncompressed size */
+    memcpy(&len2, inbytes, sizeof(uint32_t));
+
+    pmix_output_verbose(2, pmix_pcompress_base_framework.framework_output,
+                        "DECOMPRESSING INPUT OF LEN %" PRIsize_t " OUTPUT %u", inlen, len2);
+
+    if (!doit(outbytes, len2, len2, inbytes + sizeof(uint32_t), inlen - sizeof(uint32_t))) {
+        return false;
+    }
+    *outlen = len2;
+    return true;
+}
+
+static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len)
+{
+    uint32_t len2;
+
+    /* set the default error answer */
+    *outstring = NULL;
+
+    if (NULL == inbytes || len < sizeof(uint32_t)) {
+        return false;
+    }
+
+    /* the first 4 bytes contains the uncompressed size */
+    memcpy(&len2, inbytes, sizeof(uint32_t));
+    if (UINT32_MAX == len2) {
+        /* the error sentinel the format reserves */
+        return false;
+    }
+
+    /* inflate into exactly the promised length, then add the terminator the
+     * stored length deliberately does not count */
+    if (!doit((uint8_t **) outstring, len2 + 1, len2, inbytes + sizeof(uint32_t),
+              len - sizeof(uint32_t))) {
+        return false;
+    }
+    (*outstring)[len2] = '\0';
+    return true;
+}
+
+/* A blob produced by lz4_compress / compress_string carries the uncompressed
+ * length in its leading 4 bytes (see the shared blob format). These helpers
+ * return that length by reading the prefix, without inflating the payload, so
+ * callers computing the in-memory footprint of a PMIX_COMPRESSED_BYTE_OBJECT /
+ * PMIX_COMPRESSED_STRING need not decompress it first. */
+static size_t get_decompressed_size(const pmix_byte_object_t *bo)
+{
+    uint32_t len = 0;
+
+    if (NULL == bo || NULL == bo->bytes || bo->size < sizeof(uint32_t)) {
+        return 0;
+    }
+    /* the first 4 bytes contain the uncompressed size */
+    memcpy(&len, bo->bytes, sizeof(uint32_t));
+    return (size_t) len;
+}
+
+static size_t get_decompressed_strlen(const pmix_byte_object_t *bo)
+{
+    uint32_t len = 0;
+
+    if (NULL == bo || NULL == bo->bytes || bo->size < sizeof(uint32_t)) {
+        return 0;
+    }
+    memcpy(&len, bo->bytes, sizeof(uint32_t));
+    /* +1 for the NUL terminator, mirroring how a plain PMIX_STRING is sized */
+    return (size_t) len + 1;
+}

--- a/src/mca/pcompress/lz4/compress_lz4.h
+++ b/src/mca/pcompress/lz4/compress_lz4.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * LZ4 COMPRESS component
+ *
+ * Uses the lz4 library
+ */
+
+#ifndef MCA_COMPRESS_LZ4_EXPORT_H
+#define MCA_COMPRESS_LZ4_EXPORT_H
+
+#include "pmix_config.h"
+
+#include "src/util/pmix_output.h"
+
+#include "src/mca/mca.h"
+#include "src/mca/pcompress/pcompress.h"
+
+#if defined(c_plusplus) || defined(__cplusplus)
+extern "C" {
+#endif
+
+/* Compression level handed to LZ4F_compressFrame().  Zero selects the plain
+ * LZ4 codec, which is the whole point of this component; a positive value
+ * switches the library to LZ4HC, which is a different (slower, denser)
+ * algorithm reached through the same call.  A parameter rather than a
+ * constant for the same reason as the other components - see the framework's
+ * AGENTS.md. */
+extern int pmix_pcompress_lz4_level;
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_mca_base_component_t pmix_mca_pcompress_lz4_component;
+extern pmix_compress_base_module_t pmix_pcompress_lz4_module;
+
+#if defined(c_plusplus) || defined(__cplusplus)
+}
+#endif
+
+#endif /* MCA_COMPRESS_LZ4_EXPORT_H */

--- a/src/mca/pcompress/lz4/compress_lz4_component.c
+++ b/src/mca/pcompress/lz4/compress_lz4_component.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+
+#include "compress_lz4.h"
+#include "pmix_common.h"
+#include "src/mca/pcompress/base/base.h"
+
+/*
+ * Public string for version number
+ */
+const char *pmix_compress_lz4_component_version_string
+    = "PMIX COMPRESS lz4 MCA component version " PMIX_VERSION;
+
+/* Zero is LZ4's own fast mode and is the only level this component exists
+ * for: it trades ratio for speed, which is the trade the other three
+ * components do not offer.  A positive value hands the call to LZ4HC, which
+ * is slower than zstd at a similar ratio and therefore not a useful place to
+ * be - if you want density, use zstd.  Like the other components' levels it
+ * is a parameter rather than a constant; see the framework AGENTS.md. */
+int pmix_pcompress_lz4_level = 0;
+
+/*
+ * Local functionality
+ */
+static int compress_lz4_register(void);
+static int compress_lz4_query(pmix_mca_base_module_t **module, int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointer to our public functions in it
+ */
+PMIX_EXPORT pmix_mca_base_component_t pmix_mca_pcompress_lz4_component = {
+    /* Handle the general mca_component_t struct containing
+     *  meta information about the component lz4
+     */
+    PMIX_COMPRESS_BASE_VERSION_2_0_0,
+
+    /* Component name and version */
+    .pmix_mca_component_name = "lz4",
+    PMIX_MCA_BASE_MAKE_VERSION(component, PMIX_MAJOR_VERSION, PMIX_MINOR_VERSION,
+                               PMIX_RELEASE_VERSION),
+
+    /* Component open and close functions */
+    .pmix_mca_register_component_params = compress_lz4_register,
+    .pmix_mca_query_component = compress_lz4_query
+};
+PMIX_MCA_BASE_COMPONENT_INIT(pmix, pcompress, lz4)
+
+static int compress_lz4_register(void)
+{
+    pmix_mca_base_component_var_register(&pmix_mca_pcompress_lz4_component, "level",
+                                         "Compression level passed to lz4 (0 selects the "
+                                         "fast LZ4 codec this component exists for; a "
+                                         "positive value switches to the slower, denser "
+                                         "LZ4HC codec)",
+                                         PMIX_MCA_BASE_VAR_TYPE_INT,
+                                         &pmix_pcompress_lz4_level);
+    return PMIX_SUCCESS;
+}
+
+static int compress_lz4_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *module = (pmix_mca_base_module_t *) &pmix_pcompress_lz4_module;
+    /* Above zlib (50), below zlibng (75) and zstd (90).
+     *
+     * Deliberately NOT the default where zstd is present.  This component is
+     * the fastest and the least dense of the four, so which of the two should
+     * be preferred is a bandwidth-against-CPU judgement that depends on the
+     * link a payload will cross - not something to settle by ranking it first
+     * and changing every existing build's behaviour.  It sits above zlib
+     * because it beats zlib on both terms.  Select it explicitly with
+     * "--pmixmca pcompress lz4"; re-rank it here if measurement on a real
+     * fabric says it should win by default.
+     *
+     * Like the others, this query gates on nothing: a component is compiled
+     * only if its configure.m4 found the library, so an unavailable one is
+     * simply not in the build. */
+    *priority = 60;
+
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pcompress/lz4/configure.m4
+++ b/src/mca/pcompress/lz4/configure.m4
@@ -1,0 +1,60 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pcompress_lz4_CONFIG([action-if-can-compile],
+#                           [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pcompress_lz4_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pcompress/lz4/Makefile])
+
+    AC_ARG_WITH([lz4],
+                [AS_HELP_STRING([--with-lz4=DIR],
+                                [Search for lz4 headers and libraries in DIR ])])
+    AC_ARG_WITH([lz4-libdir],
+                [AS_HELP_STRING([--with-lz4-libdir=DIR],
+                                [Search for lz4 libraries in DIR ])])
+
+    pmix_lz4_support=0
+
+    OAC_CHECK_PACKAGE([lz4],
+                      [pcompress_lz4],
+                      [lz4frame.h],
+                      [lz4],
+                      [LZ4F_compressFrame],
+                      [pmix_lz4_support=1],
+                      [pmix_lz4_support=0])
+
+    if test ! -z "$with_lz4" && test "$with_lz4" != "no" && test "$pmix_lz4_support" != "1"; then
+        AC_MSG_WARN([LZ4 SUPPORT REQUESTED AND NOT FOUND])
+        AC_MSG_ERROR([CANNOT CONTINUE])
+    fi
+
+    # --enable-test-build force-builds this component (against the
+    # non-functional testbuild_lz4.h shim if the real headers are
+    # absent) so it can be compile-checked.
+    AC_MSG_CHECKING([will lz4 support be built])
+    AS_IF([test "$pmix_lz4_support" = "1" || test "$pmix_testbuild" = "1"],
+          [$1
+           AC_MSG_RESULT([yes])],
+          [$2
+           AC_MSG_RESULT([no])])
+
+    PMIX_SUMMARY_ADD([External Packages], [LZ4], [], [${pcompress_lz4_SUMMARY}])
+
+    # substitute in the things needed to build pcompress/lz4
+    AC_SUBST([pcompress_lz4_CPPFLAGS])
+    AC_SUBST([pcompress_lz4_LDFLAGS])
+    AC_SUBST([pcompress_lz4_LIBS])
+
+    PMIX_EMBEDDED_LIBS="$PMIX_EMBEDDED_LIBS $pcompress_lz4_LIBS"
+    PMIX_EMBEDDED_LDFLAGS="$PMIX_EMBEDDED_LDFLAGS $pcompress_lz4_LDFLAGS"
+    PMIX_EMBEDDED_CPPFLAGS="$PMIX_EMBEDDED_CPPFLAGS $pcompress_lz4_CPPFLAGS"
+
+])dnl

--- a/src/mca/pcompress/lz4/owner.txt
+++ b/src/mca/pcompress/lz4/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner:project
+status:maintenance

--- a/src/mca/pcompress/lz4/testbuild_lz4.h
+++ b/src/mca/pcompress/lz4/testbuild_lz4.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Non-functional "test build" shim for the subset of the lz4 frame API
+ * used by this component. It is included in place of the real
+ * <lz4frame.h> only when the library is configured with
+ * --enable-test-build (PMIX_TESTBUILD) so that the component can be
+ * compile-checked on a machine that lacks the lz4 development headers.
+ * The stubs return placeholder values and do NOT perform any compression
+ * - a component built against this shim is not functional.
+ */
+
+#ifndef PMIX_PCOMPRESS_LZ4_TESTBUILD_H
+#define PMIX_PCOMPRESS_LZ4_TESTBUILD_H
+
+#include "pmix_config.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define LZ4F_VERSION 100
+
+typedef struct {
+    unsigned long long contentSize;
+} LZ4F_frameInfo_t;
+
+typedef struct {
+    LZ4F_frameInfo_t frameInfo;
+    int compressionLevel;
+} LZ4F_preferences_t;
+
+typedef struct LZ4F_dctx_s LZ4F_dctx;
+
+static inline unsigned LZ4F_isError(size_t code)
+{
+    (void) code;
+    return 0;
+}
+
+static inline size_t LZ4F_compressFrameBound(size_t srcSize, const LZ4F_preferences_t *prefs)
+{
+    (void) prefs;
+    return srcSize;
+}
+
+static inline size_t LZ4F_compressFrame(void *dst, size_t dstCapacity, const void *src,
+                                        size_t srcSize, const LZ4F_preferences_t *prefs)
+{
+    (void) dst;
+    (void) dstCapacity;
+    (void) src;
+    (void) prefs;
+    return srcSize;
+}
+
+static inline size_t LZ4F_createDecompressionContext(LZ4F_dctx **dctx, unsigned version)
+{
+    (void) version;
+    *dctx = NULL;
+    return 0;
+}
+
+static inline size_t LZ4F_freeDecompressionContext(LZ4F_dctx *dctx)
+{
+    (void) dctx;
+    return 0;
+}
+
+static inline size_t LZ4F_decompress(LZ4F_dctx *dctx, void *dst, size_t *dstSize,
+                                     const void *src, size_t *srcSize, const void *dOptPtr)
+{
+    (void) dctx;
+    (void) dst;
+    (void) src;
+    (void) dOptPtr;
+    (void) dstSize;
+    (void) srcSize;
+    return 0;
+}
+
+#endif /* PMIX_PCOMPRESS_LZ4_TESTBUILD_H */


### PR DESCRIPTION
Adds an `lz4` component to `pcompress`, and fixes the reason nobody
noticed the framework already had a better one than the swarm was using.

### The swarm was measuring the wrong compressor

`contrib/dockerswarm`'s image carried `libzstd.so.1` but not
`libzstd-dev`. A pcompress component is compiled only if its
`configure.m4` finds the library's **headers**, so `zstd` — priority 90,
the framework's default wherever it is available — was silently dropped,
and `zlib` — priority 50, the slowest of them — was the only component
built.

**Every measurement ever taken in that swarm was therefore made against a
compressor a real deployment would not select.** It is not a small
difference. On four daemons at 512 KB per rank, the premium a collecting
fence carries over a barrier:

| codec | random payload | compressible payload |
|---|---|---|
| zstd | 9145 us | 2577 us |
| **lz4** | **8510 us** | **2547 us** |
| zlib | 46503 us | 4058 us |

zlib is **5.5x** slower than zstd on data that does not compress. A
callgrind profile taken before this was found showed 83% of a daemon's
fence instructions inside `zlib_compress`, which read as a finding about
compression in general and was really a finding about a missing package.

The Dockerfile now installs the dev packages for zlib, zstd and lz4, and
says in the file why they are not optional — so a new component's dev
package gets added with it rather than after someone re-derives this.
(`valgrind` and `time` go in for a related reason: profiling the daemons
needed both, and installing them by hand into a running container does
not survive the next `docker compose up`.)

### The lz4 component

The other three components sit close together on the speed/size curve.
None offers the fast end, where the compressor costs so little that
attempting it is nearly free even when it does not pay off — which
matters here because `pcompress` decides whether to compress on **size
alone** and never looks at the data, so an incompressible payload costs
the full compression and returns nothing.

On this corpus lz4 and zstd are within noise of each other, with lz4
ahead on the payload that does not compress. Both are far better than
zlib there.

**Priority 60** — above `zlib`, which it beats on both terms, and
deliberately below `zstd`. Which of those two should win is a
bandwidth-against-CPU judgement that depends on the link the payload will
cross, and nothing in the library can see that link, so ranking lz4 first
would silently change the trade for every existing build. Select it with
`--pmixmca pcompress lz4`, and re-rank it if measurement on a real fabric
says it should win by default.

Two implementation notes worth review attention:

* It uses the **frame** API, not the block API, even though block is
  marginally faster and the framework's 4-byte length prefix already
  carries the size a block decoder needs. A blob says nothing about which
  component produced it, and the LZ4 block format has no header — so a
  DEFLATE blob handed to a block decoder is decoded as far as it happens
  to parse. A frame starts with a magic number and is refused at the first
  byte, exactly as `zstd` refuses a non-zstd frame. That does not make a
  mixed build work; it turns a corrupted modex into a clean error.
* `pcompress_lz4_level` defaults to **0**, which here is not "the lowest
  setting of one algorithm": in the lz4 library 0 selects the plain LZ4
  codec and any positive value switches the same call to LZ4HC, a slower
  and denser algorithm that `zstd` beats anyway.

`configure.m4` probes `LZ4F_compressFrame`, not `LZ4_compress` — the
latter is the long-deprecated block entry point, removed from current lz4
releases, so probing it would fail on exactly the systems where the
library is newest.

### Also here

`examples/fence_timing` gains `PMIX_PERF_COMPRESSIBLE=1`, which fills
values with a repeating pattern instead of the PRNG. Whether compressing
the modex pays is a question in its own right, and answering it needs both
ends of the range; the reported line now says which was used, so a number
cannot be quoted without it.

A one-line `.gitignore` entry for `test/unit/hwloc_devices`, a
`check_PROGRAM` that was missed when it was added and shows up untracked
after every build.

### What it does not change

The gds sweep was re-run with zstd actually selected: at 8 daemons the
shmem3-vs-`hash` ratio is **1.34x** against 1.38x under zlib —
essentially unchanged, because compression is a common cost that scales
in both arms. Both arms got 11-14% faster in absolute terms.

### Testing

macOS: warning-free, `make check` 133/133, and `compress` +
`compress_block` round-trip under each of lz4/zstd/zlib (sourcing
`test/pmix_test_env.sh`, without which the loader finds whatever is
installed rather than what was built — which is how a component that was
never built can appear to work by silently being a different one).

Linux (`contrib/dockerswarm`, rebuilt image): warning-free with all three
components built and installed, `run-gds-tests.sh` 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
