### PR TITLE
Compress small modex buckets, and stop leaking compressed strings to applications

### DIFF
--- a/docs/how-things-work/modex.rst
+++ b/docs/how-things-work/modex.rst
@@ -66,8 +66,8 @@ Publication: ``PMIx_Put``
 
 ``PMIx_Put`` (``src/client/pmix_client.c``) validates its arguments and
 thread-shifts to ``_putfn``, which builds a ``pmix_kval_t`` holding a
-copy of the key string and the value — compressing large strings into a
-``PMIX_COMPRESSED_STRING`` — and hands it to the datastore::
+copy of the key string and the value exactly as the caller supplied it,
+and hands it to the datastore::
 
     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &pmix_globals.myid, cb->scope, kv);
     ...

--- a/docs/man/man5/pmix_data_type_t.5.rst
+++ b/docs/man/man5/pmix_data_type_t.5.rst
@@ -60,7 +60,7 @@ C Syntax
    #define PMIX_DATA_ARRAY                 39
    #define PMIX_PROC_RANK                  40
    #define PMIX_QUERY                      41
-   #define PMIX_COMPRESSED_STRING          42  // string compressed with zlib
+   // Hole left by deprecation of PMIX_COMPRESSED_STRING
    #define PMIX_ALLOC_DIRECTIVE            43
    // Hole left by deprecation/removal of PMIX_INFO_ARRAY
    #define PMIX_IOF_CHANNEL                45
@@ -126,9 +126,12 @@ header. The values fall into the following broad categories:
   ``PMIX_INT``/``PMIX_UINT``, ``PMIX_FLOAT``, ``PMIX_DOUBLE``,
   ``PMIX_TIMEVAL``, ``PMIX_TIME``, and ``PMIX_POINTER``.
 
-* **Strings** |mdash| ``PMIX_STRING`` for a NULL-terminated character string,
-  and its compressed form ``PMIX_COMPRESSED_STRING`` (a string that has been
-  compressed with zlib for transmission).
+* **Strings** |mdash| ``PMIX_STRING`` for a NULL-terminated character string.
+  A compressed form, ``PMIX_COMPRESSED_STRING``, is **deprecated**: nothing
+  in PMIx produces one, and a value that arrives carrying that type is
+  expanded and delivered as a ``PMIX_STRING``. Do not tag a value with it.
+  Compression of a collective payload is applied to the whole payload by
+  the operation that ships it, not to individual values.
 
 * **Enumerated / directive types** |mdash| the typed PMIx enumerations and
   bit-mask directive types, such as ``PMIX_STATUS``, ``PMIX_PERSIST``,

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1877,7 +1877,8 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_DATA_ARRAY                 39
 #define PMIX_PROC_RANK                  40
 #define PMIX_QUERY                      41
-#define PMIX_COMPRESSED_STRING          42  // string compressed with zlib
+// Hole left by deprecation of PMIX_COMPRESSED_STRING (nothing produces
+// one; a string value is carried as PMIX_STRING)
 #define PMIX_ALLOC_DIRECTIVE            43
 // Hole left by deprecation/removal of PMIX_INFO_ARRAY
 #define PMIX_IOF_CHANNEL                45

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -65,6 +65,26 @@
 extern "C" {
 #endif
 
+/***** v7 DEPRECATIONS/REMOVALS *****/
+/* DATATYPES */
+/* PMIX_COMPRESSED_STRING is deprecated - use PMIX_STRING.  Nothing in
+ * PMIx produces one any more: PMIx_Put used to convert a large string
+ * value into this type, which compressed the copy handed to the
+ * datastore as well as the one put on the wire, so a PMIx_Get of that
+ * value returned bytes the caller had no API to expand.  It also made
+ * the fence payload *larger*, because pre-compressing one value
+ * destroys the cross-rank redundancy that the bucket-level compression
+ * exploits.  Compression of collective payloads belongs to the fence,
+ * which compresses the whole bucket.
+ *
+ * The numeric value is preserved, every bfrops component still
+ * registers the type, and pmix_bfrops_base_unpack_val() still expands
+ * one into a PMIX_STRING - because every released PMIx produces these
+ * and will keep sending them to us for as long as those releases run.
+ * Deprecated means "do not tag a value with this", not "we stopped
+ * reading it". */
+#define PMIX_COMPRESSED_STRING          42
+
 /***** v5 DEPRECATIONS/REMOVALS *****/
 /* APIs */
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -829,7 +829,13 @@ inspection against the code that consumes them.
   `PMIX_VALUE_CREATE`, which zeroes and sets `PMIX_UNDEF`. The rule
   worth carrying: **anything a destructor will inspect has to be valid
   from the moment the object exists**, not from the moment the happy
-  path fills it in.
+  path fills it in. (The compression branch itself is gone as of
+  August 2026 — `_putfn` stores the value exactly as the caller gave it.
+  See "Strings are not compressed individually" in
+  [`src/mca/pcompress/AGENTS.md`](../mca/pcompress/AGENTS.md) for why,
+  and do not reintroduce a conversion here: it compressed the copy the
+  *datastore* keeps, so a `PMIx_Get` of our own put came back as bytes
+  the caller has no API to expand.)
 - `PMIx_Spawn_nb` took `PMIX_PARENT_ID` straight to `PMIX_XFER_PROCID`
   without checking that the value really carried a `pmix_proc_t`. Same
   defect as the `PMIX_HOSTNAME` qualifier fixed in `process_request()`

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1542,8 +1542,6 @@ static void _putfn(int sd, short args, void *cbdata)
     pmix_cb_t *cb = (pmix_cb_t *) cbdata;
     pmix_status_t rc;
     pmix_kval_t *kv = NULL;
-    uint8_t *tmp;
-    size_t len;
 
     /* need to acquire the cb object from its originating thread */
     PMIX_ACQUIRE_OBJECT(cb);
@@ -1572,25 +1570,16 @@ static void _putfn(int sd, short args, void *cbdata)
         rc = PMIX_ERR_NOMEM;
         goto done;
     }
-    if (PMIX_STRING_SIZE_CHECK(cb->value)) {
-        /* compress large strings */
-        if (pmix_compress.compress_string(cb->value->data.string, &tmp, &len)) {
-            if (PMIX_UNLIKELY(NULL == tmp)) {
-                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-                rc = PMIX_ERR_NOMEM;
-                PMIX_ERROR_LOG(rc);
-                goto done;
-            }
-            kv->value->type = PMIX_COMPRESSED_STRING;
-            kv->value->data.bo.bytes = (char *) tmp;
-            kv->value->data.bo.size = len;
-            rc = PMIX_SUCCESS;
-        } else {
-            PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, kv->value, cb->value);
-        }
-    } else {
-        PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, kv->value, cb->value);
-    }
+    /* Store the value as the caller gave it to us. A large string used to
+     * be converted to a PMIX_COMPRESSED_STRING here, which compressed the
+     * copy we hand the datastore as well as the one we later put on the
+     * wire - so a PMIx_Get of our own put came back as bytes the caller
+     * has no way to expand, and the modex carried a pre-compressed blob
+     * that the bucket-level compression could no longer find any
+     * redundancy in. Compression of the fence payload belongs to the
+     * fence, which compresses the whole bucket; see
+     * src/mca/pcompress/AGENTS.md for the measurements. */
+    PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer, kv->value, cb->value);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
         goto done;

--- a/src/mca/bfrops/base/AGENTS.md
+++ b/src/mca/bfrops/base/AGENTS.md
@@ -146,6 +146,50 @@ every unpacker. Add to it rather than to a scratch program. Note that
 both defects above were found by that fuzz stage, not by reading -
 which is the argument for keeping it.
 
+## The one place unpack does not hand back the type it was given
+
+`pmix_bfrops_base_unpack_val()` expands a `PMIX_COMPRESSED_STRING` and
+returns a `PMIX_STRING`. That is deliberate and is the only such
+transformation in the framework, so it is worth knowing before you read
+the switch and assume a typo.
+
+The reason is that PMIx publishes no way to expand one: there is no
+`PMIx_Value_decompress`, so a compressed string that survives
+deserialization reaches the application through `PMIx_Get` as bytes it
+cannot read, and reaches the datastore in a form nothing can match
+against. `unpack_val` is the single point every value arriving from
+anywhere passes through exactly once, which makes it the only place the
+expansion can be done once rather than at each of the many consumers —
+the same argument as putting the NULL screen inside
+`PMIx_Value_get_number()` rather than at its thirty-odd callers.
+
+Three things follow:
+
+- **This is live compatibility code, not legacy cleanup.** Every
+  released PMIx compresses large string values on the way out, so peers
+  will keep sending them regardless of what this release chooses to
+  send. The arm must stay.
+- **It is not a wire-format change.** The bytes are identical; only the
+  in-memory result differs, and `PMIX_COMPRESSED_STRING` remains
+  registered in every component.
+- **Only scalar values are affected.** An *array* of
+  `PMIX_COMPRESSED_STRING` goes through `unpack_darray` to the per-type
+  unpacker (`unpack_bo`) and never reaches `unpack_val`, so array
+  elements keep their declared type. If that ever needs to change, it is
+  a separate decision — `data_array_construct()` sizes the block as
+  `pmix_byte_object_t`.
+
+A failure to expand is `PMIX_ERR_UNPACK_FAILURE`, not a fallback to
+handing back the compressed bytes under a `PMIX_STRING` tag. Same
+reasoning as the compressed-bucket path in
+[`gds_base_fns.c`](../../gds/base/gds_base_fns.c): if the sender says
+these bytes are compressed and we cannot expand them, we have no string
+— not the original one.
+
+Coverage: `test/unit/compress_block.c` packs a hand-built
+`PMIX_COMPRESSED_STRING` value and asserts the unpack yields a matching
+`PMIX_STRING`. It fails against a library without the arm.
+
 ## Defects found in the August 2026 review
 
 Recorded because each is a shape that will recur, not for history's

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -27,6 +27,7 @@
 
 #include "src/hwloc/pmix_hwloc.h"
 #include "src/include/pmix_globals.h"
+#include "src/mca/pcompress/base/base.h"
 #include "src/mca/preg/preg.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
@@ -694,6 +695,45 @@ pmix_status_t pmix_bfrops_base_unpack_val(pmix_pointer_array_t *regtypes, pmix_b
             }
             PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.regex2, &m, PMIX_REGEX2, regtypes);
             return ret;
+
+        case PMIX_COMPRESSED_STRING: {
+            /* A compressed string is a transport encoding, not a thing a
+             * value is allowed to still be once it has been received. We
+             * publish no way for an application to expand one - there is
+             * no PMIx_Value_decompress - so a PMIX_COMPRESSED_STRING that
+             * survives deserialization is handed to whoever called
+             * PMIx_Get as an opaque byte object they cannot read, and is
+             * stored by the datastore in a form nothing can match. Expand
+             * it here, where every value that arrives from anywhere passes
+             * exactly once, and let it be a string from that point on.
+             *
+             * Peers still send these - every released PMIx compressed
+             * large string values on the way out - so this is not dead
+             * compatibility code, and it must stay whatever this release
+             * chooses to send. */
+            pmix_byte_object_t bo;
+            char *str = NULL;
+
+            PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &bo, &m, PMIX_BYTE_OBJECT, regtypes);
+            if (PMIX_SUCCESS != ret) {
+                PMIX_BYTE_OBJECT_DESTRUCT(&bo);
+                return ret;
+            }
+            if (!pmix_compress.decompress_string(&str, (uint8_t *) bo.bytes, bo.size)) {
+                /* the peer said these bytes are a compressed string. If we
+                 * cannot expand them - no compression library on this side,
+                 * or a component that does not read the sender's format -
+                 * we have no string, and handing back the compressed bytes
+                 * under a PMIX_STRING tag would be worse than an error. */
+                PMIX_BYTE_OBJECT_DESTRUCT(&bo);
+                return PMIX_ERR_UNPACK_FAILURE;
+            }
+            PMIX_BYTE_OBJECT_DESTRUCT(&bo);
+            val->type = PMIX_STRING;
+            val->data.string = str;
+            return PMIX_SUCCESS;
+        }
 
         default:
             if (value_type_overflows_union(val->type)) {

--- a/src/mca/bfrops/v61/bfrop_pmix61.c
+++ b/src/mca/bfrops/v61/bfrop_pmix61.c
@@ -224,6 +224,13 @@ static pmix_status_t init(void)
                        pmix_bfrops_base_unpack_query, pmix_bfrops_base_copy_query,
                        pmix_bfrops_base_print_query, &pmix_mca_bfrops_v61_component.types);
 
+    /* PMIX_COMPRESSED_STRING is deprecated and nothing in this release
+     * produces one - but it stays registered here, and in every other
+     * component, because peers do. A PMIx built before the deprecation
+     * negotiates v61 with us and compresses its large string values on
+     * the way out, so dropping this entry would make those values
+     * unreadable rather than merely unfashionable. The base unpacker
+     * expands one into a PMIX_STRING; see pmix_bfrops_base_unpack_val(). */
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_STRING", PMIX_COMPRESSED_STRING, pmix_bfrops_base_pack_bo,
                        pmix_bfrops_base_unpack_bo, pmix_bfrops_base_copy_bo,
                        pmix_bfrops_base_print_bo, &pmix_mca_bfrops_v61_component.types);

--- a/src/mca/gds/AGENTS.md
+++ b/src/mca/gds/AGENTS.md
@@ -305,9 +305,10 @@ Threading.
   one entry on `actives`, pairing a module with the priority it was
   inserted at and its component.
 - **`pmix_gds_modex_key_fmt_t`** (`NATIVE_FMT` / `KEYMAP_FMT`) and the
-  `PMIX_GDS_COLLECT_BIT` / `PMIX_GDS_KEYMAP_BIT` blob-info flags — used when
-  (de)serializing modex blobs so a reader knows the key encoding and
-  whether data was collected.
+  `PMIX_GDS_COLLECT_BIT` / `PMIX_GDS_KEYMAP_BIT` blob-info flags — dead
+  since the modex keymap was removed in 2024; no code reads or writes
+  them. See "The modex keymap, and why it is not coming back" in
+  [`base/AGENTS.md`](base/AGENTS.md) before reviving the idea.
 
 ## Directory layout
 

--- a/src/mca/gds/AGENTS.md
+++ b/src/mca/gds/AGENTS.md
@@ -296,7 +296,7 @@ state the framework's interface version — the numbers
 comment that **the GDS is not guaranteed to be thread-safe** — see
 Threading.
 
-### `base/base.h` — globals, active-module wrapper, modex key formats
+### `base/base.h` — globals and the active-module wrapper
 
 - **`pmix_gds_globals`** (`pmix_gds_globals_t`) — the framework state:
   `actives` (the priority-ordered module list), `initialized`, `selected`,
@@ -304,11 +304,11 @@ Threading.
 - **`pmix_gds_base_active_module_t`** `{ super, pri, module, component }` —
   one entry on `actives`, pairing a module with the priority it was
   inserted at and its component.
-- **`pmix_gds_modex_key_fmt_t`** (`NATIVE_FMT` / `KEYMAP_FMT`) and the
-  `PMIX_GDS_COLLECT_BIT` / `PMIX_GDS_KEYMAP_BIT` blob-info flags — dead
-  since the modex keymap was removed in 2024; no code reads or writes
-  them. See "The modex keymap, and why it is not coming back" in
-  [`base/AGENTS.md`](base/AGENTS.md) before reviving the idea.
+`pmix_gds_modex_key_fmt_t` and the `PMIX_GDS_COLLECT_BIT` /
+`PMIX_GDS_KEYMAP_BIT` blob-info flags used to be declared here too. They
+were deleted in August 2026, having been dead since the modex keymap was
+removed in 2024. See "The modex keymap, and why it is not coming back"
+in [`base/AGENTS.md`](base/AGENTS.md) before reviving the idea.
 
 ## Directory layout
 
@@ -316,7 +316,7 @@ Threading.
 src/mca/gds/
 ├── gds.h                   Framework API: module struct, PMIX_GDS_* macros, version
 ├── base/                   Framework infrastructure (see above)
-│   ├── base.h              Internal base API: globals, active-module wrapper, modex flags
+│   ├── base.h              Internal base API: globals, active-module wrapper
 │   ├── gds_base_frame.c    open/close, framework decl (no MCA params), class instance
 │   ├── gds_base_select.c   query components → build priority-ordered actives list
 │   └── gds_base_fns.c      available-modules, assign/fallback module, setup_fork, store_modex

--- a/src/mca/gds/base/AGENTS.md
+++ b/src/mca/gds/base/AGENTS.md
@@ -11,7 +11,7 @@ depends on.
 
 | File | Contents |
 |------|----------|
-| [`base.h`](base.h) | the internal base API — `pmix_gds_globals`, the active-module wrapper class, the modex blob-info flags, and the exported helpers below |
+| [`base.h`](base.h) | the internal base API — `pmix_gds_globals`, the active-module wrapper class, and the exported helpers below |
 | [`gds_base_frame.c`](gds_base_frame.c) | `PMIX_MCA_BASE_FRAMEWORK_DECLARE`, the globals, `pmix_gds_open`/`pmix_gds_close`, and the `pmix_gds_base_active_module_t` class instance |
 | [`gds_base_select.c`](gds_base_select.c) | `pmix_gds_base_select()` — query every component, init each returned module, build the priority-ordered `actives` list |
 | [`gds_base_fns.c`](gds_base_fns.c) | the five exported helpers: available-modules, assign-module, fallback-module, setup-fork, store-modex, plus `pmix_gds_base_proc_array_id()` |
@@ -160,12 +160,14 @@ Two other things to keep in mind if you touch it:
 - **`pmix_gds_globals`** — `actives`, `initialized`, `selected`, `all_mods`.
 - **`pmix_gds_base_active_module_t`** — one entry on `actives`, pairing a
   module with the priority it was inserted at and its component.
-- **`pmix_gds_modex_key_fmt_t`** (`NATIVE_FMT` / `KEYMAP_FMT`), the
-  `PMIX_GDS_COLLECT_BIT` / `PMIX_GDS_KEYMAP_BIT` blob-info flags and the
-  `PMIX_GDS_*_IS_SET` accessors — **all dead**. Nothing in the tree
-  reads or writes any of them; they are the residue of the modex keymap,
-  described below. The collect flag the walker actually reads is a plain
-  `PMIX_COLLECT_YES`/`PMIX_COLLECT_NO` byte, not a bitmask.
+There is nothing else. `pmix_gds_modex_key_fmt_t`, the
+`PMIX_GDS_COLLECT_BIT` / `PMIX_GDS_KEYMAP_BIT` blob-info flags, the
+`PMIX_GDS_*_IS_SET` accessors and `pmix_gds_modex_blob_info_t` were all
+deleted in August 2026: they were the residue of the modex keymap
+(below) and nothing had read or written any of them since 2024. The
+collect flag the walker reads is a plain
+`PMIX_COLLECT_YES`/`PMIX_COLLECT_NO` byte, not a bitmask — do not
+reintroduce the bit accessors on the theory that it is one.
 
 ## The modex keymap, and why it is not coming back
 

--- a/src/mca/gds/base/AGENTS.md
+++ b/src/mca/gds/base/AGENTS.md
@@ -228,9 +228,13 @@ Two further things worth knowing before reviving it:
 The small-payload corner that a keymap *did* still win — a node whose
 bucket fell under `pmix_compress_base.compress_limit` and was therefore
 shipped raw — was closed in August 2026 by lowering that limit from 4096
-to 1024. See "Choosing `compress_limit`" in
+to 256, which is where the compressor starts declining on its own. See
+"Choosing `compress_limit`" in
 [`../../pcompress/AGENTS.md`](../../pcompress/AGENTS.md) for the curve
-that number came from.
+that number came from, and the section after it for why large string
+values are no longer compressed individually before they reach the
+bucket — the same cross-rank redundancy argument, pointing the other
+way.
 
 ## When working here
 

--- a/src/mca/gds/base/AGENTS.md
+++ b/src/mca/gds/base/AGENTS.md
@@ -160,10 +160,75 @@ Two other things to keep in mind if you touch it:
 - **`pmix_gds_globals`** — `actives`, `initialized`, `selected`, `all_mods`.
 - **`pmix_gds_base_active_module_t`** — one entry on `actives`, pairing a
   module with the priority it was inserted at and its component.
-- **`pmix_gds_modex_key_fmt_t`** (`NATIVE_FMT` / `KEYMAP_FMT`) and the
-  `PMIX_GDS_COLLECT_BIT` / `PMIX_GDS_KEYMAP_BIT` blob-info flags, with the
-  `PMIX_GDS_*_IS_SET` accessors — the encoding a modex reader uses to
-  learn how keys were written and whether data was collected.
+- **`pmix_gds_modex_key_fmt_t`** (`NATIVE_FMT` / `KEYMAP_FMT`), the
+  `PMIX_GDS_COLLECT_BIT` / `PMIX_GDS_KEYMAP_BIT` blob-info flags and the
+  `PMIX_GDS_*_IS_SET` accessors — **all dead**. Nothing in the tree
+  reads or writes any of them; they are the residue of the modex keymap,
+  described below. The collect flag the walker actually reads is a plain
+  `PMIX_COLLECT_YES`/`PMIX_COLLECT_NO` byte, not a bitmask.
+
+## The modex keymap, and why it is not coming back
+
+The envelope above writes each `pmix_kval_t`'s key as a string, once per
+proc that published it. Every process on a node normally publishes the
+*same* handful of keys, so a 64-process node repeats each key string 64
+times, and key text is around 40% of the raw bucket. That is an obvious
+thing to fix and it has been fixed once already, so before anyone fixes
+it again:
+
+**2019** (`8cfbac9ea`) added a keymap: the bucket carried a string table
+in its header and each kval carried a `uint32` index into it, selected
+per fence against the native format by the `pmix_gds_modex_key_fmt_t`
+above. **October 2024** (`184ca966e`) removed it *and, in the same
+commit, compressed the bucket instead* — which is the part that matters.
+It was not removed and left unreplaced; it was replaced by something
+that measures better.
+
+Measured on a modex-shaped payload whose values are distinct per rank,
+so the only thing either scheme has to work with is the repeated key
+text (64 procs, 8 keys, `pcompress_zlib_level` 1):
+
+| | bytes | vs. raw |
+|---|---|---|
+| raw, keys as strings | 17408 | — |
+| keymap, no compression | 10756 | −38% |
+| compression, keys as strings | 7681 | −56% |
+| keymap **and** compression | 7394 | −58% |
+
+A keymap on top of what the tree already does is worth **3.7%**. LZ77
+back-references encode a repeated key string in two or three bytes; the
+one-byte index is the entire remaining margin, and it costs a string
+table, an index space, a second wire format to keep interoperable
+forever, and a decode path that has to bound an index that arrived off
+the wire.
+
+Two further things worth knowing before reviving it:
+
+- **A job-wide keymap is worth less, not more.** The dominant repetition
+  is procs-per-node × keys-per-proc, and a per-node map already captures
+  all of it; the measured keymap header is 132 bytes, so deduplicating
+  it across N nodes saves about 1.8% of the aggregate. The host would
+  also have to decode a blob it currently treats as opaque — PRRTE hands
+  the bucket straight to `prte_grpcomm.fence` as a byte object — which
+  would mean publishing this envelope as API surface and owning it
+  forever.
+- **The 2019 implementation had defects that are easy to reintroduce.**
+  Its format-selection pre-pass ran a full `PMIX_GDS_FETCH_KV` with
+  `cb.copy = true` over every local proc purely to count keys, then threw
+  the result away and fetched again to pack — a deep copy of the whole
+  node's modex, discarded. The sizing loop that consumed those counts
+  assigned rather than accumulated (`=`, not `+=`), so the native-vs-keymap
+  decision was made on the last key alone. And `modex_unpack_kval()`
+  indexed the map with a `uint32` taken straight off the wire and no
+  bound against the map's length — a remote out-of-bounds read whose NULL
+  check was performed on the already-out-of-bounds element.
+
+The small-payload corner that a keymap *did* still win — a node whose
+bucket fell under `pmix_compress_base.compress_limit` and was therefore
+shipped raw — was closed in August 2026 by lowering that limit from 4096
+to 1024. See "Choosing `compress_limit`" in
+[`../../pcompress/AGENTS.md`](../../pcompress/AGENTS.md) for the curve
+that number came from.
 
 ## When working here
 

--- a/src/mca/gds/base/AGENTS.md
+++ b/src/mca/gds/base/AGENTS.md
@@ -242,8 +242,29 @@ way.
   caddy pattern anywhere in `gds`; the thread-shift happens above it, in
   the caller. See the Threading section of the framework doc.
 - **A change to the envelope layout in `store_modex` is a wire-format
-  change.** Peers built from different releases exchange these blobs.
-  Treat the layout as append-only per the top-level interoperability rules.
+  change** — but not a *cross-version* one, and the distinction is worth
+  getting right before you either panic about it or take liberties with
+  it.
+
+  This envelope is exchanged **server to server**, and those two servers
+  never connect to each other: each packs and unpacks with
+  `pmix_globals.mypeer`, its own native bfrops, because the host carries
+  the blob between them as an opaque byte object. So there is no
+  handshake on this path and **nothing to version-negotiate against**.
+
+  That is survivable only because the Standard requires every server in
+  a DVM to be running the same PMIx version; cross-version support is
+  promised between a server and its *clients*, not between servers. It
+  is why the October 2024 commit could insert a `bool compressed` ahead
+  of the payload without a version gate — a change that would otherwise
+  have made every pre-2024 server misread the collect flag.
+
+  Two rules follow. **Do not "fix" the absence of a version gate here**
+  by adding one; there is no negotiated peer version on this path to
+  gate on. And **do not treat that freedom as general**: it belongs to
+  the server-to-server envelope specifically. Anything a *client* reads
+  is genuinely cross-version and stays append-only per the top-level
+  interoperability rules.
 - **The helpers here are `PMIX_EXPORT`ed and the components' are not.**
   That is why `test/unit/gds_datastore` and `test/unit/gds_fallback` can
   test this directory directly but have to reach the components through

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -78,22 +78,6 @@ struct pmix_gds_globals_t {
     char *all_mods;
 };
 
-typedef enum {
-    PMIX_MODEX_KEY_INVALID = -1,
-    PMIX_MODEX_KEY_NATIVE_FMT,
-    PMIX_MODEX_KEY_KEYMAP_FMT,
-    PMIX_MODEX_KEY_MAX
-} pmix_gds_modex_key_fmt_t;
-
-/* define a modex blob info */
-typedef uint8_t pmix_gds_modex_blob_info_t;
-
-#define PMIX_GDS_COLLECT_BIT 0x0001
-#define PMIX_GDS_KEYMAP_BIT  0x0002
-
-#define PMIX_GDS_KEYMAP_IS_SET(byte)  (PMIX_GDS_KEYMAP_BIT & (byte))
-#define PMIX_GDS_COLLECT_IS_SET(byte) (PMIX_GDS_COLLECT_BIT & (byte))
-
 typedef struct pmix_gds_globals_t pmix_gds_globals_t;
 
 typedef pmix_status_t (*pmix_gds_base_store_modex_cb_fn_t)(pmix_proc_t *proc,

--- a/src/mca/pcompress/AGENTS.md
+++ b/src/mca/pcompress/AGENTS.md
@@ -53,7 +53,7 @@ The selected module is reached through the exported global
 | Caller | Uses |
 |--------|------|
 | `PMIx_Data_compress` / `PMIx_Data_decompress` ([`src/common/pmix_data.c`](../../common/pmix_data.c)) | the public block API |
-| `src/client/pmix_client.c` | `compress_string` on large modex string values |
+| `src/mca/bfrops/base/bfrop_base_unpack.c` | `decompress_string` when expanding a `PMIX_COMPRESSED_STRING` value off the wire |
 | `src/server/pmix_server_fence.c` | `compress` the collected fence blob |
 | `src/mca/gds/base/gds_base_fns.c` | `decompress` a stored blob |
 | `src/mca/preg/compress/` | `compress_string`/`decompress_string` behind the `blob:` regex encoding (see [`../preg/AGENTS.md`](../preg/AGENTS.md)) |
@@ -195,40 +195,76 @@ strings to work with. `zstd` is what actually runs wherever it was
 built (priority 90); `zlib` at level 1 is shown beside it because it is
 the fallback and because its cost is easy to attribute:
 
-| procs on the node | bucket | `zstd` ratio | `zlib`-1 ratio | `zlib`-1 deflate |
-|---|---|---|---|---|
-| 1 | 272 | — | 0.93 | 9.0 us |
-| 2 | 544 | — | 0.70 | 9.6 us |
-| 4 | 1088 | 0.55 | 0.58 | 13.2 us |
-| 8 | 2176 | 0.47 | 0.52 | 17.3 us |
-| 16 | 4352 | 0.43 | 0.48 | 24.1 us |
-| 64 | 17408 | 0.40 | 0.44 | 60.9 us |
+| bytes offered | `zstd` result | `zlib`-1 result | `zlib`-1 deflate |
+|---|---|---|---|
+| 64 – 192 | declined | declined | — |
+| 256 | 255 | — | — |
+| 384 | 318 | — | — |
+| 512 | 374 | — | — |
+| 1088 (4 procs) | 601 (0.55) | 0.58 | 13.2 us |
+| 2176 (8 procs) | 1028 (0.47) | 0.52 | 17.3 us |
+| 4352 (16 procs) | 1866 (0.43) | 0.48 | 24.1 us |
+| 17408 (64 procs) | 6881 (0.40) | 0.44 | 60.9 us |
 
-(The two smallest rows have no `zstd` figure because they sit below the
-new limit and are therefore never offered to it. Their `zlib` numbers
-come from calling deflate directly, and are what justifies not going
-lower still: at 272 bytes there is almost nothing left to win.)
+There is no crossover: the ratio improves monotonically with size, the
+cost stays in the tens of microseconds, and it is paid once per node per
+fence. Below roughly 256 bytes the compressor **declines on its own** —
+the result is not smaller — so a floor there costs no opportunity at all
+and only saves the pointless attempt, which is exactly what a floor is
+for. That is why the value is **256** rather than something larger: every
+byte of headroom above it was a payload we could have shrunk and did not.
+The old 4096 meant a node running fewer than about sixteen processes
+shipped its whole modex raw, which is most of the GPU-dense machines now
+in service.
 
-There is no crossover — the ratio improves monotonically with size and
-the cost stays in the tens of microseconds, paid once per node per
-fence. The old 4096 meant a node running fewer than about sixteen
-processes shipped its modex raw, which is most of the GPU-dense machines
-now in service. **1024** was chosen rather than something smaller for one
-reason that has nothing to do with compression: the same parameter is
-read by `PMIX_STRING_SIZE_CHECK`, so it also decides the length above
-which `PMIx_Put` turns a string value into a `PMIX_COMPRESSED_STRING`
-that the receiving application sees typed as such. Lowering the threshold
-therefore changes the type of a class of values an application gets back
-from `PMIx_Get`, and 1024 keeps that blast radius small while still
-covering every node worth compressing. **If you lower it further, that
-string-typing consequence is the thing to think about, not the CPU.**
+This parameter used to govern a second, unrelated decision — the length
+above which `PMIx_Put` converted a string value into a
+`PMIX_COMPRESSED_STRING` — which is what kept it from being lowered.
+That coupling is gone; see the next section.
 
-Note that `PMIX_VALUE_COMPRESSED_STRING_UNPACK` — the macro that would
-inflate such a value back into a `PMIX_STRING` — currently has no call
-sites, which is why the compressed form reaches the application at all.
-Giving the two parameters independent lives (a string threshold separate
-from the block threshold) is the clean fix if the coupling ever becomes a
-problem.
+### Strings are not compressed individually, and never arrive compressed
+
+`PMIx_Put` used to convert a string value longer than `compress_limit`
+into a `PMIX_COMPRESSED_STRING` before storing it. That is no longer
+done, for two independent reasons.
+
+**It leaked an unreadable type to the application.** PMIx publishes no
+way to expand a `PMIX_COMPRESSED_STRING` — there is no
+`PMIx_Value_decompress` — so a caller who got one back from `PMIx_Get`
+held bytes they could not read, and the datastore held a value nothing
+could match against. The macro meant to undo it at the far end,
+`PMIX_VALUE_COMPRESSED_STRING_UNPACK`, had its last two call sites
+removed by `d5ec82c11` in the client get path and sat unused thereafter.
+Both macros are gone now, and the expansion happens instead in
+`pmix_bfrops_base_unpack_val()`, which is the one point every value
+arriving from anywhere passes through exactly once. **A peer may still
+send one and always will** — every released PMIx compresses large string
+values on the way out — so that arm is live compatibility code, not
+legacy cleanup.
+
+**And it made the fence bucket bigger, not smaller.** Compressing a
+string on its own destroys the cross-rank redundancy that the
+bucket-level pass would otherwise exploit, and large string values are
+precisely the ones every rank on a node emits a near-identical copy of
+(a locality string, a topology rendering). Measured as a 64-rank bucket
+carrying one large string per rank, shipped size after the fence's own
+compression:
+
+| string size | ranks emit similar strings | ranks emit unrelated strings |
+|---|---|---|
+| 1 KB | no change | no change |
+| 2 KB | **+53%** worse | −1% |
+| 4 KB | **+21%** worse | no change |
+| 8 KB | −21% better | +1% |
+| 16 KB | −49% better | +0.5% |
+
+For unrelated strings it is a wash at every size. For similar ones —
+the realistic case — pre-compression is a substantial *loss* below about
+8 KB and only starts paying above it. If that upper range ever matters
+enough to reclaim, give it a **separate** threshold rather than reviving
+this one, compress at pack time rather than at `PMIx_Put` time so the
+datastore still holds the natural string, and keep the unpack-side
+expansion.
 
 Each component additionally registers its own compression level, and every
 one of them is a parameter rather than a constant for the same reason: the
@@ -256,16 +292,12 @@ behaviour, not in digit — see [`zlibng/AGENTS.md`](zlibng/AGENTS.md).
 Per the top-level guidance, prefer a new MCA parameter over a hard-coded
 constant if you introduce a tunable here.
 
-`base/base.h` also exports two convenience macros used by callers (not by
-the components):
-
-- **`PMIX_STRING_SIZE_CHECK(s)`** — true when a `pmix_value_t` holds a
-  `PMIX_STRING` longer than `pmix_compress_base.compress_limit`, i.e. "is
-  this string worth compressing?"
-- **`PMIX_VALUE_COMPRESSED_STRING_UNPACK(s)`** — if a value's type is
-  `PMIX_COMPRESSED_STRING`, inflate it in place via
-  `pmix_compress.decompress_string` and retype it back to `PMIX_STRING`.
-  (Used in `src/client/pmix_client.c`.)
+`base/base.h` used to export two convenience macros for callers —
+`PMIX_STRING_SIZE_CHECK`, which asked whether a string value was long
+enough to be worth compressing, and
+`PMIX_VALUE_COMPRESSED_STRING_UNPACK`, which inflated one back into a
+`PMIX_STRING`. Both are gone; see "Strings are not compressed
+individually" above. Do not reintroduce either without reading it.
 
 ## The shared compressed-blob format
 

--- a/src/mca/pcompress/AGENTS.md
+++ b/src/mca/pcompress/AGENTS.md
@@ -178,8 +178,57 @@ Two MCA parameters are registered in `pcompress_base_frame.c`
 
 | Parameter | Type / default | Meaning |
 |-----------|----------------|---------|
-| `pcompress_base_limit` | size_t, **4096** | value written into `compress_limit`; the byte threshold below which data is left uncompressed |
+| `pcompress_base_limit` | size_t, **1024** | value written into `compress_limit`; the byte threshold below which data is left uncompressed |
 | `pcompress_base_silence_warning` | bool, **false** | value written into `silent`; suppresses the base default's "unavailable" warning |
+
+### Choosing `compress_limit`
+
+The floor is an economy measure, not a safety one: every component
+already declines a result that is not strictly smaller than its input, so
+lowering it cannot make a payload grow. What it buys or wastes is CPU.
+
+It was **4096** until August 2026, and that turned out to be far above
+where compression stops paying. Measured on modex-shaped payloads — the
+per-node fence bucket, whose values are endpoint blobs and therefore
+close to incompressible, so the compressor has only the repeated key
+strings to work with. `zstd` is what actually runs wherever it was
+built (priority 90); `zlib` at level 1 is shown beside it because it is
+the fallback and because its cost is easy to attribute:
+
+| procs on the node | bucket | `zstd` ratio | `zlib`-1 ratio | `zlib`-1 deflate |
+|---|---|---|---|---|
+| 1 | 272 | — | 0.93 | 9.0 us |
+| 2 | 544 | — | 0.70 | 9.6 us |
+| 4 | 1088 | 0.55 | 0.58 | 13.2 us |
+| 8 | 2176 | 0.47 | 0.52 | 17.3 us |
+| 16 | 4352 | 0.43 | 0.48 | 24.1 us |
+| 64 | 17408 | 0.40 | 0.44 | 60.9 us |
+
+(The two smallest rows have no `zstd` figure because they sit below the
+new limit and are therefore never offered to it. Their `zlib` numbers
+come from calling deflate directly, and are what justifies not going
+lower still: at 272 bytes there is almost nothing left to win.)
+
+There is no crossover — the ratio improves monotonically with size and
+the cost stays in the tens of microseconds, paid once per node per
+fence. The old 4096 meant a node running fewer than about sixteen
+processes shipped its modex raw, which is most of the GPU-dense machines
+now in service. **1024** was chosen rather than something smaller for one
+reason that has nothing to do with compression: the same parameter is
+read by `PMIX_STRING_SIZE_CHECK`, so it also decides the length above
+which `PMIx_Put` turns a string value into a `PMIX_COMPRESSED_STRING`
+that the receiving application sees typed as such. Lowering the threshold
+therefore changes the type of a class of values an application gets back
+from `PMIx_Get`, and 1024 keeps that blast radius small while still
+covering every node worth compressing. **If you lower it further, that
+string-typing consequence is the thing to think about, not the CPU.**
+
+Note that `PMIX_VALUE_COMPRESSED_STRING_UNPACK` — the macro that would
+inflate such a value back into a `PMIX_STRING` — currently has no call
+sites, which is why the compressed form reaches the application at all.
+Giving the two parameters independent lives (a string threshold separate
+from the block threshold) is the clean fix if the coupling ever becomes a
+problem.
 
 Each component additionally registers its own compression level, and every
 one of them is a parameter rather than a constant for the same reason: the

--- a/src/mca/pcompress/base/base.h
+++ b/src/mca/pcompress/base/base.h
@@ -28,31 +28,14 @@
 extern "C" {
 #endif
 
-/* define a macro for quickly checking if a string exceeds the
- * compression limit */
-#define PMIX_STRING_SIZE_CHECK(s)                         \
-    (PMIX_STRING == (s)->type && NULL != (s)->data.string \
-     && pmix_compress_base.compress_limit < strlen((s)->data.string))
-
-#define PMIX_VALUE_COMPRESSED_STRING_UNPACK(s)                                    \
-    do {                                                                          \
-        char *tmp;                                                                \
-        /* if this is a compressed string, then uncompress it */                  \
-        if (PMIX_COMPRESSED_STRING == (s)->type) {                                \
-            pmix_compress.decompress_string(&tmp, (uint8_t *) (s)->data.bo.bytes, \
-                                            (s)->data.bo.size);                   \
-            if (NULL == tmp) {                                                    \
-                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);                                   \
-                rc = PMIX_ERR_NOMEM;                                              \
-                PMIX_VALUE_RELEASE(s);                                            \
-                val = NULL;                                                       \
-            } else {                                                              \
-                PMIX_VALUE_DESTRUCT(s);                                           \
-                (s)->data.string = tmp;                                           \
-                (s)->type = PMIX_STRING;                                          \
-            }                                                                     \
-        }                                                                         \
-    } while (0)
+/* A value is never left holding a PMIX_COMPRESSED_STRING: there is no
+ * public way for an application to expand one, so pmix_bfrops_base_unpack_val()
+ * expands every one it receives and hands back a PMIX_STRING. The two
+ * macros that used to live here - PMIX_STRING_SIZE_CHECK, which decided
+ * whether PMIx_Put should compress a string before storing it, and
+ * PMIX_VALUE_COMPRESSED_STRING_UNPACK, which was meant to undo that at
+ * the far end and had lost its last call site - are gone with that
+ * decision. */
 
 typedef struct {
     size_t compress_limit;

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -119,9 +119,22 @@ pmix_compress_base_t pmix_compress_base = {
 static int pmix_compress_base_register(pmix_mca_base_register_flag_t flags)
 {
     (void) flags;
-    pmix_compress_base.compress_limit = 4096;
+    /* Inputs below this size are never offered to the compressor. The
+     * floor exists to keep us from spending CPU where there is nothing
+     * to gain - it is not a correctness guard, because every component
+     * declines any result that is not strictly smaller than its input.
+     * A fence bucket from a node running four processes is around a
+     * kilobyte and still deflates to well under two-thirds of that for
+     * about 13us, so 4096 - the value this carried until August 2026 -
+     * left every small-node job shipping its modex raw. See the
+     * "Choosing compress_limit" note in AGENTS.md before changing it;
+     * this same threshold decides when PMIx_Put converts a large string
+     * value into a PMIX_COMPRESSED_STRING. */
+    pmix_compress_base.compress_limit = 1024;
     (void) pmix_mca_base_var_register("pmix", "pcompress", "base", "limit",
-                                      "Threshold beyond which data will be compressed",
+                                      "Size in bytes below which data is left uncompressed. "
+                                      "Also the length above which PMIx_Put converts a string "
+                                      "value into a PMIX_COMPRESSED_STRING.",
                                       PMIX_MCA_BASE_VAR_TYPE_SIZE_T,
                                       &pmix_compress_base.compress_limit);
 

--- a/src/mca/pcompress/base/pcompress_base_frame.c
+++ b/src/mca/pcompress/base/pcompress_base_frame.c
@@ -123,18 +123,16 @@ static int pmix_compress_base_register(pmix_mca_base_register_flag_t flags)
      * floor exists to keep us from spending CPU where there is nothing
      * to gain - it is not a correctness guard, because every component
      * declines any result that is not strictly smaller than its input.
-     * A fence bucket from a node running four processes is around a
-     * kilobyte and still deflates to well under two-thirds of that for
-     * about 13us, so 4096 - the value this carried until August 2026 -
-     * left every small-node job shipping its modex raw. See the
-     * "Choosing compress_limit" note in AGENTS.md before changing it;
-     * this same threshold decides when PMIx_Put converts a large string
-     * value into a PMIX_COMPRESSED_STRING. */
-    pmix_compress_base.compress_limit = 1024;
+     * Measured on modex-shaped payloads the compressor declines outright
+     * below about 256 bytes and starts returning real gains just above
+     * it, for under 10us, so this is where the floor stops costing us
+     * opportunity and starts saving pointless work. 4096 - the value
+     * this carried until August 2026 - left every small-node job
+     * shipping its whole modex raw. See "Choosing compress_limit" in
+     * AGENTS.md before changing it. */
+    pmix_compress_base.compress_limit = 256;
     (void) pmix_mca_base_var_register("pmix", "pcompress", "base", "limit",
-                                      "Size in bytes below which data is left uncompressed. "
-                                      "Also the length above which PMIx_Put converts a string "
-                                      "value into a PMIX_COMPRESSED_STRING.",
+                                      "Size in bytes below which data is left uncompressed",
                                       PMIX_MCA_BASE_VAR_TYPE_SIZE_T,
                                       &pmix_compress_base.compress_limit);
 

--- a/test/unit/compress_block.c
+++ b/test/unit/compress_block.c
@@ -225,6 +225,80 @@ int main(int argc, char **argv)
         zip = NULL;
     }
     free(str);
+    str = NULL;
+
+    /* --- a compressed string must not survive deserialization ----------
+     *
+     * PMIx offers no way for an application to expand a
+     * PMIX_COMPRESSED_STRING, so one that reaches a caller through
+     * PMIx_Get is bytes they cannot read, and one that reaches the
+     * datastore is stored in a form nothing can match against. Peers
+     * still send them - every released PMIx compressed large string
+     * values on the way out - so unpack has to expand what it is given
+     * and hand back a plain PMIX_STRING. Regression for the leak that
+     * opened when the two PMIX_VALUE_COMPRESSED_STRING_UNPACK call sites
+     * were dropped from the client get path. */
+    if (NULL != pmix_compress.compress_string &&
+        NULL != pmix_compress.decompress_string) {
+        pmix_data_buffer_t dbuf;
+        pmix_value_t vsrc, vdst;
+        int32_t cnt = 1;
+
+        str = (char *) malloc(8192 + 1);
+        if (NULL == str) {
+            fprintf(stderr, "out of memory\n");
+            return 1;
+        }
+        fill_modexish((uint8_t *) str, 8192);
+        for (n = 0; n < 8192; n++) {
+            if (0 == str[n]) {
+                str[n] = 'x';
+            }
+        }
+        str[8192] = '\0';
+
+        if (!pmix_compress.compress_string(str, &zip, &ziplen)) {
+            fprintf(stdout, "NOTE: component declined an 8k string; "
+                            "skipping the compressed-value unpack check\n");
+        } else {
+            /* hand-build exactly what an older peer puts on the wire */
+            memset(&vsrc, 0, sizeof(vsrc));
+            vsrc.type = PMIX_COMPRESSED_STRING;
+            vsrc.data.bo.bytes = (char *) zip;
+            vsrc.data.bo.size = ziplen;
+
+            PMIX_DATA_BUFFER_CONSTRUCT(&dbuf);
+            rc = PMIx_Data_pack(NULL, &dbuf, &vsrc, 1, PMIX_VALUE);
+            CHECK(PMIX_SUCCESS == rc, "packing a compressed-string value failed: %s",
+                  PMIx_Error_string(rc));
+            if (PMIX_SUCCESS == rc) {
+                memset(&vdst, 0, sizeof(vdst));
+                rc = PMIx_Data_unpack(NULL, &dbuf, &vdst, &cnt, PMIX_VALUE);
+                CHECK(PMIX_SUCCESS == rc, "unpacking a compressed-string value failed: %s",
+                      PMIx_Error_string(rc));
+                if (PMIX_SUCCESS == rc) {
+                    CHECK(PMIX_STRING == vdst.type,
+                          "unpack returned type %s, expected PMIX_STRING - a compressed "
+                          "string reached the caller unexpanded",
+                          PMIx_Data_type_string(vdst.type));
+                    if (PMIX_STRING == vdst.type) {
+                        CHECK(NULL != vdst.data.string && 0 == strcmp(vdst.data.string, str),
+                              "the expanded string does not match what was compressed");
+                    }
+                    PMIX_VALUE_DESTRUCT(&vdst);
+                }
+            }
+            PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
+            free(zip);
+            zip = NULL;
+        }
+        free(str);
+        str = NULL;
+    }
+
+    if (NULL != str) {
+        free(str);
+    }
     free(raw);
 
     PMIx_server_finalize();


### PR DESCRIPTION
This started as an investigation into re-implementing the modex keymap and
ended somewhere else: the keymap does not pay, but the reason it looked
attractive — a header full of live-looking declarations for a feature removed
in 2024 — is worth closing, and chasing the string half of it turned up a real
regression.

### Why the keymap is not coming back

The keymap was added in 2019 (`8cfbac9ea`) and removed in October 2024
(`184ca966e`) — and that same commit compressed the fence bucket instead. It
was not removed and left unreplaced; it was replaced by something that measures
better. On a 64-rank bucket whose values are distinct per rank, so repeated key
text is all either scheme has to work with:

| | bytes | vs. raw |
|---|---|---|
| raw, keys as strings | 17408 | — |
| keymap, no compression | 10756 | −38% |
| compression, keys as strings | 7681 | −56% |
| keymap **and** compression | 7394 | −58% |

A keymap on top of what we already do is worth 3.7%: LZ77 encodes a repeated
key string in two or three bytes, and the one-byte index is the whole remaining
margin. A *job-wide* keymap (built by the host over the aggregated payload) is
worth less rather than more — the dominant repetition is procs × keys, which a
per-node map already captures, so deduplicating the 132-byte per-node header
across N nodes saves about 1.8%, and it would require the host to decode a blob
it currently treats as opaque.

That reasoning is now recorded in `src/mca/gds/base/AGENTS.md`, along with the
three defects the 2019 implementation carried, and the dead declarations
(`pmix_gds_modex_key_fmt_t`, `PMIX_GDS_KEYMAP_BIT`, the `_IS_SET` accessors)
are deleted.

### The one corner the keymap did still win, and the real fix for it

A per-node bucket that fell under `pmix_compress_base.compress_limit` shipped
raw. The limit was **4096**, which is far above where compression stops paying:
the compressor declines on its own below about 256 bytes, and returns 0.83 at
384, 0.73 at 512, 0.55 by a kilobyte, all for under 10us paid once per node per
fence. A node running fewer than roughly sixteen processes — most GPU-dense
machines now in service — was shipping its whole modex uncompressed.

It is now **256**. The floor cannot make anything worse: every component
already declines a result that is not strictly smaller than its input.

### A compressed string could reach the application, and it still can't be read

What kept that limit from being lowered was that it governed a second, unrelated
decision: the length above which `PMIx_Put` converted a string value into a
`PMIX_COMPRESSED_STRING`. PMIx publishes no way to expand one — there is no
`PMIx_Value_decompress` — and `d5ec82c11` removed both
`PMIX_VALUE_COMPRESSED_STRING_UNPACK` call sites from the client get path, so
since then a large string value has been delivered to applications as bytes
they cannot read, and stored by the datastore in a form nothing can match.

Two changes:

* **Expand on unpack**, in `pmix_bfrops_base_unpack_val()` — the one point every
  value arriving from anywhere passes through exactly once. No wire-format
  change; the bytes are identical and `PMIX_COMPRESSED_STRING` stays registered
  in every component. Peers will keep sending them, so this arm is permanent
  compatibility code rather than cleanup. Scalar values only — array elements go
  through the per-type unpacker and keep their declared type.
* **Stop compressing at `PMIx_Put`.** It compressed the copy handed to the
  *datastore* as well as the one put on the wire, so a `PMIx_Get` of our own put
  came back compressed with nothing in the path to undo it.

Dropping it also makes the modex smaller, which was not obvious: pre-compressing
a value destroys the cross-rank redundancy the bucket-level pass exploits, and
large strings are exactly the ones every rank on a node emits a near-identical
copy of. Over a 64-rank bucket, shipped size after the fence's own compression:

| string size | similar across ranks | unrelated across ranks |
|---|---|---|
| 2 KB | **+53% worse** | −1% |
| 4 KB | **+21% worse** | ±0 |
| 8 KB | −21% better | +1% |
| 16 KB | −49% better | +0.5% |

It only turns a profit above about 8 KB. Reclaiming that tail would want a
separate threshold and a pack-time conversion — so the datastore still holds the
natural string — not a revival of this one; the docs say so.

### Note on the commit series

Two commits move `compress_limit`: the first stops at 1024 because the string
coupling still existed, the last takes it to 256 once that coupling is gone.
Kept separate deliberately so the reason for each value is on the record, but
happy to squash them if you would rather.

### Testing

* New regression in `test/unit/compress_block.c`: packs a hand-built
  `PMIX_COMPRESSED_STRING` value and asserts the unpack yields a matching
  `PMIX_STRING`. Verified it fails against the library without the fix.
* `make check` clean — 21/21 in `test/`, 77/77 in `test/unit/`.
* `contrib/dockerswarm` across the ten-container swarm, so the fence modex and
  the newly-compressed small buckets cross real sockets between separate PMIx
  servers — `run-client-tests.sh` 12/12, `run-bfrops-tests.sh` 8/8 (every data
  type across 2, 4 and 8 servers, static and `--enable-mca-dso`),
  `run-gds-tests.sh` 29/29 (collective modex at 2/4/8 servers, forced onto
  `hash`, second fence, `fast_get` disabled, put scopes, direct modex, GDS
  fallback).

**What the swarm does not cover:** nothing in an all-new swarm *produces* a
`PMIX_COMPRESSED_STRING` any more, so the new expansion arm only fires against
an older peer. The unit test covers the arm directly, and I verified it fails
without it, but a genuine mixed-version run (this build against a v5/v6 one, as
`run-xversion` does) would be the real check. Happy to add that if you want it
before merge.

### `PMIX_COMPRESSED_STRING` is deprecated

With no producer left it is a trap for anyone reading the header looking for a
way to shrink a value, so it moves to `pmix_deprecated.h` alongside
`PMIX_REGEX`, following that precedent exactly, with the usual hole comment at
id 42.

**Deprecated means "do not tag a value with this", not "we stopped reading
it".** Every bfrops component still registers the type and
`pmix_bfrops_base_unpack_val()` still expands one, because every released PMIx
produces these and will keep sending them for as long as those releases run —
including over `v61`, which a PMIx built before this change negotiates with us.
The `v61` registration carries a comment saying so, since it is the one that
looks removable.

`PMIX_COMPRESSED_BYTE_OBJECT` is deliberately **not** deprecated. The two are
not symmetric: a compressed string could not be expanded by the receiver at all
(there is no `PMIx_Value_decompress`), which made it a bug, whereas a compressed
byte object is self-describing and the receiver can expand it with the public
`PMIx_Data_decompress`. It is also the only cross-version-safe way to compress a
single large value — the type tag rides inside the existing field sequence, so
no message shape changes, and `PMIX_BFROPS_PACK` resolves the *peer's* module
and refuses to send a type that module does not register. Message-level
compression has no such protection.
