### PR TITLE
Skip a segment-blob field we do not recognize

### DIFF
--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -2003,9 +2003,26 @@ unpack_shmem3_connection_info(
             usb->is_delta = ('0' != val[0]);
         }
         else {
-            rc = PMIX_ERR_BAD_PARAM;
-            PMIX_ERROR_LOG(rc);
-            break;
+            /* A key we have not been taught to hear. Skip it.
+             *
+             * This blob grows the way every other PMIx wire structure
+             * grows - by appending - and the project's own rule is that
+             * a reader tolerates what it does not recognize. Refusing
+             * the whole blob instead makes every future addition a flag
+             * day: a server that has learned to send one more field
+             * cannot talk to a client that has not yet learned to read
+             * it, and the client does not degrade, it fails PMIx_Init.
+             *
+             * That is not hypothetical - it is what a newer server
+             * describing its address-space arena to an older client
+             * does, and the xversion CI job is where it shows up. The
+             * fields such a client skips are ones it has no use for by
+             * construction: it does not know the feature they describe,
+             * so it does exactly what it did before they existed. */
+            PMIX_GDS_SHMEM3_VOUT(
+                "%s: ignoring unrecognized seg blob key=%s",
+                __func__, kv.key
+            );
         }
         // Done with this one.
         PMIX_DESTRUCT(&kv);


### PR DESCRIPTION
This is what #4158 is failing `xversion (master)` on, and it needs to
land first.

## What breaks

The seg blob is how a server describes a shared segment to a client. Its
reader refuses any key it does not recognize:

```c
else {
    rc = PMIX_ERR_BAD_PARAM;
    PMIX_ERROR_LOG(rc);
    break;
}
```

So the moment a server learns to send one more field, every client that
has not yet learned to read it fails — and not gracefully. It does not
fall back to `hash`; the whole blob is rejected, `store_job_info` returns
`PMIX_ERR_UNPACK_FAILURE`, and `PMIx_Init` dies:

```
PMIX ERROR: PMIX_ERR_BAD_PARAM in file gds_shmem3.c at line 2007
PMIX ERROR: PMIX_ERR_UNPACK_FAILURE in file gds_shmem3.c at line 2400
Client ns foobar rank 0: PMIx_Init failed: PMIX_ERR_UNPACK_FAILURE
```

That is the opposite of the rule we set for ourselves in the top-level
guide — *"Readers must tolerate trailing data they do not recognize
(forward compatibility)"* — and it is the one thing that makes two
releases interoperate while one is ahead of the other.

## Why a layout-ID bump is not the answer

The obvious guess is that `PMIX_GDS_SHMEM3_LAYOUT_ID` should change. It
would not help: that stamp is checked in `pmix_shmem_segment_attach()`,
and the client never gets that far. `unpack_shmem3_seg_blob_and_attach_if_necessary()`
parses the blob *first* and attaches second, so the failure happens
before anything reads the stamp. (Renaming the component would work, by
making an old peer decline `shmem3` and use `hash` — but that is the
remedy for a change in the shared *memory layout*, and nothing here
changes what is in the segment.)

## Why it cannot be deferred

Once a reader is out there refusing unknown keys, nothing a future
server sends can reach it. The tolerance has to be in place **before**
the first addition that needs it, not alongside it — which is why this
is separate from #4158 rather than part of it.

Skipping is safe by construction: a field a client does not recognize
describes a feature it does not know about, so ignoring it leaves it
doing exactly what it did before that field existed. Every field it
actually uses is unchanged.

## Verified

Reproduced the CI job locally — build two trees, run one's `simptest`
against the other's `simpclient`, the same thing `.github/workflows`
does:

| server | client | before | after |
|---|---|---|---|
| #4158 | master | `TEST FAILED WITH ERROR 236` | — |
| #4158 | master + this | — | `Test finished OK!` |
| master | #4158 | `Test finished OK!` | — |
| this | master | — | `Test finished OK!` |

Both directions, and the same-version cases, pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
