### PR TITLE
Say that a companion project may use the FULL framework declaration

### DIFF
--- a/src/mca/base/pmix_mca_base_framework.h
+++ b/src/mca/base/pmix_mca_base_framework.h
@@ -289,8 +289,16 @@ PMIX_EXPORT bool pmix_mca_base_framework_is_open(struct pmix_mca_base_framework_
                                              openfn, closefn, static_components, flags)
 
 /**
- * The declaration both of the above expand to. Not to be called
- * directly - use one of the two macros above.
+ * The declaration both of the above expand to.
+ *
+ * Frameworks in this project use one of the two macros above rather than
+ * this one. A companion project is the exception, and a sanctioned one:
+ * the versioned form reaches its numbers by pasting a PMIX_ prefix, which
+ * is this project's namespace, so a project whose frameworks state their
+ * own versions builds its equivalent on top of this - PRRTE's
+ * PRTE_MCA_BASE_FRAMEWORK_DECLARE pastes PRTE_MCA_<name>_*_VERSION and
+ * hands the result here. Treat the argument list as part of the installed
+ * interface for that reason.
  */
 #    define PMIX_MCA_BASE_FRAMEWORK_DECLARE_FULL(project, name, type_major, type_minor,     \
                                                  description, registerfn, openfn,           \


### PR DESCRIPTION
Documentation only — no code change.

`PMIX_MCA_BASE_FRAMEWORK_DECLARE_FULL` carried:

> The declaration both of the above expand to. Not to be called directly -
> use one of the two macros above.

That is right for frameworks in this project and wrong for the projects
layered on it, which #4108 made concrete.

The versioned form reaches a framework's interface version by pasting a
`PMIX_` prefix onto its name — `PMIX_MCA_<name>_MAJOR_VERSION` — and that is
this project's namespace. So a companion project whose frameworks state their
own versions cannot use it: PRRTE's frameworks want
`PRTE_MCA_plm_MAJOR_VERSION`, and asking PRRTE to define `PMIX_`-prefixed
macros would violate the prefix rule in both directions.

What such a project does instead is paste its own prefix and hand the result
to this macro, which is exactly what a "FULL" form taking explicit version
arguments is for. openpmix/prrte#2674 does that — its
`PRTE_MCA_BASE_FRAMEWORK_DECLARE` expands through here — so the comment now
says the use is sanctioned, and that the argument list is part of the
installed interface as a consequence.

Split out of #4108, which was already merged when this came up.
