### PR TITLE
Reserve shmem3's addresses instead of hoping for them, and stop a failed modex attach from taking the job data with it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ examples/debugger
 examples/debuggerd
 examples/datatypes
 examples/delete_key
+examples/modex_attach_fail
 examples/dmodex
 examples/dynamic
 examples/modex_twice

--- a/contrib/dockerswarm/run-gds-tests.sh
+++ b/contrib/dockerswarm/run-gds-tests.sh
@@ -223,6 +223,24 @@ run_across_nodes() {
             bad "$prog $label, $np servers: both fences reported ok but exit was $rc"
             return 1
         fi
+    elif [ "$prog" = modex_attach_fail ]; then
+        # Every rank has to say OK: the fence succeeded, its own
+        # namespace's job data was still reachable, and it still got a
+        # peer's value - by whatever route. Counting the OK lines rather
+        # than trusting the exit status matters here, because the failure
+        # this covers is one a caller that ignores a return code does not
+        # see (openpmix#4156 reached production through exactly that).
+        nok=$(echo "$out" | grep -c 'MODEX-ATTACH-FAIL OK')
+        if [ "$nok" != "$np" ]; then
+            bad "$prog $label, $np servers: only $nok/$np ranks degraded cleanly"
+            echo "$out" | grep -iE 'FAILED|TAKE_NEXT_OPTION|INVALID_NAMESPACE' \
+                | head -3 | sed 's/^/       /'
+            return 1
+        fi
+        if [ "$rc" != 0 ]; then
+            bad "$prog $label, $np servers: every rank was OK but exit was $rc"
+            return 1
+        fi
     elif [ "$prog" = client ]; then
         # client reports per key per peer and returns 0 regardless, so
         # count the confirmations: each of the $np ranks confirms one key
@@ -385,7 +403,8 @@ test_linux() {
         -e PFX="$PMIX_PREFIX" \
         "$IMAGE" bash -euo pipefail -c '
             mkdir -p /opt/prte/tests-gds
-            for p in datatypes dmodex client modex_twice delete_key get_timing fence_timing; do
+            for p in datatypes dmodex client modex_twice delete_key \
+                     modex_attach_fail get_timing fence_timing; do
                 gcc -O0 -g -o /opt/prte/tests-gds/$p /pmix-src/examples/$p.c \
                     -I"$PFX/include" -I/pmix-src/examples \
                     -L"$PFX/lib" -lpmix -Wl,-rpath,"$PFX/lib"
@@ -520,6 +539,34 @@ test_linux() {
         run_across_nodes datatypes "$hosts" "$np" \
             "PMIX_MCA_gds_shmem3_force_client_attach_failure=1" "(fallback)" \
             && ok "$np servers: clients fell back and still read every peer"
+    done
+
+    banner "a modex the client cannot map (openpmix#4156)"
+    # The OTHER attach failure, and the one with no fallback available.
+    # force_client_attach_failure above cannot reach it: that fails every
+    # attach, so the client leaves PMIx_Init on gds/hash and never gets to
+    # a fence on shmem3. This one fails only the modex segment, which is
+    # attached at fence time - and used to take the client's job and
+    # session segments down with it while handing PMIx_Fence's caller
+    # PMIX_ERR_TAKE_NEXT_OPTION.
+    #
+    # Two nodes minimum is not a convention here, it is the whole test: a
+    # single-node job exchanges no remote data, so no modex segment is
+    # ever sent to the client and there is nothing to fail.
+    for geom in $GEOMETRIES; do
+        hosts="${geom%|*}"; np="${geom#*|}"
+        run_across_nodes modex_attach_fail "$hosts" "$np" \
+            "PMIX_MCA_gds_shmem3_force_modex_attach_failure=1" "(no modex map)" \
+            && ok "$np servers: fence succeeded and job data survived"
+    done
+
+    banner "the same program with the modex mapping normally"
+    # The control. If this fails, the program is broken rather than the
+    # degradation path it is meant to be checking.
+    for geom in $GEOMETRIES; do
+        hosts="${geom%|*}"; np="${geom#*|}"
+        run_across_nodes modex_attach_fail "$hosts" "$np" "" "(modex mapped)" \
+            && ok "$np servers: baseline with the modex segment mapped"
     done
 }
 

--- a/contrib/dockerswarm/run-gds-tests.sh
+++ b/contrib/dockerswarm/run-gds-tests.sh
@@ -140,6 +140,7 @@ GEOMETRIES="${GEOMETRIES:-node1:1,node2:1|2 node1:1,node2:1,node3:1,node4:1|4 no
 #   over its checks, so the only usable signal is the absence of its
 #   failure lines together with rank 0's finalize line. Grade it that way
 #   rather than on the exit status, which proves nothing here.
+
 run_across_nodes() {
     local prog="$1" hosts="$2" np="$3" envs="${4:-}" label="${5:-}"
     local out rc nok xargs exports v trace
@@ -260,6 +261,78 @@ run_across_nodes() {
             bad "$prog $label, $np servers: no rank reached finalize"
             return 1
         fi
+    fi
+    return 0
+}
+
+# Two jobs at once over the same nodes.
+#
+# Concurrent jobs on a node are ordinary, and each one's server reserves
+# its own address-space arena. This checks the obvious things: both jobs
+# get the right answers, no arena reservation fails, and the two jobs are
+# not sitting on the same base.
+#
+# BE CLEAR ABOUT WHAT THIS DOES NOT SHOW. gds/shmem3 spreads jobs by
+# hashing the namespace into the placement, and this test does NOT
+# demonstrate that it works - it passes just as happily with the scatter
+# compiled out, which was confirmed by doing exactly that. The reason is
+# that ASLR has already moved each server's load base, the placement is
+# computed relative to it, and so two servers diverge anyway here. Where
+# the scatter earns its place is where ASLR does not do that job -
+# systems with randomization disabled, and non-PIE executables - neither
+# of which this swarm can produce. That property is pinned down in
+# test/unit/util/util_vmem.c instead, against the placement function
+# directly, where it is decidable.
+#
+# So read a pass here as "two jobs coexist", not as "the spreading
+# works".
+run_concurrent_jobs() {
+    local hosts="$1" np="$2"
+    local out apass bpass abase bbase missed cmd
+
+    cleanup_swarm
+
+    cmd='export PMIX_MCA_gds_base_verbose=2;
+         rm -rf /tmp/gdsjobA.log /tmp/gdsjobB.log /tmp/gdsjobA /tmp/gdsjobB;
+         mkdir -p /tmp/gdsjobA /tmp/gdsjobB;
+         ( TMPDIR=/tmp/gdsjobA prterun --host '"$hosts"' -np '"$np"' \
+             --map-by node --timeout 180 /opt/prte/tests-gds/datatypes \
+             > /tmp/gdsjobA.log 2>&1 ) &
+         ( TMPDIR=/tmp/gdsjobB prterun --host '"$hosts"' -np '"$np"' \
+             --map-by node --timeout 180 /opt/prte/tests-gds/datatypes \
+             > /tmp/gdsjobB.log 2>&1 ) &
+         wait;
+         echo "APASS=$(grep -c "datatypes: rank .*: PASS" /tmp/gdsjobA.log)";
+         echo "BPASS=$(grep -c "datatypes: rank .*: PASS" /tmp/gdsjobB.log)";
+         echo "ABASE=$(grep -ho "reserved arena \[0x[0-9a-f]*" /tmp/gdsjobA.log | head -1)";
+         echo "BBASE=$(grep -ho "reserved arena \[0x[0-9a-f]*" /tmp/gdsjobB.log | head -1)";
+         echo "MISSED=$(cat /tmp/gdsjobA.log /tmp/gdsjobB.log | grep -c "could not reserve arena")"'
+
+    out="$(RUN "$cmd")"
+
+    apass=$(echo "$out" | sed -n 's/^APASS=//p')
+    bpass=$(echo "$out" | sed -n 's/^BPASS=//p')
+    abase=$(echo "$out" | sed -n 's/^ABASE=//p')
+    bbase=$(echo "$out" | sed -n 's/^BBASE=//p')
+    missed=$(echo "$out" | sed -n 's/^MISSED=//p')
+
+    if [ "$apass" != "$np" ] || [ "$bpass" != "$np" ]; then
+        bad "concurrent jobs, $np servers: ranks passing A=$apass B=$bpass (want $np each)"
+        return 1
+    fi
+    if [ "${missed:-0}" != 0 ]; then
+        bad "concurrent jobs, $np servers: $missed arena reservation(s) failed"
+        return 1
+    fi
+    # No arena at all (shmem3 not selected, or reserving unavailable) is
+    # not a failure of this test, but it does mean it proved nothing.
+    if [ -z "$abase" ] || [ -z "$bbase" ]; then
+        skp "concurrent jobs, $np servers: no arena was reserved - nothing to compare"
+        return 1
+    fi
+    if [ "$abase" = "$bbase" ]; then
+        bad "concurrent jobs, $np servers: both jobs took the same arena base ($abase)"
+        return 1
     fi
     return 0
 }
@@ -558,6 +631,16 @@ test_linux() {
         run_across_nodes modex_attach_fail "$hosts" "$np" \
             "PMIX_MCA_gds_shmem3_force_modex_attach_failure=1" "(no modex map)" \
             && ok "$np servers: fence succeeded and job data survived"
+    done
+
+    banner "two jobs at once over the same nodes"
+    # Only the larger geometries: the point is contention between two
+    # servers on a node, which two nodes show as well as eight, and each
+    # of these stands up two DVMs.
+    for geom in node1:1,node2:1\|2 node1:1,node2:1,node3:1,node4:1\|4; do
+        hosts="${geom%|*}"; np="${geom#*|}"
+        run_concurrent_jobs "$hosts" "$np" \
+            && ok "$np servers x2: both jobs coexisted on separate arenas"
     done
 
     banner "the same program with the modex mapping normally"

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -91,7 +91,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   group_invite_abort group_invite_others group_invite_suppress group_invite_nb \
                   group_invite_endpts topology \
                   spawn_reuse spawn_iof iof_watcher group_badinfo datatypes toolswitch \
-                  modex_twice delete_key
+                  modex_twice delete_key modex_attach_fail
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -341,6 +341,10 @@ delete_key_SOURCES = delete_key.c examples.h
 delete_key_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 delete_key_LDADD = $(top_builddir)/src/libpmix.la
 
+modex_attach_fail_SOURCES = modex_attach_fail.c examples.h
+modex_attach_fail_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+modex_attach_fail_LDADD = $(top_builddir)/src/libpmix.la
+
 abort_SOURCES = abort.c examples.h
 abort_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 abort_LDADD = $(top_builddir)/src/libpmix.la
@@ -356,4 +360,4 @@ distclean-local:
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
         simple simple_server abort datatypes toolswitch \
-        modex_twice delete_key
+        modex_twice delete_key modex_attach_fail

--- a/examples/modex_attach_fail.c
+++ b/examples/modex_attach_fail.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * A client that cannot map the modex segment must degrade, not break.
+ *
+ * gds/shmem3 hands a client the address of the segment holding a
+ * collecting fence's result, and the client has to map it at exactly
+ * that address. That can fail - the address is chosen by the server,
+ * and the client is a different process whose address space has moved
+ * on since it started. openpmix#4156 is what used to happen when it
+ * did, and it is worth being precise about, because two separate things
+ * went wrong and only one of them is what the title said:
+ *
+ *   PMIx_Fence returned PMIX_ERR_TAKE_NEXT_OPTION to the application.
+ *   There is no "next option" to take at that point - the fence path
+ *   resolves one GDS module and the modex cannot be re-delivered in
+ *   another's format - so this was an internal signal escaping into a
+ *   public return code. Open MPI does not check that return, so the
+ *   job carried on with a modex it had not stored.
+ *
+ *   The failed attach ALSO tore down the client's job tracker, which
+ *   owned the job and session segments it had been reading happily
+ *   since PMIx_Init. So every job-level lookup for the client's OWN
+ *   namespace then failed with PMIX_ERR_INVALID_NAMESPACE - which is
+ *   how it was noticed, as MPI_Comm_split_type(MPI_COMM_TYPE_SHARED)
+ *   putting five processes in five communicators of one.
+ *
+ * What should happen instead is that the client loses the fast path and
+ * nothing else: the fence succeeds, job-level data is still there, and
+ * remote procs' values are fetched from the server on demand. That is
+ * what this program asserts.
+ *
+ * RUN IT WITH the failure forced, or it proves nothing:
+ *
+ *   PMIX_MCA_gds_shmem3_force_modex_attach_failure=1
+ *
+ * and across AT LEAST TWO NODES. A single-node job has no remote data
+ * to exchange, so no modex segment is sent to the client, so there is
+ * no attach to fail. (The neighbouring force_client_attach_failure
+ * cannot be used here: it fails every attach, so the client falls back
+ * to gds/hash during PMIx_Init and never reaches a fence on shmem3.)
+ *
+ * Prints "MODEX-ATTACH-FAIL OK" per rank and exits 0 when correct.
+ */
+
+#include <pmix.h>
+
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc, wildcard, peer;
+    pmix_value_t put;
+    pmix_value_t *val = NULL;
+    pmix_info_t info;
+    bool collect = true;
+    uint32_t nprocs = 1;
+    pmix_status_t rc;
+    int failures = 0;
+
+    (void) argc;
+    (void) argv;
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    PMIX_LOAD_PROCID(&wildcard, myproc.nspace, PMIX_RANK_WILDCARD);
+
+    rc = PMIx_Get(&wildcard, PMIX_JOB_SIZE, NULL, 0, &val);
+    if (PMIX_SUCCESS == rc && NULL != val) {
+        nprocs = val->data.uint32;
+        PMIX_VALUE_RELEASE(val);
+        val = NULL;
+    }
+    if (2 > nprocs) {
+        fprintf(stderr, "[rank %u] this test needs at least 2 procs on 2 nodes\n",
+                myproc.rank);
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+
+    /* Publish something every other rank will come looking for. */
+    PMIX_VALUE_CONSTRUCT(&put);
+    put.type = PMIX_UINT32;
+    put.data.uint32 = myproc.rank;
+    rc = PMIx_Put(PMIX_GLOBAL, "modex-attach-key", &put);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[rank %u] PMIx_Put failed: %s\n",
+                myproc.rank, PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    rc = PMIx_Commit();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[rank %u] PMIx_Commit failed: %s\n",
+                myproc.rank, PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+
+    /* (1) The fence itself must succeed. This is the assertion that
+     * fails with PMIX_ERR_TAKE_NEXT_OPTION on an unfixed library. */
+    PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &collect, PMIX_BOOL);
+    rc = PMIx_Fence(NULL, 0, &info, 1);
+    printf("[rank %u] PMIx_Fence rc=%s\n", myproc.rank, PMIx_Error_string(rc));
+    if (PMIX_SUCCESS != rc) {
+        printf("[rank %u] FAILED: fence did not succeed\n", myproc.rank);
+        ++failures;
+    }
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* (2) Job-level data for our own namespace must still be reachable.
+     * This is the one that broke MPI locality: the tracker holding the
+     * job segment was released along with the modex attach. */
+    rc = PMIx_Get(&wildcard, PMIX_LOCAL_PEERS, NULL, 0, &val);
+    printf("[rank %u] PMIx_Get(PMIX_LOCAL_PEERS) rc=%s value=%s\n",
+           myproc.rank, PMIx_Error_string(rc),
+           (PMIX_SUCCESS == rc && NULL != val && PMIX_STRING == val->type
+            && NULL != val->data.string) ? val->data.string : "(none)");
+    if (PMIX_SUCCESS != rc) {
+        printf("[rank %u] FAILED: lost job-level data for my own namespace\n",
+               myproc.rank);
+        ++failures;
+    }
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+        val = NULL;
+    }
+
+    /* (3) A remote peer's value must still arrive - by whatever route.
+     * Without the segment this is answered by the server rather than
+     * out of shared memory, which is slower and entirely correct. */
+    PMIX_LOAD_PROCID(&peer, myproc.nspace, (myproc.rank + 1) % nprocs);
+
+    rc = PMIx_Get(&peer, "modex-attach-key", NULL, 0, &val);
+    printf("[rank %u] PMIx_Get(rank %u, modex-attach-key) rc=%s\n",
+           myproc.rank, peer.rank, PMIx_Error_string(rc));
+    if (PMIX_SUCCESS != rc || NULL == val) {
+        printf("[rank %u] FAILED: could not read peer %u's value\n",
+               myproc.rank, peer.rank);
+        ++failures;
+    } else if (PMIX_UINT32 != val->type || val->data.uint32 != peer.rank) {
+        printf("[rank %u] FAILED: peer %u's value is wrong\n",
+               myproc.rank, peer.rank);
+        ++failures;
+    }
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+        val = NULL;
+    }
+
+    printf("[rank %u] MODEX-ATTACH-FAIL %s\n",
+           myproc.rank, (0 == failures) ? "OK" : "FAILED");
+    fflush(stdout);
+
+    PMIx_Finalize(NULL, 0);
+    return (0 == failures) ? 0 : 1;
+}

--- a/src/mca/gds/shmem3/AGENTS.md
+++ b/src/mca/gds/shmem3/AGENTS.md
@@ -404,6 +404,15 @@ and triggers the framework's **GDS fallback** (`fallback_to_next_gds` in
 to exercise this path in tests without depending on each process's VM
 layout — never set it in production.
 
+**That fallback only exists at init.** It is reached because
+`PMIx_Init` re-requests its job data, and the *server* can re-register
+that data in another module's format. Nothing equivalent is possible for
+a modex: `PMIX_GDS_RECV_MODEX_COMPLETE` resolves a single module, and
+`PMIX_GDS_FALLBACK_CMD` re-sends job data only — a completed modex
+cannot be re-delivered in `hash` format without a new wire command. So
+the two attach failures are genuinely different problems, and the next
+section is about the other one.
+
 ### The address-space arena — why a fence-time attach must not need luck
 
 A client attaches the **job** segment during `PMIx_Init`, when its
@@ -489,6 +498,7 @@ terabytes of empty space.
 | `gds_shmem3_arena_modex_slots` | size_t (default `4`, capped at 32) | how many modex generations the arena can hold at once. More than one is live only where deltas are in play; past the last slot a generation is placed outside the arena. |
 | `gds_shmem3_offset_placement` | bool (default `true`) | place segments a quarter of the way into the biggest hole instead of at its midpoint. |
 | `gds_shmem3_force_client_attach_failure` | bool (default `false`) | **testing only** — force *every* client attach to fail, so the init-time GDS fallback can be exercised. |
+| `gds_shmem3_force_modex_attach_failure` | bool (default `false`) | **testing only** — force only the *modex* attach to fail. This is the one `force_client_attach_failure` cannot reach: that one fails the init attach too, so the client leaves `PMIx_Init` on `hash` and never reaches a fence on `shmem3`. Drives `examples/modex_attach_fail.c`. |
 
 These are the *only* `gds` MCA parameters in the tree; the framework core
 registers none.

--- a/src/mca/gds/shmem3/AGENTS.md
+++ b/src/mca/gds/shmem3/AGENTS.md
@@ -479,6 +479,30 @@ the whole failure mode above. `VMEM_HOLE_BIGGEST_OFFSET` is the
 alternative, selected by the `offset_placement` parameter (on by
 default), and it lands a **quarter** of the way into the hole.
 
+**Deterministic placement has a second edge, and it needs blunting.**
+Being a pure function of the map is what lets a server and its clients
+agree on an address without exchanging one — but it also makes two
+things that have no reason to agree land on top of each other, and
+concurrent jobs on a node are exactly that. So the address is displaced
+within a window around the quarter point by a *scatter* value, which
+`shmem3` derives by hashing the namespace (`nspace_scatter()`, FNV-1a):
+identical for every process of one job, different between jobs. The
+independent-placement path mixes in the segment id and the retry count
+as well, since otherwise a job's three segments would all be aimed at
+one address and a retry would keep naming the address it just lost.
+
+Be careful about what evidence exists for this. Two jobs launched on a
+node land far apart **whether or not anything scatters them**, because
+ASLR has already moved each server's load base and the placement is
+computed relative to it — the concurrent-jobs stage in
+`run-gds-tests.sh` passes with the scatter compiled out, which was
+confirmed by doing it. Where the scatter earns its place is where ASLR
+does not do that job: systems with randomization disabled (not rare in
+HPC, where it is turned off for reproducibility) and non-PIE
+executables. Neither is reachable from the swarm, so the property is
+pinned down in [`test/unit/util/util_vmem.c`](../../../../test/unit/util/util_vmem.c)
+against the placement function directly, where it *is* decidable.
+
 The quarter is not arbitrary, and the obvious alternative is worse:
 placing at the **top** of the hole was tried first and failed
 immediately in the swarm, because the top of that hole is the underside

--- a/src/mca/gds/shmem3/AGENTS.md
+++ b/src/mca/gds/shmem3/AGENTS.md
@@ -404,12 +404,91 @@ and triggers the framework's **GDS fallback** (`fallback_to_next_gds` in
 to exercise this path in tests without depending on each process's VM
 layout — never set it in production.
 
+### The address-space arena — why a fence-time attach must not need luck
+
+A client attaches the **job** segment during `PMIx_Init`, when its
+address space is nearly empty, and the **modex** segment at a *fence*,
+by which time it has loaded an MPI stack, opened components, grown
+arenas, and registered fabric memory. The server picks both addresses
+from its own `/proc/self/maps`. The first attach therefore almost always
+works and the second is a gamble — openpmix#4156 was that gamble lost,
+about 1 run in 25 on a four-node job, taking every rank on a node at once.
+
+The fix is to stop asking. At `register_job_info` time the server calls
+`arena_reserve()`, which claims **one contiguous range** big enough for
+the job segment plus a slot per modex generation that can be live at
+once, using `pmix_vmem_reserve()` — an
+inaccessible `PROT_NONE` mapping that commits no memory and costs one
+VMA. The range travels to clients on every seg blob
+(`SHMEM3_SEG_ARBS_KEY` / `SHMEM3_SEG_ARSZ_KEY`), and each client claims
+the same range in `unpack_shmem3_seg_blob_and_attach_if_necessary()` —
+inside `PMIx_Init`, the one moment it reliably can. Every later mapping,
+including each modex generation, is then `MAP_FIXED` over ground the
+process already holds (`PMIX_SHMEM_MAP_OVER_RESERVATION`), which cannot
+lose a race for the address.
+
+Four things about it are load-bearing:
+
+- **Carve by the footprint, not the requested size.** A segment maps a
+  page of header ahead of its data, so `pmix_shmem_utils_segment_footprint()`
+  is what says where it ends. Carving to the requested size instead
+  overlapped each segment with the next by one page, and the next
+  `MAP_FIXED` silently replaced it — a prompt, spectacular segfault in
+  the daemon.
+- **Detach restores the reservation.** `pmix_shmem_segment_detach()`
+  re-maps `PROT_NONE` over an in-arena range rather than unmapping it
+  (`pmix_vmem_restore()`), or the first modex generation to be released
+  would punch a hole in the arena for something else to take.
+- **A modex generation holds its slot for as long as it is readable,
+  which is not just until the next one arrives.** This started life as
+  an alternation between two slots, on the assumption that only one
+  generation was live at a time. That assumption died with openpmix#4087:
+  a *delta* contribution repeats nothing, so every generation before it
+  stays mapped and answerable on `job->modex_prior`, and reusing the
+  slot from two generations ago would erase data nothing else holds.
+  `arena_alloc_modex()` therefore reads occupancy off the live segments
+  — the current one plus each retired one — and takes the lowest free
+  slot. Deriving it rather than keeping a tally means no path that
+  releases a generation can leave the accounting stale. A generation
+  arriving when all slots are taken places itself outside the arena.
+- **The session segment is deliberately outside the arena.** A session
+  outlives the job that first described it (`component.sessions` holds a
+  reference), and `job_destruct()` releases the whole arena, so a shared
+  session's segment inside it would be unmapped under a live holder.
+
+If the arena cannot be reserved, or a modex does not fit its slot, every
+segment places itself independently exactly as before — degraded, never
+broken.
+
+### Placement: not the midpoint, and definitely not the edge
+
+`pmix_vmem_find_hole(VMEM_HOLE_BIGGEST)` puts a segment at the
+**midpoint of the biggest hole**, and hwloc and Open MPI — which share
+this routine's ancestry — aim there too. That convergence is what makes
+an address picked in one process likely to be taken in another, which is
+the whole failure mode above. `VMEM_HOLE_BIGGEST_OFFSET` is the
+alternative, selected by the `offset_placement` parameter (on by
+default), and it lands a **quarter** of the way into the hole.
+
+The quarter is not arbitrary, and the obvious alternative is worse:
+placing at the **top** of the hole was tried first and failed
+immediately in the swarm, because the top of that hole is the underside
+of the executable's load address — the region where ASLR moves processes
+around the most and where the heap grows. On aarch64, clients on a
+second node could not reserve the range their own server had chosen. A
+quarter of the way in is far from the crowded midpoint, far from the
+populated region near the binary, and still deep inside tens of
+terabytes of empty space.
+
 ## MCA parameters (registered in `gds_shmem3_component.c`)
 
 | Parameter | Type | Meaning |
 |-----------|------|---------|
 | `gds_shmem3_segment_size_multiplier` | double (default `1.0`) | scales the computed segment sizes; raise it if a job overflows a segment (which aborts). |
-| `gds_shmem3_force_client_attach_failure` | bool (default `false`) | **testing only** — force the client's fixed-address attach to fail so the GDS fallback can be exercised. |
+| `gds_shmem3_arena_slot_size` | size_t (default 1 GiB) | address space reserved per modex slot. `0` disables the arena and restores independent placement. Virtual address space only — nothing is committed. |
+| `gds_shmem3_arena_modex_slots` | size_t (default `4`, capped at 32) | how many modex generations the arena can hold at once. More than one is live only where deltas are in play; past the last slot a generation is placed outside the arena. |
+| `gds_shmem3_offset_placement` | bool (default `true`) | place segments a quarter of the way into the biggest hole instead of at its midpoint. |
+| `gds_shmem3_force_client_attach_failure` | bool (default `false`) | **testing only** — force *every* client attach to fail, so the init-time GDS fallback can be exercised. |
 
 These are the *only* `gds` MCA parameters in the tree; the framework core
 registers none.

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -1284,6 +1284,40 @@ segment_hole_kind(void)
 }
 
 /**
+ * A value that differs between jobs and is the same everywhere within
+ * one, used to keep concurrent jobs' segments from being placed on top
+ * of each other.
+ *
+ * The namespace is the right thing to derive it from: it is unique
+ * within the scope of the resource manager, which is exactly the scope
+ * over which two jobs can be resident on a node at once, and every
+ * process of a job knows it. It matters that this is a pure function of
+ * the name and nothing else - a server and its clients never compare
+ * notes about the address, they each compute it and are expected to
+ * arrive at the same one.
+ *
+ * FNV-1a, because it is four lines and the requirement is only that
+ * different names land in different places, not that anything is hard to
+ * guess. A collision costs a failed reservation and a fall back to
+ * placing segments individually, which is where we were before.
+ */
+static inline uint64_t
+nspace_scatter(
+    const char *nspace
+) {
+    uint64_t h = 14695981039346656037ULL;
+
+    if (NULL == nspace) {
+        return 0;
+    }
+    for (const unsigned char *p = (const unsigned char *)nspace; *p; ++p) {
+        h ^= (uint64_t)*p;
+        h *= 1099511628211ULL;
+    }
+    return h;
+}
+
+/**
  * Is [addr, addr+size) inside this job's arena?
  */
 static inline bool
@@ -1598,7 +1632,9 @@ arena_reserve(
     const size_t total = statics + (slots * slot);
 
     uintptr_t base = 0;
-    if (PMIX_SUCCESS != pmix_vmem_reserve(segment_hole_kind(), total, &base)) {
+    if (PMIX_SUCCESS != pmix_vmem_reserve(segment_hole_kind(),
+                                          nspace_scatter(job->nspace_id),
+                                          total, &base)) {
         PMIX_GDS_SHMEM3_VOUT(
             "%s: could not reserve a %zu B arena for namespace=%s; "
             "segments will be placed individually",
@@ -1835,10 +1871,17 @@ shmem3_segment_create_and_attach(
         // wrong for the server, which chose the address and can simply try
         // another hole.
         enum { MAX_ATTACH_ATTEMPTS = 16 };
+        /* Spread by namespace here too, for the same reason the arena
+         * does. Segment id and attempt go into it as well: without them
+         * this job's three segments would each be pointed at one address
+         * and a retry would keep naming the one it just lost. */
+        const uint64_t scatter =
+            nspace_scatter(job->nspace_id) + (uint64_t)shmem3_id;
         for (int attempt = 1; ; ++attempt) {
             size_t base_addr = 0;
-            rc = pmix_vmem_find_hole(
-                segment_hole_kind(), &base_addr, real_segsize
+            rc = pmix_vmem_find_hole_scattered(
+                segment_hole_kind(), scatter + (uint64_t)attempt,
+                &base_addr, real_segsize
             );
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -59,6 +59,8 @@
  * attaching after the removal has to be told, or it would read what
  * every process already attached has been told to ignore. */
 #define SHMEM3_TOMBSTONE_KEY "PMIX_GDS_SHMEM3_TOMBSTONE"
+#define SHMEM3_SEG_ARBS_KEY "PMIX_GDS_SHMEM3_SEG_ARBS"
+#define SHMEM3_SEG_ARSZ_KEY "PMIX_GDS_SHMEM3_SEG_ARSZ"
 
 
 #define EMSG_SHMEM3_IS_BROKEN "\n***\nAn unrecoverable error occurred in the " \
@@ -124,6 +126,11 @@ typedef struct {
     size_t seg_size;
     size_t seg_hadr;
     bool is_delta;
+    /** The job's address-space arena, if it has one. Carried on every
+     *  seg blob rather than only the first, so a client that has not yet
+     *  reserved it learns of it from whichever blob reaches it first. */
+    size_t arena_base;
+    size_t arena_size;
 } pmix_gds_shmem3_unpacked_seg_blob_t;
 PMIX_CLASS_DECLARATION(pmix_gds_shmem3_unpacked_seg_blob_t);
 
@@ -137,6 +144,8 @@ unpacked_seg_blob_construct(
     ub->seg_size = 0;
     ub->seg_hadr = 0;
     ub->is_delta = false;
+    ub->arena_base = 0;
+    ub->arena_size = 0;
 }
 
 static void
@@ -582,6 +591,12 @@ job_construct(
     job->modex_is_delta = false;
     PMIX_CONSTRUCT(&job->modex_prior, pmix_list_t);
     PMIX_CONSTRUCT(&job->tombstones, pmix_list_t);
+    // Address-space arena
+    job->arena_base = 0;
+    job->arena_size = 0;
+    job->arena_static_used = 0;
+    job->arena_slot_bytes = 0;
+    job->arena_slots = 0;
     // Connection info
     job->conni = NULL;
 }
@@ -709,6 +724,18 @@ job_destruct(
         PMIX_RELEASE(shmem3);
         // Invalidate the shmem3 flags.
         pmix_gds_shmem3_clearall_status(job, sid);
+    }
+
+    /* The arena goes last: releasing it unmaps everything inside it, so
+     * every segment that was carved from it has to have let go first.
+     * The session segment is deliberately NOT in there - a session
+     * outlives the job that first described it, and unmapping a shared
+     * session's segment along with this job's arena would pull it out
+     * from under whoever still holds a reference. */
+    if (0 != job->arena_size) {
+        pmix_vmem_release(job->arena_base, job->arena_size);
+        job->arena_base = 0;
+        job->arena_size = 0;
     }
 
     if (job->session) {
@@ -1242,6 +1269,40 @@ get_shmem3_session_name(
 }
 
 /**
+ * The rule to use when a segment has to place itself independently.
+ *
+ * See VMEM_HOLE_BIGGEST_OFFSET: the midpoint of the biggest hole is where
+ * every implementation of this idea in the stack converges, so it is the
+ * worst place to put something that another process also has to map.
+ */
+static inline pmix_vmem_hole_kind_t
+segment_hole_kind(void)
+{
+    return pmix_gds_shmem3_offset_placement
+        ? VMEM_HOLE_BIGGEST_OFFSET
+        : VMEM_HOLE_BIGGEST;
+}
+
+/**
+ * Is [addr, addr+size) inside this job's arena?
+ */
+static inline bool
+addr_in_arena(
+    const pmix_gds_shmem3_job_t *job,
+    uintptr_t addr,
+    size_t size
+) {
+    if (0 == job->arena_size || 0 == size) {
+        return false;
+    }
+    if (addr < job->arena_base || size > job->arena_size) {
+        return false;
+    }
+    // Written as a subtraction so the sum cannot wrap.
+    return (addr - job->arena_base) <= (job->arena_size - size);
+}
+
+/**
  * Attaches to the given shared-memory segment.
  */
 static pmix_status_t
@@ -1261,9 +1322,18 @@ shmem3_attach(
         return rc;
     }
 
+    /* If this address is inside the arena we reserved for the job, then
+     * we are not asking for it - we are already holding it, and mapping
+     * over our own reservation cannot be refused. That is the point of
+     * having reserved it: the client's address space has moved on since
+     * PMIx_Init, but this range has been ours the whole time. */
+    const pmix_shmem_flags_t aflags =
+        addr_in_arena(job, req_addr, shmem3->size)
+            ? PMIX_SHMEM_MAP_OVER_RESERVATION
+            : PMIX_SHMEM_MUST_MAP_AT_RADDR;
+
     rc = pmix_shmem_segment_attach(
-        shmem3, req_addr, PMIX_SHMEM_MUST_MAP_AT_RADDR,
-        PMIX_GDS_SHMEM3_LAYOUT_ID
+        shmem3, req_addr, aflags, PMIX_GDS_SHMEM3_LAYOUT_ID
     );
     if (PMIX_UNLIKELY(pmix_gds_shmem3_force_client_attach_failure)) {
         // Testing only: pretend the fixed-address attach failed so the
@@ -1438,6 +1508,205 @@ shmem3_segment_fix_perms(
 }
 
 /**
+ * Reserve this job's address-space arena.
+ *
+ * Called by the server once, before it creates the first of the job's
+ * segments, and mirrored by each client the first time it is told about
+ * the arena - which is inside PMIx_Init, while the client's address space
+ * is still close to empty and a fixed address is still easy to come by.
+ * That timing is the whole idea: the address a client will need at fence
+ * time, when it is full of MPI, is claimed while it is not.
+ *
+ * A failure here is not one: without an arena every segment places itself
+ * as it did before, which is what the caller does anyway when the arena
+ * cannot hold what it is asked for.
+ */
+static void
+arena_reserve(
+    pmix_gds_shmem3_job_t *job,
+    size_t job_segsize
+) {
+    if (0 == pmix_gds_shmem3_arena_slot_size) {
+        // Explicitly disabled.
+        return;
+    }
+    if (0 != job->arena_size) {
+        // Already have one.
+        return;
+    }
+
+    /* Ask what the segment will actually occupy, rather than assuming it
+     * is the size we asked for: a segment maps a page of header ahead of
+     * its data. Carving to the requested size instead left every segment
+     * overlapping the next by that page. */
+    const size_t statics = pmix_shmem_utils_segment_footprint(job_segsize);
+    size_t slot = pmix_shmem_utils_pad_to_page(
+        pmix_gds_shmem3_arena_slot_size
+    );
+    /* A job whose job-level data alone exceeds the configured slot is
+     * one whose modex will not be small either. Do not hand it slots it
+     * is guaranteed to overflow. */
+    if (slot < statics) {
+        slot = statics;
+    }
+
+    /* One slot per modex generation that can be live at once. More than
+     * one is live whenever a contribution carried only what changed -
+     * the generations before it are still the only copy of what it did
+     * not repeat - so this is a depth, not the two an alternation would
+     * need. The bitmap in arena_alloc_modex() is what caps it at 32. */
+    size_t slots = pmix_gds_shmem3_arena_modex_slots;
+    if (0 == slots) {
+        return;
+    }
+    if (slots > 32) {
+        slots = 32;
+    }
+    // Guard the arithmetic rather than trust two tunables to be sane.
+    if (slot > (SIZE_MAX - statics) / slots) {
+        return;
+    }
+    const size_t total = statics + (slots * slot);
+
+    uintptr_t base = 0;
+    if (PMIX_SUCCESS != pmix_vmem_reserve(segment_hole_kind(), total, &base)) {
+        PMIX_GDS_SHMEM3_VOUT(
+            "%s: could not reserve a %zu B arena for namespace=%s; "
+            "segments will be placed individually",
+            __func__, total, job->nspace_id
+        );
+        return;
+    }
+    job->arena_base = base;
+    job->arena_size = total;
+    job->arena_static_used = 0;
+    job->arena_slot_bytes = slot;
+    job->arena_slots = slots;
+
+    PMIX_GDS_SHMEM3_VOUT(
+        "%s: reserved arena [0x%zx, 0x%zx) (%zu B, %zu slots of %zu B) "
+        "for namespace=%s",
+        __func__, (size_t)base, (size_t)(base + total), total, slots, slot,
+        job->nspace_id
+    );
+}
+
+/**
+ * Hand out arena space for a segment that lives as long as the job does.
+ *
+ * Returns false if there is no arena or it cannot hold this, in which
+ * case the caller places the segment the old way.
+ */
+static bool
+arena_alloc_static(
+    pmix_gds_shmem3_job_t *job,
+    size_t size,
+    uintptr_t *addr
+) {
+    if (0 == job->arena_size || 0 == job->arena_slots) {
+        return false;
+    }
+    const size_t statics =
+        job->arena_size - (job->arena_slots * job->arena_slot_bytes);
+    if (size > statics - job->arena_static_used) {
+        return false;
+    }
+    *addr = job->arena_base + job->arena_static_used;
+    job->arena_static_used += size;
+    return true;
+}
+
+/**
+ * Where the modex slots begin - everything below this is the static
+ * region the job segment came out of.
+ */
+static inline uintptr_t
+arena_modex_base(
+    const pmix_gds_shmem3_job_t *job
+) {
+    return job->arena_base + job->arena_size
+           - (job->arena_slots * job->arena_slot_bytes);
+}
+
+/**
+ * Mark the slot a mapped segment occupies, if it is in the arena.
+ */
+static inline void
+note_slot_in_use(
+    const pmix_gds_shmem3_job_t *job,
+    const pmix_shmem_t *shmem3,
+    uint32_t *inuse
+) {
+    if (NULL == shmem3 || !shmem3->attached || NULL == shmem3->hdr_address) {
+        return;
+    }
+    const uintptr_t addr = (uintptr_t)shmem3->hdr_address;
+    const uintptr_t mbase = arena_modex_base(job);
+
+    if (addr < mbase || addr >= job->arena_base + job->arena_size) {
+        // Placed outside the arena; owns no slot.
+        return;
+    }
+    *inuse |= (uint32_t)1 << ((addr - mbase) / job->arena_slot_bytes);
+}
+
+/**
+ * Hand out an arena slot for a new modex generation.
+ *
+ * A generation cannot simply take the slot before last. It used to be
+ * true that at most one was live at a time, and this alternated between
+ * two slots on that basis; it stopped being true when a contribution
+ * became able to carry only what changed. A delta generation leaves
+ * every generation before it mapped and answerable on job->modex_prior,
+ * so the slot each of those sits in is still in use, and writing over
+ * one would take away data nothing else holds a copy of.
+ *
+ * So read the occupancy off the segments themselves - the current
+ * generation and every retired one - rather than keeping a count.
+ * Deriving it means there is no allocation tally to be left stale by a
+ * path that releases a generation without telling us, and the whole
+ * thing is a walk of a list that is empty in the common case.
+ *
+ * Returns false when every slot is taken, which is not an error: the
+ * caller places the generation outside the arena exactly as it would
+ * have without one.
+ */
+static bool
+arena_alloc_modex(
+    pmix_gds_shmem3_job_t *job,
+    size_t size,
+    uintptr_t *addr
+) {
+    uint32_t inuse = 0;
+
+    if (0 == job->arena_size || 0 == job->arena_slots) {
+        return false;
+    }
+    if (size > job->arena_slot_bytes) {
+        return false;
+    }
+
+    note_slot_in_use(job, job->modex_shmem3, &inuse);
+    pmix_gds_shmem3_modex_seg_t *seg;
+    PMIX_LIST_FOREACH (seg, &job->modex_prior, pmix_gds_shmem3_modex_seg_t) {
+        note_slot_in_use(job, seg->shmem3, &inuse);
+    }
+
+    for (size_t slot = 0; slot < job->arena_slots; ++slot) {
+        if (0 == (inuse & ((uint32_t)1 << slot))) {
+            *addr = arena_modex_base(job) + (slot * job->arena_slot_bytes);
+            return true;
+        }
+    }
+    PMIX_GDS_SHMEM3_VOUT(
+        "%s: all %zu modex slots are in use for namespace=%s; placing "
+        "generation %u outside the arena",
+        __func__, job->arena_slots, job->nspace_id, job->modex_generation
+    );
+    return false;
+}
+
+/**
  * Create and attach to a shared-memory segment.
  */
 static pmix_status_t
@@ -1476,50 +1745,95 @@ shmem3_segment_create_and_attach(
         PMIX_ERROR_LOG(rc);
         goto out;
     }
-    // Find a hole in virtual memory and attach the segment there.
+    // Place the segment. Out of the job's arena where it fits, because a
+    // reserved address is one every client can be sure of holding too;
+    // otherwise from a hole located here and now, which is what the arena
+    // exists to avoid having to do.
     //
-    // The hole is located by scanning /proc/self/maps and is then claimed by a
-    // separate mmap(); those two steps are not atomic. PMIx runs its internal
-    // work on a single progress thread, so PMIx never races itself here -- but
-    // the address space is process-wide, so other activity in the process can
-    // take the located hole in between: another thread, the dynamic loader
-    // (dlopen as components/namespaces come up), the C allocator growing an
-    // arena via mmap, or AddressSanitizer's own mappings. This is rare in
-    // general but considerably more likely under ASAN and during
-    // MPI_Comm_spawn. Because the server chooses this address (clients are
-    // later told whichever one we land on), recover from a lost hole by
-    // selecting a new one and retrying rather than failing the spawned job's
-    // PMIx_Init.
-    //
-    // Bypass shmem3_attach() here: on a failed map it reports a client-style
-    // address mismatch and tears the job down, which is wrong for the server,
-    // which chose the address and can simply try another hole.
-    enum { MAX_ATTACH_ATTEMPTS = 16 };
-    for (int attempt = 1; ; ++attempt) {
-        size_t base_addr = 0;
-        rc = pmix_vmem_find_hole(
-            VMEM_HOLE_BIGGEST, &base_addr, real_segsize
-        );
-        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-            PMIX_ERROR_LOG(rc);
-            goto out;
-        }
+    // Carve by what the mapping will occupy, not by what we asked to
+    // store: pmix_shmem_segment_create() put a page of header in front of
+    // it, and shmem3->size below reports the larger number.
+    const size_t mapped_size = pmix_shmem_utils_segment_footprint(
+        real_segsize
+    );
+    uintptr_t arena_addr = 0;
+    const bool from_arena =
+        (PMIX_GDS_SHMEM3_MODEX_ID == shmem3_id)
+            ? arena_alloc_modex(job, mapped_size, &arena_addr)
+            : arena_alloc_static(job, mapped_size, &arena_addr);
+
+    if (from_arena) {
         PMIX_GDS_SHMEM3_VOUT(
-            "%s: %s found vmhole at address=0x%zx (attempt %d)",
-            __func__, segment_name, base_addr, attempt
+            "%s: %s placed in arena at address=0x%zx",
+            __func__, segment_name, (size_t)arena_addr
         );
         rc = pmix_shmem_segment_attach(
-            shmem3, (uintptr_t)base_addr, PMIX_SHMEM_MUST_MAP_AT_RADDR,
+            shmem3, arena_addr, PMIX_SHMEM_MAP_OVER_RESERVATION,
             PMIX_GDS_SHMEM3_LAYOUT_ID
         );
-        if (PMIX_LIKELY(PMIX_SUCCESS == rc)) {
-            break;
-        }
-        // Only the "could not map at the requested address" case is retryable;
-        // pmix_shmem_segment_attach() already detached its failed attempt.
-        if (PMIX_ERR_NOT_AVAILABLE != rc || attempt >= MAX_ATTACH_ATTEMPTS) {
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+            // Mapping over our own reservation cannot lose a race for the
+            // address, so this is a real failure, not a lost hole.
             PMIX_ERROR_LOG(rc);
             goto out_release;
+        }
+    }
+    else {
+        // Find a hole in virtual memory and attach the segment there.
+        //
+        // The hole is located by scanning /proc/self/maps and is then claimed
+        // by a separate mmap(); those two steps are not atomic. PMIx runs its
+        // internal work on a single progress thread, so PMIx never races
+        // itself here -- but the address space is process-wide, so other
+        // activity in the process can take the located hole in between:
+        // another thread, the dynamic loader (dlopen as components/namespaces
+        // come up), the C allocator growing an arena via mmap, or
+        // AddressSanitizer's own mappings. This is rare in general but
+        // considerably more likely under ASAN and during MPI_Comm_spawn.
+        // Because the server chooses this address (clients are later told
+        // whichever one we land on), recover from a lost hole by selecting a
+        // new one and retrying rather than failing the spawned job's
+        // PMIx_Init.
+        //
+        // Note what this retry cannot do anything about: it re-picks an
+        // address that is free *here*, and the client that has to map at the
+        // same one is a different process. That is the failure the arena
+        // above addresses, and reaching this path means we are back to
+        // hoping - which is why the placement rule matters here most.
+        //
+        // Bypass shmem3_attach() here: on a failed map it reports a
+        // client-style address mismatch and tears the job down, which is
+        // wrong for the server, which chose the address and can simply try
+        // another hole.
+        enum { MAX_ATTACH_ATTEMPTS = 16 };
+        for (int attempt = 1; ; ++attempt) {
+            size_t base_addr = 0;
+            rc = pmix_vmem_find_hole(
+                segment_hole_kind(), &base_addr, real_segsize
+            );
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+                PMIX_ERROR_LOG(rc);
+                goto out;
+            }
+            PMIX_GDS_SHMEM3_VOUT(
+                "%s: %s found vmhole at address=0x%zx (attempt %d)",
+                __func__, segment_name, base_addr, attempt
+            );
+            rc = pmix_shmem_segment_attach(
+                shmem3, (uintptr_t)base_addr, PMIX_SHMEM_MUST_MAP_AT_RADDR,
+                PMIX_GDS_SHMEM3_LAYOUT_ID
+            );
+            if (PMIX_LIKELY(PMIX_SUCCESS == rc)) {
+                break;
+            }
+            // Only the "could not map at the requested address" case is
+            // retryable; pmix_shmem_segment_attach() already detached its
+            // failed attempt.
+            if (PMIX_ERR_NOT_AVAILABLE != rc ||
+                attempt >= MAX_ATTACH_ATTEMPTS) {
+                PMIX_ERROR_LOG(rc);
+                goto out_release;
+            }
         }
     }
     pmix_gds_shmem3_set_status(job, shmem3_id, PMIX_GDS_SHMEM3_ATTACHED);
@@ -1682,6 +1996,12 @@ prepare_shmem3_stores_for_local_job_data(
     seg_size *= fluff;
     // Adjust (increase or decrease) segment size by the given parameter size.
     seg_size *= pmix_gds_shmem3_segment_size_multiplier;
+    /* Reserve this job's address space before placing anything in it.
+     * Everything below, and every modex this job ever produces, is then
+     * carved from a range that clients will hold too - which is what a
+     * fixed-address attach needs and cannot otherwise be given, because
+     * the client that has to honor it does not exist yet. */
+    arena_reserve(job, seg_size);
     // Create and attach to the shared-memory segment associated with this job.
     // This will be the backing store for data associated with static, read-only
     // data shared between the server and its clients.
@@ -1850,6 +2170,58 @@ pack_shmem3_connection_info(
             PMIX_ERROR_LOG(rc);
             break;
         }
+        if (0 == job->arena_size) {
+            // Nothing more to say - this job has no arena.
+            break;
+        }
+        PMIX_DESTRUCT(&kv);
+        /* Describe the arena. This rides on every seg blob rather than
+         * only the first, so a client reserves it on the strength of
+         * whichever one reaches it first and does not depend on the
+         * order they were packed in. */
+        PMIX_CONSTRUCT(&kv, pmix_kval_t);
+        kv.key = strdup(SHMEM3_SEG_ARBS_KEY);
+        kv.value = (pmix_value_t *)calloc(1, sizeof(pmix_value_t));
+        if (PMIX_UNLIKELY(NULL == kv.value)) {
+            rc = PMIX_ERR_NOMEM;
+            PMIX_ERROR_LOG(rc);
+            break;
+        }
+        kv.value->type = PMIX_STRING;
+        nw = pmix_asprintf(
+            &kv.value->data.string, "%zx", (size_t)job->arena_base
+        );
+        if (PMIX_UNLIKELY(nw == -1)) {
+            rc = PMIX_ERR_NOMEM;
+            PMIX_ERROR_LOG(rc);
+            break;
+        }
+        PMIX_BFROPS_PACK(rc, peer, buffer, &kv, 1, PMIX_KVAL);
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+            PMIX_ERROR_LOG(rc);
+            break;
+        }
+        PMIX_DESTRUCT(&kv);
+        PMIX_CONSTRUCT(&kv, pmix_kval_t);
+        kv.key = strdup(SHMEM3_SEG_ARSZ_KEY);
+        kv.value = (pmix_value_t *)calloc(1, sizeof(pmix_value_t));
+        if (PMIX_UNLIKELY(NULL == kv.value)) {
+            rc = PMIX_ERR_NOMEM;
+            PMIX_ERROR_LOG(rc);
+            break;
+        }
+        kv.value->type = PMIX_STRING;
+        nw = pmix_asprintf(&kv.value->data.string, "%zx", job->arena_size);
+        if (PMIX_UNLIKELY(nw == -1)) {
+            rc = PMIX_ERR_NOMEM;
+            PMIX_ERROR_LOG(rc);
+            break;
+        }
+        PMIX_BFROPS_PACK(rc, peer, buffer, &kv, 1, PMIX_KVAL);
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+            PMIX_ERROR_LOG(rc);
+            break;
+        }
         if (PMIX_GDS_SHMEM3_MODEX_ID != shmem3_id) {
             break;
         }
@@ -2001,6 +2373,20 @@ unpack_shmem3_connection_info(
         else if (PMIX_CHECK_KEY(&kv, SHMEM3_SEG_DELTA_KEY)) {
             /* only the modex carries this; absent means "stands alone" */
             usb->is_delta = ('0' != val[0]);
+        }
+        else if (PMIX_CHECK_KEY(&kv, SHMEM3_SEG_ARBS_KEY)) {
+            rc = strtost(val, 16, &usb->arena_base);
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+                PMIX_ERROR_LOG(rc);
+                break;
+            }
+        }
+        else if (PMIX_CHECK_KEY(&kv, SHMEM3_SEG_ARSZ_KEY)) {
+            rc = strtost(val, 16, &usb->arena_size);
+            if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+                PMIX_ERROR_LOG(rc);
+                break;
+            }
         }
         else {
             /* A key we have not been taught to hear. Skip it.
@@ -2423,6 +2809,40 @@ unpack_shmem3_seg_blob_and_attach_if_necessary(
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             break;
+        }
+        /* Claim the job's arena the first time we are told about it.
+         *
+         * This is the moment that matters. We are inside PMIx_Init, the
+         * address space is nearly as empty as it will ever be, and the
+         * range we are claiming is the one the server will place THIS
+         * job's later segments in - including the modex, which does not
+         * exist yet and will be handed to us at a fence, by which time
+         * this process is full of whatever it went on to load. Taking the
+         * address now is what makes that later attach a certainty rather
+         * than a coin toss.
+         *
+         * Failing is survivable and deliberately quiet: without the
+         * reservation each attach falls back to asking for its address
+         * and hoping, which is exactly what this component did before. */
+        if (0 != usb.arena_size && 0 == job->arena_size) {
+            if (PMIX_SUCCESS == pmix_vmem_reserve_at(
+                    (uintptr_t)usb.arena_base, usb.arena_size)) {
+                job->arena_base = (uintptr_t)usb.arena_base;
+                job->arena_size = usb.arena_size;
+                PMIX_GDS_SHMEM3_VOUT(
+                    "%s: reserved arena [0x%zx, 0x%zx) for namespace=%s",
+                    __func__, usb.arena_base,
+                    usb.arena_base + usb.arena_size, usb.nsid
+                );
+            }
+            else {
+                PMIX_GDS_SHMEM3_VOUT(
+                    "%s: could not reserve arena [0x%zx, 0x%zx) for "
+                    "namespace=%s; attaching without one",
+                    __func__, usb.arena_base,
+                    usb.arena_base + usb.arena_size, usb.nsid
+                );
+            }
         }
         // Make sure we aren't already attached to the given shmem3.
         if (pmix_gds_shmem3_has_status(job, usb.smid, PMIX_GDS_SHMEM3_ATTACHED)) {

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -1341,6 +1341,14 @@ shmem3_attach(
         // below detaches the segment if the real attach actually succeeded.
         rc = PMIX_ERR_NOT_AVAILABLE;
     }
+    if (PMIX_UNLIKELY(pmix_gds_shmem3_force_modex_attach_failure &&
+                      PMIX_GDS_SHMEM3_MODEX_ID == shmem3_id)) {
+        /* Testing only: fail just this segment. Unlike the parameter
+         * above, this leaves the client on shmem3 through PMIx_Init and
+         * so reaches the fence-time attach - the path that has no GDS
+         * fallback to take. */
+        rc = PMIX_ERR_NOT_AVAILABLE;
+    }
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         // We were given a fixed base address but could not map the segment
         // there in this process's address space -- its VM layout (ASLR,
@@ -1378,9 +1386,30 @@ shmem3_attach(
 out:
     if (PMIX_SUCCESS != rc) {
         (void)pmix_shmem_segment_detach(shmem3);
-        // remove the job from the tracker
-        pmix_list_remove_item(&pmix_mca_gds_shmem3_component.jobs, &job->super);
-        PMIX_RELEASE(job);
+        if (PMIX_GDS_SHMEM3_MODEX_ID == shmem3_id) {
+            /* Only this segment is lost. The job and session segments
+             * this client has been reading since PMIx_Init are mapped
+             * and perfectly good, so keep the tracker: dropping it here
+             * took them down too, and left the client answering every
+             * job-level lookup for its OWN namespace with
+             * PMIX_ERR_INVALID_NAMESPACE - long after the fence that
+             * caused it. See openpmix#4156.
+             *
+             * What the client actually loses is the fast path to remote
+             * procs' data. The fetch side already copes: it gates every
+             * modex read on PMIX_GDS_SHMEM3_READY_FOR_USE, so a job
+             * without a modex segment simply misses, and the miss goes
+             * up to the server like any other. Clearing the status is
+             * what leaves a later generation free to attach cleanly. */
+            pmix_gds_shmem3_clearall_status(job, shmem3_id);
+        }
+        else {
+            // remove the job from the tracker
+            pmix_list_remove_item(
+                &pmix_mca_gds_shmem3_component.jobs, &job->super
+            );
+            PMIX_RELEASE(job);
+        }
     }
     else {
         pmix_gds_shmem3_set_status(
@@ -2896,6 +2925,28 @@ unpack_shmem3_seg_blob_and_attach_if_necessary(
         // Looks like we have to attach and initialize it.
         rc = shmem3_segment_attach_and_init(job, &usb);
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+            /* A modex we could not map is a slower client, not a broken
+             * one, and there is no "next option" to take at fence time
+             * anyway: PMIX_GDS_RECV_MODEX_COMPLETE resolves one module,
+             * and the modex data it describes cannot be re-delivered in
+             * another module's format. Reporting the failure upward put
+             * PMIX_ERR_TAKE_NEXT_OPTION in the application's hands as the
+             * return of PMIx_Fence, where it was either checked and
+             * treated as a failed fence or - more often - not checked at
+             * all. Say what happened and let the fence succeed; the data
+             * is still reachable, one request to the server at a time.
+             * See openpmix#4156. */
+            if (PMIX_ERR_TAKE_NEXT_OPTION == rc &&
+                PMIX_GDS_SHMEM3_MODEX_ID == usb.smid) {
+                PMIX_GDS_SHMEM3_VOUT(
+                    "%s: could not map the modex segment for namespace=%s; "
+                    "this process will fetch remote data from its server "
+                    "instead of reading it from shared memory",
+                    __func__, usb.nsid
+                );
+                rc = PMIX_SUCCESS;
+                break;
+            }
             break;
         }
     } while (false);

--- a/src/mca/gds/shmem3/gds_shmem3.h
+++ b/src/mca/gds/shmem3/gds_shmem3.h
@@ -138,6 +138,16 @@ PMIX_EXPORT extern size_t pmix_gds_shmem3_arena_modex_slots;
 PMIX_EXPORT extern bool pmix_gds_shmem3_offset_placement;
 
 /**
+ * Testing-only MCA parameter. When true, a client's attach is forced to
+ * fail only for the modex segment, leaving the job and session attaches
+ * at PMIx_Init alone. This is the case force_client_attach_failure
+ * cannot reach: that one fails every attach, so the client falls back to
+ * hash during PMIx_Init and never gets as far as a fence. Never set this
+ * in production.
+ */
+PMIX_EXPORT extern bool pmix_gds_shmem3_force_modex_attach_failure;
+
+/**
  * IDs for pmix_shmem_ts in pmix_gds_shmem3_job_t.
  */
 typedef enum {

--- a/src/mca/gds/shmem3/gds_shmem3.h
+++ b/src/mca/gds/shmem3/gds_shmem3.h
@@ -116,6 +116,28 @@ PMIX_EXPORT extern double pmix_gds_shmem3_segment_size_multiplier;
 PMIX_EXPORT extern bool pmix_gds_shmem3_force_client_attach_failure;
 
 /**
+ * Address space reserved for each modex slot in a job's arena, in bytes.
+ * Setting it to zero disables the arena entirely, which restores the
+ * pre-arena behavior of placing every segment independently.
+ */
+PMIX_EXPORT extern size_t pmix_gds_shmem3_arena_slot_size;
+
+/**
+ * How many modex slots a job's arena holds - that is, how many modex
+ * generations can be live at once and still be placed in it. More than
+ * one is live whenever a fence contributed only what changed, since the
+ * generations before such a one remain the only copy of what it did not
+ * repeat. Capped at 32 by the occupancy bitmap.
+ */
+PMIX_EXPORT extern size_t pmix_gds_shmem3_arena_modex_slots;
+
+/**
+ * Whether to keep away from the midpoint of the biggest hole when
+ * choosing an address (see VMEM_HOLE_BIGGEST_OFFSET). On by default.
+ */
+PMIX_EXPORT extern bool pmix_gds_shmem3_offset_placement;
+
+/**
  * IDs for pmix_shmem_ts in pmix_gds_shmem3_job_t.
  */
 typedef enum {
@@ -374,6 +396,38 @@ typedef struct {
      * still the only copy of everything it did not repeat. A read walks
      * this after the current generation. */
     pmix_list_t modex_prior;
+    /** Base of this job's reserved address-space arena, or 0 if it has
+     *  none. See "The address-space arena" in AGENTS.md.
+     *
+     * Every process that takes part in this job - the server and each of
+     * its local clients - holds the SAME range, in its own address space,
+     * from the moment it learns of the job. Segments are then mapped over
+     * that reservation rather than into whatever happens to be free,
+     * which is what makes a fixed-address attach reliable at a point in
+     * the run when the process is no longer empty.
+     */
+    uintptr_t arena_base;
+    /** Size of the reservation above. Zero means there is none. */
+    size_t arena_size;
+    /** Bytes of the arena handed out to segments that live for as long as
+     *  the job does (the job segment). Server-side only: a client maps
+     *  wherever the server tells it to, so it has no carving to do. */
+    size_t arena_static_used;
+    /** Size of each modex slot at the top of the arena.
+     *
+     * A modex generation gets a slot of its own and holds it for as long
+     * as it is readable, which is NOT just until the next one arrives: a
+     * delta generation carries only what changed, so the generations
+     * before it stay mapped and answerable on job->modex_prior. The
+     * slots therefore have to be allocated and freed, not alternated
+     * between - see arena_alloc_modex(), which reads the occupancy off
+     * the live segments rather than keeping a tally that could drift.
+     * Server-side only, like arena_static_used. */
+    size_t arena_slot_bytes;
+    /** How many modex slots the arena was reserved with. A generation
+     *  that arrives when they are all taken places itself outside the
+     *  arena, the way everything did before there was one. */
+    size_t arena_slots;
     /** Packed connection information to this segment. */
     pmix_buffer_t *conni;
 } pmix_gds_shmem3_job_t;

--- a/src/mca/gds/shmem3/gds_shmem3_component.c
+++ b/src/mca/gds/shmem3/gds_shmem3_component.c
@@ -79,6 +79,8 @@ double pmix_gds_shmem3_segment_size_multiplier = 1.0;
 
 bool pmix_gds_shmem3_force_client_attach_failure = false;
 
+bool pmix_gds_shmem3_force_modex_attach_failure = false;
+
 /* One gibibyte per slot. Nothing is committed, so the cost of being
  * generous is a virtual address range and a VMA; the cost of being
  * stingy is a modex that does not fit and has to be placed the old
@@ -121,6 +123,21 @@ gds_shmem3_component_register(void)
         "exercised. Do not set this in production.",
         PMIX_MCA_BASE_VAR_TYPE_BOOL,
         &pmix_gds_shmem3_force_client_attach_failure
+    );
+    if (varidx < 0) {
+        return PMIX_ERROR;
+    }
+
+    varidx = pmix_mca_base_component_var_register(
+        &pmix_mca_gds_shmem3_component.super,
+        "force_modex_attach_failure",
+        "(Testing only) Force a client's attach of the MODEX segment to "
+        "fail, leaving its job and session attaches alone. Unlike "
+        "force_client_attach_failure, this reaches the fence-time attach, "
+        "because the client still completes PMIx_Init on shmem3. Do not "
+        "set this in production.",
+        PMIX_MCA_BASE_VAR_TYPE_BOOL,
+        &pmix_gds_shmem3_force_modex_attach_failure
     );
     if (varidx < 0) {
         return PMIX_ERROR;

--- a/src/mca/gds/shmem3/gds_shmem3_component.c
+++ b/src/mca/gds/shmem3/gds_shmem3_component.c
@@ -79,6 +79,21 @@ double pmix_gds_shmem3_segment_size_multiplier = 1.0;
 
 bool pmix_gds_shmem3_force_client_attach_failure = false;
 
+/* One gibibyte per slot. Nothing is committed, so the cost of being
+ * generous is a virtual address range and a VMA; the cost of being
+ * stingy is a modex that does not fit and has to be placed the old
+ * way. */
+size_t pmix_gds_shmem3_arena_slot_size = 1024UL * 1024UL * 1024UL;
+
+/* Four generations live at once. One is the steady state; more than one
+ * only arises where a fence contributed just what changed, and each such
+ * fence adds one until a cumulative contribution collapses them. Four
+ * covers the shapes seen in practice and costs nothing but address
+ * space; past it, a generation is placed outside the arena. */
+size_t pmix_gds_shmem3_arena_modex_slots = 4;
+
+bool pmix_gds_shmem3_offset_placement = true;
+
 static int
 gds_shmem3_component_register(void)
 {
@@ -106,6 +121,51 @@ gds_shmem3_component_register(void)
         "exercised. Do not set this in production.",
         PMIX_MCA_BASE_VAR_TYPE_BOOL,
         &pmix_gds_shmem3_force_client_attach_failure
+    );
+    if (varidx < 0) {
+        return PMIX_ERROR;
+    }
+
+    varidx = pmix_mca_base_component_var_register(
+        &pmix_mca_gds_shmem3_component.super,
+        "arena_slot_size",
+        "Bytes of address space reserved for each modex slot in a job's "
+        "arena. The reservation holds the addresses a client will later "
+        "need to map at; nothing is committed, so this costs virtual "
+        "address space only. Set to 0 to disable the arena and place "
+        "every segment independently.",
+        PMIX_MCA_BASE_VAR_TYPE_SIZE_T,
+        &pmix_gds_shmem3_arena_slot_size
+    );
+    if (varidx < 0) {
+        return PMIX_ERROR;
+    }
+
+    varidx = pmix_mca_base_component_var_register(
+        &pmix_mca_gds_shmem3_component.super,
+        "arena_modex_slots",
+        "How many modex generations a job's arena can hold at once. More "
+        "than one is live whenever a fence contributed only what changed, "
+        "since the generations before such a one are still the only copy "
+        "of what it did not repeat. A generation that arrives with every "
+        "slot taken is placed outside the arena. Capped at 32.",
+        PMIX_MCA_BASE_VAR_TYPE_SIZE_T,
+        &pmix_gds_shmem3_arena_modex_slots
+    );
+    if (varidx < 0) {
+        return PMIX_ERROR;
+    }
+
+    varidx = pmix_mca_base_component_var_register(
+        &pmix_mca_gds_shmem3_component.super,
+        "offset_placement",
+        "Place shared-memory segments a quarter of the way into the biggest "
+        "hole in the address space rather than at its midpoint. The midpoint "
+        "is where hwloc, Open MPI and this component's own former default "
+        "all aim, so it is the address most likely to be taken already in "
+        "some other process that has to map here too.",
+        PMIX_MCA_BASE_VAR_TYPE_BOOL,
+        &pmix_gds_shmem3_offset_placement
     );
     if (varidx < 0) {
         return PMIX_ERROR;

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -174,6 +174,36 @@ server that died; but the path carries a pid, and pids get reused, and
 in place. There is exactly one caller of this function and it always
 populates the segment from scratch, so the truncate costs nothing.
 
+### `pmix_vmem` — reserving an address before you need it
+
+`pmix_vmem_find_hole()` answers "where could I map something?", which is
+only useful if you map it immediately, and useless if the process that
+has to map at the *same* address is a different one that will get there
+later. `pmix_vmem_reserve()` / `_reserve_at()` / `_restore()` /
+`_release()` exist for that second case: claim the range now, with an
+inaccessible `PROT_NONE` anonymous mapping that commits nothing, and map
+over it later with `MAP_FIXED` — which cannot fail for want of the
+address, because you have been holding it.
+
+Two rules for a caller:
+
+- **Give the range back with `pmix_vmem_restore()`, not `munmap()`,** when
+  you are done with something you mapped inside it. Unmapping punches a
+  hole in the reservation and hands the address to whatever asks next.
+  `pmix_shmem_segment_detach()` does this for you when the segment was
+  attached with `PMIX_SHMEM_MAP_OVER_RESERVATION`.
+- **Ask `pmix_shmem_utils_segment_footprint()` where a segment ends.** It
+  is not the size you asked for — a segment carries a page-aligned header
+  ahead of its data — so placing segments back to back by the requested
+  size overlaps each with the next.
+
+`pmix_gds_shmem3` is the caller, and
+[its AGENTS.md](../mca/gds/shmem3/AGENTS.md) explains the whole design
+under "The address-space arena". Note also `VMEM_HOLE_BIGGEST_OFFSET`,
+which exists because the midpoint that `use_hole()` picks is the same
+midpoint hwloc and Open MPI pick — see the comment on `use_hole_offset()`
+for why the top of the hole is a worse answer than either.
+
 ### `keyval/` — the flex lexer
 
 `keyval_lex.l` is the flex source; `keyval_lex.c` is a **generated build

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -204,6 +204,16 @@ which exists because the midpoint that `use_hole()` picks is the same
 midpoint hwloc and Open MPI pick — see the comment on `use_hole_offset()`
 for why the top of the hole is a worse answer than either.
 
+The `_scattered` variants exist because determinism cuts both ways:
+computing the same answer from the same map is what lets two processes
+agree without talking, and is also what makes two *unrelated* callers
+collide. A scatter value derived from something that differs between
+them (for `shmem3`, the namespace) displaces the result within a window
+around the chosen placement, without giving up the agreement. Tested in
+[`test/unit/util/util_vmem.c`](../../test/unit/util/util_vmem.c) — which
+is where it has to be tested, since ASLR separates real processes well
+enough to hide whether the scatter works at all.
+
 ### `keyval/` — the flex lexer
 
 `keyval_lex.l` is the flex source; `keyval_lex.c` is a **generated build

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2023 Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2022-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,6 +17,7 @@
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_show_help.h"
 #include "src/util/pmix_string_copy.h"
+#include "src/util/pmix_vmem.h"
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
@@ -96,11 +97,25 @@ segment_attach(
     // address), use MAP_FIXED_NOREPLACE: the kernel either honors the address
     // exactly or fails with EEXIST. A bare address is only a hint that the
     // kernel may silently relocate even when the target range is free.
+    //
+    // Unless, that is, the caller is mapping over a range it already
+    // reserved. Then the address is not a request that might be refused -
+    // the range is held, by the caller, for exactly this - so MAP_FIXED
+    // takes it back with no chance of EEXIST. This is the one path that is
+    // immune to the address having been claimed by something else while
+    // the process was busy, which is the whole point of reserving.
     int mmap_flags = MAP_SHARED;
-    const int must_map_at_raddr =
-        (flags & PMIX_SHMEM_MUST_MAP_AT_RADDR) &&
+    const int over_reservation =
+        (flags & PMIX_SHMEM_MAP_OVER_RESERVATION) &&
         (uintptr_t) NULL != desired_base_address;
-    if (must_map_at_raddr) {
+    const int must_map_at_raddr =
+        over_reservation ||
+        ((flags & PMIX_SHMEM_MUST_MAP_AT_RADDR) &&
+         (uintptr_t) NULL != desired_base_address);
+    if (over_reservation) {
+        mmap_flags |= MAP_FIXED;
+    }
+    else if (must_map_at_raddr) {
         mmap_flags |= MAP_FIXED_NOREPLACE;
     }
     mmap_addr = mmap(
@@ -135,6 +150,9 @@ out:
     }
     else {
         shmem->attached = true;
+        /* Remember how we got here: detach has to hand this range back to
+         * the reservation it came out of, not simply drop it. */
+        shmem->in_reservation = (0 != over_reservation);
     }
     // Always set base addresses. On error it is useful for reporting.
     shmem->hdr_address = mmap_addr;
@@ -175,15 +193,13 @@ pmix_shmem_segment_create(
     uint32_t layout_id
 ) {
     int rc = PMIX_SUCCESS;
-    // Real size of the segment. The data region begins a full page in
+    // Real size of the segment: the data region begins a full page in
     // (data_addr_from_base() rounds the header up to a page boundary), so
-    // the segment must reserve that page-aligned header offset PLUS a
-    // page-rounded data region of the requested size. Rounding
-    // "size + sizeof(header)" as a single quantity would under-allocate the
-    // data region whenever size is not a page multiple, leaving the tail of
-    // the requested range past the end of the mapping.
-    const size_t real_size = pmix_shmem_utils_pad_to_page(sizeof(pmix_shmem_header_t))
-                             + pmix_shmem_utils_pad_to_page(size);
+    // this is larger than what the caller asked to store. The arithmetic
+    // is in pmix_shmem_utils_segment_footprint() because callers placing
+    // segments adjacently need the same answer, and two copies of it
+    // would drift.
+    const size_t real_size = pmix_shmem_utils_segment_footprint(size);
 
     /* O_TRUNC is what makes "a freshly created segment reads as zero" a
      * guarantee rather than an assumption. Segments are unlinked when their
@@ -263,8 +279,21 @@ pmix_shmem_segment_detach(
     int rc = 0;
 
     if (shmem && shmem->attached) {
-        rc = munmap(shmem->hdr_address, shmem->size);
+        if (shmem->in_reservation) {
+            /* This range was carved out of a reservation the caller is
+             * still holding, and it expects to be able to place something
+             * here again. Unmapping would give the address back to the
+             * system - and the next thing to ask for one could take it,
+             * which is the failure the reservation exists to prevent. Put
+             * the placeholder back in the same call that removes us. */
+            rc = (PMIX_SUCCESS == pmix_vmem_restore(
+                      (uintptr_t)shmem->hdr_address, shmem->size)) ? 0 : -1;
+        }
+        else {
+            rc = munmap(shmem->hdr_address, shmem->size);
+        }
         shmem->attached = false;
+        shmem->in_reservation = false;
         shmem->hdr_address = NULL;
         shmem->data_address = NULL;
     }
@@ -356,11 +385,24 @@ pmix_shmem_utils_pad_to_page(
     return size + pad;
 }
 
+size_t
+pmix_shmem_utils_segment_footprint(
+    size_t size
+) {
+    /* The two paddings are deliberately separate. Rounding
+     * "size + sizeof(header)" as a single quantity would under-allocate
+     * the data region whenever size is not a page multiple, leaving the
+     * tail of the requested range past the end of the mapping. */
+    return pmix_shmem_utils_pad_to_page(sizeof(pmix_shmem_header_t))
+           + pmix_shmem_utils_pad_to_page(size);
+}
+
 static void
 shmem_construct(
     pmix_shmem_t *s
 ) {
     s->attached = false;
+    s->in_reservation = false;
     s->size = 0;
     s->hdr_address = NULL;
     s->data_address = NULL;

--- a/src/util/pmix_shmem.h
+++ b/src/util/pmix_shmem.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2023 Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,25 @@ typedef enum {
      * Indicates that during attach the requested address
      * must match the address returned by memory mapping.
      */
-    PMIX_SHMEM_MUST_MAP_AT_RADDR = 0x01
+    PMIX_SHMEM_MUST_MAP_AT_RADDR = 0x01,
+    /**
+     * Indicates that the caller already owns the requested address range
+     * - it holds a reservation covering it (see pmix_vmem_reserve()) -
+     * and the mapping is to be placed over that reservation.
+     *
+     * This turns the attach from "map here if the address happens to be
+     * free" into "map here", which is the whole reason a caller goes to
+     * the trouble of reserving: the address cannot have been taken by
+     * anything else in the meantime, because the reservation is what was
+     * holding it.
+     *
+     * Only pass this for a range the caller genuinely reserved. It maps
+     * MAP_FIXED, which silently replaces whatever is at the address,
+     * so a wrong address here unmaps something that mattered.
+     *
+     * Implies PMIX_SHMEM_MUST_MAP_AT_RADDR.
+     */
+    PMIX_SHMEM_MAP_OVER_RESERVATION = 0x02
 } pmix_shmem_flag_t;
 
 typedef struct pmix_shmem_t {
@@ -35,6 +53,9 @@ typedef struct pmix_shmem_t {
     pmix_object_t super;
     /** Flag indicating if attached to segment. */
     volatile bool attached;
+    /** True if this mapping was placed over a caller-held reservation,
+     *  and so must be given back to it rather than simply unmapped. */
+    bool in_reservation;
     /** Size of shared-memory segment. */
     size_t size;
     /** Address of shared memory segment header. */
@@ -146,6 +167,26 @@ pmix_shmem_segment_protect_data(
  */
 PMIX_EXPORT size_t
 pmix_shmem_utils_pad_to_page(
+    size_t size
+);
+
+/**
+ * How much address space a segment created for "size" bytes of data
+ * actually occupies once mapped.
+ *
+ * This is NOT "size", and the difference has teeth: a segment carries an
+ * internal header ahead of the data region, and the data region begins on
+ * the page after it, so the mapping runs a page longer than the caller
+ * asked for. A caller that has to know where the segment ENDS - one
+ * placing segments next to each other in a range it is managing - must
+ * ask, or it will overlap the next one by that page and find out later,
+ * somewhere else, as corruption.
+ *
+ * Kept here, beside pmix_shmem_segment_create()'s own arithmetic, so the
+ * two cannot drift.
+ */
+PMIX_EXPORT size_t
+pmix_shmem_utils_segment_footprint(
     size_t size
 );
 

--- a/src/util/pmix_vmem.c
+++ b/src/util/pmix_vmem.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2022 Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,6 +37,18 @@
 
 #define PMIX_VMEM_ALIGN2MB  (2  * 1024 * 1024UL)
 #define PMIX_VMEM_ALIGN64MB (64 * 1024 * 1024UL)
+
+/* MAP_FIXED_NOREPLACE (Linux 4.17+) may be unavailable; fall back to a
+ * plain address hint and verify what we got, exactly as pmix_shmem.c
+ * does. MAP_NORESERVE is likewise not universal - where it is missing
+ * the reservation simply is not marked as uncommitted, which costs
+ * nothing on a PROT_NONE mapping. */
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0
+#endif
+#ifndef MAP_NORESERVE
+#define MAP_NORESERVE 0
+#endif
 
 typedef enum {
     VMEM_MAP_FILE = 0,
@@ -143,6 +155,65 @@ use_hole(
     return PMIX_SUCCESS;
 }
 
+/**
+ * Place a quarter of the way into the hole rather than halfway.
+ *
+ * use_hole() above aims for the middle, and so does every other
+ * implementation of this idea in the HPC stack - the routine it is
+ * derived from is shared, in spirit and largely in code, with hwloc and
+ * Open MPI. That convergence is the problem. Two processes with quite
+ * different address spaces still compute a similar "middle of the biggest
+ * hole", because on a 64-bit process the biggest hole is the enormous span
+ * below the executable and its midpoint moves only with the load base. So
+ * a server picks an address by that rule, and the client it hands the
+ * address to has often already had something else placed there by the same
+ * rule.
+ *
+ * The fix is to be somewhere else, deterministically. Which "somewhere
+ * else" is not arbitrary, and the obvious answer is wrong: aiming at the
+ * TOP of the hole was tried and is worse than the midpoint, because the
+ * top of that hole is the underside of the executable's load address.
+ * That is the one part of the range where processes differ most - ASLR
+ * moves a PIE base over tens of gigabytes, and the heap grows there - so
+ * a range placed just below one process's binary routinely lands on
+ * another's. It was measurable immediately: on aarch64, where PIE bases
+ * cluster around 0xaaaa..., clients on a second node could not reserve
+ * the range their own server had picked.
+ *
+ * A quarter of the way in has the property both of those lack. It is far
+ * from the midpoint every other implementation converges on, far from the
+ * populated region near the executable, and still deep inside a span that
+ * is empty in every process - on x86-64 it lands around 0x1555_xxxx_xxxx,
+ * on aarch64 around 0x2aaa_xxxx_xxxx. The hole is measured in tens of
+ * terabytes, so a quarter of it is nowhere near either end.
+ */
+static pmix_status_t
+use_hole_offset(
+    unsigned long holebegin,
+    unsigned long holesize,
+    unsigned long *addrp,
+    unsigned long size
+) {
+    unsigned long quarter, aligned;
+
+    if (holesize < size) {
+        return PMIX_ERROR;
+    }
+
+    quarter = holebegin + (holesize / 4);
+    /* Same 64MB alignment as the midpoint placement, for the same reason
+     * (POWER's 64k-page PMD). */
+    aligned = (quarter + PMIX_VMEM_ALIGN64MB) & ~(PMIX_VMEM_ALIGN64MB - 1);
+    if (aligned >= holebegin && size <= (holebegin + holesize) - aligned) {
+        *addrp = aligned;
+        return PMIX_SUCCESS;
+    }
+
+    /* The request is a large fraction of the hole, so there is no room to
+     * be choosy. Take the ordinary placement rather than nothing. */
+    return use_hole(holebegin, holesize, addrp, size);
+}
+
 pmix_status_t
 pmix_vmem_find_hole(
     pmix_vmem_hole_kind_t hkind,
@@ -205,6 +276,7 @@ pmix_vmem_find_hole(
                     /* fallthrough */
 
                 case VMEM_HOLE_BIGGEST:
+                case VMEM_HOLE_BIGGEST_OFFSET:
                     if (begin - prevend > biggestsize) {
                         biggestbegin = prevend;
                         biggestsize = begin - prevend;
@@ -235,9 +307,119 @@ pmix_vmem_find_hole(
 
 done:
     fclose(file);
+    if (hkind == VMEM_HOLE_BIGGEST_OFFSET) {
+        return use_hole_offset(biggestbegin, biggestsize, addrp, size);
+    }
     if (hkind == VMEM_HOLE_IN_LIBS || hkind == VMEM_HOLE_BIGGEST) {
         return use_hole(biggestbegin, biggestsize, addrp, size);
     }
 
     return PMIX_ERROR;
+}
+
+/**
+ * Claim "size" bytes at "base", or report that we could not.
+ *
+ * The mapping is PROT_NONE: it exists to occupy the range, and touching
+ * it is a bug we would rather see as a fault than as silent corruption.
+ */
+static pmix_status_t
+reserve_at(
+    uintptr_t base,
+    size_t size
+) {
+    void *got;
+
+    got = mmap(
+        (void *)base, size, PROT_NONE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED_NOREPLACE,
+        -1, 0
+    );
+    if (MAP_FAILED == got) {
+        return PMIX_ERR_NOT_AVAILABLE;
+    }
+    /* Where MAP_FIXED_NOREPLACE is unavailable the address was only a
+     * hint and the kernel may have honored it elsewhere. A reservation
+     * somewhere else is no reservation at all to our caller. */
+    if ((uintptr_t)got != base) {
+        (void)munmap(got, size);
+        return PMIX_ERR_NOT_AVAILABLE;
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t
+pmix_vmem_reserve(
+    pmix_vmem_hole_kind_t hkind,
+    size_t size,
+    uintptr_t *base
+) {
+    /* The scan of /proc/self/maps and the mmap that acts on it are not
+     * one operation, so the hole can be taken in between - by another
+     * thread, the dynamic loader, or the allocator growing an arena.
+     * Rescanning after a loss finds the now-occupied range and moves on,
+     * so a small number of attempts is enough; a persistent failure
+     * means we are out of usable holes, not that we are unlucky. */
+    enum { MAX_RESERVE_ATTEMPTS = 8 };
+
+    *base = 0;
+    for (int attempt = 1; attempt <= MAX_RESERVE_ATTEMPTS; ++attempt) {
+        size_t addr = 0;
+        pmix_status_t rc = pmix_vmem_find_hole(hkind, &addr, size);
+        if (PMIX_SUCCESS != rc) {
+            return PMIX_ERR_NOT_AVAILABLE;
+        }
+        if (PMIX_SUCCESS == reserve_at((uintptr_t)addr, size)) {
+            *base = (uintptr_t)addr;
+            return PMIX_SUCCESS;
+        }
+    }
+    return PMIX_ERR_NOT_AVAILABLE;
+}
+
+pmix_status_t
+pmix_vmem_reserve_at(
+    uintptr_t base,
+    size_t size
+) {
+    if (0 == base || 0 == size) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    return reserve_at(base, size);
+}
+
+pmix_status_t
+pmix_vmem_restore(
+    uintptr_t base,
+    size_t size
+) {
+    void *got;
+
+    if (0 == base || 0 == size) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    /* MAP_FIXED, not MAP_FIXED_NOREPLACE: the range is ours and is
+     * expected to be occupied - by whatever we mapped over the
+     * reservation - and replacing it in one call is what leaves no
+     * window in which the address is unclaimed. */
+    got = mmap(
+        (void *)base, size, PROT_NONE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED,
+        -1, 0
+    );
+    if (MAP_FAILED == got) {
+        return PMIX_ERROR;
+    }
+    return PMIX_SUCCESS;
+}
+
+void
+pmix_vmem_release(
+    uintptr_t base,
+    size_t size
+) {
+    if (0 == base || 0 == size) {
+        return;
+    }
+    (void)munmap((void *)base, size);
 }

--- a/src/util/pmix_vmem.c
+++ b/src/util/pmix_vmem.c
@@ -186,39 +186,82 @@ use_hole(
  * is empty in every process - on x86-64 it lands around 0x1555_xxxx_xxxx,
  * on aarch64 around 0x2aaa_xxxx_xxxx. The hole is measured in tens of
  * terabytes, so a quarter of it is nowhere near either end.
+ *
+ * Being deterministic is what lets two processes agree on an address
+ * without exchanging one, so it cannot simply be given up - but it also
+ * means two things that have no reason to agree land on top of each
+ * other. Concurrent jobs on a node are exactly that: each server picks
+ * from its own map, the maps look alike, and they pick alike. "scatter"
+ * therefore displaces the result deterministically within a window
+ * around the quarter point, so callers that differ (different
+ * namespaces) spread out while callers that must agree (the server and
+ * clients of one namespace, which are handed the same value) still do.
+ * The window spans an eighth to three eighths of the hole, which for the
+ * spans involved here is tens of terabytes and hundreds of thousands of
+ * distinct 64MB-aligned positions.
  */
 static pmix_status_t
 use_hole_offset(
     unsigned long holebegin,
     unsigned long holesize,
     unsigned long *addrp,
-    unsigned long size
+    unsigned long size,
+    uint64_t scatter,
+    bool scattered
 ) {
-    unsigned long quarter, aligned;
+    unsigned long aligned;
 
     if (holesize < size) {
         return PMIX_ERROR;
     }
 
-    quarter = holebegin + (holesize / 4);
-    /* Same 64MB alignment as the midpoint placement, for the same reason
-     * (POWER's 64k-page PMD). */
-    aligned = (quarter + PMIX_VMEM_ALIGN64MB) & ~(PMIX_VMEM_ALIGN64MB - 1);
-    if (aligned >= holebegin && size <= (holebegin + holesize) - aligned) {
-        *addrp = aligned;
-        return PMIX_SUCCESS;
+    if (!scattered) {
+        const unsigned long quarter = holebegin + (holesize / 4);
+        /* Same 64MB alignment as the midpoint placement, for the same
+         * reason (POWER's 64k-page PMD). */
+        aligned = (quarter + PMIX_VMEM_ALIGN64MB) & ~(PMIX_VMEM_ALIGN64MB - 1);
+        if (aligned >= holebegin && size <= (holebegin + holesize) - aligned) {
+            *addrp = aligned;
+            return PMIX_SUCCESS;
+        }
+        /* The request is a large fraction of the hole, so there is no
+         * room to be choosy. Take the ordinary placement rather than
+         * nothing. */
+        return use_hole(holebegin, holesize, addrp, size);
     }
 
-    /* The request is a large fraction of the hole, so there is no room to
-     * be choosy. Take the ordinary placement rather than nothing. */
-    return use_hole(holebegin, holesize, addrp, size);
+    /* Window centered on the quarter point: [1/8, 3/8) of the hole. */
+    const unsigned long winbegin = holebegin + (holesize / 8);
+    const unsigned long winsize = holesize / 4;
+
+    aligned = (winbegin + PMIX_VMEM_ALIGN64MB) & ~(PMIX_VMEM_ALIGN64MB - 1);
+    if (aligned < holebegin || winsize <= size ||
+        aligned - winbegin > winsize - size) {
+        /* No room to spread within the window. */
+        return use_hole_offset(holebegin, holesize, addrp, size, 0, false);
+    }
+
+    /* How many 64MB-aligned positions fit between here and the end of
+     * the window, once the request itself is accounted for. */
+    const unsigned long room = (winsize - size) - (aligned - winbegin);
+    const unsigned long slots = (room / PMIX_VMEM_ALIGN64MB) + 1;
+
+    aligned += (unsigned long)(scatter % (uint64_t)slots) * PMIX_VMEM_ALIGN64MB;
+    if (aligned < holebegin || size > (holebegin + holesize) - aligned) {
+        return use_hole_offset(holebegin, holesize, addrp, size, 0, false);
+    }
+
+    *addrp = aligned;
+    return PMIX_SUCCESS;
 }
 
-pmix_status_t
-pmix_vmem_find_hole(
+static pmix_status_t
+find_hole(
     pmix_vmem_hole_kind_t hkind,
     size_t *addrp,
-    size_t size
+    size_t size,
+    uint64_t scatter,
+    bool scattered
 ) {
     unsigned long biggestbegin = 0;
     unsigned long biggestsize = 0;
@@ -308,13 +351,34 @@ pmix_vmem_find_hole(
 done:
     fclose(file);
     if (hkind == VMEM_HOLE_BIGGEST_OFFSET) {
-        return use_hole_offset(biggestbegin, biggestsize, addrp, size);
+        return use_hole_offset(
+            biggestbegin, biggestsize, addrp, size, scatter, scattered
+        );
     }
     if (hkind == VMEM_HOLE_IN_LIBS || hkind == VMEM_HOLE_BIGGEST) {
         return use_hole(biggestbegin, biggestsize, addrp, size);
     }
 
     return PMIX_ERROR;
+}
+
+pmix_status_t
+pmix_vmem_find_hole(
+    pmix_vmem_hole_kind_t hkind,
+    size_t *addrp,
+    size_t size
+) {
+    return find_hole(hkind, addrp, size, 0, false);
+}
+
+pmix_status_t
+pmix_vmem_find_hole_scattered(
+    pmix_vmem_hole_kind_t hkind,
+    uint64_t scatter,
+    size_t *addrp,
+    size_t size
+) {
+    return find_hole(hkind, addrp, size, scatter, true);
 }
 
 /**
@@ -351,21 +415,28 @@ reserve_at(
 pmix_status_t
 pmix_vmem_reserve(
     pmix_vmem_hole_kind_t hkind,
+    uint64_t scatter,
     size_t size,
     uintptr_t *base
 ) {
     /* The scan of /proc/self/maps and the mmap that acts on it are not
      * one operation, so the hole can be taken in between - by another
      * thread, the dynamic loader, or the allocator growing an arena.
-     * Rescanning after a loss finds the now-occupied range and moves on,
-     * so a small number of attempts is enough; a persistent failure
-     * means we are out of usable holes, not that we are unlucky. */
+     *
+     * Perturbing the scatter on each pass is what makes retrying mean
+     * anything. The placement rule is a function of the map and the
+     * scatter, and a rescan after a loss to something that is NOT in our
+     * map - a range we already hold for another job, most obviously -
+     * returns the same answer as before, so a retry that changed neither
+     * input would simply fail the same way eight times. */
     enum { MAX_RESERVE_ATTEMPTS = 8 };
 
     *base = 0;
-    for (int attempt = 1; attempt <= MAX_RESERVE_ATTEMPTS; ++attempt) {
+    for (uint64_t attempt = 0; attempt < MAX_RESERVE_ATTEMPTS; ++attempt) {
         size_t addr = 0;
-        pmix_status_t rc = pmix_vmem_find_hole(hkind, &addr, size);
+        pmix_status_t rc = pmix_vmem_find_hole_scattered(
+            hkind, scatter + attempt, &addr, size
+        );
         if (PMIX_SUCCESS != rc) {
             return PMIX_ERR_NOT_AVAILABLE;
         }

--- a/src/util/pmix_vmem.h
+++ b/src/util/pmix_vmem.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022      Triad National Security, LLC. All rights reserved.
- * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,13 +27,88 @@ typedef enum {
     /* Use the biggest hole between heap and stack. */
     VMEM_HOLE_IN_LIBS = 4,
     /* Use given address, if available. */
-    VMEM_HOLE_CUSTOM = 5
+    VMEM_HOLE_CUSTOM = 5,
+    /* Use the biggest hole, but placed a quarter of the way into it
+     * rather than at its midpoint. See the note on use_hole_offset() in
+     * pmix_vmem.c: everything else here - and in hwloc and Open MPI -
+     * aims for the midpoint, which is precisely why an address picked
+     * that way in one process tends to be taken already in another that
+     * has to map at the same place. */
+    VMEM_HOLE_BIGGEST_OFFSET = 6
 } pmix_vmem_hole_kind_t;
 
 PMIX_EXPORT pmix_status_t
 pmix_vmem_find_hole(
     pmix_vmem_hole_kind_t hkind,
     size_t *addrp,
+    size_t size
+);
+
+/**
+ * Reserve a range of this process's address space.
+ *
+ * Finds a hole of the requested size using "hkind" and claims it with an
+ * inaccessible (PROT_NONE) anonymous mapping. Nothing is committed - the
+ * kernel charges no memory for it - so the only resource consumed is the
+ * virtual address range itself and one VMA.
+ *
+ * The point is to hold an address range *before* something else takes
+ * it, so that a later mapping can be placed there with certainty. A
+ * caller that must map the same address in several processes (gds/shmem3
+ * stores absolute pointers, so every reader has to) reserves the range in
+ * each of them at a moment when the address space is still quiet, and
+ * thereafter maps into its own reservation, which cannot fail for want of
+ * the address.
+ *
+ * Returns PMIX_ERR_NOT_AVAILABLE if no hole of that size could be found
+ * or claimed.
+ */
+PMIX_EXPORT pmix_status_t
+pmix_vmem_reserve(
+    pmix_vmem_hole_kind_t hkind,
+    size_t size,
+    uintptr_t *base
+);
+
+/**
+ * Reserve one specific range, or fail.
+ *
+ * The peer half of pmix_vmem_reserve(): a process that was told which
+ * range to hold claims exactly that one. Returns PMIX_ERR_NOT_AVAILABLE
+ * if any part of it is already occupied - never a different range, since
+ * a different range would be useless to the caller.
+ */
+PMIX_EXPORT pmix_status_t
+pmix_vmem_reserve_at(
+    uintptr_t base,
+    size_t size
+);
+
+/**
+ * Put a sub-range of a reservation back the way pmix_vmem_reserve() left
+ * it, after something was mapped over it.
+ *
+ * A mapping placed inside a reservation replaces that part of it, so
+ * simply unmapping when done would punch a hole in the reservation and
+ * hand the address back to the next thing that asks for one. This
+ * restores the PROT_NONE placeholder in a single step, leaving no window
+ * in which the range is unclaimed.
+ */
+PMIX_EXPORT pmix_status_t
+pmix_vmem_restore(
+    uintptr_t base,
+    size_t size
+);
+
+/**
+ * Release a reservation obtained from pmix_vmem_reserve()/_reserve_at().
+ *
+ * Every mapping the caller placed inside it goes away too, so this must
+ * not run until the caller is done with all of them.
+ */
+PMIX_EXPORT void
+pmix_vmem_release(
+    uintptr_t base,
     size_t size
 );
 

--- a/src/util/pmix_vmem.h
+++ b/src/util/pmix_vmem.h
@@ -45,6 +45,37 @@ pmix_vmem_find_hole(
 );
 
 /**
+ * As pmix_vmem_find_hole(), but spread over the hole by "scatter".
+ *
+ * Picking the same rule in two processes is what lets them agree on an
+ * address without talking. The cost is that it also makes two UNRELATED
+ * things agree, and then collide: concurrent jobs on one node each have
+ * a server computing an address from its own map, and those maps look
+ * alike, so they arrive at the same answer and only the first can have
+ * it. A process that has to hold ranges from both - a client that was
+ * spawned by, or connected to, another namespace - is the one that then
+ * cannot.
+ *
+ * "scatter" moves the result deterministically within a window around
+ * the placement "hkind" would otherwise choose. Callers should derive it
+ * from something that differs between the things that must not collide
+ * and is identical everywhere within one of them - for a PMIx job, its
+ * namespace. Two processes given the same scatter still agree; two jobs
+ * do not have to.
+ *
+ * Only VMEM_HOLE_BIGGEST_OFFSET spreads. The other kinds name one
+ * position each, so there is nothing to spread over and scatter is
+ * ignored.
+ */
+PMIX_EXPORT pmix_status_t
+pmix_vmem_find_hole_scattered(
+    pmix_vmem_hole_kind_t hkind,
+    uint64_t scatter,
+    size_t *addrp,
+    size_t size
+);
+
+/**
  * Reserve a range of this process's address space.
  *
  * Finds a hole of the requested size using "hkind" and claims it with an
@@ -60,12 +91,19 @@ pmix_vmem_find_hole(
  * thereafter maps into its own reservation, which cannot fail for want of
  * the address.
  *
+ * "scatter" spreads the choice as described on
+ * pmix_vmem_find_hole_scattered(), so that two callers whose address
+ * spaces look alike do not both settle on the same range. It is also
+ * perturbed between retries, because a deterministic rule that has just
+ * lost the address it named will otherwise name it again.
+ *
  * Returns PMIX_ERR_NOT_AVAILABLE if no hole of that size could be found
  * or claimed.
  */
 PMIX_EXPORT pmix_status_t
 pmix_vmem_reserve(
     pmix_vmem_hole_kind_t hkind,
+    uint64_t scatter,
     size_t size,
     uintptr_t *base
 );

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -18,4 +18,5 @@ util_net
 util_if
 util_parse_options
 util_os_path
+util_vmem
 hash_perf

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -18,7 +18,7 @@ check_PROGRAMS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    hash_perf
+    util_vmem hash_perf
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
@@ -26,7 +26,7 @@ TESTS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    hash_perf
+    util_vmem hash_perf
 
 util_hash_SOURCES = util_hash.c
 util_hash_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -135,6 +135,13 @@ util_os_path_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_os_path_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+# Address placement and reservation. Skips itself where there is no
+# /proc/self/maps to scan; see the header comment in util_vmem.c.
+util_vmem_SOURCES = util_vmem.c
+util_vmem_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_vmem_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
 	rm -f util_hash util_name_fns \
 	    util_output util_error util_cmd_line \
@@ -142,4 +149,4 @@ clean-local:
 	    util_basename util_string_copy util_argv util_path \
 	    util_environ util_alfg util_printf util_os_dirpath \
 	    util_net util_if util_parse_options util_os_path \
-	    hash_perf
+	    util_vmem hash_perf

--- a/test/unit/util/util_vmem.c
+++ b/test/unit/util/util_vmem.c
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for src/util/pmix_vmem.c - address placement and reserving.
+ *
+ * Two properties are being pinned down here, and they pull against each
+ * other, which is why they are worth a test rather than a reading of the
+ * code:
+ *
+ *   AGREEMENT. Processes that must map a segment at one address never
+ *   exchange that address - each computes it. So the same inputs have to
+ *   give the same answer, every time, in every process.
+ *
+ *   SPREADING. Two things with no reason to agree must not be handed the
+ *   same address anyway. Concurrent jobs on a node are the case that
+ *   matters: each server picks from its own map, and those maps resemble
+ *   one another.
+ *
+ * The second is the one that cannot be tested end to end. Run two jobs
+ * on a node and their servers land far apart whether or not anything
+ * spreads them, because ASLR has already moved each server's load base
+ * and the placement is computed relative to it. That makes a passing
+ * two-job run no evidence at all - it passes just as happily with the
+ * scatter compiled out, which is exactly what a trial run of it did.
+ * Where the spreading actually earns its place is where ASLR does not do
+ * the job for it: systems that disable randomization for reproducibility,
+ * and non-PIE executables. Neither is reachable from a test suite, but
+ * the function underneath is, and it is decidable there. Hence this.
+ *
+ * SKIPS rather than fails where there is no /proc/self/maps to scan (any
+ * non-Linux host, which is also where gds/shmem3 - the only caller - is
+ * not built).
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+#include "src/util/pmix_vmem.h"
+
+#define ALIGN64MB (64 * 1024 * 1024UL)
+
+/* Big enough to be a realistic request, small enough to reserve for real
+ * several times over without troubling anything. */
+#define TEST_SIZE (256 * 1024 * 1024UL)
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* Is there a map to scan at all? Everything here depends on it. */
+static bool have_maps(void)
+{
+    size_t addr = 0;
+
+    return PMIX_SUCCESS == pmix_vmem_find_hole(
+        VMEM_HOLE_BIGGEST, &addr, TEST_SIZE);
+}
+
+static void test_agreement(void)
+{
+    size_t a = 0, b = 0;
+
+    /* Same scatter, same map, twice: the answer cannot wobble, or two
+     * processes computing it would not arrive at the same place. */
+    if (PMIX_SUCCESS != pmix_vmem_find_hole_scattered(
+            VMEM_HOLE_BIGGEST_OFFSET, 12345, &a, TEST_SIZE) ||
+        PMIX_SUCCESS != pmix_vmem_find_hole_scattered(
+            VMEM_HOLE_BIGGEST_OFFSET, 12345, &b, TEST_SIZE)) {
+        report("scattered placement succeeds", 0);
+        return;
+    }
+    report("scattered placement succeeds", 1);
+    report("same scatter gives the same address", a == b);
+    report("scattered address is 64MB aligned", 0 == (a % ALIGN64MB));
+}
+
+static void test_spreading(void)
+{
+    /* Distinct scatter values must land in distinct places. These stand
+     * in for distinct namespaces; the caller hashes the name, so what
+     * reaches here is arbitrary 64-bit values. */
+    static const uint64_t scatters[] = {
+        0u, 1u, 7u, 1024u, 999983u,
+        14695981039346656037ULL, 1099511628211ULL, 0xdeadbeefcafef00dULL
+    };
+    const size_t n = sizeof(scatters) / sizeof(scatters[0]);
+    size_t addrs[sizeof(scatters) / sizeof(scatters[0])];
+    size_t i, j;
+    int distinct = 1;
+    int aligned = 1;
+
+    for (i = 0; i < n; ++i) {
+        addrs[i] = 0;
+        if (PMIX_SUCCESS != pmix_vmem_find_hole_scattered(
+                VMEM_HOLE_BIGGEST_OFFSET, scatters[i], &addrs[i], TEST_SIZE)) {
+            report("every scatter value places successfully", 0);
+            return;
+        }
+        if (0 != (addrs[i] % ALIGN64MB)) {
+            aligned = 0;
+        }
+    }
+    report("every scatter value places successfully", 1);
+    report("every scattered address is 64MB aligned", aligned);
+
+    for (i = 0; i < n && distinct; ++i) {
+        for (j = i + 1; j < n; ++j) {
+            if (addrs[i] == addrs[j]) {
+                fprintf(stdout, "    scatter %llu and %llu both gave 0x%zx\n",
+                        (unsigned long long) scatters[i],
+                        (unsigned long long) scatters[j], addrs[i]);
+                distinct = 0;
+                break;
+            }
+        }
+    }
+    report("different scatter values give different addresses", distinct);
+
+    /* And the unscattered rule is a single fixed answer, which is what
+     * the scattered one is spreading away from. */
+    {
+        size_t plain = 0, plain2 = 0;
+        int ok = (PMIX_SUCCESS == pmix_vmem_find_hole(
+                      VMEM_HOLE_BIGGEST_OFFSET, &plain, TEST_SIZE))
+                 && (PMIX_SUCCESS == pmix_vmem_find_hole(
+                         VMEM_HOLE_BIGGEST_OFFSET, &plain2, TEST_SIZE))
+                 && plain == plain2;
+        report("unscattered placement is stable", ok);
+    }
+}
+
+static void test_offset_avoids_midpoint(void)
+{
+    size_t mid = 0, off = 0;
+
+    if (PMIX_SUCCESS != pmix_vmem_find_hole(
+            VMEM_HOLE_BIGGEST, &mid, TEST_SIZE) ||
+        PMIX_SUCCESS != pmix_vmem_find_hole(
+            VMEM_HOLE_BIGGEST_OFFSET, &off, TEST_SIZE)) {
+        report("offset placement differs from the midpoint", 0);
+        return;
+    }
+    /* The whole reason VMEM_HOLE_BIGGEST_OFFSET exists is that the
+     * midpoint is where hwloc and Open MPI aim too. If these ever
+     * coincide it has stopped doing its job. */
+    report("offset placement differs from the midpoint", mid != off);
+}
+
+static void test_reserve_roundtrip(void)
+{
+    uintptr_t base = 0;
+    volatile unsigned char *p;
+
+    if (PMIX_SUCCESS != pmix_vmem_reserve(
+            VMEM_HOLE_BIGGEST_OFFSET, 4242, TEST_SIZE, &base)) {
+        report("reserve succeeds", 0);
+        return;
+    }
+    report("reserve succeeds", 1);
+    report("reserve returns a 64MB aligned base", 0 == (base % ALIGN64MB));
+
+    /* A reservation is held, so asking for the same range again must be
+     * refused - that is the property the whole design rests on. */
+    report("a held range cannot be reserved twice",
+           PMIX_SUCCESS != pmix_vmem_reserve_at(base, TEST_SIZE));
+
+    /* Mapping over our own reservation is what a caller does next, and
+     * MAP_FIXED must land exactly where asked. */
+    p = mmap((void *) base, TEST_SIZE, PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+    if (MAP_FAILED == (void *) p) {
+        report("can map over the reservation", 0);
+    } else {
+        report("can map over the reservation", (uintptr_t) p == base);
+        p[0] = 0x5a;
+        p[TEST_SIZE - 1] = 0xa5;
+        report("the mapping is usable end to end",
+               0x5a == p[0] && 0xa5 == p[TEST_SIZE - 1]);
+        /* Give it back to the reservation, and confirm the range is
+         * still held afterwards rather than handed to the system. */
+        report("restore succeeds",
+               PMIX_SUCCESS == pmix_vmem_restore(base, TEST_SIZE));
+        report("the range is still held after restore",
+               PMIX_SUCCESS != pmix_vmem_reserve_at(base, TEST_SIZE));
+    }
+
+    pmix_vmem_release(base, TEST_SIZE);
+    /* Once released it is anybody's, so we can take it again. */
+    report("the range is free after release",
+           PMIX_SUCCESS == pmix_vmem_reserve_at(base, TEST_SIZE));
+    pmix_vmem_release(base, TEST_SIZE);
+}
+
+static void test_reserve_rejects_nonsense(void)
+{
+    report("reserve_at rejects a zero base",
+           PMIX_SUCCESS != pmix_vmem_reserve_at(0, TEST_SIZE));
+    report("reserve_at rejects a zero size",
+           PMIX_SUCCESS != pmix_vmem_reserve_at(0x1000, 0));
+    report("restore rejects a zero base",
+           PMIX_SUCCESS != pmix_vmem_restore(0, TEST_SIZE));
+    /* Releasing nothing must be a no-op rather than an munmap of
+     * something else. */
+    pmix_vmem_release(0, TEST_SIZE);
+    pmix_vmem_release(0x1000, 0);
+    report("release of an empty range is harmless", 1);
+}
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "pmix_vmem tests\n");
+
+    if (!have_maps()) {
+        /* No /proc/self/maps: nothing here can run, and gds/shmem3 is
+         * not built on such a host either. Say so and pass. */
+        fprintf(stdout,
+                "  SKIP: no usable /proc/self/maps on this platform\n");
+        fprintf(stdout, "SUMMARY: 0 passed, 0 failed (skipped)\n");
+        return 0;
+    }
+
+    test_agreement();
+    test_spreading();
+    test_offset_avoids_midpoint();
+    test_reserve_roundtrip();
+    test_reserve_rejects_nonsense();
+
+    fprintf(stdout, "SUMMARY: %d passed, %d failed\n", npass, nfail);
+    return (0 == nfail) ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #4156.

The report is accurate, and two separate things were wrong. Only one of
them is what the title said.

### The fence returned an internal signal to the application

`unpack_return()` has no GDS fallback to take, and cannot cheaply be
given one: `PMIX_GDS_RECV_MODEX_COMPLETE` resolves a single module, and
`PMIX_GDS_FALLBACK_CMD` re-registers job data only, so a completed modex
cannot be re-delivered in another module's format without a new wire
command. `PMIX_ERR_TAKE_NEXT_OPTION` therefore escaped out of
`PMIx_Fence` as its return code. Open MPI does not check that return, so
a job carried on with a modex it had not stored.

### The failed attach also destroyed data that was fine

This is the damaging half. `shmem3_attach()` had a single failure
policy, written for the init case: detach, take the job tracker off the
list, release it. At fence time the segment being attached is the MODEX
one, so that also dropped the job and session segments the client had
been reading successfully since `PMIx_Init` — after which every
job-level lookup for the client's **own** namespace failed with
`PMIX_ERR_INVALID_NAMESPACE`, long after and nowhere near the fence that
caused it. That is how it was noticed: `MPI_Comm_split_type(MPI_COMM_TYPE_SHARED)`
putting a node's five processes into five communicators of one.

A failed modex attach now clears that segment's status and keeps the
tracker, and the fence completes. The client loses the fast path to
remote data and nothing else — the fetch side already gates every modex
read on `PMIX_GDS_SHMEM3_READY_FOR_USE`, so the lookup misses and goes
up to the server like any other, and a later generation can still attach
into the cleared slot.

## Not needing luck in the first place

Losing the shared-memory fast path is a poor outcome even when it is
survivable, so the rest of the branch is about not reaching it.

A client attaches the **job** segment during `PMIx_Init`, when its
address space is nearly empty, and the **modex** segment at a *fence* —
by which time it has loaded an MPI stack, opened components, grown
allocator arenas and registered fabric memory over the same ground. Both
addresses are chosen by the server from its own map and both must be
honored exactly, because the structures in a segment hold absolute
pointers. So the first attach nearly always works and the second is a
gamble; #4156 is that gamble lost, about one run in 25, taking every
rank on a node at once.

So stop asking for the address and hold it instead. Before creating any
of a job's segments the server reserves one contiguous range with the
new `pmix_vmem_reserve()` — a `PROT_NONE` mapping that commits nothing
and costs a VMA. The range travels on every seg blob, and each client
claims it while still inside `PMIx_Init`, the one moment it reliably
can. Every later mapping, including each modex generation, is then
`MAP_FIXED` over ground the process already owns.

Placement changed too. `VMEM_HOLE_BIGGEST` aims at the **midpoint of the
biggest hole**, and hwloc and Open MPI — which share this routine's
ancestry — aim there as well; that convergence is what makes an address
picked in one process likely to be taken in another. `VMEM_HOLE_BIGGEST_OFFSET`
lands a quarter of the way in instead, and the placement is scattered by
a hash of the namespace so concurrent jobs on a node do not agree either.

Four things are load-bearing and are commented as such:

* **Carve by `pmix_shmem_utils_segment_footprint()`, not the requested
  size.** A segment maps a page of header ahead of its data; carving to
  the size asked for overlapped each segment with the next by that page
  and the following `MAP_FIXED` replaced it. It segfaulted the daemon on
  the first fence.
* **Detach restores the reservation** rather than unmapping, or
  releasing a modex generation punches a hole for something else to take.
* **A modex generation holds its slot for as long as it is readable.**
  This began as an alternation between two slots, on the assumption that
  one generation was live at a time; #4087 ended that. A delta
  generation leaves every earlier one mapped on `job->modex_prior`, so
  `arena_alloc_modex()` reads occupancy off the live segments and takes
  the lowest free slot.
* **The session segment stays outside the arena.** A session outlives
  the job that first described it, and `job_destruct()` releases the
  whole arena.

If the arena cannot be reserved, or a modex outgrows its slot, every
segment places itself independently exactly as before — degraded, never
broken.

## Two dead ends, recorded so they are not retried

**Placing at the top of the hole is worse than the midpoint.** It was
the first thing tried. The top of that hole is the underside of the
executable's load address — where ASLR moves processes around most and
where the heap grows — so on aarch64 clients on a second node could not
reserve the range their own server had picked.

**A two-job test cannot show that the scatter works.** ASLR has already
moved each server's load base and the placement is relative to it, so
two jobs land far apart whether or not anything scatters them; the
concurrent-jobs stage added here passes with the scatter compiled out,
which was confirmed by compiling it out. The scatter is for where ASLR
does not do that job — randomization disabled (not rare in HPC) and
non-PIE executables — so the property is pinned down in
`test/unit/util/util_vmem.c` against the placement function directly,
where it is decidable.

## Testing

`examples/modex_attach_fail.c` asserts the three things that must
survive a modex that will not map: the fence succeeds, job-level data
for the client's own namespace is still reachable, and a peer's value
still arrives by some route. `run-gds-tests.sh` drives it over 2, 4 and
8 servers with the failure forced and again without, plus a
concurrent-jobs stage. Two nodes is not a convention there but the whole
test — a single-node job exchanges no remote data, so no modex segment
is ever sent and there is nothing to fail.

The new `gds_shmem3_force_modex_attach_failure` parameter is what makes
that drivable. The existing `force_client_attach_failure` cannot reach
this path: it fails every attach, so the client leaves `PMIx_Init` on
`gds/hash` and never gets as far as a fence on `shmem3` — which is why
the reporter had to `LD_PRELOAD` a shim.

`test/unit/util/util_vmem.c` covers placement and the
reserve/map/restore/release round trip; it skips itself where there is
no `/proc/self/maps`, which is also where `gds/shmem3` is not built.

Both behavioral fixes were checked against negative controls: reverting
them reproduces #4156 verbatim, including the same
`pmix_client_fence.c:276` error line, and reverting the scatter fails
exactly the `different scatter values give different addresses`
assertion.

Verified on macOS (clean build, `make check`) and on Linux through
`contrib/dockerswarm` (warning-free `shmem3` build, gds/client/common/bfrops
suites).

### One thing this does not fix

The 8-server stages of `run-gds-tests.sh` hang intermittently. That is
**pre-existing and unrelated** — measured at 10 of 12 runs on `master`
against 11 of 12 on this branch. It is a deadlock rather than load: it
reproduces on an idle host and stays wedged for ten minutes, with each
stuck rank's main thread in `futex_wait` and its progress thread idle in
`epoll_wait`, blocked in `PMIx_Get` for a remote peer's key whose owner
has already finished. It will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
