### PR TITLE
Hold a spawned job's early output until the reply can format it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,6 +306,7 @@ test/unit/singleton_register
 test/unit/iof_pattern
 test/unit/iof_flow
 test/unit/iof_output
+test/unit/iof_pending
 test/unit/iof_inherit
 test/unit/proc_array_id
 test/unit/attr_dictionary

--- a/docs/news/news-v7.x.rst
+++ b/docs/news/news-v7.x.rst
@@ -7,6 +7,21 @@ series, in reverse chronological order.
 7.0.0 -- TBD
 ------------
 Detailed changes since v6.1.0:
+ - Output from a spawned job that reaches a tool before the spawn reply
+   naming its namespace is now held until that reply arrives, rather than
+   formatted with a process-wide stand-in. The stand-in could not tell
+   two concurrent spawns apart - the second overwrote the first's
+   directives, so whichever job's output arrived first was formatted with
+   the other's - and it could not carry an output-to-file or
+   output-to-directory directive at all, since no file can be opened for
+   a namespace we have not been told about. For a spawn whose output was
+   directed to a file (where the default is not to write locally as
+   well), that meant such output was written nowhere: it is now written
+   to the file, as the spawn asked. Held output is released as soon as
+   the reply lands, in arrival order, and formatted with the directives
+   its own spawn was issued with. The amount held is bounded by the new
+   pmix_iof_pending_limit MCA parameter (default 1MB), past which output
+   falls back to the stand-in as before
  - A group formed through PMIx_Group_invite / PMIx_Group_join now
    exchanges its members' endpoint data, which only the collective
    PMIx_Group_construct did before. An acceptance carries the accepting

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -63,6 +63,17 @@ each time somebody asks.
           one that still assigns inside its guard.  Everything else was
           re-verified against the tree and stands as written.
 
+          A second entry went the same way on 2026-08-16: the open
+          decision about two concurrent spawns not being formattable
+          differently.  It listed three unattractive choices and missed
+          a fourth — hold the output until the reply that can identify
+          it arrives, rather than formatting it on a guess at all.  The
+          entry is retired; see ``test/unit/iof_pending``.  Worth noting
+          *why* it read as closed, since the shape recurs: it framed the
+          problem as "which flags does this output get", which really
+          has no answer at that moment, when the question that does have
+          one is "does this output have to be formatted yet".
+
 Review coverage
 ---------------
 
@@ -184,31 +195,6 @@ data from it means putting a lock on a read path that is lock-free by
 design and is the reason that component exists.  Any real fix has to
 answer the ``shmem3`` case first; the messaging half is not worth building
 on its own.
-
-Two concurrent spawns cannot be formatted differently
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``pmix_globals.spawn_iof_flags`` is a single process-wide slot holding
-the output-formatting directives of the spawn a tool has in flight.  It
-exists because forwarded output can arrive *before* the spawn reply names
-the namespace it belongs to, and until it existed that output was
-formatted with the process-wide defaults instead — so ``prun --output
-tag`` lost the tag on whichever rank happened to be quickest.  Two spawns
-in flight at once from one process means the second overwrites the
-first's flags.
-
-This cannot simply "become per-request", which is how it was recorded
-before.  The reader is ``spawn_or_global_flags()`` in
-``src/common/pmix_iof.c``, reached from ``pmix_iof_write_output()``
-precisely when the arriving output names a namespace we have no record
-of; the only things in scope there are that unknown namespace and the
-stream.  Nothing identifies *which* in-flight spawn the output came
-from, and nothing can until the reply arrives — which is the very thing
-the stand-in exists to cover for.  So the choices are: keep one slot and
-accept that concurrent spawns share it; let the reply establish the
-flags, which re-opens the window the stand-in was built to close; or
-carry something in the IOF message that names the spawn, which is a
-wire-format and Standard question rather than a bug fix.
 
 Deferred work
 -------------

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1919,23 +1919,44 @@ other.
   `direct_modex` is the same class for the same reason (its product is a
   data blob delivered through the callback) and now carries the same
   diagnostic. Those two are the only up-calls in this position.
-- **The `spawn_iof_flags` stand-in is process-wide and is written from the
-  caller's thread** (`stash_spawn_iof_flags`) while `spawn_or_global_flags()`
-  in [`pmix_iof.c`](../common/pmix_iof.c) reads it on the progress thread.
-  It is safe for the case it was built for: the store happens before
+- **FIXED — two spawns in flight at once shared one set of output
+  directives, and the entry that recorded it had ruled out the fix.**
+  `stash_spawn_iof_flags` writes `pmix_globals.spawn_iof_flags`, a single
+  process-wide slot, from the caller's thread; `spawn_or_global_flags()`
+  in [`pmix_iof.c`](../common/pmix_iof.c) reads it on the progress thread
+  when output arrives naming a namespace we have no record of. The second
+  spawn overwrote the first's flags, and the first reply to land cleared
+  the slot for both — so whichever job's output arrived first was
+  formatted with the other's directives, or with none.
+
+  This entry used to say the problem "cannot be closed by making the slot
+  per-request", which is true and was mistaken for the whole answer. The
+  reader really does have nothing in scope but the unknown namespace and
+  the stream, and really cannot learn more until the reply arrives — so
+  **the output waits for the reply** rather than being formatted on a
+  guess. `PMIx_Spawn_nb` now calls `pmix_iof_spawn_begin()` before the
+  send, `wait_cbfunc` calls `pmix_iof_release_pending(nspace)` right
+  after it records the flags on the namespace and `pmix_iof_spawn_end()`
+  on every exit, and the held bytes are written with that spawn's own
+  directives. See the pending-cache section of
+  [`src/common/AGENTS.md`](../common/AGENTS.md) for the rules, and
+  `test/unit/iof_pending` for coverage.
+
+  Two things fall out that are easy to get wrong here. **`begin` and
+  `end` must ask the same question**, which is why both go through
+  `spawn_iof_tracked()` rather than repeating the `PMIX_PEER_IS_TOOL &&
+  flags->set` test — a spawn counted in and not counted out holds output
+  indefinitely, and the failed-`PMIX_PTL_SEND_RECV` path is the one that
+  is easy to miss, since no reply is coming to do it. And **the release
+  goes above the `end`**, not below: `end` at zero flushes what is left
+  with the process-wide flags, so releasing after it would hand this
+  spawn's output the defaults it was waiting to escape.
+
+  The stand-in itself stays, as the answer for output past
+  `pmix_globals.iof_pending_limit`. Its thread-safety argument is
+  unchanged and still worth knowing: the store happens before
   `PMIX_PTL_SEND_RECV`, and forwarded output cannot arrive before the
-  request goes out, so the send path's peer lock publishes it. What it does
-  **not** survive is two spawns in flight at once from one process — the
-  second overwrites the first's flags. That is inherent to a single
-  process-wide slot, not a bug in this file, and **it cannot be closed by
-  making the slot per-request**, which is how this entry used to end.
-  `spawn_or_global_flags()` is reached exactly when the arriving output
-  names a namespace we have no record of, and the only things in scope
-  there are that unknown namespace and the stream — nothing says which
-  in-flight spawn the output came from, and nothing can until the reply
-  arrives, which is the very thing the stand-in covers for. See
-  `docs/todo.rst`, where it is now recorded as an open decision rather
-  than as work waiting to be done.
+  request goes out, so the send path's peer lock publishes it.
 - **FIXED — the server branch read `pmix_server_globals.clients` from the
   caller's thread.** `pmix_get_peer_object()` walks that pointer array
   unlocked to resolve a `PMIX_PARENT_ID`, and `PMIx_Spawn_nb` in a server

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -48,6 +48,7 @@
 #include <event.h>
 
 #include "src/class/pmix_list.h"
+#include "src/common/pmix_iof.h"
 #include "src/common/pmix_pfexec.h"
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/gds/gds.h"
@@ -73,22 +74,42 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
                         void *cbdata);
 static void spawn_cbfunc(pmix_status_t status, char nspace[], void *cbdata);
 
+/* Whether this spawn's output arrangements are ours to carry until the
+ * reply lands. Only a tool receives forwarded output for the jobs it
+ * spawns, and only a spawn that carried output directives has anything
+ * the reply will tell us that the process-wide defaults do not. Both
+ * halves of the arrangement below ask this rather than each keeping its
+ * own copy of the test, because they have to agree: a spawn counted as
+ * in flight that is never counted back out holds output forever. */
+static bool spawn_iof_tracked(pmix_iof_flags_t *flags)
+{
+    return PMIX_PEER_IS_TOOL(pmix_globals.mypeer) && flags->set;
+}
+
 /* Hold a spawn's output-formatting flags where output can find them before
  * the reply names the namespace they belong to.
  *
- * Only meaningful for a tool: a tool receives forwarded output for the jobs
- * it spawned, so output arriving for a namespace it has not been told about
- * yet can only be from the spawn it just issued. Until this existed, that
- * output fell back to the process-wide defaults and came out unformatted -
- * so "prun --output tag" lost the tag on whichever rank happened to be
- * quickest, which showed up as an intermittent failure whenever anything
- * slowed the reply down (two pruns against one DVM was enough).
+ * A tool receives forwarded output for the jobs it spawned, so output
+ * arriving for a namespace it has not been told about yet is most likely
+ * from the spawn it just issued. Until this existed, that output fell back
+ * to the process-wide defaults and came out unformatted - so "prun --output
+ * tag" lost the tag on whichever rank happened to be quickest, which showed
+ * up as an intermittent failure whenever anything slowed the reply down
+ * (two pruns against one DVM was enough).
+ *
+ * "Most likely" is as far as this can go, which is why it is no longer the
+ * primary answer: one process-wide slot cannot tell two concurrent spawns
+ * apart, and it cannot carry file or directory directives at all, since no
+ * sink can be opened for a namespace we have not been told about. The
+ * output is held for the reply instead (see pmix_iof_spawn_begin() in
+ * src/common/pmix_iof.c) and this remains only as the answer for output
+ * that overflows the bound on that.
  *
  * The string members are not copied: this stand-in owns nothing.
  */
 static void stash_spawn_iof_flags(pmix_iof_flags_t *flags)
 {
-    if (!PMIX_PEER_IS_TOOL(pmix_globals.mypeer) || !flags->set) {
+    if (!spawn_iof_tracked(flags)) {
         return;
     }
     memcpy(&pmix_globals.spawn_iof_flags, flags, sizeof(pmix_iof_flags_t));
@@ -738,10 +759,23 @@ envars_done:
                              &fcd->inherit_iof,
                              fcd->info, fcd->ninfo);
     stash_spawn_iof_flags(&fcd->flags);
+    /* Record the spawn as issued and unanswered before the request goes
+     * out, not after: the reply - and the job's first output - can arrive
+     * the moment it has. Storing it ahead of the send is also what
+     * publishes it to the progress thread, since nothing can be forwarded
+     * to us before the request has left. */
+    if (spawn_iof_tracked(&fcd->flags)) {
+        pmix_iof_spawn_begin();
+    }
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg, wait_cbfunc, (void *) fcd);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+        /* no reply is coming, so nothing else will count this one back
+         * out - and a spawn left in flight holds output indefinitely */
+        if (spawn_iof_tracked(&fcd->flags)) {
+            pmix_iof_spawn_end();
+        }
         PMIX_RELEASE(msg);
         PMIX_RELEASE(fcd);
     }
@@ -846,14 +880,24 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr, pmix_buffer
             if (fcd->flags.nocopy) {
                 nptr->iof_flags.local_output = false;
             }
-            /* the namespace now carries its own flags, so the stand-in for
-             * output that arrived before this reply is no longer wanted */
-            pmix_iof_init_flags(&pmix_globals.spawn_iof_flags);
-            pmix_globals.spawn_iof_flags.set = false;
+            /* The namespace now carries its own flags, which is the answer
+             * any output we held for it has been waiting for. Release it
+             * here, before the count is dropped below, so it is written
+             * with this spawn's directives rather than the process-wide
+             * defaults - and while we are still on the progress thread, so
+             * it goes out ahead of anything this job sends next. */
+            pmix_iof_release_pending(nspace);
         }
     }
 
 report:
+    /* every exit owes this: the reply has arrived (or has been synthesized
+     * for a lost connection), so this spawn is no longer one the pending
+     * cache should be holding output for. It is also what clears the
+     * stand-in flags once nothing at all is in flight. */
+    if (spawn_iof_tracked(&fcd->flags)) {
+        pmix_iof_spawn_end();
+    }
     if (NULL != fcd->spcbfunc) {
         fcd->spcbfunc(ret, nspace, fcd->cbdata);
     }

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -165,6 +165,61 @@ lose the user's output *silently*.
   and out of order, and a client or tool never sweeps that list at all
   (`iof_sink_destruct` gates `flush_sink_residuals` on being a server).
 
+### Output a tool cannot format yet is held, not guessed at
+
+A tool receives forwarded output for the jobs it spawns, and a rank that
+writes and exits immediately can get its first chunk here *before* the
+spawn reply names the namespace it came from. Nothing in scope at that
+moment says which of the tool's in-flight spawns produced it — the only
+things `pmix_iof_write_output()` has are that unknown namespace and the
+stream — and nothing can until the reply arrives.
+
+So it is not formatted at that moment. `hold_for_spawn_reply()` parks the
+bytes on `pmix_globals.iof_pending`, and the spawn reply — which knows
+both the namespace and the directives that spawn was issued with —
+releases them through `pmix_iof_release_pending()`. Five things about
+that arrangement are load-bearing:
+
+- **The gate is "is a spawn of ours unanswered", not "is this namespace
+  unknown".** `pmix_globals.spawns_in_flight` is bumped by
+  `pmix_iof_spawn_begin()` before the request goes out and dropped by
+  `pmix_iof_spawn_end()` when the reply (or a synthesized
+  lost-connection reply) lands. With nothing in flight there is no reply
+  coming that could name a namespace, so output for an unknown one — a
+  `PMIx_IOF_pull` against a job we did not spawn — must go straight
+  through rather than wait for something that never happens.
+- **Declining to hold is always safe, which is what makes the bound and
+  the allocation failures harmless.** The caller then does exactly what
+  it did before this cache existed: `spawn_or_global_flags()`, the
+  process-wide stand-in. That stand-in is now *only* the overflow answer;
+  `pmix_globals.iof_pending_limit` (MCA `pmix_iof_pending_limit`) is
+  where it starts being used again.
+- **`release_pending()` writes with `may_hold = false`.** Without it, a
+  spawn whose directives leave `iof_flags.set` false would find the
+  namespace record still saying nothing, hand the chunk straight back to
+  `hold_for_spawn_reply()`, and spin. That is the whole reason
+  `pmix_iof_write_output()` is a wrapper around a static `write_output()`
+  carrying the flag.
+- **A zero-size chunk is held too.** It is the end-of-stream marker, and
+  letting it past would put it ahead of the output it ends.
+- **`pmix_iof_spawn_end()` drops the count and, at zero, flushes
+  everything left.** Output nobody's reply ever named belongs to no spawn
+  of ours, so it goes out with the process-wide flags rather than sitting
+  there. Every path that ends a spawn owes this call, the failed
+  `PMIX_PTL_SEND_RECV` included — `spawn_iof_tracked()` in
+  `src/client/pmix_client_spawn.c` is the single predicate both the begin
+  and the end ask, precisely so they cannot disagree. A spawn counted in
+  and never counted out holds output until the limit and then forever.
+
+Everything but `pmix_iof_spawn_begin()` is progress-thread only.
+`begin()` runs on the caller's thread, and the count is atomic for that
+reason; it is published by being stored ahead of the send, since nothing
+can be forwarded to us before the request has left — the same bargain
+`stash_spawn_iof_flags()` makes.
+
+Coverage is [`test/unit/iof_pending.c`](../../test/unit/iof_pending.c),
+which comes up as a tool and drives the entry points directly.
+
 Two related facts worth knowing before you touch that code:
 
 - `pmix_server_globals.iof_residuals` is **statically initialized**

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -49,6 +49,15 @@
 #include "src/include/pmix_globals.h"
 #include "src/server/pmix_server_ops.h"
 
+/* the pending-output cache and the write path it feeds are defined far
+ * below, but pmix_iof_finalize() drains the one and the drain calls the
+ * other - see the comments at their definitions */
+static pmix_status_t write_output(const pmix_proc_t *name,
+                                  pmix_iof_channel_t stream,
+                                  const pmix_byte_object_t *bo,
+                                  bool may_hold);
+static void release_pending(const char *nspace);
+
 static void myregcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata)
 {
@@ -525,6 +534,16 @@ void pmix_iof_finalize(void)
         PMIX_RELEASE(stdinev_global);
         stdinev_global = NULL;
     }
+    /* Anything still being held for a spawn reply is never going to get
+     * one now. Write it with whatever we have rather than dropping it,
+     * the way pmix_iof_flush_residuals() does at server finalize - and
+     * with the same caveat, that the progress thread is already paused
+     * by the time we get here, so this is best effort. It is normally
+     * empty: pmix_iof_spawn_end() drains the cache when the last spawn
+     * is answered, and a lost connection completes that reply too. */
+    release_pending(NULL);
+    PMIX_LIST_DESTRUCT(&pmix_globals.iof_pending);
+    pmix_globals.iof_pending_bytes = 0;
 }
 
 /* Start reading our own stdin into stdinev_global, arming the SIGCONT
@@ -1940,10 +1959,12 @@ static void flush_residual(const pmix_proc_t *name, pmix_iof_channel_t stream)
 }
 
 /* What to format output with when the namespace it came from has nothing to
- * say about it. A tool that has a spawn in flight has already parsed that
- * spawn's directives (see stash_spawn_iof_flags() in pmix_client_spawn.c);
- * output that beat the reply here belongs to that spawn, so those flags are
- * the right answer rather than the process-wide default. */
+ * say about it and we are not holding the bytes for a reply. A tool that has
+ * a spawn in flight has already parsed that spawn's directives (see
+ * stash_spawn_iof_flags() in pmix_client_spawn.c), so those flags are a
+ * better guess than the process-wide default - but they are a guess, which
+ * is why they are now reached only once the pending cache has declined to
+ * hold the output. */
 static pmix_iof_flags_t spawn_or_global_flags(void)
 {
     if (pmix_globals.spawn_iof_flags.set) {
@@ -1965,6 +1986,14 @@ static pmix_iof_flags_t spawn_or_global_flags(void)
  * for a tool - and went to the terminal after all. The result was that a
  * nondeterministic subset of the job's output appeared on a terminal the user
  * had asked to keep clean: whichever ranks' first chunk beat the reply.
+ *
+ * Note what that fix could not do, and why this is no longer the first
+ * answer tried: it suppresses the local write but has nowhere to put the
+ * output instead, because no file can be opened for a namespace we have not
+ * been told about - so a file-only spawn's early output was written nowhere
+ * at all. Holding it for the reply is what makes the file reachable. This
+ * remains the answer for output past pmix_globals.iof_pending_limit, where
+ * suppressing is still better than writing to the wrong place.
  */
 static pmix_iof_flags_t stand_in_flags(bool *outputio)
 {
@@ -1976,9 +2005,120 @@ static pmix_iof_flags_t stand_in_flags(bool *outputio)
     return flags;
 }
 
-pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
-                                    pmix_iof_channel_t stream,
-                                    const pmix_byte_object_t *bo)
+/* Take custody of output we cannot yet format, reporting whether we did.
+ *
+ * The condition is narrow on purpose. Only a tool receives forwarded output
+ * for a job it spawned, and only while one of our spawns is unanswered is
+ * there a reply coming that can name a namespace - with nothing in flight,
+ * output for an unknown namespace is from something else entirely (a
+ * PMIx_IOF_pull against a job we did not spawn, say) and holding it would
+ * delay it for a reply that never comes.
+ *
+ * Declining is always safe: the caller then does what it did before this
+ * cache existed. That is what the limit relies on, and what makes an
+ * allocation failure here a formatting question rather than a lost chunk.
+ *
+ * Runs on the progress thread, as every caller of pmix_iof_write_output()
+ * does, so the list and the byte count need no lock. */
+static bool hold_for_spawn_reply(const pmix_proc_t *name,
+                                 pmix_iof_channel_t stream,
+                                 const pmix_byte_object_t *bo)
+{
+    pmix_iof_pending_t *pend;
+
+    if (!PMIX_PEER_IS_TOOL(pmix_globals.mypeer) ||
+        0 == atomic_load(&pmix_globals.spawns_in_flight)) {
+        return false;
+    }
+    if (pmix_globals.iof_pending_limit < pmix_globals.iof_pending_bytes + bo->size) {
+        return false;
+    }
+    pend = PMIX_NEW(pmix_iof_pending_t);
+    if (PMIX_UNLIKELY(NULL == pend)) {
+        return false;
+    }
+    PMIX_XFER_PROCID(&pend->name, name);
+    pend->stream = stream;
+    /* a zero-size chunk is the end-of-stream marker and carries no bytes -
+     * it still has to be held, or it would overtake the output it ends */
+    if (0 < bo->size) {
+        pend->bo.bytes = (char *) malloc(bo->size);
+        if (PMIX_UNLIKELY(NULL == pend->bo.bytes)) {
+            PMIX_RELEASE(pend);
+            return false;
+        }
+        memcpy(pend->bo.bytes, bo->bytes, bo->size);
+        pend->bo.size = bo->size;
+    }
+    pmix_list_append(&pmix_globals.iof_pending, &pend->super);
+    pmix_globals.iof_pending_bytes += bo->size;
+
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "%s iof: holding %lu bytes from %s pending spawn reply",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
+                        (unsigned long) bo->size, PMIX_NAME_PRINT(name));
+    return true;
+}
+
+/* Write out everything we were holding, optionally only for one namespace.
+ *
+ * Each entry is unlinked before it is written, and the write is told not to
+ * hold: without that, a spawn whose directives set no flags would find the
+ * namespace record still saying nothing, hand the chunk straight back to
+ * hold_for_spawn_reply(), and spin. Order within the list is arrival order
+ * and is preserved, which is the whole reason the marker above is held. */
+static void release_pending(const char *nspace)
+{
+    pmix_iof_pending_t *pend, *next;
+    pmix_status_t rc;
+
+    PMIX_LIST_FOREACH_SAFE(pend, next, &pmix_globals.iof_pending, pmix_iof_pending_t) {
+        if (NULL != nspace && !PMIX_CHECK_NSPACE(pend->name.nspace, nspace)) {
+            continue;
+        }
+        pmix_list_remove_item(&pmix_globals.iof_pending, &pend->super);
+        pmix_globals.iof_pending_bytes -= pend->bo.size;
+        rc = write_output(&pend->name, pend->stream, &pend->bo, false);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+        PMIX_RELEASE(pend);
+    }
+}
+
+void pmix_iof_release_pending(const char *nspace)
+{
+    release_pending(nspace);
+}
+
+void pmix_iof_spawn_begin(void)
+{
+    atomic_fetch_add_explicit(&pmix_globals.spawns_in_flight, 1, memory_order_seq_cst);
+}
+
+void pmix_iof_spawn_end(void)
+{
+    /* fetch_sub returns the value before the subtraction */
+    if (1 < atomic_fetch_sub_explicit(&pmix_globals.spawns_in_flight, 1,
+                                      memory_order_seq_cst)) {
+        return;
+    }
+    /* that was the last one. Nothing is coming that can name a namespace
+     * now, so the stand-in has nothing left to stand in for, and whatever
+     * is still held belongs to no spawn of ours - write it with the
+     * process-wide flags, which is what it would have had all along */
+    pmix_iof_init_flags(&pmix_globals.spawn_iof_flags);
+    pmix_globals.spawn_iof_flags.set = false;
+    release_pending(NULL);
+}
+
+/* The body of pmix_iof_write_output(). "may_hold" is false only when the
+ * caller is the pending cache draining itself, which must not be handed its
+ * own output back - see release_pending(). */
+static pmix_status_t write_output(const pmix_proc_t *name,
+                                  pmix_iof_channel_t stream,
+                                  const pmix_byte_object_t *bo,
+                                  bool may_hold)
 {
     pmix_status_t rc;
     size_t n, start;
@@ -2013,6 +2153,17 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
     channel = NULL;
     /* default outputio to our flag */
     outputio = pmix_globals.iof_flags.local_output;
+
+    /* Nothing on the namespace says how this output is to be formatted, or
+     * even whether we are meant to write it at all. If a spawn of ours is
+     * still unanswered, its reply will say - and that is an exact answer
+     * where stand_in_flags() below is a guess that cannot tell two
+     * concurrent spawns apart. So hold the bytes for it rather than
+     * committing to a format now. */
+    if (may_hold && (NULL == nptr || !nptr->iof_flags.set) &&
+        hold_for_spawn_reply(name, stream, bo)) {
+        return PMIX_SUCCESS;
+    }
 
     if (NULL != nptr) {
         if (nptr->iof_flags.set) {
@@ -2176,6 +2327,13 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
         free(inputdata);
     }
     return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
+                                    pmix_iof_channel_t stream,
+                                    const pmix_byte_object_t *bo)
+{
+    return write_output(name, stream, bo, true);
 }
 
 void pmix_iof_flush_residuals(void)
@@ -3066,3 +3224,19 @@ static void iofresdes(pmix_iof_residual_t *p)
 PMIX_CLASS_INSTANCE(pmix_iof_residual_t,
                     pmix_list_item_t,
                     iofrescon, iofresdes);
+
+static void iofpendcon(pmix_iof_pending_t *p)
+{
+    PMIX_LOAD_PROCID(&p->name, NULL, PMIX_RANK_UNDEF);
+    p->stream = PMIX_FWD_NO_CHANNELS;
+    PMIX_BYTE_OBJECT_CONSTRUCT(&p->bo);
+}
+static void iofpenddes(pmix_iof_pending_t *p)
+{
+    if (NULL != p->bo.bytes) {
+        free(p->bo.bytes);
+    }
+}
+PMIX_CLASS_INSTANCE(pmix_iof_pending_t,
+                    pmix_list_item_t,
+                    iofpendcon, iofpenddes);

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -148,6 +148,21 @@ typedef struct {
 } pmix_iof_residual_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_residual_t);
 
+/* One chunk of output being held because nothing yet says how to format
+ * it - see the pending-cache comment on pmix_globals_t and the entry
+ * points below. Deliberately unlike pmix_iof_residual_t above, this
+ * carries no flags and no channel: the whole point is that neither is
+ * known yet, and both are worked out when the chunk is finally written.
+ * A zero-size bo is a legitimate entry - it is the end-of-stream marker,
+ * which has to keep its place in the sequence. */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_proc_t name;
+    pmix_iof_channel_t stream;
+    pmix_byte_object_t bo;
+} pmix_iof_pending_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_pending_t);
+
 /* Write event macro's */
 
 static inline bool pmix_iof_fd_always_ready(int fd)
@@ -294,6 +309,33 @@ PMIX_EXPORT pmix_status_t pmix_iof_process_iof(pmix_iof_channel_t channels,
                                                pmix_iof_req_t *req);
 PMIX_EXPORT void pmix_iof_init_flags(pmix_iof_flags_t *flags);
 PMIX_EXPORT void pmix_iof_check_flags(pmix_info_t *info, pmix_iof_flags_t *flags);
+
+/* Holding output until a spawn reply says how to format it.
+ *
+ * A tool receives forwarded output for the jobs it spawns, and that
+ * output can beat the spawn reply here - so it can arrive naming a
+ * namespace we have never been told about, with nothing in scope to say
+ * which of our in-flight spawns it came from. pmix_iof_write_output()
+ * holds such output rather than formatting it on a guess, and these are
+ * the two ends of that arrangement.
+ *
+ * pmix_iof_spawn_begin() records a spawn as issued and unanswered; it
+ * must be called before the request goes out, because the reply - and
+ * the output - can arrive as soon as it has. pmix_iof_spawn_end() is its
+ * partner and is owed by every path that ends the spawn, the failed send
+ * included; when the last one is answered it releases anything still
+ * held, since output left over belongs to no spawn of ours.
+ *
+ * pmix_iof_release_pending() writes out what was held for one namespace.
+ * Call it once that namespace's formatting flags are in place and before
+ * pmix_iof_spawn_end(), so the held output is formatted with the
+ * directives its own spawn was issued with.
+ *
+ * begin() may be called from any thread; the other two are progress-
+ * thread only, as is everything they touch. */
+PMIX_EXPORT void pmix_iof_spawn_begin(void);
+PMIX_EXPORT void pmix_iof_spawn_end(void);
+PMIX_EXPORT void pmix_iof_release_pending(const char *nspace);
 
 /* IOF flow control.
  *

--- a/src/include/AGENTS.md
+++ b/src/include/AGENTS.md
@@ -174,6 +174,20 @@ AND INIT/FINALIZE THE GLOBAL CLASSES."* It is almost entirely
   `unlink`/`rmdir`).
 - Thin libevent wrappers `pmix_event_assign()` / `pmix_event_new()`
   (the `pmix_event_*` macros they back live in `pmix_types.h`).
+- `pmix_event_del_checked()` — the one wrapper here that is **not**
+  thin, and the reason `pmix_event_del()` is not simply `event_del()`.
+  Deleting an event takes the lock of the base it sits on, and objects
+  in this file outlive that base: every role releases its peers after
+  `pmix_rte_finalize()` has freed it (see the two-reference note on
+  `mypeer` in [`src/runtime/AGENTS.md`](../runtime/AGENTS.md)), and
+  `pdes()` reaches the peer's own events, its namespace, that
+  namespace's IOF sinks, and each sink's write event. There is nothing
+  left to delete by then, so the wrapper declines once `evbase` and
+  `evauxbase` are both NULL rather than reaching into freed memory —
+  where the failure mode is not a crash but a permanent block on a mutex
+  in reused heap, appearing and disappearing with unrelated changes.
+  A destructor here may call `pmix_event_del()` freely *because* of
+  that; do not push the check back out into the callers.
 - `pmix_dstor_new_tma()` / `pmix_dstor_release_tma()` and the
   `keyindex` con/destructor — note these are **TMA-aware** (they honor a
   `pmix_tma_t` custom allocator so the objects can live in shared

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -330,12 +330,34 @@ static void pdes(pmix_peer_t *p)
     if (0 <= p->sd) {
         CLOSE_THE_SOCKET(p->sd);
     }
-    if (p->send_ev_active) {
-        pmix_event_del(&p->send_event);
+    /* Only while there is still an event base to delete them from.
+     *
+     * Each role releases its peers *after* pmix_rte_finalize(), which is
+     * what stops the progress thread and frees the base - see the
+     * two-reference note on mypeer in src/runtime/pmix_finalize.c. By
+     * then libevent has already torn every event off that base, so there
+     * is nothing here left to delete; what event_del() does instead is
+     * take the base's lock, which is freed memory. Whatever has since
+     * been written over it decides what happens - usually nothing, but a
+     * byte pattern that reads as "held" hangs the process on a mutex
+     * nobody will ever release. A connected peer is what makes this
+     * reachable, since a peer that never armed its events has neither
+     * flag set: it hung a tool cycling init/finalize against a real
+     * server, and only on the machines whose heap happened to land the
+     * wrong value there.
+     *
+     * pmix_rte_finalize() NULLs evbase once the base is gone, which is
+     * the only in-scope thing here that can say so. */
+    if (NULL != pmix_globals.evbase) {
+        if (p->send_ev_active) {
+            pmix_event_del(&p->send_event);
+        }
+        if (p->recv_ev_active) {
+            pmix_event_del(&p->recv_event);
+        }
     }
-    if (p->recv_ev_active) {
-        pmix_event_del(&p->recv_event);
-    }
+    p->send_ev_active = false;
+    p->recv_ev_active = false;
 
     if (NULL != p->info) {
         PMIX_RELEASE(p->info);

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -330,31 +330,16 @@ static void pdes(pmix_peer_t *p)
     if (0 <= p->sd) {
         CLOSE_THE_SOCKET(p->sd);
     }
-    /* Only while there is still an event base to delete them from.
-     *
-     * Each role releases its peers *after* pmix_rte_finalize(), which is
-     * what stops the progress thread and frees the base - see the
-     * two-reference note on mypeer in src/runtime/pmix_finalize.c. By
-     * then libevent has already torn every event off that base, so there
-     * is nothing here left to delete; what event_del() does instead is
-     * take the base's lock, which is freed memory. Whatever has since
-     * been written over it decides what happens - usually nothing, but a
-     * byte pattern that reads as "held" hangs the process on a mutex
-     * nobody will ever release. A connected peer is what makes this
-     * reachable, since a peer that never armed its events has neither
-     * flag set: it hung a tool cycling init/finalize against a real
-     * server, and only on the machines whose heap happened to land the
-     * wrong value there.
-     *
-     * pmix_rte_finalize() NULLs evbase once the base is gone, which is
-     * the only in-scope thing here that can say so. */
-    if (NULL != pmix_globals.evbase) {
-        if (p->send_ev_active) {
-            pmix_event_del(&p->send_event);
-        }
-        if (p->recv_ev_active) {
-            pmix_event_del(&p->recv_event);
-        }
+    /* This is the destructor that runs with no event base left - a role
+     * releases its peers after pmix_rte_finalize() has freed it - so the
+     * deletes below are the ones pmix_event_del_checked() exists for.
+     * The flags are cleared either way, so the state a released peer
+     * leaves behind says what is true of it. */
+    if (p->send_ev_active) {
+        pmix_event_del(&p->send_event);
+    }
+    if (p->recv_ev_active) {
+        pmix_event_del(&p->recv_event);
     }
     p->send_ev_active = false;
     p->recv_ev_active = false;
@@ -895,6 +880,38 @@ pmix_event_t *pmix_event_new(pmix_event_base_t *b, int fd, short fg, event_callb
 
     ev = event_new(b, fd, fg, (event_callback_fn) cbfn, cbd);
     return ev;
+}
+
+/* An object that owns an event normally dies before the base that event
+ * is registered on, and then this is just event_del(). Some cannot: each
+ * role releases its peers *after* pmix_rte_finalize(), because the
+ * two-reference arrangement on mypeer described in
+ * src/runtime/pmix_finalize.c requires it - and pmix_rte_finalize() is
+ * what stops the progress thread and frees the base. So the peer
+ * destructor below, and everything it reaches (its namespace, that
+ * namespace's IOF sinks, and each sink's write event), can run with no
+ * base left.
+ *
+ * There is nothing for them to delete by then: libevent tore every event
+ * off the base when it freed it. What event_del() does instead is take
+ * the base's lock, which is memory that has been handed back. Usually
+ * the bytes there still read as an unheld mutex and nobody notices; when
+ * they do not, the process blocks on a mutex no thread will ever release
+ * and the only symptom is a hang with no output. That is a defect whose
+ * appearance depends on what the allocator happens to reuse, so it comes
+ * and goes with unrelated changes elsewhere.
+ *
+ * Rather than leave each such destructor to remember, decline here for
+ * all of them: no base, nothing registered, nothing to delete.
+ * pmix_rte_finalize() NULLs both pointers once the base is gone, and
+ * they are NULL before the first init as well - a window in which no
+ * event can have been added either. */
+int pmix_event_del_checked(struct event *ev)
+{
+    if (NULL == pmix_globals.evbase && NULL == pmix_globals.evauxbase) {
+        return 0;
+    }
+    return event_del(ev);
 }
 
 static void tcon(pmix_timer_t *p)

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -923,17 +923,37 @@ typedef struct {
     bool external_topology;
     bool external_progress;
     pmix_iof_flags_t iof_flags;
-    /* Output-formatting flags belonging to a spawn we have issued but whose
-     * namespace we have not been told yet. A tool's spawn directives are
-     * parsed before the request goes out (see pmix_server_spawn_parser() in
-     * PMIx_Spawn_nb, "helps to catch any early output"), but they can only be
-     * recorded against the namespace once the reply names it - and a proc
-     * that writes and exits immediately can get its output to us first. That
-     * output has nowhere to look for its format, so it came out unformatted.
-     * Holding the flags here gives it somewhere. Cleared once the reply has
-     * been processed and the per-namespace flags are in place. Note the file
-     * and directory members are deliberately left NULL: this copy does not
-     * own strings, it only carries the formatting decisions. */
+    /* Output arriving for a namespace we cannot yet format for.
+     *
+     * A tool's spawn directives are parsed before the request goes out (see
+     * pmix_server_spawn_parser() in PMIx_Spawn_nb, "helps to catch any early
+     * output"), but they can only be recorded against the namespace once the
+     * reply names it - and a proc that writes and exits immediately can get
+     * its output to us first. Nothing in scope at that moment says which of
+     * our in-flight spawns the output belongs to, and nothing can until the
+     * reply arrives. So the bytes are held here instead of being formatted
+     * on a guess, and the reply - which knows both the namespace and the
+     * directives it was issued with - releases them.
+     *
+     * spawns_in_flight counts the spawns we have issued that carried output
+     * directives and have not yet been answered; while it is non-zero there
+     * is a reply coming that can name a namespace, so output for a namespace
+     * we have no formatting for is worth holding. It is incremented on the
+     * caller's thread ahead of the send and decremented on the progress
+     * thread by the reply handler, hence the atomic. iof_pending and
+     * iof_pending_bytes are progress-thread state, bounded by
+     * iof_pending_limit; past the limit the stand-in below is used instead.
+     *
+     * spawn_iof_flags is that stand-in: the directives of the most recent
+     * such spawn, kept only as the overflow answer and cleared once nothing
+     * is in flight. It cannot distinguish concurrent spawns, which is why
+     * the cache exists. Note its file and directory members are deliberately
+     * left NULL - that copy does not own strings, it only carries the
+     * formatting decisions. */
+    pmix_atomic_size_t spawns_in_flight;
+    pmix_list_t iof_pending;
+    size_t iof_pending_bytes;
+    size_t iof_pending_limit;
     pmix_iof_flags_t spawn_iof_flags;
     pmix_keyindex_t keyindex;
 } pmix_globals_t;

--- a/src/include/pmix_types.h
+++ b/src/include/pmix_types.h
@@ -210,7 +210,14 @@ PMIX_EXPORT int pmix_event_assign(struct event *ev, pmix_event_base_t *evbase, i
     pmix_event_assign((x), (b), (fd), (fg), (event_callback_fn)(cb), (arg))
 
 #define pmix_event_add(ev, tv)      event_add((ev), (tv))
-#define pmix_event_del(ev)          event_del((ev))
+
+/* Deleting an event takes the lock of the base it is registered on, so
+ * it is only meaningful while that base is alive. This declines once
+ * ours is gone rather than reaching into freed memory - see the
+ * definition in pmix_globals.c for why an object holding an event can
+ * outlive the base at all. */
+PMIX_EXPORT int pmix_event_del_checked(struct event *ev);
+#define pmix_event_del(ev)          pmix_event_del_checked((ev))
 #define pmix_event_active(x, y, z)  event_active((x), (y), (z))
 #define pmix_event_base_loopexit(b) event_base_loopexit(b, NULL)
 

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -206,6 +206,32 @@ before "fixing" either one — each has cost a debugging session.
   finalize; if you add state with the same shape, expect the same
   constraint.
 
+### The consequence: an object can outlive the base its events are on
+
+The late release above happens *after* `pmix_progress_thread_stop(NULL)`
+has freed the event base, and a peer owns two libevent events — as does
+everything the peer reaches on its way out: its namespace, that
+namespace's IOF sinks, and each sink's write event. `event_del()` on any
+of them then takes the lock of a base that has been handed back to the
+allocator.
+
+Nothing is being deleted at that point (libevent tore every event off the
+base when it freed it), so the call is pure hazard: whatever has since
+been written over the lock decides what happens. Usually the bytes still
+read as an unheld mutex and nobody notices — which is why this survived
+for so long — and when they do not, the process blocks forever on a mutex
+no thread will release, with no output and no clue. It presents as a hang
+that comes and goes with unrelated changes elsewhere in the library,
+because what moves is the heap, not the code.
+
+`pmix_event_del()` is therefore not `event_del()`: it routes through
+`pmix_event_del_checked()` in
+[`src/include/pmix_globals.c`](../include/pmix_globals.c), which declines
+once both `evbase` and `evauxbase` are NULL. **Do not "simplify" that
+back into a direct call**, and note that the two pointers being NULL is
+the only in-scope signal that the base is gone — which is part of why
+`pmix_rte_finalize` NULLs them rather than leaving them dangling.
+
 ## MCA parameters (`pmix_params.c`)
 
 `pmix_register_params` is latched by the file-scope `pmix_register_done`

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -274,6 +274,12 @@ void pmix_rte_finalize(void)
     pmix_globals.external_topology = false;
     pmix_globals.pushstdin = false;
     pmix_globals.commits_pending = false;
+    /* pmix_iof_finalize above drained the pending-output cache and
+     * destructed its list; put the accounting that goes with it back to
+     * the static-init values so the next cycle does not start out
+     * believing it is already holding bytes for a spawn that is gone */
+    atomic_store(&pmix_globals.spawns_in_flight, 0);
+    pmix_globals.iof_pending_bytes = 0;
     /* the file/directory strings were freed above; this clears the
      * formatting decisions that came with them */
     pmix_iof_init_flags(&pmix_globals.iof_flags);

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -123,6 +123,10 @@ PMIX_EXPORT pmix_globals_t pmix_globals = {
     .external_topology = false,
     .external_progress = false,
     .iof_flags = PMIX_IOF_FLAGS_STATIC_INIT,
+    .spawns_in_flight = 0,
+    .iof_pending = PMIX_LIST_STATIC_INIT,
+    .iof_pending_bytes = 0,
+    .iof_pending_limit = 0,
     .spawn_iof_flags = PMIX_IOF_FLAGS_STATIC_INIT,
     .keyindex = PMIX_KEYINDEX_STATIC_INIT
 };
@@ -395,6 +399,9 @@ int pmix_rte_init(uint32_t type, pmix_info_t info[], size_t ninfo, pmix_ptl_cbfu
     pmix_pointer_array_init(&pmix_globals.iof_requests, 128, INT_MAX, 128);
     /* setup the stdin forwarding target list */
     PMIX_CONSTRUCT(&pmix_globals.stdin_targets, pmix_list_t);
+    /* and the list of output waiting on a spawn reply to say how it is
+     * to be formatted - see pmix_iof_write_output() */
+    PMIX_CONSTRUCT(&pmix_globals.iof_pending, pmix_list_t);
     memcpy(&pmix_globals.iof_flags, &flags, sizeof(pmix_iof_flags_t));
 
     /* Setup client verbosities as all procs are allowed to

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -267,6 +267,19 @@ pmix_status_t pmix_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_SIZE_T,
                                       &pmix_globals.output_limit);
 
+    /* Bound on the output a tool will hold while waiting for a spawn reply
+     * to say how that output should be formatted (see the pending-cache
+     * comment on pmix_globals_t). Past it, output falls back to the
+     * process-wide stand-in, which is what every chunk got before the cache
+     * existed - so the limit trades formatting fidelity for a ceiling on
+     * how much of a job's early output we will buffer. */
+    pmix_globals.iof_pending_limit = 1048576;
+    (void) pmix_mca_base_var_register("pmix", "iof", NULL, "pending_limit",
+                                      "Maximum bytes of output to hold while awaiting the spawn "
+                                      "reply that says how to format it [default: 1MB]",
+                                      PMIX_MCA_BASE_VAR_TYPE_SIZE_T,
+                                      &pmix_globals.iof_pending_limit);
+
     pmix_globals.xml_output = false;
     (void) pmix_mca_base_var_register("pmix", "iof", NULL, "xml_output",
                                       "Display all output in XML format (default: false)",

--- a/test/simple/simptoolcycle.c
+++ b/test/simple/simptoolcycle.c
@@ -142,6 +142,7 @@ static pmix_status_t register_job(const char *name)
     pmix_info_t jinfo[1];
     pmix_proc_t client;
     uint32_t one = 1;
+    int timedout = 0;
     /* PMIx_server_register_nspace takes a pmix_nspace_t -- a
      * PMIX_MAX_NSLEN+1 array, not a pointer -- so hand it one.  Passing a
      * bare string draws -Wstringop-overread: the compiler reads the array
@@ -166,14 +167,23 @@ static pmix_status_t register_job(const char *name)
 
     regdone = 0;
     rc = PMIx_server_register_nspace(nspace, 1, jinfo, 1, reg_cbfunc, NULL);
+    /* The array has to stay alive until the callback fires. The caddy
+     * that carries this request to the progress thread points at the
+     * caller's info rather than copying it, so a caller that releases it
+     * on return has handed the progress thread freed memory. Destructing
+     * it here read back as an intermittent PMIX_ERR_TYPE_MISMATCH out of
+     * the job-array processing when the type field happened to be
+     * overwritten - and, when the array's size field was what got reused,
+     * as a walk over however many elements that garbage claimed. */
+    if (PMIX_SUCCESS == rc) {
+        timedout = wait_reg("register_nspace");
+    }
     PMIX_INFO_DESTRUCT(&jinfo[0]);
     if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
         return rc;
     }
-    if (PMIX_SUCCESS == rc) {
-        if (0 != wait_reg("register_nspace")) {
-            return PMIX_ERR_TIMEOUT;
-        }
+    if (0 != timedout) {
+        return PMIX_ERR_TIMEOUT;
     }
 
     PMIX_LOAD_PROCID(&client, nspace, 0);

--- a/test/simple/simptoolcycle.c
+++ b/test/simple/simptoolcycle.c
@@ -82,19 +82,34 @@ static long parse_cycles(const char *str)
     return ncycles;
 }
 
+/* how long wait_reg() will wait for a registration callback before giving
+ * up. Generous - the operation is local and takes milliseconds - but
+ * bounded, because a callback that never comes used to spin here forever
+ * and the run only ended when the harness timeout killed it, taking the
+ * buffered account of how far we got with it. */
+#define REG_WAIT_SECS 60
+
 static volatile int regdone;
 static void reg_cbfunc(pmix_status_t status, void *cbdata)
 {
     PMIX_HIDE_UNUSED_PARAMS(status, cbdata);
     regdone = 1;
 }
-static void wait_reg(void)
+static int wait_reg(const char *what)
 {
     struct timespec ts = {0, 1000000};
+    long tries = REG_WAIT_SECS * 1000;
+
     while (0 == regdone) {
+        if (0 >= tries--) {
+            fprintf(stderr, "%s: no registration callback within %d seconds\n",
+                    what, REG_WAIT_SECS);
+            return 1;
+        }
         nanosleep(&ts, NULL);
     }
     regdone = 0;
+    return 0;
 }
 
 static void tool_connect_fn(pmix_info_t *info, size_t ninfo,
@@ -156,7 +171,9 @@ static pmix_status_t register_job(const char *name)
         return rc;
     }
     if (PMIX_SUCCESS == rc) {
-        wait_reg();
+        if (0 != wait_reg("register_nspace")) {
+            return PMIX_ERR_TIMEOUT;
+        }
     }
 
     PMIX_LOAD_PROCID(&client, nspace, 0);
@@ -165,7 +182,9 @@ static pmix_status_t register_job(const char *name)
         return rc;
     }
     if (PMIX_SUCCESS == rc) {
-        wait_reg();
+        if (0 != wait_reg("register_client")) {
+            return PMIX_ERR_TIMEOUT;
+        }
     }
     return PMIX_SUCCESS;
 }
@@ -201,6 +220,11 @@ static int run_tool_child(const char *mode, long ncycles)
     }
 
     for (i = 0; i < ncycles; i++) {
+        /* a heartbeat, so a run that wedges says which cycle it wedged on
+         * rather than only which phase - see the buffering note in main() */
+        if (0 == i % 10) {
+            fprintf(stdout, "  %-6s child: cycle %ld\n", mode, i);
+        }
         if (pure) {
             /* connect to the parent as the scheduler; PMIx_tool_init then
              * skips its job-info request, so no job need be registered */
@@ -257,6 +281,8 @@ static int run_phase(const char *self, const char *mode, long ncycles, char **ba
         PMIx_Argv_free(child_env);
         return 1;
     }
+
+    fprintf(stdout, "  %-6s phase: starting %ld cycles\n", mode, ncycles);
 
     snprintf(cycles_str, sizeof(cycles_str), "%ld", ncycles);
     PMIx_Argv_append_nosize(&child_argv, (char *) self);
@@ -318,6 +344,11 @@ static int run_server(char *self, long ncycles)
     fprintf(stdout, "\n=== server-side tool init/finalize cycling test (%ld cycles) ===\n\n",
             ncycles);
 
+    /* These markers are what tells a wedged run apart from a run that
+     * never got started: with stdout line buffered (see main()), whatever
+     * is missing from the log is where it stopped. */
+    fprintf(stdout, "  server: initializing\n");
+
     /* A minimal server that accepts tool connections and advertises itself
      * as the scheduler (so the pure tool can init with no job registered
      * for it). */
@@ -329,6 +360,7 @@ static int run_server(char *self, long ncycles)
     }
 
     /* register one job so the client-tool phase has job info to retrieve */
+    fprintf(stdout, "  server: registering job\n");
     if (PMIX_SUCCESS != (rc = register_job("foobar"))) {
         fprintf(stderr, "register_job failed: %s\n", PMIx_Error_string(rc));
         PMIx_server_finalize();
@@ -350,6 +382,13 @@ static int run_server(char *self, long ncycles)
 int main(int argc, char **argv)
 {
     long ncycles = DEFAULT_CYCLES;
+
+    /* "make check" runs us with stdout on a pipe, where it is block
+     * buffered - so a run that wedges and is killed by the harness
+     * timeout takes every line it had written with it, and the failure
+     * arrives with no account of how far it got. Line buffering costs
+     * nothing here and leaves that account behind. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
 
     if (3 < argc && 0 == strcmp(argv[1], "--tool-child")) {
         ncycles = parse_cycles(argv[3]);

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -92,7 +92,36 @@ child's output to the process that spawned it is a loopback.
 **Singleton client tests** — call the real public API in a process that
 comes up with no server. `client_cycle` (init/finalize cycling),
 `tool_cycle`, `singleton_register`, `rndz_stale`, `event_chain`,
-`gds_fallback`, `client_api`.
+`gds_fallback`, `client_api`, `iof_pending`.
+
+### `iof_pending` — output held for a spawn reply that has not landed
+
+The only test here that comes up as a **tool**, because the thing under
+test is tool-only: a client is never sent a spawned job's output. It
+stands pipes up in place of stdout and stderr the way `iof_output` does,
+then drives `pmix_iof_spawn_begin` / `pmix_iof_write_output` /
+`pmix_iof_release_pending` / `pmix_iof_spawn_end` directly, each
+thread-shifted onto the progress thread — all of them touch
+`pmix_globals` state that belongs to it.
+
+No spawn is issued and none could be (`test/simple/simptest` cannot host
+one), so what it pins down is the cache's own contract rather than the
+round trip: that nothing is held when no spawn is in flight, that two
+concurrent spawns' output is released separately and formatted with each
+one's own directives — the case a single process-wide slot cannot serve,
+and the reason this exists — that arrival order survives, that the
+last spawn being answered flushes what is left, and that the byte limit
+makes the cache fall back rather than grow. Most of its cases fail
+against an unfixed library, which was checked by making
+`hold_for_spawn_reply` decline unconditionally and re-running.
+
+The two assertions worth reading before editing it are the negative
+ones. "held while a spawn is in flight" asserts that **nothing** appears
+within a settle window, which is the only way to distinguish held from
+written; and the second concurrent spawn's case asserts its output is
+*not* tagged, which is what fails when both spawns share one set of
+flags. A change that makes the release eager, or that drops the
+per-namespace match, passes every positive case and fails those two.
 
 **Perl-driven server tests** — `run_*.pl`, generated from `.pl.in` by
 `configure`, which start a `test/simple` server and drive real clients

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteendpts.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_inherit proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary event_forward
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_pending iof_inherit proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary event_forward
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteendpts.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_inherit proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary event_forward
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteendpts.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_pending iof_inherit proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary event_forward
 
 client_api_SOURCES = \
         client_api.c
@@ -287,6 +287,12 @@ iof_output_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 iof_output_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+iof_pending_SOURCES = \
+        iof_pending.c
+iof_pending_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+iof_pending_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 iof_inherit_SOURCES = \
         iof_inherit.c
 iof_inherit_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -294,7 +300,7 @@ iof_inherit_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 clean-local:
-	rm -f compress compress_block preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_inherit proc_array_id get_perf attr_dictionary
+	rm -f compress compress_block preg bfrops_regex2 bfrops_alloc_inherit nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_pending iof_inherit proc_array_id get_perf attr_dictionary
 
 ptl_uri_SOURCES = \
         ptl_uri.c

--- a/test/unit/iof_pending.c
+++ b/test/unit/iof_pending.c
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Output that arrives before the spawn reply that says how to format it.
+ *
+ * A tool receives forwarded output for the jobs it spawns, and a rank
+ * that writes and exits immediately can get its first chunk to us before
+ * the spawn reply names the namespace it came from. Nothing in scope at
+ * that moment identifies which of our in-flight spawns produced it, so
+ * the library used to format it with a single process-wide stand-in -
+ * which cannot tell two concurrent spawns apart, and cannot carry an
+ * output-to-file directive at all. Such output was therefore formatted
+ * with the wrong spawn's directives, or (for a file-only spawn, where
+ * the stand-in says "do not write locally" and has no file to write to)
+ * dropped outright.
+ *
+ * It is now held until the reply arrives and then written with that
+ * spawn's own flags. This drives that arrangement directly: the entry
+ * points are pmix_iof_spawn_begin / pmix_iof_release_pending /
+ * pmix_iof_spawn_end, all of which run on the progress thread, so every
+ * step here is thread-shifted onto it.
+ *
+ * The test comes up as a tool because the cache is a tool-role thing -
+ * a client is never sent a spawned job's output.
+ */
+
+#include "src/include/pmix_config.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "include/pmix.h"
+#include "include/pmix_tool.h"
+
+#include "src/common/pmix_iof.h"
+#include "src/include/pmix_globals.h"
+#include "src/threads/pmix_threads.h"
+
+#define WAIT_USEC    20000
+#define WAIT_TRIES   250
+#define SETTLE_TRIES 25
+#define BUFSIZE      4096
+
+static FILE *out = NULL; /* the real stdout, saved before we take it */
+static int rfd = -1;     /* read end of the pipe standing in for stdout */
+static int efd = -1;     /* read end of the pipe standing in for stderr */
+static int failures = 0;
+static pmix_proc_t myproc;
+
+static void report(const char *what, bool pass)
+{
+    fprintf(out, "%-62s : %s\n", what, pass ? "PASS" : "FAIL");
+    fflush(out);
+    if (!pass) {
+        ++failures;
+    }
+}
+
+/* Collect what shows up on a captured stream, stopping once we have
+ * "want" bytes or run out of patience. NUL-terminated so it can be
+ * compared as a string. */
+static size_t collect(int fd, char *buf, size_t want)
+{
+    size_t got = 0;
+    int i;
+    ssize_t n;
+
+    for (i = 0; i < WAIT_TRIES && got < want; i++) {
+        n = read(fd, &buf[got], BUFSIZE - 1 - got);
+        if (0 < n) {
+            got += (size_t) n;
+            continue;
+        }
+        usleep(WAIT_USEC);
+    }
+    buf[got] = '\0';
+    return got;
+}
+
+/* Give the progress thread a good run at whatever we handed it, for the
+ * cases whose assertion is that nothing comes out yet. */
+static size_t settle(int fd, char *buf)
+{
+    size_t got = 0;
+    int i;
+    ssize_t n;
+
+    for (i = 0; i < SETTLE_TRIES; i++) {
+        usleep(WAIT_USEC);
+        n = read(fd, &buf[got], BUFSIZE - 1 - got);
+        if (0 < n) {
+            got += (size_t) n;
+        }
+    }
+    buf[got] = '\0';
+    return got;
+}
+
+/* Everything below runs on the progress thread. pmix_iof_write_output
+ * and the cache entry points all touch pmix_globals state that belongs
+ * to it, so main() must not call any of them directly. */
+typedef enum {
+    OP_WRITE,
+    OP_BEGIN,
+    OP_END,
+    OP_RELEASE,
+    OP_ADD_NSPACE,
+    OP_PENDING_COUNT
+} iofut_op_t;
+
+typedef struct {
+    pmix_event_t ev;
+    pmix_lock_t lock;
+    iofut_op_t op;
+    const char *nspace;
+    pmix_rank_t rank;
+    pmix_iof_channel_t stream;
+    const char *data;
+    size_t len;
+    pmix_iof_flags_t flags;
+    pmix_status_t status;
+    size_t count;
+} iofut_req_t;
+
+static void do_op(int sd, short args, void *cbdata)
+{
+    iofut_req_t *r = (iofut_req_t *) cbdata;
+    pmix_byte_object_t bo;
+    pmix_namespace_t *nptr;
+    pmix_proc_t src;
+
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    r->status = PMIX_SUCCESS;
+    switch (r->op) {
+    case OP_WRITE:
+        PMIX_LOAD_PROCID(&src, r->nspace, r->rank);
+        bo.bytes = (char *) r->data;
+        bo.size = r->len;
+        r->status = pmix_iof_write_output(&src, r->stream, &bo);
+        break;
+    case OP_BEGIN:
+        pmix_iof_spawn_begin();
+        break;
+    case OP_END:
+        pmix_iof_spawn_end();
+        break;
+    case OP_RELEASE:
+        pmix_iof_release_pending(r->nspace);
+        break;
+    case OP_ADD_NSPACE:
+        /* what the spawn reply does when it learns the namespace: record
+         * the directives the spawn was issued with against it */
+        nptr = PMIX_NEW(pmix_namespace_t);
+        if (NULL == nptr) {
+            r->status = PMIX_ERR_NOMEM;
+            break;
+        }
+        nptr->nspace = strdup(r->nspace);
+        memcpy(&nptr->iof_flags, &r->flags, sizeof(pmix_iof_flags_t));
+        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
+        break;
+    case OP_PENDING_COUNT:
+        r->count = pmix_list_get_size(&pmix_globals.iof_pending);
+        break;
+    }
+    PMIX_WAKEUP_THREAD(&r->lock);
+}
+
+static void run_op(iofut_req_t *r)
+{
+    PMIX_CONSTRUCT_LOCK(&r->lock);
+    PMIX_THREADSHIFT(r, do_op);
+    PMIX_WAIT_THREAD(&r->lock);
+    PMIX_DESTRUCT_LOCK(&r->lock);
+}
+
+static pmix_status_t write_out(const char *nspace, pmix_rank_t rank,
+                               const char *data, size_t len)
+{
+    iofut_req_t r;
+
+    memset(&r, 0, sizeof(r));
+    r.op = OP_WRITE;
+    r.nspace = nspace;
+    r.rank = rank;
+    r.stream = PMIX_FWD_STDOUT_CHANNEL;
+    r.data = data;
+    r.len = len;
+    run_op(&r);
+    return r.status;
+}
+
+static void simple_op(iofut_op_t op, const char *nspace)
+{
+    iofut_req_t r;
+
+    memset(&r, 0, sizeof(r));
+    r.op = op;
+    r.nspace = nspace;
+    run_op(&r);
+}
+
+static size_t pending_count(void)
+{
+    iofut_req_t r;
+
+    memset(&r, 0, sizeof(r));
+    r.op = OP_PENDING_COUNT;
+    run_op(&r);
+    return r.count;
+}
+
+/* Announce a namespace with the given formatting directives, exactly as
+ * the spawn reply would, and release whatever we were holding for it. */
+static void reply_arrives(const char *nspace, pmix_iof_flags_t *flags)
+{
+    iofut_req_t r;
+
+    memset(&r, 0, sizeof(r));
+    r.op = OP_ADD_NSPACE;
+    r.nspace = nspace;
+    memcpy(&r.flags, flags, sizeof(pmix_iof_flags_t));
+    run_op(&r);
+    if (PMIX_SUCCESS != r.status) {
+        fprintf(out, "could not record namespace %s\n", nspace);
+        fflush(out);
+        ++failures;
+        return;
+    }
+    simple_op(OP_RELEASE, nspace);
+}
+
+/* replace "fd" with the write end of a fresh pipe, handing back a
+ * non-blocking read end */
+static int capture(int fd)
+{
+    int pipefd[2];
+
+    if (0 != pipe(pipefd)) {
+        fprintf(out, "pipe failed: %s\n", strerror(errno));
+        return -1;
+    }
+    if (0 > dup2(pipefd[1], fd)) {
+        fprintf(out, "dup2 failed: %s\n", strerror(errno));
+        return -1;
+    }
+    close(pipefd[1]);
+    if (0 > fcntl(pipefd[0], F_SETFL, O_NONBLOCK)) {
+        fprintf(out, "fcntl failed: %s\n", strerror(errno));
+        return -1;
+    }
+    return pipefd[0];
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_info_t tinfo;
+    pmix_iof_flags_t flags;
+    int savedout;
+    char buf[BUFSIZE];
+    size_t got;
+    (void) argc;
+    (void) argv;
+
+    /* keep a handle on the real stdout before we take it away, so the
+     * results can still be reported */
+    fflush(stdout);
+    savedout = dup(fileno(stdout));
+    if (0 > savedout) {
+        fprintf(stderr, "dup of stdout failed: %s\n", strerror(errno));
+        return 1;
+    }
+    out = fdopen(savedout, "w");
+    if (NULL == out) {
+        fprintf(stderr, "fdopen failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    fprintf(out, "\n=== PMIx IOF pending-output unit test ===\n\n");
+    fflush(out);
+
+    /* the shared sinks are built on fd 1 and fd 2 during init, so the
+     * substitution has to be in place before that runs */
+    fflush(stderr);
+    rfd = capture(fileno(stdout));
+    efd = capture(fileno(stderr));
+    if (0 > rfd || 0 > efd) {
+        return 1;
+    }
+
+    PMIX_INFO_LOAD(&tinfo, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+    rc = PMIx_tool_init(&myproc, &tinfo, 1);
+    PMIX_INFO_DESTRUCT(&tinfo);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(out, "PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* ---- with no spawn in flight, nothing is held ----
+     * The cache must not delay output that has no reply coming: a tool
+     * that pulled a job's IOF without spawning it would otherwise see
+     * nothing until something unrelated finished. */
+    rc = write_out("nospawn", 0, "alpha\n", 6);
+    got = collect(rfd, buf, 6);
+    report("output for an unknown nspace flows when nothing is in flight",
+           PMIX_SUCCESS == rc && 6 == got && 0 == strcmp(buf, "alpha\n"));
+
+    /* ---- with a spawn in flight, it is held ---- */
+    simple_op(OP_BEGIN, NULL);
+    rc = write_out("jobA", 0, "beta\n", 5);
+    got = settle(rfd, buf);
+    report("output for an unknown nspace is held while a spawn is in flight",
+           PMIX_SUCCESS == rc && 0 == got);
+    report("and is on the pending list", 1 == pending_count());
+
+    /* ---- and the reply's own directives are what format it ---- */
+    pmix_iof_init_flags(&flags);
+    flags.set = true;
+    flags.tag = true;
+    reply_arrives("jobA", &flags);
+    got = collect(rfd, buf, 5);
+    report("the reply releases it", 0 < got);
+    report("formatted with the directives that spawn was issued with",
+           NULL != strstr(buf, "[jobA,0]") && NULL != strstr(buf, "beta"));
+    simple_op(OP_END, NULL);
+
+    /* ---- two concurrent spawns, formatted differently ----
+     * This is the case a single process-wide stand-in cannot serve: the
+     * second spawn's flags overwrite the first's, so whichever job's
+     * output arrived first was formatted with the other's directives.
+     * Held output is matched to its own reply by namespace instead. */
+    simple_op(OP_BEGIN, NULL);
+    simple_op(OP_BEGIN, NULL);
+    rc = write_out("jobB", 1, "tagme\n", 6);
+    if (PMIX_SUCCESS == rc) {
+        rc = write_out("jobC", 2, "plain\n", 6);
+    }
+    got = settle(rfd, buf);
+    report("both jobs' output is held while two spawns are in flight",
+           PMIX_SUCCESS == rc && 0 == got);
+    report("and both are on the pending list", 2 == pending_count());
+
+    pmix_iof_init_flags(&flags);
+    flags.set = true;
+    flags.tag = true;
+    reply_arrives("jobB", &flags);
+    got = collect(rfd, buf, 6);
+    report("the first reply releases only its own job's output",
+           NULL != strstr(buf, "[jobB,1]") && NULL != strstr(buf, "tagme") &&
+               NULL == strstr(buf, "plain"));
+    simple_op(OP_END, NULL);
+
+    pmix_iof_init_flags(&flags);
+    flags.set = true;
+    reply_arrives("jobC", &flags);
+    got = collect(rfd, buf, 6);
+    report("the second gets its own formatting, not the first's",
+           6 == got && 0 == strcmp(buf, "plain\n"));
+    simple_op(OP_END, NULL);
+
+    /* ---- arrival order survives being held ---- */
+    simple_op(OP_BEGIN, NULL);
+    rc = write_out("jobD", 0, "one\n", 4);
+    if (PMIX_SUCCESS == rc) {
+        rc = write_out("jobD", 0, "two\n", 4);
+    }
+    if (PMIX_SUCCESS == rc) {
+        rc = write_out("jobD", 0, "three\n", 6);
+    }
+    pmix_iof_init_flags(&flags);
+    flags.set = true;
+    reply_arrives("jobD", &flags);
+    got = collect(rfd, buf, 14);
+    report("held output is written in arrival order",
+           PMIX_SUCCESS == rc && 14 == got && 0 == strcmp(buf, "one\ntwo\nthree\n"));
+    simple_op(OP_END, NULL);
+
+    /* ---- a spawn told not to write locally suppresses what was held ----
+     * The stand-in gets this half right today by refusing to write; what
+     * it cannot do is write the output to the file the spawn asked for,
+     * because no sink can be opened for a namespace we have not been
+     * told about. Releasing after the reply is what makes that possible.
+     * Here we only check the local half: the namespace says no, so the
+     * held output must not reach the terminal. */
+    simple_op(OP_BEGIN, NULL);
+    rc = write_out("jobE", 0, "unwanted\n", 9);
+    pmix_iof_init_flags(&flags);
+    flags.set = true;
+    flags.local_output_given = true;
+    flags.local_output = false;
+    reply_arrives("jobE", &flags);
+    got = settle(rfd, buf);
+    report("held output honors a spawn that declined local output",
+           PMIX_SUCCESS == rc && 0 == got);
+    report("and is no longer pending", 0 == pending_count());
+    simple_op(OP_END, NULL);
+
+    /* ---- the last spawn being answered flushes what is left ----
+     * Output held for a namespace no reply ever names belongs to no
+     * spawn of ours, so it must not sit there once nothing is in
+     * flight - it goes out with the process-wide flags, which is what
+     * it would have had all along. */
+    simple_op(OP_BEGIN, NULL);
+    rc = write_out("orphan", 0, "stranded\n", 9);
+    got = settle(rfd, buf);
+    report("output for a namespace no reply names is held first",
+           PMIX_SUCCESS == rc && 0 == got);
+    simple_op(OP_END, NULL);
+    got = collect(rfd, buf, 9);
+    report("and is flushed when the last spawn is answered",
+           9 == got && 0 == strcmp(buf, "stranded\n"));
+    report("leaving nothing pending", 0 == pending_count());
+
+    /* ---- the cache is bounded ----
+     * Past the limit output stops being held and falls back to the
+     * stand-in, so a job that produces more than we are willing to
+     * buffer before its reply lands is delayed rather than lost. */
+    pmix_globals.iof_pending_limit = 8;
+    simple_op(OP_BEGIN, NULL);
+    rc = write_out("jobF", 0, "held\n", 5);
+    if (PMIX_SUCCESS == rc) {
+        rc = write_out("jobF", 0, "overflowed\n", 11);
+    }
+    got = collect(rfd, buf, 11);
+    report("output past the pending limit is written rather than held",
+           PMIX_SUCCESS == rc && 11 == got && 0 == strcmp(buf, "overflowed\n"));
+    report("while what fit is still pending", 1 == pending_count());
+    simple_op(OP_END, NULL);
+    got = collect(rfd, buf, 5);
+    report("and what fit is written when the spawn is answered",
+           5 == got && 0 == strcmp(buf, "held\n"));
+
+    PMIx_tool_finalize();
+    close(rfd);
+    close(efd);
+
+    fprintf(out, "\n%s\n", (0 == failures) ? "ALL PASSED" : "FAILURES DETECTED");
+    fflush(out);
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
Closes the `docs/todo.rst` open decision "Two concurrent spawns cannot be formatted differently".

## The problem

Forwarded output can reach a tool *before* the spawn reply names the namespace it came from, and `pmix_iof_write_output()` has nothing in scope at that moment but the unknown namespace and the stream. It formatted such output from `pmix_globals.spawn_iof_flags` — a single process-wide slot holding the directives of the last spawn issued.

That slot cannot serve two spawns at once: the second overwrites the first's flags, and the first reply to land clears it for both. So whichever job's output arrived first was formatted with the other's directives, or with none.

It also cannot carry an output-to-file or output-to-directory directive at all, because no sink can be opened for a namespace we have not been told about. `PMIX_IOF_FILE_ONLY` is the default for such a spawn, so the slot suppressed the local write and had nowhere else to put the bytes — **early output from a file-directed job was written nowhere.** That half is a silent data loss, not just a formatting defect.

## Why the todo entry read as closed

It listed three unattractive choices — keep one slot and accept the collision, let the reply establish the flags (re-opening the window the stand-in was built to close), or carry something in the IOF message that names the spawn (a wire-format and Standard question). All three answer *"which flags does this output get"*, and that question genuinely has no answer at that moment.

The question that does have one is *"does this output have to be formatted yet"*. It does not — so hold it.

## The fix

`pmix_globals.iof_pending` holds the bytes while at least one spawn of ours is unanswered. The reply, which knows both the namespace and the directives that spawn was issued with, releases them. Formatting is exact rather than a guess, arbitrarily many spawns can be in flight, and a file-directed job's early output reaches its file. Entirely process-local: no wire change, no Standard question.

Bounded by a new `pmix_iof_pending_limit` MCA parameter (default 1MB). Past it output falls back to the stand-in, which is what every chunk got before — so declining to hold is always safe, which is also what makes the allocation failures here harmless rather than lost output.

## Four load-bearing details

- **The gate is "is a spawn of ours unanswered", not "is this namespace unknown".** With nothing in flight, no reply can name a namespace, so a `PMIx_IOF_pull` against a job we did not spawn must go straight through rather than wait for something that never comes.
- **The drain writes with `may_hold` false.** Without it, a spawn whose directives leave `iof_flags.set` false finds the namespace record still saying nothing, hands the chunk straight back, and spins. That is why `pmix_iof_write_output()` is now a wrapper around a static `write_output()` carrying the flag.
- **A zero-size chunk is held too** — it is the end-of-stream marker, and letting it past would put it ahead of the output it ends.
- **Every path that ends a spawn owes `pmix_iof_spawn_end()`**, the failed `PMIX_PTL_SEND_RECV` included. Both halves ask the same `spawn_iof_tracked()` predicate rather than repeating the test, because a spawn counted in and never counted out holds output indefinitely. And the release goes *above* the `end`, not below: `end` at zero flushes with the process-wide defaults, so releasing after it would hand this spawn's output exactly what it was waiting to escape.

`pmix_iof_spawn_begin()` runs on the caller's thread (the count is atomic for that reason, and is published by being stored ahead of the send); everything else is progress-thread only.

## Not closed

With two spawns in flight, the overflow stand-in still holds whichever spawn's flags were stashed last, so output *past the limit* can still be formatted with the wrong spawn's directives. That is inherent to having a single fallback slot, and is documented at the site. Reaching it requires exceeding the limit, at which point the choice is between a stale guess and the process defaults.

## Testing

- Clean build, zero warnings under `--enable-debug --enable-devel-check`.
- `make check`: 136 PASS, 0 FAIL/SKIP/ERROR. `test/simple/simptest` OK. Docs rebuilt from scratch, warning-free.
- New `test/unit/iof_pending` (18 cases), wired into `make check`. It comes up as a **tool**, because a client is never sent a spawned job's output, and drives the entry points directly — no spawn is issued and none could be, since `test/simple/simptest` cannot host one.
- Confirmed it is a real regression test: making `hold_for_spawn_reply()` decline unconditionally fails 11 of the 18 cases, including the two that matter — "held while a spawn is in flight" and "the second gets its own formatting, not the first's".
- The new MCA parameter was confirmed to take effect via its environment variable.

`docs/todo.rst`, `docs/news/news-v7.x.rst`, and the `src/common`, `src/client` and `test/unit` `AGENTS.md` files are updated.
