### PR TITLE
Fix the modex read path that made 8-server jobs hang in PMIx_Get

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -204,6 +204,57 @@ static inline bool is_delete_scope(pmix_scope_t scope)
             || PMIX_DEL_GLOBAL == scope || PMIX_DEL_INTERNAL == scope);
 }
 
+/* Tell the namespace's own datastore to stop answering for a key.
+ *
+ * Storing the removal into pmix_globals.mypeer corrects the "hash" store
+ * every client keeps, and that is only half of it. A namespace served by
+ * another module - gds/shmem3, reading a shared segment it is not
+ * allowed to rewrite - holds its own copy and answers out of it, so it
+ * has to be told separately or it keeps handing back the deleted key.
+ *
+ * Both halves are needed on both paths that remove a key: the one where
+ * a server tells us about somebody's deletion, and the one where we are
+ * the process doing the deleting. The second is easy to overlook,
+ * because a rank deleting its OWN key has already applied it to its own
+ * store - but its own committed data is also in the modex, which is a
+ * different module's segment, and that copy answers first. */
+static void del_key_in_nspace_module(const pmix_proc_t *proc, const char *key)
+{
+    pmix_namespace_t *nptr;
+    pmix_status_t rc;
+
+    if (NULL == proc || NULL == key) {
+        return;
+    }
+    /* The module that answers a get for server-provided data is reached
+     * through the SERVER peer's namespace object, not through
+     * pmix_globals.nspaces. On a client those are different objects -
+     * our own carries "hash", which the caller has already corrected,
+     * and only the server peer's carries the module holding the modex.
+     * Walking pmix_globals.nspaces alone therefore told nobody anything,
+     * which is why a rank went on reading a key it had just deleted.
+     *
+     * The module screens the namespace itself - it has no tracker for
+     * one it never served - so this needs no matching test here. */
+    if (NULL != pmix_client_globals.myserver
+        && NULL != pmix_client_globals.myserver->nptr) {
+        PMIX_GDS_DEL_KEY(rc, pmix_client_globals.myserver->nptr, proc, key);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+    }
+    /* Any other namespace we hold cached data for. */
+    PMIX_LIST_FOREACH (nptr, &pmix_globals.nspaces, pmix_namespace_t) {
+        if (0 == strncmp(nptr->nspace, proc->nspace, PMIX_MAX_NSLEN)) {
+            PMIX_GDS_DEL_KEY(rc, nptr, proc, key);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+            }
+            return;
+        }
+    }
+}
+
 /* A server telling us that a key has been deleted, so our own copy of it
  * goes too. See pmix_server_notify_deleted().
  *
@@ -218,7 +269,6 @@ static void client_data_delete_handler(struct pmix_peer_t *pr,
     pmix_scope_t scope;
     char *key = NULL;
     pmix_kval_t *kv;
-    pmix_namespace_t *nptr;
     pmix_status_t rc;
     int32_t cnt;
 
@@ -266,18 +316,8 @@ static void client_data_delete_handler(struct pmix_peer_t *pr,
         PMIX_ERROR_LOG(rc);
     }
     /* our own peer is pinned to "hash", which is what the store above
-     * corrected. If this namespace is served by another module - one
-     * reading a shared segment it cannot rewrite - that module has to be
-     * told separately so it stops answering for the key. */
-    PMIX_LIST_FOREACH (nptr, &pmix_globals.nspaces, pmix_namespace_t) {
-        if (0 == strncmp(nptr->nspace, proc.nspace, PMIX_MAX_NSLEN)) {
-            PMIX_GDS_DEL_KEY(rc, nptr, &proc, kv->key);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-            }
-            break;
-        }
-    }
+     * corrected - the namespace's own module has to be told separately */
+    del_key_in_nspace_module(&proc, kv->key);
     PMIX_RELEASE(kv);
 }
 
@@ -1776,6 +1816,12 @@ static void _putfn(int sd, short args, void *cbdata)
             PMIX_ERROR_LOG(rc);
             goto done;
         }
+        /* The store above is against our own peer, which is pinned to
+         * "hash". Our own committed data is ALSO in the modex, which
+         * belongs to whichever module serves this namespace and answers
+         * ahead of the hash - so deleting our own key without telling
+         * that module leaves us still reading it. */
+        del_key_in_nspace_module(&pmix_globals.myid, kv->key);
         mark_deleted(cb->scope, kv->key);
         goto done;
     }

--- a/src/mca/gds/shmem3/gds_shmem3_fetch.c
+++ b/src/mca/gds/shmem3/gds_shmem3_fetch.c
@@ -1084,9 +1084,28 @@ doover:
     }
     else {
         if (PMIX_GLOBAL == scope || PMIX_SCOPE_UNDEF == scope) {
-            if (ht == local_ht) {
+            if (!useremote) {
                 // We need to also try the remote data.
                 ht = remote_ht;
+                /* Say which store the retry is against, exactly as the
+                 * success path above does. Everything past "doover"
+                 * dispatches on this flag rather than on ht, because the
+                 * modex is a chain of generations rather than one table;
+                 * arriving there with it still false ran the JOB fetch
+                 * over the MODEX table, paired with the job segment's key
+                 * index. The indices are minted per segment, so that
+                 * pairing does not resolve the key and the lookup misses
+                 * whatever is there.
+                 *
+                 * It missed on the ordinary path, not a corner: an
+                 * unqualified PMIx_Get arrives as PMIX_SCOPE_UNDEF, finds
+                 * nothing local, and reaches the modex only through here.
+                 * Every remote key therefore went up to the server, and a
+                 * request for a rank that had already finished never came
+                 * back - a dmdx tracker is created with no timeout - so
+                 * the caller blocked forever. That is an 8-rank job over
+                 * 8 nodes hanging better than half the time. */
+                useremote = true;
                 goto doover;
             }
         }


### PR DESCRIPTION
Fixes the intermittent 8-server hangs in `run-gds-tests.sh`. They are
not flaky — they are a regression from #4087's fence work, and they
reproduce **10 times in 12** on `master`.

## The hang

`shmem3_fetch_from_job()` reaches the modex from two places: the success
path, when the first lookup worked and the scope says to collect the
remote half too, and the failure path, when it did not and the remaining
scope is worth trying. When the modex became a chain of generations
rather than one table, the dispatch past `doover` moved from testing
which table `ht` points at to testing a new `useremote` flag — and only
the success path was taught to set it.

The failure path therefore arrived with `useremote` still false, which
runs the **job** fetch over the **modex** table, paired with the **job**
segment's key index. Indices are minted per segment, so that pairing
does not resolve the key and the lookup misses data that is sitting
right there.

That is the ordinary path, not a corner: an unqualified `PMIx_Get`
arrives as `PMIX_SCOPE_UNDEF`, misses locally, and reaches the modex
only through here. So after a collecting fence *every* remote key missed
and went up to the server. Measured on an 8-rank job across 8 nodes with
`pmix_client_get_verbose`: **0** requests reached the server at
`c784d9b81~1`, **one per remote key** at `c784d9b81`, and **0** again
with this fix.

On its own that is a performance defect. What makes it a hang is where
those requests go. The server answers one it cannot satisfy locally by
asking the host and creating a tracker with no timeout
(`TRACKER CREATED - WAITING TIMEOUT -1`); when the target rank has
already finished and exited, no reply ever comes and the requesting
client blocks in `PMIx_Get` forever. Ranks finish at different times, so
whether a run wedges depends on whether anybody asks about a rank that
has left — which is exactly why it presents as an intermittent hang of
the largest geometry rather than a reproducible failure.

Caught in the act, every stuck rank has its main thread in `futex_wait`
and its progress thread idle in `epoll_wait`, and the daemon log shows
the tracker created with no matching `queue dmdx reply`.

## The deletion bug underneath it

Fixing the fetch exposed a second one, which had been unreachable
because nothing ever consulted the modex on that path: `examples/delete_key`
started failing with *rank 0 reading back a key it had just deleted*.

A client applies a removal to `pmix_globals.mypeer`, pinned to `"hash"`.
A namespace served by another module keeps its own copy and answers a
get out of it, so it has to be told separately. The half that existed
looked the namespace up in `pmix_globals.nspaces` — but on a client that
is not where the module answering a get lives. Our own namespace object
carries `"hash"`, the one the store already corrected; the module
holding the modex hangs off the **server** peer's namespace object. So
the loop matched an entry with nothing to add and the module that
mattered was never told.

And there were two paths, not one. A rank deleting its *own* key went
through nothing at all, on the reasoning that it had already applied the
removal to its own store. It had — to its hash store. Its own committed
data is also in the modex, and that copy answers first.

Both now route through one helper.

Worth noting about the test rather than the bug: `delete_key` was
passing because the code beneath it was not running.

## Numbers

Twelve runs of the 8-server `datatypes` case, counting hangs:

| tree | result |
|---|---|
| `c784d9b81~1` (before the fence work) | 8 ok, 0 hung |
| `c784d9b81` (the commit itself) | 0 ok, 8 hung |
| `master` @ `9408510ea` | 2 ok, 10 hung |
| this branch | **12 ok, 0 hung** |

`PMIX_MCA_gds=hash` on `master` is 6/6 clean, which localizes it to
`gds/shmem3`. It hangs on an idle host and stays wedged for ten minutes
under `--timeout 600`, so it is not load.

`run-gds-tests.sh` goes from 3 failures to **41 passed, 0 failed** — the
first fully clean run of that suite I have seen. `make check` is clean on
macOS, and the client and common swarm suites pass.

Note the parameter `c784d9b81` added defaults **off** and is not
involved: the regression is in the read path, which changed for
everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
