### PR TITLE
Record review coverage, and retire what the tree has closed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,10 +145,8 @@ No directory under `src/mca/` may break this pattern (except `base/` subdirector
 | `pmdl` | Programming Model support — collects env-vars and parameters for MPI, OpenMP, etc. |
 | `pnet` | Network support and endpoint computation for "instant on" launch |
 | `preg` | Regular expression generator and parser; multi-select |
-| `prm` | Resource Manager translation of generic PMIx directives |
 | `psec` | Security operations (connection handshakes); multi-select |
 | `psensor` | Process monitoring, resource utilization, and health checks |
-| `psquash` | Internal integer squashing during transmission |
 | `pstat` | System statistics at process, node, and disk levels |
 | `ptl` | Transport Layer for client-server and tool-server communication; single-select |
 

--- a/docs/developers/frameworks.rst
+++ b/docs/developers/frameworks.rst
@@ -15,7 +15,6 @@ this writing |date|:
 * ``gds``: Generalized DataStore for storing job-level and other data
 * ``pcompress``: Compress to support compression of large data objects
 * ``pdl``: DLopen support
-* ``pfexec``: Fork/Exec support to allow tools to start child processes
 * ``pgpu``: GPU support
 * ``pif``: Interface discovery
 * ``pinstalldirs``: Install Directories - provides a struct containing
@@ -28,14 +27,9 @@ this writing |date|:
 * ``pnet``: Network support, including computation of endpoints to
   support the ``instant on`` launch procedure
 * ``preg``: Regular expression generator and parser
-* ``prm``: Resource Manager support - translation of generic PMIx directives
-  (e.g., mapping and resource definitions) to RM-specific values and
-  general RM-specific support
 * ``psec``: Security operations such as connection handshakes
 * ``psensor``: Sensor framework for monitoring processes, including
   resource utilization and state-of-health (e.g., heartbeat)
-* ``psquash``: Internal framework for squashing integer data values
-  during transmission
 * ``pstat``: Statistics, including reporting resource usage at the
   process, node, and disk levels
 * ``ptl``: Transport Layer for client-server and tool-server

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -50,6 +50,19 @@ each time somebody asks.
           partner of the ``__atomic_test_and_set`` that sets it), and
           ``refcb()``'s dropped store status.
 
+          **Checked again on 2026-08-15**, which retired one more: the
+          open decision about a tool caching an event nobody handled
+          while a client discarded it.  The fan-out fix for
+          `openpmix#4101 <https://github.com/openpmix/openpmix/issues/4101>`_
+          answered it — a client now parks such an event, the tool's
+          unreachable copy of the parking code is gone, and
+          ``test/unit/event_forward`` covers both halves.  Two entries
+          were corrected rather than retired, both because the code had
+          moved: the tool's SIGCONT stdin handler now lives in
+          ``src/common``, and the ``cd->nondefault`` blocks are down to
+          one that still assigns inside its guard.  Everything else was
+          re-verified against the tree and stands as written.
+
 Review coverage
 ---------------
 
@@ -197,35 +210,6 @@ flags, which re-opens the window the stand-in was built to close; or
 carry something in the IOF message that names the spawn, which is a
 wire-format and Standard question rather than a bug fix.
 
-A tool caches an event nobody handled; a client discards it
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When a local event chain in a tool ends with nothing having handled the
-event, ``_notify_complete`` in ``src/tool/pmix_tool.c`` parks a copy in
-the notification hotel so that a handler registered *later* can still be
-given it.  A client in the same position simply releases the chain — the
-equivalent branch does not exist in ``src/client/pmix_client.c``.
-
-Only one of those can be right, and choosing is a statement about
-event-delivery behavior in a released library rather than a bug fix.
-Either the tool's branch is unreachable and should go, or it is correct
-and the client is losing events a late registrant was entitled to see.
-
-Nothing has been found that reaches it.  A server forwards an event to a
-tool only if that tool registered for the code, and it applies the
-tool's affected-proc filter before forwarding, so a tool does not
-normally receive an event it has no handler for.  The one shape that
-might — an event already on the wire when the handler is deregistered —
-**has not been confirmed**, and should not be treated as evidence until
-somebody checks whether the server stops forwarding before or after the
-deregistration round-trips.
-
-What is *not* at issue is the branch's correctness if it is entered:
-its two unchecked allocations and its caddy-leaking failure arms are
-fixed, as are the same two in the event layer's copy of the block
-(``_notify_client_event``).  Tracked as
-`openpmix#4101 <https://github.com/openpmix/openpmix/issues/4101>`_.
-
 Deferred work
 -------------
 
@@ -274,11 +258,15 @@ Coverage gaps
   allocation failures and the third needs a server reply whose declared
   count exceeds its payload.  Reaching the receive path at all requires
   a client whose *local* hwloc computation failed.
-* **Two fixes in ``src/tool`` ship without regression tests** because
-  the conditions cannot be arranged in ``make check``: the SIGCONT
-  handler for forwarded stdin needs a tty, and the late-finalize-reply
-  guard needs a server that answers the finalize handshake more than
-  five seconds late.
+* **Two fixes found in ``src/tool`` ship without regression tests**
+  because the conditions cannot be arranged in ``make check``: the
+  SIGCONT handler for forwarded stdin needs a tty, and the
+  late-finalize-reply guard needs a server that answers the finalize
+  handshake more than five seconds late.  Only the second is still in
+  ``src/tool``; the stdin read event and its SIGCONT handler moved to
+  ``src/common/pmix_iof.c`` when the tool was given the library's
+  forwarding instead of its own, and are untested there for the same
+  reason.
 * **The debugger-wait teardown in ``PMIx_Init`` is not exercised.**
   Reaching it needs the debugger-stop key set on the namespace *and* the
   ``PMIX_READY_FOR_DEBUG`` notification to then fail, which no test
@@ -310,16 +298,18 @@ not "fixed" by a later reader.
   anywhere in it.  Both in-tree hosts (PRRTE and ``test/simple/simptest``)
   currently leak it.  See ``src/server/AGENTS.md``.
 
-* **The event-caching blocks assign ``cd->nondefault`` inside their**
-  ``0 < chain->ninfo`` **guard**, which reads as though a non-default
-  event carrying no info would be parked as a default one and then
-  delivered to default handlers that should not see it.  It cannot
-  happen: every path that sets ``chain->nondefault`` reads it out of a
-  ``PMIX_EVENT_NON_DEFAULT`` directive in the info array, so the flag is
-  only ever true when there is info to have carried it.  Hoisting the
-  assignment out of the guard is equivalent, not a fix.  Both copies —
-  ``_notify_complete`` in ``src/tool`` and ``_notify_client_event`` in
-  ``src/event`` — are left as they are.
+* **An event-caching block that assigns ``cd->nondefault`` inside its**
+  ``0 < ninfo`` **guard is not dropping a flag.**  It reads as though a
+  non-default event carrying no info would be parked as a default one
+  and then delivered to default handlers that should not see it.  It
+  cannot happen: every path that sets ``chain->nondefault`` reads it out
+  of a ``PMIX_EVENT_NON_DEFAULT`` directive in the info array, so the
+  flag is only ever true when there is info to have carried it.  Moving
+  the assignment out of the guard is equivalent, not a fix — two of the
+  three caching blocks now assign unconditionally only because the
+  guarded form kept being re-reported.  The third, in
+  ``pmix_notify_server_of_event``, still assigns inside the guard and is
+  equally correct.
 * **``pmix_srand()`` copies the seeded state into a file-static buffer**
   (``src/util/pmix_alfg.c``).  It looks like a footgun, but it is the
   only way to seed the global that ``pmix_random()`` reads, and the unit

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -21,6 +21,11 @@ Three kinds of entry appear here:
 Entries that are *by design* are also listed, under their own heading,
 so that they are not repeatedly "rediscovered" and re-fixed.
 
+The page opens with a fourth thing that is not an issue at all —
+**Review coverage**, which records where the deep review has and has not
+yet been, so that the remaining work is visible rather than rediscovered
+each time somebody asks.
+
 .. note:: Each directory's ``AGENTS.md`` carries the full reasoning for
           the items found in it.  Those files are orientation maps, not
           work logs, so this page is the place that records an item as
@@ -44,6 +49,100 @@ so that they are not repeatedly "rediscovered" and re-fixed.
           ``init_called`` clear (now ``pmix_atomic_clear``, the required
           partner of the ``__atomic_test_and_set`` that sets it), and
           ``refcb()``'s dropped store status.
+
+Review coverage
+---------------
+
+Assessed on **2026-08-15** from the commit history.  Move an entry out of
+"Not yet reviewed" as its review lands, and refresh the churn figures in
+"Reviewed, but changed materially since" when a re-review closes one.
+
+.. note:: **An** ``AGENTS.md`` **is not evidence of a review.**  Every
+          directory under ``src/`` has one; most were written in the July
+          2026 orientation sweep, before any review started.  What marks
+          a reviewed directory is a run of repair commits — "Repair…",
+          "Screen…", "Close the … holes", "Sweep the leftovers in…" —
+          and a commit that records the result in the guide.
+
+Reviewed and current
+^^^^^^^^^^^^^^^^^^^^
+
+``src/class``, ``src/common``, ``src/event``, ``src/include``,
+``src/runtime``, ``src/tool``, ``src/tools``, ``src/mca/base``,
+``src/mca/bfrops``, ``src/mca/gds/base``, ``src/mca/gds/hash``,
+``src/mca/ptl``, and ``bindings/python``.  ``src/client``, ``src/server``,
+``src/hwloc``, ``src/util`` and ``src/mca/gds/shmem3`` were reviewed too,
+but have moved since — see below.
+
+Not yet reviewed
+^^^^^^^^^^^^^^^^
+
+Each of these has an orientation guide and nothing else: no findings were
+ever recorded in it, and only drive-by fixes have landed.  Ordered by
+size, which is a rough proxy for how much there is to find.
+
+* ``src/mca/pstat`` (with ``plinux``, ``pmacos``, ``test``) — 4988
+  lines.  Four bug fixes on 2026-07-04, never a sweep.
+* ``src/mca/pnet`` (with ``base``, ``tcp``, ``opa``, ``nvd``,
+  ``simptest``) — 4064 lines.  Revived on 2026-07-15 and not looked at
+  since.
+* ``src/mca/preg`` (with ``native``, ``raw``, ``compress``) — 2641
+  lines.  It parses regular expressions arriving off the wire, which
+  makes it the highest-risk member of this list.
+* ``src/mca/pgpu`` (with ``amd``, ``intel``, ``nvd``, ``test``) — 2467
+  lines.  The 2026-07-15 "repair the stale components" work was not a
+  review.
+* ``src/mca/pmdl`` (with ``ompi``) — 2422 lines.
+* ``src/util/keyval`` — 2397 lines of lexer and parser, and the only
+  directory in ``src/`` with **no** ``AGENTS.md`` at all.
+* ``src/mca/pcompress`` (with ``zlib``, ``zlibng``, ``zstd``, ``lz4``) —
+  2394 lines.  ``zstd`` (2026-08-08) and ``lz4`` (2026-08-15) are new
+  code that has never been read by anyone but its author.
+* ``src/mca/plog`` (with ``smtp``, ``stdfd``, ``syslog``) — 2176 lines.
+  Three fixes on 2026-07-04 only.
+* ``src/mca/psec`` (with ``native``, ``none``, ``munge``,
+  ``dummy_handshake``) — 1901 lines.  This is the connection-handshake
+  code; two small fixes on 2026-07-14/15 are all it has had.
+* ``src/mca/psensor`` (with ``file``, ``heartbeat``) — 1398 lines.
+* ``src/mca/pdl``, ``src/mca/pinstalldirs``, ``src/mca/pif`` — about
+  3200 lines between them, and the lowest risk of the group.
+* ``src/threads`` — 737 lines.  The 2026-07-17 cleanup fixed a TSD key
+  leak and removed dead code, but was not a full pass.
+
+Outside ``src/``, nothing has been reviewed: ``examples/`` (16678 lines,
+leak-swept only), ``test/simple`` (11011), ``test/unit/util`` and
+``test/unit/mca``, and the public headers in ``include/``.
+
+Reviewed, but changed materially since
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ordered by how much of the directory the review no longer covers.
+
+#. **``src/util``** — reviewed 2026-07-17/18, the oldest review in the
+   tree.  31 commits and +1440/-203 across 16 files since, none of it
+   re-read: the CLI option-parsing rework, the ``dirpath`` conversion to
+   descriptor-based operations, and the ``pmix_hash`` qualifier arrays.
+#. **``src/hwloc``** — reviewed 2026-08-02.  The 2026-08-10 → 15 work
+   added a device enumerator and reworked the distance computation,
+   +753 lines in ``pmix_hwloc.c`` alone, against a five-line touch to the
+   guide.  Effectively new, unreviewed code.
+#. **``src/mca/gds/shmem3``** — reviewed 2026-08-03, then redesigned
+   between 2026-08-04 and 15 (string key index, per-segment key indexes,
+   tables sized by rank): 16 commits, +833/-916.  The guide was rewritten
+   alongside it, but a redesign is not a review.
+#. **``src/client``** — the per-file review is current through
+   2026-08-13.  What sits outside it is the group-invite and context-id
+   work of 2026-08-15: +355 lines in ``pmix_client_group.c`` and +245 in
+   ``pmix_client_spawn.c``.
+#. **``src/server``** — the 2026-08-09 → 15 commit run *is* the review,
+   performed after the source was split into function-oriented files, so
+   the body of the directory is covered.  Outside it is the same late
+   feature work: group invite/endpoint exchange (2026-08-15) and the
+   spawn output-forwarding inheritance (2026-08-12/13).
+
+Lower priority, with current guides and modest churn: ``src/mca/base``
+(+162/-79), ``src/common`` (+197/-12), ``src/event`` (+196/-11), and
+``src/mca/ptl`` (mostly deletions).
 
 Open decisions
 --------------

--- a/src/mca/AGENTS.md
+++ b/src/mca/AGENTS.md
@@ -135,11 +135,8 @@ Naming follows from the prefix rule: files are
 | [`pstat`](pstat/) | single | process/node/disk statistics |
 | [`ptl`](ptl/) | single | client/server and tool/server transport |
 
-Note that the top-level [`AGENTS.md`](../../AGENTS.md) also lists `prm`
-and `psquash`. Neither directory exists in this tree any more; the table
-above is what is actually here. Trust `ls` over either document, and
-each framework's own `AGENTS.md` over this table's one-word
-select column.
+Trust `ls` over this table, and each framework's own `AGENTS.md` over
+its one-word select column.
 
 **`pdl` is special: it is opened by the MCA base itself**, in
 `pmix_mca_base_component_repository_init()`, before any other framework


### PR DESCRIPTION
Three docs-only commits about the state of the deep reviews.

**Record where the deep review has and has not been.** The reviews have
been running directory by directory since July, and answering "what is
left" has meant reading the commit log and inferring it. Two things make
that inference easy to get wrong: every directory under `src/` carries
an `AGENTS.md`, so its presence looks like evidence of a review when
most of them predate the reviews entirely; and several directories were
reviewed and have since moved enough that the review no longer describes
them. `docs/todo.rst` now opens with a Review coverage section holding
the inventory as of 2026-08-15 — what is done, what has never been
looked at (ordered by size, with the evidence for each claim), and what
was reviewed but has changed materially since, with the churn that says
so. It is meant to be edited as the remaining work lands.

**Drop three frameworks that no longer exist from the lists.** The
top-level guide's framework table listed `prm` and `psquash`, and
`docs/developers/frameworks.rst` listed those two plus `pfexec`. None of
the three has a directory under `src/mca` any more, and the MCA tree's
own guide had grown a paragraph whose only job was to warn about the
discrepancy.

**Retire the todo entry that the event fan-out fix closed.** Re-checked
every entry on the known-gaps page against the tree. The open decision
about a tool caching an event nobody handled while a client discarded it
is answered by #4101's fix, so it is gone. Two entries were corrected
rather than retired, both because the code moved out from under them:
the tool's SIGCONT stdin handler is in `src/common/pmix_iof.c` now, and
the `cd->nondefault` caching blocks are down to one that assigns inside
its `ninfo` guard. Everything else was re-verified and stands.

Docs build clean (warning-free, man pages included).