### PR TITLE
Filter forwarded events on the code, and cache what nothing matched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -314,6 +314,7 @@ test/unit/tool_nspace
 test/unit/tool_rndz
 test/unit/tool_api
 test/unit/tool_evcache
+test/unit/event_forward
 test/unit/tool_relay
 test/unit/run_gds_fallback.pl
 test/unit/run_simpcycle.pl

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -7,6 +7,25 @@ series, in reverse chronological order.
 7.0.0 -- TBD
 ------------
 Detailed changes since v6.1.0:
+ - A PMIx server no longer drops an event one of its clients wanted. The
+   fan-out filter matched an event's affected processes against the
+   affected-process list a client's event registration had carried - but
+   that list belongs to a single registration message, and a handler
+   registered afterwards for a code the server is already forwarding
+   sends no message at all. So a process that registered one handler
+   restricted to a particular process and a second handler with no
+   restriction stopped receiving the code entirely for the second one.
+   The filter now matches on the event code, which is the only thing a
+   server can decide correctly; the affected-process and source-range
+   restrictions a handler registered with are enforced by the receiving
+   process, which is the only place that knows what each handler asked
+   for
+ - A client now caches an event forwarded to it that none of its
+   handlers accepted, so a handler registering a moment later is still
+   given it - the behavior a tool has always had, and the reason the
+   notification cache exists. An event can legitimately arrive unmatched
+   because a handler's source range is never sent to the server, so the
+   server cannot filter on it
  - A collective no longer counts a participant's orderly PMIx_Finalize
    as the loss of that participant. Such a rank has not left - its local
    process count is deliberately retained and its peer object tombstoned

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -239,6 +239,19 @@ gone — see [openpmix#4059][i4059].)
   they return `PMIX_SUCCESS`; waiting on the lock unconditionally (as the
   group invite path did) blocks forever on any error. Guard every wait
   with `if (PMIX_SUCCESS == rc)`.
+- **An event our server forwarded that no local handler accepted is
+  parked, not dropped.** `pmix_client_notify_recv` hangs
+  `pmix_event_notify_complete` (in [`src/event`](../event/AGENTS.md)) on
+  the chain's `final_cbfunc`, and that is the one completion in the tree
+  that is told whether anything matched — `pmix_invoke_local_event_hdlr`
+  reports `PMIX_ERR_NOT_FOUND` when the walk finds nothing. Arriving
+  unmatched is ordinary rather than exceptional: a handler's source range
+  never leaves this process, so the server cannot filter on it. Until
+  August 2026 this callback released the chain and nothing else, so such
+  an event was lost to a handler registering a moment later; the parking
+  code sat in `src/tool` instead, where it could not fire. See
+  [openpmix#4101](https://github.com/openpmix/openpmix/issues/4101) and
+  `test/unit/event_forward.c`.
 - **A zero-byte recv buffer means the connection was lost.** Every PTL
   recv callback must check `PMIX_BUFFER_IS_EMPTY(buf)` before unpacking.
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -90,15 +90,6 @@ static const char pmix_version_string[] = "OpenPMIx " PMIX_VERSION
 
 #define PMIX_MAX_RETRIES 10
 
-static void _notify_complete(pmix_status_t status, void *cbdata)
-{
-    pmix_event_chain_t *chain = (pmix_event_chain_t *) cbdata;
-    PMIX_HIDE_UNUSED_PARAMS(status);
-
-    PMIX_ACQUIRE_OBJECT(chain);
-    PMIX_RELEASE(chain);
-}
-
 static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
                                     pmix_buffer_t *buf, void *cbdata)
 {
@@ -126,7 +117,7 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hd
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return;
     }
-    chain->final_cbfunc = _notify_complete;
+    chain->final_cbfunc = pmix_event_notify_complete;
     chain->final_cbdata = chain;
 
     cnt = 1;

--- a/src/event/AGENTS.md
+++ b/src/event/AGENTS.md
@@ -321,11 +321,12 @@ call because it may be cached) and thread-shifts to
    `pmix_prep_event_chain`;
 3. unless the range is `PMIX_RANGE_RM` or `PMIX_RANGE_PROC_LOCAL`,
    walks `pmix_server_globals.events` and sends a `PMIX_NOTIFY_CMD`
-   message to every registered peer that passes the
-   source/target/affected filters — deduplicated via a `pmix_namelist_t`
-   tracker, never echoing to the event's source or to itself. With
-   custom targets it counts down `nleft` and evicts the cached entry
-   once every target has been notified;
+   message to every peer registered for the **code** — deduplicated via
+   a `pmix_namelist_t` tracker, never echoing to the event's source or
+   to itself, and (for a server that is not itself a tool) still subject
+   to the event's own custom-target range. With custom targets it counts
+   down `nleft` and evicts the cached entry once every target has been
+   notified;
 4. if this server is itself the event's source (and the event is not
    `PMIX_RANGE_LOCAL` / `PMIX_EVENT_STAYS_LOCAL`), up-calls
    `pmix_host_server.notify_event` so the host can broadcast beyond
@@ -364,6 +365,14 @@ Do not confuse them:
   the oldest occupant when full. Entries are checked out (and
   released) when replayed, when all custom targets have been notified,
   or on eviction.
+
+  Three places check an event in, and knowing which is which saves
+  re-deriving it: `_notify_client_event` parks **every** event a server
+  role fans out (a tool included — that call is how a tool delivers a
+  forwarded event to itself); `pmix_notify_server_of_event` parks a
+  `PMIX_RANGE_PROC_LOCAL` one it did not send; and
+  `pmix_event_notify_complete` parks a *forwarded* event that the
+  receiving process's own handlers all declined.
 - **The `PMIX_REPORT_EVENT` aggregation window**
   (`pmix_globals.cached_events` + the `event_window` timer +
   `pmix_event_timeout_cb`). Purpose: coalesce *internally generated*
@@ -375,6 +384,56 @@ Do not confuse them:
   must stay at the end; that is why the macro prepends). When the timer
   fires, the chain is pushed through the server fan-out (server role)
   or the local chain (everyone else).
+
+## The fan-out filter is a fast path, not the authority
+
+**`_notify_client_event` matches a peer on the event code and nothing
+else about that peer's registrations.** This is the single most important
+thing to get right when touching the fan-out, and it was wrong until
+August 2026: the loop also required the event's affected procs to
+intersect `pr->affected`, the affected-proc list carried by one
+registration *message*.
+
+That cannot work, because a peer's handlers do not agree on it and the
+server is not told when they disagree. `_add_hdlr` sends a registration
+message only when a code is new to this server **or** the handler carries
+directives — so a handler registered afterwards for an already-active
+code with no restrictions sends nothing at all, and the server's one
+record still says what some earlier handler asked for. The result was a
+silently dropped event: register a handler restricted to process P and
+then a general handler for the same code, and the general one stops
+seeing the code. Nor can the record be repaired by bookkeeping —
+`pmix_server_deregister_events` clears *every* entry a peer holds for a
+code, because nothing in a deregistration says which handler it belongs
+to.
+
+So the division of labor is:
+
+- **the server filters on the code** (plus the event's own
+  `PMIX_EVENT_CUSTOM_RANGE` targets and the default-handler/nondefault
+  rule, both of which are properties of the *event*, not of a
+  registration);
+- **the receiving process filters per handler**, on the source range and
+  the affected procs, in `pmix_invoke_local_event_hdlr` — the only place
+  that knows what each handler asked for;
+- **anything the receiver then declined is parked**
+  (`pmix_event_notify_complete`), because a handler registering a moment
+  later may want it.
+
+A corollary worth remembering when reading the fan-out: **a handler's
+source range never leaves its own process.**
+`pmix_internal_reg_event_hdlr` consumes `PMIX_RANGE` and
+`PMIX_EVENT_CUSTOM_RANGE` and does not put either on the `xfer` list, and
+`pmix_peer_events_info_t` has no range member. An event forwarded to a
+process whose only handler for that code registered a range is therefore
+routine, and arriving-and-matching-nothing is an ordinary outcome rather
+than a corner case. `pmix_peer_events_info_t::affected` is still recorded
+— `_check_cached_events` replays against it — it just does not gate
+delivery.
+
+Covered by [`test/unit/event_forward.c`](../../test/unit/event_forward.c),
+whose two cases drive a real client behind a real socket; each fails
+against the unfixed library.
 
 ## Threading and ownership rules
 

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -285,6 +285,19 @@ PMIX_EXPORT pmix_status_t pmix_prep_event_chain(pmix_event_chain_t *chain, const
  * affected, plus any additional info provided by the server */
 PMIX_EXPORT void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain);
 
+/* The completion of a chain built from an event our server forwarded to
+ * us: park the event if nothing accepted it, then release the chain.
+ * pmix_client_notify_recv hangs it on chain->final_cbfunc with the chain
+ * itself as final_cbdata.
+ *
+ * It lives here rather than in src/client because parking an event is
+ * event-layer business, and because the tool's receive path used to
+ * carry its own copy of it - reachable from nowhere, since a tool hands
+ * its forwarded events to pmix_server_notify_client_of_event and never
+ * walks a handler list against the chain it built (see the comment on
+ * release_chain in src/tool/pmix_tool.c, and openpmix#4101). */
+PMIX_EXPORT void pmix_event_notify_complete(pmix_status_t status, void *cbdata);
+
 PMIX_EXPORT bool pmix_notify_check_range(pmix_range_trkr_t *rng, const pmix_proc_t *proc);
 
 PMIX_EXPORT bool pmix_notify_check_affected(pmix_proc_t *interested, size_t ninterested,

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -215,6 +215,92 @@ pmix_status_t pmix_notify_event_cache(pmix_notify_caddy_t *cd)
     return rc;
 }
 
+/* Completion of a chain built from an event our server forwarded to us -
+ * see the declaration in pmix_event.h for where it is used and why it
+ * lives here.
+ *
+ * A forwarded event that matched no local handler is parked in the
+ * notification cache so a handler registering a moment later still gets
+ * it, exactly as the server parks the events it fans out. That an event
+ * can arrive here unmatched at all is not a corner case: the server's
+ * fan-out filters on the code alone, while this process filters each
+ * handler on the event's source range and affected procs as well, and
+ * the handler's range is never sent to the server (see the note in
+ * _notify_client_event). So an event no handler accepts is an ordinary
+ * outcome of a registration that named a range, and dropping it here
+ * cost a later registrant an event the cache exists to preserve. */
+void pmix_event_notify_complete(pmix_status_t status, void *cbdata)
+{
+    pmix_event_chain_t *chain = (pmix_event_chain_t *) cbdata;
+    pmix_notify_caddy_t *cd;
+    size_t n;
+    pmix_status_t rc;
+
+    PMIX_ACQUIRE_OBJECT(chain);
+
+    if (PMIX_ERR_NOT_FOUND != status || chain->cached) {
+        PMIX_RELEASE(chain);
+        return;
+    }
+
+    cd = PMIX_NEW(pmix_notify_caddy_t);
+    if (NULL == cd) {
+        PMIX_RELEASE(chain);
+        return;
+    }
+    cd->status = chain->status;
+    PMIX_LOAD_PROCID(&cd->source, chain->source.nspace, chain->source.rank);
+    cd->range = chain->range;
+    /* nondefault can only have come from a directive in the info array,
+     * so this is a no-op when there is none - but read it unconditionally
+     * rather than from inside the guard below, where it looked like a
+     * defect every time somebody read this function */
+    cd->nondefault = chain->nondefault;
+    if (0 < chain->ninfo) {
+        cd->ninfo = chain->ninfo;
+        PMIX_INFO_CREATE(cd->info, cd->ninfo);
+        if (NULL == cd->info) {
+            cd->ninfo = 0;
+            goto relcd;
+        }
+        for (n = 0; n < cd->ninfo; n++) {
+            PMIX_INFO_XFER(&cd->info[n], &chain->info[n]);
+        }
+    }
+    if (NULL != chain->targets) {
+        cd->ntargets = chain->ntargets;
+        PMIX_PROC_CREATE(cd->targets, cd->ntargets);
+        if (NULL == cd->targets) {
+            cd->ntargets = 0;
+            goto relcd;
+        }
+        memcpy(cd->targets, chain->targets, cd->ntargets * sizeof(pmix_proc_t));
+    }
+    if (NULL != chain->affected) {
+        cd->naffected = chain->naffected;
+        PMIX_PROC_CREATE(cd->affected, cd->naffected);
+        if (NULL == cd->affected) {
+            cd->naffected = 0;
+            goto relcd;
+        }
+        memcpy(cd->affected, chain->affected, cd->naffected * sizeof(pmix_proc_t));
+    }
+    rc = pmix_notify_event_cache(cd);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto relcd;
+    }
+    chain->cached = true;
+    PMIX_RELEASE(chain);
+    return;
+
+relcd:
+    /* the caddy never reached the cache, so nothing else will free it -
+     * releasing only the chain would leak everything already copied in */
+    PMIX_RELEASE(cd);
+    PMIX_RELEASE(chain);
+}
+
 /* as a client, we pass the notification to our server */
 pmix_status_t pmix_notify_server_of_event(pmix_status_t status, const pmix_proc_t *source,
                                           pmix_data_range_t range, const pmix_info_t info[],
@@ -1344,12 +1430,27 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                     if (matched) {
                         continue;
                     }
-                    /* check if the affected procs (if given) match those they
-                     * wanted to know about */
-                    if (!pmix_notify_check_affected(cd->affected, cd->naffected, pr->affected,
-                                                    pr->naffected)) {
-                        continue;
-                    }
+                    /* Deliberately NOT filtered on pr->affected here. That
+                     * array is the affected-proc restriction carried by one
+                     * registration *message*, and a peer's handlers do not
+                     * agree on it: _add_hdlr sends a message only when a
+                     * code is new to us or the handler carries directives,
+                     * so a handler registered later for an already-active
+                     * code with no restriction at all never tells us it
+                     * exists. Filtering on the one record we hold therefore
+                     * dropped events that an unrestricted local handler had
+                     * asked for, and no deregistration can restore the
+                     * distinction either (it clears every entry the peer
+                     * holds for the code).
+                     *
+                     * So this filter matches on the code alone and is a fast
+                     * path, not the authority: the receiving process applies
+                     * the affected-proc and source-range restrictions per
+                     * handler in pmix_invoke_local_event_hdlr, which is the
+                     * only place that knows what each handler asked for.
+                     * pmix_peer_events_info_t still records what the message
+                     * said - it is what _check_cached_events replays
+                     * against - it just does not gate delivery. */
                     if (!PMIX_PEER_IS_TOOL(pmix_globals.mypeer) && NULL != cd->targets) {
                         rngtrk.procs = cd->targets;
                         rngtrk.nprocs = cd->ntargets;

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -1128,8 +1128,15 @@ easy to get wrong.
 deregistration has to clear them all.** The client library packs a
 handler's *whole* code list whenever any code in that list is new to this
 server, so a client that registers one handler for `{A}` and a second for
-`{A, B}` sends both lists and we record `A` twice — deliberately, since
-each entry carries that handler's own `PMIX_EVENT_AFFECTED_PROC` filter.
+`{A, B}` sends both lists and we record `A` twice — each entry carrying
+that handler's own `PMIX_EVENT_AFFECTED_PROC` filter. **That filter does
+not gate delivery**, and must not: a handler registered later for an
+already-active code sends no message at all, so the entries we hold do
+not describe every handler the peer has. `_notify_client_event` forwards
+on the code alone and the receiver filters per handler — see the fan-out
+section of [`src/event/AGENTS.md`](../event/AGENTS.md). What still reads
+the recorded filter is `_check_cached_events`, replaying against the
+registration that is in front of it.
 It then sends exactly one deregistration for `A`, when its last handler
 for `A` goes away. `pmix_server_deregister_events` stopped at the first
 match and left the rest behind for the life of the connection: the server

--- a/src/tool/AGENTS.md
+++ b/src/tool/AGENTS.md
@@ -476,13 +476,14 @@ named are the ones that fail against the unfixed library.
     handshake later than five seconds.
 14. **FIXED (consistency, not an observed failure) —
     `pmix_tool_notify_recv` never stored the unpacked range on the chain
-    and never ran `pmix_prep_event_chain`.** Those fields are what
-    `_notify_complete` builds a *parked* event out of when no handler
-    matches, so a parked event would carry `PMIX_RANGE_UNDEF` and no
-    affected procs. No arrangement was found that gets a server-forwarded
-    event into that branch — the server filters on the tool's registered
-    codes and affected procs before forwarding — so treat this as keeping
-    the two recv paths saying the same thing.
+    and never ran `pmix_prep_event_chain`.** This was justified at the
+    time by what the parking branch below it would have read; that branch
+    has since been shown to be unreachable here and removed (see *Still
+    open*), and nothing else reads those fields off this chain —
+    `pmix_server_notify_client_of_event` is handed the info array and
+    works the range, targets and affected procs out for itself. Keep them
+    in step anyway, so a reader comparing the two recv paths does not
+    have to derive that the difference does not matter.
 15. **FIXED — malformed directives were dereferenced.**
     `PMIX_TOOL_NSPACE`, `PMIX_SERVER_TMPDIR` and `PMIX_SYSTEM_TMPDIR` each
     went straight to `strdup()`, so a caller that supplied the key with
@@ -491,24 +492,43 @@ named are the ones that fail against the unfixed library.
 
 ### Still open
 
-- **The tool's event cache in `_notify_complete` looks unreachable, and
-  `src/client` has no equivalent branch at all.** See item 14 and
+- **RESOLVED — the tool's event cache in `_notify_complete` was dead
+  code, and it was dead for a reason nobody had spotted.**
   [openpmix#4101](https://github.com/openpmix/openpmix/issues/4101).
-  What is *no longer* open is the branch itself: it indexed an unchecked
-  `PMIX_INFO_CREATE` and an unchecked `PMIX_PROC_CREATE`, and its
-  allocation-failure arms fell straight into the chain release, leaking
-  the caddy with everything already copied into it. Those are fixed, and
-  the same two allocations were fixed in the event layer's copy of this
-  block (`_notify_client_event` in
-  [`pmix_event_notification.c`](../event/pmix_event_notification.c) —
-  the two are copy-paste siblings, so check both when you touch either).
-  Note the `cd->nondefault` assignment sitting inside the
-  `0 < chain->ninfo` guard is **not** a defect: `nondefault` is only
-  ever set from a `PMIX_EVENT_NON_DEFAULT` directive in the info array,
-  so it cannot be true when there is no info. What remains open is the
-  question the issue is about — whether a server-forwarded event can
-  reach a tool with no handler for it, and whether a client should cache
-  one when it does — which is an event-delivery semantics decision.
+  The branch parked an event when its completion was told
+  `PMIX_ERR_NOT_FOUND` — but that status comes from
+  `pmix_invoke_local_event_hdlr`, and **a tool never runs its chain
+  through it**. `pmix_tool_notify_recv` hands the event to
+  `pmix_server_notify_client_of_event`, which caches it, fans it out to
+  any tools connected to us, and walks our handlers against a chain of
+  its own making; the status our completion is then given is the
+  *notification's*, never a report that nothing matched. The chain the
+  tool builds is a carrier, nothing more.
+
+  So the parking code has moved to where it can fire — the client, whose
+  `pmix_client_notify_recv` really does call
+  `pmix_invoke_local_event_hdlr` and which used to drop such an event —
+  and now lives once, as `pmix_event_notify_complete` in
+  [`pmix_event_notification.c`](../event/pmix_event_notification.c).
+  What is left here is `release_chain`, which releases the carrier and
+  says why it is not that function. **Note the roles are not
+  asymmetric in behavior and never were**: a tool has always parked
+  *every* forwarded event, through the hotel check-in at the top of
+  `_notify_client_event`; what it never had was a way to reach its own
+  second copy of the code.
+
+  The earlier note that an event no handler wants "cannot arrive at the
+  tool at all, because the server filters on codes and affected procs"
+  was wrong twice over, and is worth knowing about because both halves
+  bite elsewhere. The server does not filter on a handler's *source
+  range* — that never leaves the registering process — so an unmatched
+  event arrives routinely. And it should never have been filtering on
+  affected procs either; that filter dropped events and is gone (see
+  [`src/event/AGENTS.md`](../event/AGENTS.md)).
+
+  Covered by [`test/unit/event_forward.c`](../../test/unit/event_forward.c),
+  which drives a real client behind a real socket; both of its cases
+  fail against the unfixed library.
 - **FIXED — the relay assumed both peers negotiated the same bfrops
   module and buffer type.** `pmix_tool_relay_op` copies the downstream
   tool's raw payload into a fresh buffer and sends it to `myserver`

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -115,75 +115,25 @@ static void pdiedfn(int fd, short flags, void *arg)
                       _pdiedcb, (void*)cb);
 }
 
-static void _notify_complete(pmix_status_t status, void *cbdata)
+/* Release the carrier chain once pmix_server_notify_client_of_event has
+ * finished with the event it was built from. That call is where a tool's
+ * local delivery happens: it caches the event, fans it out to any tools
+ * connected to us, and walks our own handlers against a chain of its own
+ * making. So this chain never visits a handler list, and the status
+ * handed here is the notification's, not a report of whether anything
+ * matched.
+ *
+ * That is why this is not pmix_event_notify_complete, which parks an
+ * event nothing accepted: the client hangs that on final_cbfunc because
+ * its chain really is the one walked, and a tool has no equivalent
+ * moment. The tool carried a copy of the parking code here for years
+ * with no way to reach it - see openpmix#4101. */
+static void release_chain(pmix_status_t status, void *cbdata)
 {
     pmix_event_chain_t *chain = (pmix_event_chain_t *) cbdata;
-    pmix_notify_caddy_t *cd;
-    size_t n;
-    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(status);
 
     PMIX_ACQUIRE_OBJECT(chain);
-
-    /* if the event wasn't found, then cache it as it might
-     * be registered later */
-    if (PMIX_ERR_NOT_FOUND == status && !chain->cached) {
-        cd = PMIX_NEW(pmix_notify_caddy_t);
-        if (NULL == cd) {
-            goto cleanup;
-        }
-        cd->status = chain->status;
-        PMIX_LOAD_PROCID(&cd->source, chain->source.nspace, chain->source.rank);
-        cd->range = chain->range;
-        if (0 < chain->ninfo) {
-            cd->ninfo = chain->ninfo;
-            PMIX_INFO_CREATE(cd->info, cd->ninfo);
-            if (NULL == cd->info) {
-                cd->ninfo = 0;
-                goto relcd;
-            }
-            cd->nondefault = chain->nondefault;
-            /* need to copy the info */
-            for (n = 0; n < cd->ninfo; n++) {
-                PMIX_INFO_XFER(&cd->info[n], &chain->info[n]);
-            }
-        }
-        if (NULL != chain->targets) {
-            cd->ntargets = chain->ntargets;
-            PMIX_PROC_CREATE(cd->targets, cd->ntargets);
-            if (NULL == cd->targets) {
-                cd->ntargets = 0;
-                goto relcd;
-            }
-            memcpy(cd->targets, chain->targets, cd->ntargets * sizeof(pmix_proc_t));
-        }
-        if (NULL != chain->affected) {
-            cd->naffected = chain->naffected;
-            PMIX_PROC_CREATE(cd->affected, cd->naffected);
-            if (NULL == cd->affected) {
-                cd->naffected = 0;
-                goto relcd;
-            }
-            memcpy(cd->affected, chain->affected, cd->naffected * sizeof(pmix_proc_t));
-        }
-        /* cache it */
-        rc = pmix_notify_event_cache(cd);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(cd);
-            goto cleanup;
-        }
-        chain->cached = true;
-    }
-    PMIX_RELEASE(chain);
-    return;
-
-relcd:
-    /* the caddy never reached the cache, so nothing else will free it -
-     * the affected-array arm used to fall straight into the chain release
-     * below and leak everything the caddy had already been given */
-    PMIX_RELEASE(cd);
-
-cleanup:
     PMIX_RELEASE(chain);
 }
 
@@ -207,10 +157,11 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         return;
     }
 
-    /* start the local notification chain */
+    /* Build the chain we will hand to pmix_server_notify_client_of_event
+     * below. No final_cbfunc: nothing walks a handler list against this
+     * chain, so there is no completion for one to be the completion of.
+     * See release_chain above. */
     chain = PMIX_NEW(pmix_event_chain_t);
-    chain->final_cbfunc = _notify_complete;
-    chain->final_cbdata = chain;
 
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, buf, &cmd, &cnt, PMIX_COMMAND);
@@ -276,23 +227,15 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
         range = PMIX_RANGE_LOCAL;
     }
-    /* Record the range on the chain, and translate the directives the
+    /* Record the range on the chain and translate the directives the
      * event carried into the chain's own fields, the way the client's
-     * equivalent (pmix_client_notify_recv) always has. It matters because
-     * of what happens when no handler matches: _notify_complete parks the
-     * event for a handler that registers later, and it builds that parked
-     * copy out of chain->range, chain->nondefault, chain->targets and
-     * chain->affected. Left at their constructed defaults, the parked
-     * event has PMIX_RANGE_UNDEF and no affected procs - restrictions
-     * every later check then accepts.
-     *
-     * Be clear about the reach of this: no arrangement was found that
-     * gets a server-forwarded event into that branch, because the server
-     * filters on the tool's registered codes and affected procs before it
-     * forwards anything, so a mismatched event never arrives to be
-     * parked. This keeps the two recv paths saying the same thing and
-     * makes the branch right if it is ever entered; it is not a fix for
-     * an observed failure. */
+     * equivalent (pmix_client_notify_recv) always has. Nothing below
+     * reads them from here - pmix_server_notify_client_of_event is given
+     * the info array and works out the range, targets and affected procs
+     * for itself - so this is consistency between the two recv paths
+     * rather than a fix for an observed failure. Keep them in step: a
+     * reader comparing the two should not have to work out that the
+     * difference does not matter. */
     chain->range = range;
     pmix_prep_event_chain(chain, chain->info, ninfo, false);
 
@@ -317,7 +260,7 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         chain->source.nspace, chain->source.rank);
 
     rc = pmix_server_notify_client_of_event(chain->status, &chain->source, range,
-                                            chain->info, chain->ninfo, _notify_complete, chain);
+                                            chain->info, chain->ninfo, release_chain, chain);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(chain);

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -318,6 +318,47 @@ under either, so it cannot fail on them. That half is
 separate nodes by
 [`contrib/dockerswarm/run-bfrops-tests.sh`](../../contrib/dockerswarm/AGENTS.md).
 
+### `event_forward` — what a server forwards, and what a client keeps
+
+[`event_forward.c`](event_forward.c) is the only program here that runs a
+real **client** against a real server, and it has to: both behaviors it
+pins down live on the socket between them. It registers an nspace, forks,
+and **execs itself** with a `client` argument — an exec rather than a bare
+fork, because the parent has an initialized PMIx server in it and
+`PMIx_Init` in a forked child finds the one-time-init latch already set.
+
+Two cases, from [openpmix#4101](https://github.com/openpmix/openpmix/issues/4101):
+
+- the server's fan-out must not drop an event a local handler wanted. The
+  client registers a handler restricted to one process and then an
+  unrestricted one — which sends nothing to the server, the code being
+  already active — and the event names a third process;
+- an event the client's handlers all declined must be parked and replayed
+  to a handler registering afterwards. The declining handler restricts on
+  its *source range*, which never leaves the client's process, so the
+  server forwards an event it has no way to know is unwanted.
+
+Both fail against the unfixed library, which was checked by reverting
+each fix independently.
+
+**Passing the parent's environment to the exec is load-bearing**, and
+getting it wrong produces a very convincing false result. Handing
+`execve` only what `PMIx_server_setup_fork` produces strands the child
+without the library search path — and libtool starts an
+uninstalled test through a wrapper script that sets exactly that — so the
+child silently runs against the *installed* PMIx instead of the one under
+test. That is the stale-install trap from
+[`src/client/AGENTS.md`](../../src/client/AGENTS.md) wearing a different
+hat: the parent behaves correctly, the child behaves like last month's
+library, and the disagreement looks like a bug in the code under review.
+`PMIx_Argv_copy(environ)` first, then `PMIx_server_setup_fork`, exactly
+as `test/simple/simptest.c` does.
+
+The second case's blocking round trip is the other load-bearing detail:
+it puts the notification ahead of the second registration on the same
+socket, so a library that parks nothing cannot pass by delivering the
+event live.
+
 ### `server_get` — the server-side `PMIx_Get` regression test
 
 [`server_get.c`](server_get.c) comes up as a PMIx server with a stub host

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_inherit proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_inherit proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary event_forward
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_inherit proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_inherit proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary event_forward
 
 client_api_SOURCES = \
         client_api.c
@@ -330,6 +330,12 @@ tool_evcache_SOURCES = \
         tool_evcache.c
 tool_evcache_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 tool_evcache_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+event_forward_SOURCES = \
+        event_forward.c
+event_forward_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+event_forward_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 tool_relay_SOURCES = \

--- a/test/unit/event_forward.c
+++ b/test/unit/event_forward.c
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * What a PMIx server decides to forward, and what the receiving client
+ * does with an event none of its handlers accepted. Both halves of that
+ * were wrong, and both need a real client behind a real socket - which
+ * is why this program forks and execs itself rather than driving the
+ * library in one process.
+ *
+ * Case 1 - the server's fan-out filter must not drop an event a local
+ * handler wanted. The filter matches on the event code; it deliberately
+ * does not consult the affected-proc list a registration carried,
+ * because that list belongs to one registration *message* and a peer's
+ * handlers do not agree on it. The client here registers a handler
+ * restricted to one process and then a second handler with no
+ * restriction at all - the second sends no message, since the code is
+ * already active and it carries no directives - and the event names a
+ * third process. Only the unrestricted handler may fire.
+ *
+ * Case 2 - an event that arrived and matched nothing must be parked, so
+ * a handler registering a moment later still gets it. The client
+ * registers a handler whose *source range* excludes the server, which
+ * the server cannot know (a handler's range never leaves its own
+ * process), so the event is forwarded, rejected locally, and has
+ * nowhere to go but the cache. A second handler then registers and must
+ * be given it.
+ *
+ * The ordering in case 2 is what makes it an assertion rather than a
+ * race: the client makes a blocking round trip to the server before
+ * registering the second handler, and the notification travels the same
+ * socket ahead of that reply, so the event has been received and
+ * rejected by the time the second handler exists. Without that, a
+ * library that never parks anything would still pass by delivering the
+ * event live.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern char **environ;
+
+/* codes with no meaning to the library, so nothing else reacts to them */
+#define CODE_DROP  (PMIX_EXTERNAL_ERR_BASE - 51)
+#define CODE_PARK  (PMIX_EXTERNAL_ERR_BASE - 52)
+
+#define NSPACE     "event-fwd"
+/* processes that are neither the client nor each other */
+#define NS_ASKED   "event-fwd-asked-about"
+#define NS_HAPPENED "event-fwd-happened-to"
+
+/* how long to wait for a handler that must fire, and for one that must not */
+#define LOUD_SECS  20
+#define QUIET_SECS 2
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed, const char *detail)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        ++npass;
+    } else {
+        fprintf(stdout, "  FAIL: %s (%s)\n", name, NULL == detail ? "" : detail);
+        ++nfail;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* the client                                                         */
+/* ------------------------------------------------------------------ */
+
+static volatile int fired_restricted = 0;
+static volatile int fired_open = 0;
+static volatile int fired_ranged = 0;
+static volatile int fired_late = 0;
+
+static void count_hdlr(volatile int *counter, pmix_event_notification_cbfunc_fn_t cbfunc,
+                       void *cbdata)
+{
+    ++(*counter);
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void hdlr_restricted(size_t id, pmix_status_t status, const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo, pmix_info_t results[],
+                            size_t nresults, pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    (void) id; (void) status; (void) source; (void) info; (void) ninfo;
+    (void) results; (void) nresults;
+    count_hdlr(&fired_restricted, cbfunc, cbdata);
+}
+
+static void hdlr_open(size_t id, pmix_status_t status, const pmix_proc_t *source,
+                      pmix_info_t info[], size_t ninfo, pmix_info_t results[], size_t nresults,
+                      pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    (void) id; (void) status; (void) source; (void) info; (void) ninfo;
+    (void) results; (void) nresults;
+    count_hdlr(&fired_open, cbfunc, cbdata);
+}
+
+static void hdlr_ranged(size_t id, pmix_status_t status, const pmix_proc_t *source,
+                        pmix_info_t info[], size_t ninfo, pmix_info_t results[], size_t nresults,
+                        pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    (void) id; (void) status; (void) source; (void) info; (void) ninfo;
+    (void) results; (void) nresults;
+    count_hdlr(&fired_ranged, cbfunc, cbdata);
+}
+
+static void hdlr_late(size_t id, pmix_status_t status, const pmix_proc_t *source,
+                      pmix_info_t info[], size_t ninfo, pmix_info_t results[], size_t nresults,
+                      pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    (void) id; (void) status; (void) source; (void) info; (void) ninfo;
+    (void) results; (void) nresults;
+    count_hdlr(&fired_late, cbfunc, cbdata);
+}
+
+static void reg_cbfunc(pmix_status_t status, size_t refid, void *cbdata)
+{
+    pmix_status_t *sp = (pmix_status_t *) cbdata;
+    (void) refid;
+    *sp = status;
+}
+
+/* register one handler and block until the registration is acknowledged.
+ * The info array must stay alive across the wait - the library does not
+ * copy it - which is why it is the caller's and not built in here. */
+static pmix_status_t register_hdlr(pmix_status_t code, pmix_info_t *info, size_t ninfo,
+                                   pmix_notification_fn_t fn)
+{
+    pmix_status_t regstatus = PMIX_ERR_WOULD_BLOCK;
+    int i;
+
+    PMIx_Register_event_handler(&code, 1, info, ninfo, fn, reg_cbfunc, (void *) &regstatus);
+    for (i = 0; i < 400 && PMIX_ERR_WOULD_BLOCK == regstatus; i++) {
+        usleep(50000);
+    }
+    return regstatus;
+}
+
+static int wait_fires(volatile int *counter, int secs)
+{
+    int i;
+
+    for (i = 0; i < secs * 10; i++) {
+        if (0 < *counter) {
+            break;
+        }
+        usleep(100000);
+    }
+    return *counter;
+}
+
+/* A blocking round trip to the server, used only for its ordering: the
+ * notification the server sent before this went out travels the same
+ * socket, so it has been received and processed by the time we return.
+ *
+ * A query rather than a get: a get for a key nobody has posted parks
+ * until the key appears, which would simply hang. This server has no
+ * host query interface, so the request comes back as soon as the server
+ * has looked at it. */
+static void round_trip(void)
+{
+    pmix_query_t *query;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    pmix_status_t rc;
+
+    PMIX_QUERY_CREATE(query, 1);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_NAMESPACES);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_QUERY_FREE(query, 1);
+        return;
+    }
+    (void) PMIx_Query_info(query, 1, &results, &nresults);
+    PMIX_QUERY_FREE(query, 1);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+}
+
+static int sync_with_server(int readyfd, int gofd)
+{
+    char c = 'r';
+
+    if (1 != write(readyfd, &c, 1)) {
+        return 0;
+    }
+    if (1 != read(gofd, &c, 1)) {
+        return 0;
+    }
+    return 1;
+}
+
+static int run_client(int readyfd, int gofd)
+{
+    pmix_proc_t myproc, asked, rngproc;
+    pmix_info_t info[2];
+    pmix_status_t rc;
+    pmix_data_range_t range = PMIX_RANGE_CUSTOM;
+    int fires;
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "  client: PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* ---- case 1: an affected-restricted registration must not speak
+     * for the handlers registered after it ---- */
+    PMIX_LOAD_PROCID(&asked, NS_ASKED, 0);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_AFFECTED_PROC, &asked, PMIX_PROC);
+    rc = register_hdlr(CODE_DROP, info, 1, hdlr_restricted);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    if (0 > rc) {
+        fprintf(stderr, "  client: restricted registration failed: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    /* no directives and the code is already active, so this registration
+     * is never sent to the server - the server's record of what we want
+     * still says only what the handler above asked for */
+    rc = register_hdlr(CODE_DROP, NULL, 0, hdlr_open);
+    if (0 > rc) {
+        fprintf(stderr, "  client: unrestricted registration failed: %s\n",
+                PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (!sync_with_server(readyfd, gofd)) {
+        goto done;
+    }
+
+    fires = wait_fires(&fired_open, LOUD_SECS);
+    report("an unrestricted handler receives an event the server was told "
+           "another handler did not want",
+           1 == fires, "the server dropped it");
+    report("the restricted handler is not given an event about a process it "
+           "did not ask about",
+           0 == fired_restricted, "it fired");
+
+    /* ---- case 2: an event nothing accepted is parked for a handler
+     * that registers later ---- */
+    PMIX_LOAD_PROCID(&rngproc, NS_ASKED, PMIX_RANK_WILDCARD);
+    PMIX_INFO_LOAD(&info[0], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_CUSTOM_RANGE, &rngproc, PMIX_PROC);
+    rc = register_hdlr(CODE_PARK, info, 2, hdlr_ranged);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    if (0 > rc) {
+        fprintf(stderr, "  client: range-restricted registration failed: %s\n",
+                PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (!sync_with_server(readyfd, gofd)) {
+        goto done;
+    }
+
+    /* order ourselves behind the notification the server has now sent */
+    round_trip();
+
+    fires = wait_fires(&fired_ranged, QUIET_SECS);
+    report("a handler is not given an event from a source outside the range "
+           "it registered with",
+           0 == fires, "it fired");
+
+    /* registering this one replays anything parked that it matches. It
+     * carries no directives and CODE_PARK is already active, so nothing
+     * about this registration reaches the server: whatever it sees came
+     * out of our own cache */
+    rc = register_hdlr(CODE_PARK, NULL, 0, hdlr_late);
+    if (0 > rc) {
+        fprintf(stderr, "  client: late registration failed: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    fires = wait_fires(&fired_late, LOUD_SECS);
+    report("an event no handler accepted is parked and replayed to a handler "
+           "that registers afterwards",
+           1 == fires, "it was dropped");
+
+done:
+    PMIx_Finalize(NULL, 0);
+    fprintf(stdout, "  client: %d passed, %d failed\n", npass, nfail);
+    return (0 == nfail && 4 == npass) ? 0 : 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* the server                                                         */
+/* ------------------------------------------------------------------ */
+
+static volatile bool regdone = false;
+static volatile int notified = 0;
+
+static void regcbfunc(pmix_status_t status, void *cbdata)
+{
+    (void) status; (void) cbdata;
+    regdone = true;
+}
+
+static void opcbfunc(pmix_status_t status, void *cbdata)
+{
+    (void) status; (void) cbdata;
+    ++notified;
+}
+
+static pmix_server_module_t mymodule = {0};
+
+static pmix_status_t register_job(void)
+{
+    pmix_info_t info[4];
+    pmix_proc_t proc;
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    char *noderegex = NULL, *ppnregex = NULL;
+    uint32_t nprocs = 1;
+    int i;
+
+    PMIx_generate_regex(pmix_globals.hostname, &noderegex);
+    PMIx_generate_ppn("0", &ppnregex);
+    PMIX_INFO_LOAD(&info[0], PMIX_NODE_MAP, noderegex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&info[1], PMIX_PROC_MAP, ppnregex, PMIX_REGEX);
+    PMIX_INFO_LOAD(&info[2], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&info[3], PMIX_UNIV_SIZE, &nprocs, PMIX_UINT32);
+
+    /* a pmix_nspace_t rather than the literal: the API takes a
+     * fixed-size array, and gcc rejects a shorter literal outright */
+    PMIX_LOAD_NSPACE(ns, NSPACE);
+    rc = PMIx_server_register_nspace(ns, 1, info, 4, NULL, NULL);
+    for (i = 0; i < 4; i++) {
+        PMIX_INFO_DESTRUCT(&info[i]);
+    }
+    free(noderegex);
+    free(ppnregex);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+
+    PMIX_LOAD_PROCID(&proc, NSPACE, 0);
+    rc = PMIx_server_register_client(&proc, geteuid(), getegid(), NULL, regcbfunc, NULL);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        return PMIX_SUCCESS;
+    }
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    /* don't fork the client until it is registered */
+    for (i = 0; i < 400 && !regdone; i++) {
+        usleep(50000);
+    }
+    return PMIX_SUCCESS;
+}
+
+/* send one event and do not return until the library is done with it */
+static void notify(pmix_status_t code, pmix_info_t *info, size_t ninfo)
+{
+    int i, was = notified;
+
+    PMIx_Notify_event(code, &pmix_globals.myid, PMIX_RANGE_LOCAL, info, ninfo, opcbfunc, NULL);
+    /* PMIx_Notify_event does not copy the directives - the caller keeps
+     * them alive until the callback fires */
+    for (i = 0; i < 200 && notified == was; i++) {
+        usleep(50000);
+    }
+}
+
+static int wait_readable(int fd, int secs)
+{
+    fd_set rd;
+    struct timeval tv;
+
+    FD_ZERO(&rd);
+    FD_SET(fd, &rd);
+    tv.tv_sec = secs;
+    tv.tv_usec = 0;
+    return (0 < select(fd + 1, &rd, NULL, NULL, &tv));
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_info_t sinfo, ainfo;
+    pmix_proc_t proc, happened;
+    char **client_env = NULL;
+    char *client_argv[5];
+    char fdbuf[64];
+    int readypipe[2], gopipe[2];
+    pid_t child;
+    int status = 0;
+    char c = 'g';
+    bool flag = true;
+
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
+    /* re-executed as our own client - the fd numbers ride in argv */
+    if (3 < argc && 0 == strcmp(argv[1], "client")) {
+        return run_client(atoi(argv[2]), atoi(argv[3]));
+    }
+
+    fprintf(stdout, "\n=== event forwarding and caching unit test ===\n\n");
+
+    if (0 != pipe(readypipe) || 0 != pipe(gopipe)) {
+        fprintf(stderr, "pipe() failed\n");
+        return 1;
+    }
+
+    PMIX_INFO_LOAD(&sinfo, PMIX_SERVER_TOOL_SUPPORT, &flag, PMIX_BOOL);
+    rc = PMIx_server_init(&mymodule, &sinfo, 1);
+    PMIX_INFO_DESTRUCT(&sinfo);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    rc = register_job();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "could not register the job: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+
+    PMIX_LOAD_PROCID(&proc, NSPACE, 0);
+    /* Seed the child's environment with our own before the library adds
+     * its variables. Handing execve only the PMIx variables strands the
+     * child without the library search path this program was started
+     * with - and libtool starts an uninstalled test through a wrapper
+     * script that sets exactly that - so the child would silently run
+     * against the *installed* PMIx rather than the one under test. */
+    client_env = PMIx_Argv_copy(environ);
+    rc = PMIx_server_setup_fork(&proc, &client_env);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_server_setup_fork failed: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+
+    child = fork();
+    if (0 > child) {
+        fprintf(stderr, "fork() failed\n");
+        goto done;
+    }
+    if (0 == child) {
+        /* exec rather than run in the fork: this process has an
+         * initialized PMIx server in it, and PMIx_Init would find the
+         * one-time-init latch already set */
+        close(readypipe[0]);
+        close(gopipe[1]);
+        client_argv[0] = argv[0];
+        client_argv[1] = (char *) "client";
+        snprintf(fdbuf, sizeof(fdbuf), "%d", readypipe[1]);
+        client_argv[2] = strdup(fdbuf);
+        snprintf(fdbuf, sizeof(fdbuf), "%d", gopipe[0]);
+        client_argv[3] = strdup(fdbuf);
+        client_argv[4] = NULL;
+        execve(argv[0], client_argv, client_env);
+        fprintf(stderr, "exec of %s failed\n", argv[0]);
+        _exit(127);
+    }
+    close(readypipe[1]);
+    close(gopipe[0]);
+
+    /* case 1: the event names a process neither handler asked about */
+    if (!wait_readable(readypipe[0], 60) || 1 != read(readypipe[0], &c, 1)) {
+        fprintf(stderr, "the client never reported ready\n");
+        goto reap;
+    }
+    PMIX_LOAD_PROCID(&happened, NS_HAPPENED, 0);
+    PMIX_INFO_LOAD(&ainfo, PMIX_EVENT_AFFECTED_PROC, &happened, PMIX_PROC);
+    notify(CODE_DROP, &ainfo, 1);
+    PMIX_INFO_DESTRUCT(&ainfo);
+    c = 'g';
+    if (1 != write(gopipe[1], &c, 1)) {
+        goto reap;
+    }
+
+    /* case 2: an event carrying nothing, from us - a source the client's
+     * only handler for this code has excluded */
+    if (!wait_readable(readypipe[0], 60) || 1 != read(readypipe[0], &c, 1)) {
+        fprintf(stderr, "the client never reported ready a second time\n");
+        goto reap;
+    }
+    notify(CODE_PARK, NULL, 0);
+    c = 'g';
+    if (1 != write(gopipe[1], &c, 1)) {
+        goto reap;
+    }
+
+reap:
+    waitpid(child, &status, 0);
+    if (WIFEXITED(status)) {
+        status = WEXITSTATUS(status);
+    } else {
+        fprintf(stderr, "the client died on a signal\n");
+        status = 1;
+    }
+
+done:
+    PMIx_server_finalize();
+    if (NULL != client_env) {
+        PMIx_Argv_free(client_env);
+    }
+    if (0 != status) {
+        fprintf(stdout, "\n=== FAILED ===\n\n");
+        return 1;
+    }
+    fprintf(stdout, "\n=== PASSED ===\n\n");
+    return 0;
+}

--- a/test/unit/tool_evcache.c
+++ b/test/unit/tool_evcache.c
@@ -33,18 +33,18 @@
  *   5. the server notifies the code about Z, and B must fire - so the
  *      test cannot pass by never delivering anything at all.
  *
- * WHAT THIS DOES NOT REACH, and it is worth knowing before extending it.
- * The original target was the tool's *cached*-event path: when no
- * handler matches, _notify_complete parks the event for a handler that
- * registers later, and it builds the parked copy out of chain->range and
- * chain->affected - which pmix_tool_notify_recv never filled in. But the
- * server filters on the tool's registered codes and affected procs
- * before forwarding, so an event no handler wants does not arrive at the
- * tool at all and is never parked. Instrumenting _notify_complete during
- * this run shows it called exactly once, with PMIX_SUCCESS. Do not
- * assume a change to that branch is covered here. Whether that branch is
- * reachable at all - src/client has no equivalent - is
- * openpmix#4101.
+ * WHERE THE PARKED EVENT COMES FROM, since this file used to say the
+ * opposite. A tool hands an event its server forwarded straight to
+ * pmix_server_notify_client_of_event, which caches it in the
+ * notification hotel, fans it out to any tools connected to us, and
+ * walks our handlers against a chain of its own. So the caching this
+ * test relies on is that one, not the copy of the parking code that
+ * used to sit in the tool's own completion callback - which was
+ * unreachable, because the chain the tool builds never visits a handler
+ * list and its completion is therefore never told that nothing matched.
+ * That dead copy is gone; the client keeps the live one
+ * (pmix_event_notify_complete). See openpmix#4101, and
+ * test/unit/event_forward.c for the client half.
  */
 
 #include "src/include/pmix_config.h"


### PR DESCRIPTION
Resolves #4101, and fixes a dropped-event bug found while investigating it.

## The server dropped events a local handler wanted

`_notify_client_event` chose which peers to forward an event to by matching the event's affected processes against `pr->affected` — the affected-proc list that peer's event registration had carried. That list describes a single registration *message*, not the peer: `_add_hdlr` sends a message only when a code is new to the server or the handler carries directives, so a handler registered afterwards for an already-active code with no restrictions never tells the server it exists.

So this loses events:

```c
/* restricted - this one is reported to the server */
PMIX_INFO_LOAD(&info, PMIX_EVENT_AFFECTED_PROC, &someproc, PMIX_PROC);
PMIx_Register_event_handler(&code, 1, &info, 1, hdlr_a, ...);

/* unrestricted - the code is already active and this carries no
 * directives, so nothing is sent, and the server's record still says
 * what hdlr_a asked for */
PMIx_Register_event_handler(&code, 1, NULL, 0, hdlr_b, ...);
```

`hdlr_b` stops seeing the code entirely. The record cannot be repaired by bookkeeping either — `pmix_server_deregister_events` clears *every* entry a peer holds for a code, because nothing in a deregistration says which handler it belongs to.

The fan-out now matches on the event code. The event's own `PMIX_EVENT_CUSTOM_RANGE` targets and the default-handler/nondefault rule stay, since those are properties of the event rather than of a registration. The affected-proc and source-range restrictions a handler registered with are enforced by the receiving process in `pmix_invoke_local_event_hdlr`, which is the only place that knows what each handler asked for. `pmix_peer_events_info_t::affected` is still recorded — `_check_cached_events` replays against it — it just no longer gates delivery.

## What the receiver does with an event nothing matched

An event can arrive matching no handler as an ordinary outcome, not a corner case: a handler's `PMIX_RANGE` / `PMIX_EVENT_CUSTOM_RANGE` never leaves its own process (`pmix_internal_reg_event_hdlr` consumes both and `pmix_peer_events_info_t` has no range member), so the server cannot filter on it. A client dropped such an event, which cost a handler registering a moment later an event the notification cache exists to preserve. It now parks it, in `pmix_event_notify_complete`.

## The `src/tool` branch in #4101 was dead, for a reason nobody had spotted

Not because the server filters ahead of it — it doesn't filter on ranges, so unmatched events reach a tool routinely. It is dead because **a tool never runs its chain through `pmix_invoke_local_event_hdlr`**: `pmix_tool_notify_recv` hands the event to `pmix_server_notify_client_of_event`, which caches it, fans it out to any tools connected to us, and walks our handlers against a chain of its own making. The chain the tool builds is a carrier, and the status its completion is given is the notification's, never a report that nothing matched. Instrumenting it shows it called exactly once, with `PMIX_SUCCESS`.

Worth being clear that the two roles were never asymmetric in *behavior*: a tool has always parked every forwarded event, through the hotel check-in at the top of `_notify_client_event`. What it never had was a way to reach its own second copy of the code. That copy is gone, replaced by a release-only callback that records why it is not `pmix_event_notify_complete`.

## Testing

New `test/unit/event_forward.c` — the only program in `make check` that drives a real client behind a real socket (registers an nspace, forks, and execs itself, since the parent holds an initialized PMIx server). One case per half; each fails against the unfixed library, verified by reverting the two fixes independently.

`make check` is 74/74 on macOS/clang, and `test/simple/run_simptest.sh` is clean. `AGENTS.md` updated in `src/event` (a new section on why the fan-out filter is a fast path rather than the authority), `src/server`, `src/tool`, `src/client` and `test/unit`, plus news entries.