### PR TITLE
Name a device by the node it is on, and tell a process which GPUs it may use

### DIFF
--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -289,6 +289,22 @@ a normal build does exercise it.
   `pmix_hwloc_compute_distances()` is the one caller entitled to pass
   `pmix_globals.hostname`, because it measures against a cpuset of *this*
   machine's PUs and so can only ever be reading the local topology.
+- **A device's vendor identity is usually absent, and that is not a
+  failure.** `pmix_hwloc_device_t.vendor_id` carries the handle a GPU
+  runtime will actually accept — NVIDIA's `GPU-<uuid>` and its AMD and
+  Level Zero equivalents — and hwloc records it only from the matching
+  vendor backend (`NVIDIAUUID`, `AMDUUID`, `LevelZeroUUID`). An hwloc
+  built without them describes the same GPUs with no way to name any of
+  them, so `NULL` is the common answer and callers decide what it means.
+  Two properties worth knowing: the identity is harvested across the
+  whole PCI **function**, not read off the OS device that names it (with
+  CUDA and NVML both loaded the function is named `cuda0` while the uuid
+  sits on `nvml0`, so reading only the named device reports "no identity"
+  on exactly the machines that have one); and *whether* a topology has
+  identities is structural — an absent info attribute changes an object's
+  info count, which `hwloc_topology_diff_build()` calls "too complex" —
+  while the *values* are per-node and must be read from that node's own
+  topology.
 - **Always check `source` first, and match it with `strncasecmp(...,
   "hwloc", 5)`.** Returning `PMIX_ERR_TAKE_NEXT_OPTION` (not an error) for
   a non-hwloc object is the contract. A `NULL` source is legal on *input*

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -274,6 +274,21 @@ a normal build does exercise it.
 
 ## Pitfalls specific to this directory
 
+- **A device uuid names the node the device is on, not the node reading
+  the topology.** `pmix_hwloc_get_devices()` takes the hostname as a
+  *required* parameter and `build_device_uuid()` uses it — neither reads
+  `pmix_globals.hostname`, and a `NULL` is `PMIX_ERR_BAD_PARAM` rather
+  than a convenience default. The reason is that the interesting caller
+  reads someone else's topology: PRRTE's mapper runs on the head node and
+  enumerates every compute node's devices, and while it read the global
+  it stamped the head node's hostname onto every device in the job. The
+  uuid travels *instead of* an ordinal precisely so a process can compute
+  the same string locally from `PMIX_DEVICE_DISTANCES` and correlate the
+  two, and that correlation then worked on exactly one node. Nothing
+  detects it: the string is well-formed, unique, and consistently wrong.
+  `pmix_hwloc_compute_distances()` is the one caller entitled to pass
+  `pmix_globals.hostname`, because it measures against a cpuset of *this*
+  machine's PUs and so can only ever be reading the local topology.
 - **Always check `source` first, and match it with `strncasecmp(...,
   "hwloc", 5)`.** Returning `PMIX_ERR_TAKE_NEXT_OPTION` (not an error) for
   a non-hwloc object is the contract. A `NULL` source is legal on *input*

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -1456,6 +1456,54 @@ static bool osdev_is_render_node(hwloc_obj_t osdev)
     return (NULL != osdev->name && 0 == strncasecmp(osdev->name, "renderD", 7));
 }
 
+/* The info key each vendor's hwloc backend records its device identity
+ * under: NVML writes NVIDIAUUID, RSMI writes AMDUUID, Level Zero writes
+ * LevelZeroUUID.  There is no generic spelling to fall back on, which is
+ * why this is a table rather than a rule.
+ *
+ * Deliberately not BXIUUID, which hwloc also writes: that is a network
+ * interconnect, and this is about naming a device to the vendor runtime
+ * that will compute on it. */
+static const char *vendor_id_keys[] = {"NVIDIAUUID", "AMDUUID", "LevelZeroUUID", NULL};
+
+/* The vendor's identifier for the device this OS device belongs to, or NULL.
+ *
+ * Scanned across the whole PCI function rather than read off the given OS
+ * device, because the two are routinely different objects: a topology with
+ * both the CUDA and NVML backends loaded exposes "cuda0" and "nvml0" on one
+ * function, get_devices() names the function by the first vendor compute
+ * node it meets - "cuda0" - and the uuid is on "nvml0".  Reading only the
+ * named device would report "no identity" on precisely the machines that
+ * have one. */
+static char *vendor_id_of(hwloc_obj_t osdev, hwloc_obj_t pci)
+{
+    hwloc_obj_t child;
+    const char *val;
+    unsigned k;
+
+    for (k = 0; NULL != vendor_id_keys[k]; k++) {
+        val = hwloc_obj_get_info_by_name(osdev, vendor_id_keys[k]);
+        if (NULL != val) {
+            return strdup(val);
+        }
+    }
+    if (NULL == pci) {
+        return NULL;
+    }
+    for (child = pci->io_first_child; NULL != child; child = child->next_sibling) {
+        if (HWLOC_OBJ_OS_DEVICE != child->type) {
+            continue;
+        }
+        for (k = 0; NULL != vendor_id_keys[k]; k++) {
+            val = hwloc_obj_get_info_by_name(child, vendor_id_keys[k]);
+            if (NULL != val) {
+                return strdup(val);
+            }
+        }
+    }
+    return NULL;
+}
+
 /* The PCI function an OS device hangs off, or NULL if it has none. */
 static hwloc_obj_t pci_ancestor(hwloc_obj_t osdev)
 {
@@ -1821,6 +1869,7 @@ pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
         }
         array[n].dev.osname = strdup(c->osdev->name);
         array[n].dev.type = c->type;
+        array[n].vendor_id = vendor_id_of(c->osdev, c->pci);
         if (NULL != c->pci) {
             pmix_asprintf(&array[n].busid, "%04x:%02x:%02x.%01x",
                           c->pci->attr->pcidev.domain, c->pci->attr->pcidev.bus,
@@ -1864,6 +1913,9 @@ void pmix_hwloc_release_devices(pmix_hwloc_device_t *devs, size_t ndevs)
         PMIx_Device_destruct(&devs[n].dev);
         if (NULL != devs[n].busid) {
             free(devs[n].busid);
+        }
+        if (NULL != devs[n].vendor_id) {
+            free(devs[n].vendor_id);
         }
         /* locality is borrowed from the topology */
     }

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -1281,8 +1281,14 @@ pmix_status_t pmix_hwloc_compute_distances(pmix_topology_t *topo, pmix_cpuset_t 
      * is what makes them agree by construction: it is also what gives this
      * function per-PCI-function dedup (a GPU exposing a card node, a render
      * node and a vendor node is one device, not three) and a deterministic
-     * order, neither of which the walk here used to have. */
-    prc = pmix_hwloc_get_devices(topo, type, (NULL == devids) ? NULL : devids[0],
+     * order, neither of which the walk here used to have.
+     *
+     * pmix_globals.hostname is the right node here, and is the only place in
+     * the tree where that is true by construction: distances are measured
+     * against a cpuset of this machine's PUs, so the topology being read can
+     * only be the local one. */
+    prc = pmix_hwloc_get_devices(topo, pmix_globals.hostname, type,
+                                 (NULL == devids) ? NULL : devids[0],
                                  &devs, &ndevs);
     if (PMIX_SUCCESS != prc) {
         rc = prc;
@@ -1530,8 +1536,15 @@ static bool osdev_preferred(hwloc_obj_t candidate, hwloc_obj_t incumbent)
  * device it was given against the ones it can see, so this grammar must not
  * vary between the paths that produce it - hence one function.  Returns
  * PMIX_ERR_TAKE_NEXT_OPTION for a device type that has no uuid form, which
- * the caller reads as "not a device I can report". */
-static pmix_status_t build_device_uuid(hwloc_obj_t osdev, char **uuid)
+ * the caller reads as "not a device I can report".
+ *
+ * "hostname" is the node this topology describes and is supplied by the
+ * caller rather than read from pmix_globals: it names the node the device
+ * lives on, not the node this code is running on, and those are the same
+ * thing only when the topology is the local one.  See the note on
+ * pmix_hwloc_get_devices() in the header. */
+static pmix_status_t build_device_uuid(hwloc_obj_t osdev, const char *hostname,
+                                       char **uuid)
 {
     unsigned i;
     char *addr = NULL, *ngid = NULL, *sgid = NULL;
@@ -1577,11 +1590,11 @@ static pmix_status_t build_device_uuid(hwloc_obj_t osdev, char **uuid)
 
         case HWLOC_OBJ_OSDEV_GPU:
         case HWLOC_OBJ_OSDEV_COPROC:
-            pmix_asprintf(uuid, "gpu://%s::%s", pmix_globals.hostname, osdev->name);
+            pmix_asprintf(uuid, "gpu://%s::%s", hostname, osdev->name);
             break;
 
         case HWLOC_OBJ_OSDEV_BLOCK:
-            pmix_asprintf(uuid, "blk://%s::%s", pmix_globals.hostname, osdev->name);
+            pmix_asprintf(uuid, "blk://%s::%s", hostname, osdev->name);
             break;
 
         default:
@@ -1596,7 +1609,7 @@ static pmix_status_t build_device_uuid(hwloc_obj_t osdev, char **uuid)
 
 /* Does this OS device answer to the caller's name?  Either spelling counts:
  * the OS name hwloc gave it, or the uuid PMIx reports for it. */
-static bool osdev_named(hwloc_obj_t osdev, const char *devid)
+static bool osdev_named(hwloc_obj_t osdev, const char *hostname, const char *devid)
 {
     char *uuid = NULL;
     bool found;
@@ -1607,7 +1620,7 @@ static bool osdev_named(hwloc_obj_t osdev, const char *devid)
     if (0 == strcasecmp(devid, osdev->name)) {
         return true;
     }
-    if (PMIX_SUCCESS != build_device_uuid(osdev, &uuid)) {
+    if (PMIX_SUCCESS != build_device_uuid(osdev, hostname, &uuid)) {
         return false;
     }
     found = (0 == strcasecmp(devid, uuid));
@@ -1661,6 +1674,7 @@ static int devcmp(const void *a, const void *b)
 }
 
 pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
+                                     const char *hostname,
                                      pmix_device_type_t type,
                                      const char *devid,
                                      pmix_hwloc_device_t **devs,
@@ -1675,7 +1689,11 @@ pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
     size_t n, ncands, ntypes;
     char *uuid = NULL;
 
-    if (NULL == topo || NULL == topo->topology || NULL == devs || NULL == ndevs) {
+    /* the hostname is not optional: a uuid that names the wrong node is
+     * worse than no uuid, and defaulting it to the local one is exactly how
+     * that happens */
+    if (NULL == topo || NULL == topo->topology || NULL == hostname
+        || NULL == devs || NULL == ndevs) {
         return PMIX_ERR_BAD_PARAM;
     }
     *devs = NULL;
@@ -1736,7 +1754,7 @@ pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
         if (NULL != match) {
             /* the name the caller used wins the right to name the function -
              * asking for mlx5_0 and being told about ib0 is not an answer */
-            if (osdev_named(osdev, devid)) {
+            if (osdev_named(osdev, hostname, devid)) {
                 match->osdev = osdev;
                 match->type = dtype;
                 match->named = true;
@@ -1754,7 +1772,7 @@ pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
         c->osdev = osdev;
         c->pci = pci;
         c->type = dtype;
-        c->named = osdev_named(osdev, devid);
+        c->named = osdev_named(osdev, hostname, devid);
         pmix_list_append(&cands, &c->super);
 
     next:
@@ -1764,7 +1782,7 @@ pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
     /* drop the ones we cannot name, or that the caller did not ask for by
      * name, then build the result */
     PMIX_LIST_FOREACH_SAFE (c, cnext, &cands, pmix_devcand_t) {
-        rc = build_device_uuid(c->osdev, &uuid);
+        rc = build_device_uuid(c->osdev, hostname, &uuid);
         if (PMIX_SUCCESS != rc) {
             /* a device we cannot name is not one we can report */
             pmix_list_remove_item(&cands, &c->super);
@@ -1797,7 +1815,7 @@ pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
     n = 0;
     PMIX_LIST_FOREACH (c, &cands, pmix_devcand_t) {
         PMIx_Device_construct(&array[n].dev);
-        rc = build_device_uuid(c->osdev, &array[n].dev.uuid);
+        rc = build_device_uuid(c->osdev, hostname, &array[n].dev.uuid);
         if (PMIX_SUCCESS != rc) {
             goto cleanup;
         }

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -1464,7 +1464,15 @@ static bool osdev_is_render_node(hwloc_obj_t osdev)
  * Deliberately not BXIUUID, which hwloc also writes: that is a network
  * interconnect, and this is about naming a device to the vendor runtime
  * that will compute on it. */
-static const char *vendor_id_keys[] = {"NVIDIAUUID", "AMDUUID", "LevelZeroUUID", NULL};
+static const struct {
+    const char *key;
+    const char *vendor;
+} vendor_id_keys[] = {
+    {"NVIDIAUUID", "NVIDIA"},
+    {"AMDUUID", "AMD"},
+    {"LevelZeroUUID", "INTEL"},
+    {NULL, NULL}
+};
 
 /* The vendor's identifier for the device this OS device belongs to, or NULL.
  *
@@ -1475,33 +1483,44 @@ static const char *vendor_id_keys[] = {"NVIDIAUUID", "AMDUUID", "LevelZeroUUID",
  * node it meets - "cuda0" - and the uuid is on "nvml0".  Reading only the
  * named device would report "no identity" on precisely the machines that
  * have one. */
-static char *vendor_id_of(hwloc_obj_t osdev, hwloc_obj_t pci)
+static bool vendor_id_read(hwloc_obj_t osdev, char **id, char **vendor)
 {
-    hwloc_obj_t child;
     const char *val;
     unsigned k;
 
-    for (k = 0; NULL != vendor_id_keys[k]; k++) {
-        val = hwloc_obj_get_info_by_name(osdev, vendor_id_keys[k]);
+    for (k = 0; NULL != vendor_id_keys[k].key; k++) {
+        val = hwloc_obj_get_info_by_name(osdev, vendor_id_keys[k].key);
         if (NULL != val) {
-            return strdup(val);
+            *id = strdup(val);
+            *vendor = strdup(vendor_id_keys[k].vendor);
+            return true;
         }
     }
+    return false;
+}
+
+static void vendor_id_of(hwloc_obj_t osdev, hwloc_obj_t pci,
+                         char **id, char **vendor)
+{
+    hwloc_obj_t child;
+
+    *id = NULL;
+    *vendor = NULL;
+
+    if (vendor_id_read(osdev, id, vendor)) {
+        return;
+    }
     if (NULL == pci) {
-        return NULL;
+        return;
     }
     for (child = pci->io_first_child; NULL != child; child = child->next_sibling) {
         if (HWLOC_OBJ_OS_DEVICE != child->type) {
             continue;
         }
-        for (k = 0; NULL != vendor_id_keys[k]; k++) {
-            val = hwloc_obj_get_info_by_name(child, vendor_id_keys[k]);
-            if (NULL != val) {
-                return strdup(val);
-            }
+        if (vendor_id_read(child, id, vendor)) {
+            return;
         }
     }
-    return NULL;
 }
 
 /* The PCI function an OS device hangs off, or NULL if it has none. */
@@ -1869,7 +1888,7 @@ pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
         }
         array[n].dev.osname = strdup(c->osdev->name);
         array[n].dev.type = c->type;
-        array[n].vendor_id = vendor_id_of(c->osdev, c->pci);
+        vendor_id_of(c->osdev, c->pci, &array[n].vendor_id, &array[n].vendor);
         if (NULL != c->pci) {
             pmix_asprintf(&array[n].busid, "%04x:%02x:%02x.%01x",
                           c->pci->attr->pcidev.domain, c->pci->attr->pcidev.bus,
@@ -1916,6 +1935,9 @@ void pmix_hwloc_release_devices(pmix_hwloc_device_t *devs, size_t ndevs)
         }
         if (NULL != devs[n].vendor_id) {
             free(devs[n].vendor_id);
+        }
+        if (NULL != devs[n].vendor) {
+            free(devs[n].vendor);
         }
         /* locality is borrowed from the topology */
     }

--- a/src/hwloc/pmix_hwloc.h
+++ b/src/hwloc/pmix_hwloc.h
@@ -91,6 +91,24 @@ typedef struct {
     /* PCI bus id ("0000:06:00.0"), or NULL for a device with no PCI
      * ancestor.  This is the sort key: see pmix_hwloc_get_devices(). */
     char *busid;
+    /* The vendor's own identifier for this device - an NVIDIA
+     * "GPU-<uuid>", an AMD uuid, a Level Zero uuid - or NULL when the
+     * topology carries none.
+     *
+     * This is the only handle a vendor runtime accepts for naming a
+     * specific device, so it is what makes an assignment actionable rather
+     * than merely reportable: dev.uuid identifies the device within PMIx,
+     * but no GPU library has ever heard of it.
+     *
+     * It is NULL far more often than not.  hwloc records it only from its
+     * vendor backends (NVML, RSMI, Level Zero), so a topology gathered by
+     * an hwloc built without them describes the same hardware with no way
+     * to name any of it.  Whether that is fatal is the caller's policy
+     * question, not this layer's - but note that whether the field CAN be
+     * filled is a property of the topology rather than of the node, since
+     * an absent attribute changes the topology's shape.  Its VALUE is
+     * per-node and must be read from that node's own topology. */
+    char *vendor_id;
     /* Nearest ancestor carrying a cpuset - the set of PUs local to this
      * device.  Borrowed from the topology, so it is valid only as long as
      * the topology is, and must not be freed. */

--- a/src/hwloc/pmix_hwloc.h
+++ b/src/hwloc/pmix_hwloc.h
@@ -109,6 +109,16 @@ typedef struct {
      * an absent attribute changes the topology's shape.  Its VALUE is
      * per-node and must be read from that node's own topology. */
     char *vendor_id;
+    /* Which vendor's grammar vendor_id is written in - "NVIDIA", "AMD",
+     * "INTEL" - or NULL whenever vendor_id is.
+     *
+     * Needed because vendor_id alone does not say who will accept it, and
+     * a node may carry cards from more than one vendor.  Each vendor wants
+     * its own environment variable and its own value syntax, so whoever
+     * acts on an assignment has to be able to pick out the devices that
+     * are theirs.  Deriving it from the identity's spelling would be a
+     * guess; this is the key hwloc actually recorded it under. */
+    char *vendor;
     /* Nearest ancestor carrying a cpuset - the set of PUs local to this
      * device.  Borrowed from the topology, so it is valid only as long as
      * the topology is, and must not be freed. */

--- a/src/hwloc/pmix_hwloc.h
+++ b/src/hwloc/pmix_hwloc.h
@@ -109,6 +109,15 @@ typedef struct {
  * reboots - which matters because a caller assigning devices to processes
  * has to make the same assignment everywhere.
  *
+ * "hostname" is the node the topology describes, and is REQUIRED - a NULL
+ * is PMIX_ERR_BAD_PARAM rather than a convenience default.  A device's uuid
+ * names the node it lives on, so producing one means saying which node that
+ * is, and the answer is not "wherever this code happens to be running": a
+ * caller reading another node's topology (a mapper on the head node, say)
+ * would otherwise stamp its own hostname on every device in the job, and
+ * the process that later computes the same uuid locally would not match it.
+ * Pass pmix_globals.hostname only when the topology really is this node's.
+ *
  * "type" is a bitmask of the desired types; PMIX_DEVTYPE_UNKNOWN means all.
  * "devid" restricts the result to a single device matching it by osname or
  * uuid, and may be NULL.
@@ -117,6 +126,7 @@ typedef struct {
  * such device" means.  Release the array with pmix_hwloc_release_devices().
  */
 PMIX_EXPORT pmix_status_t pmix_hwloc_get_devices(pmix_topology_t *topo,
+                                                 const char *hostname,
                                                  pmix_device_type_t type,
                                                  const char *devid,
                                                  pmix_hwloc_device_t **devs,

--- a/src/mca/pgpu/AGENTS.md
+++ b/src/mca/pgpu/AGENTS.md
@@ -42,27 +42,34 @@ Before you invest in this framework, understand what is and is not live:
    an in-tree caller** — the envar harvest → ship → inject pipeline is
    wired exactly as `pnet`'s is.
 
-2. **No vendor component is built by default.** The three vendor
-   components (`amd`, `intel`, `nvd`) ship a `configure.m4` whose gate is
-   literally `AS_IF([test "yes" = "no"], [build], [do not build])` — a
-   condition that is always false — so they are compiled out, the
-   generated [`base/static-components.h`](base/static-components.h)
-   contains no vendor component, and `pmix_pgpu_globals.actives` is empty
-   on a stock build. They now *compile and link* cleanly when their gate
-   is enabled, but shipping them on by default still needs real
-   vendor-runtime detection. To exercise the framework end-to-end today,
-   build the `test` component with `--with-pgpu-test` (see
-   [Building](#building)).
+2. **The vendor components build everywhere now.** `amd`, `intel` and
+   `nvd` used to gate themselves off unless `--enable-test-build` was
+   passed, on the grounds that no vendor-runtime detection existed. That
+   was the wrong place to ask the question: none of them links anything
+   or needs a vendor SDK — they read info attributes hwloc already
+   recorded and set environment variables — and the machine that builds
+   PMIx is routinely not the machine that runs it, so a cluster with GPUs
+   got no support unless somebody had thought to configure a test build.
+   Detection happens at **run** time instead, in each component's
+   `component_open`, which asks the local topology whether that vendor's
+   hardware is present (`pmix_hwloc_check_vendor`) and declines if not.
 
-3. **The vendor GPU logic is still stubbed.** The envar-harvesting
-   `allocate`/`setup_local` are fully implemented, but `collect_inventory`
-   and `deliver_inventory` are empty stubs that just `return
-   PMIX_SUCCESS`.
+3. **`nvd` and `amd` set the vendor's visible-devices variable.**
+   `setup_fork` names the GPUs a process was mapped against in
+   `CUDA_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES`, using the vendor's own
+   device identifier. `intel` deliberately does not: `ZE_AFFINITY_MASK`
+   takes indices, PMIx cannot reproduce the runtime's device ordering, and
+   a wrong value in these variables silently narrows the visible set
+   rather than failing.
 
-So the framework *is* wired into launch, but no vendor component runs in a
-stock build — enable `--with-pgpu-test` (or a vendor gate) to see it work.
-Document and extend it faithfully, and do not describe the stubs as doing
-work the code does not yet do.
+4. **The inventory hooks are still stubs.** `collect_inventory` and
+   `deliver_inventory` return `PMIX_SUCCESS` having done nothing in every
+   component.
+
+So the framework is wired into launch and the vendor components run in a
+stock build, on any host whose topology shows that vendor's hardware.
+Document and extend it faithfully, and do not describe the remaining
+stubs as doing work the code does not yet do.
 
 ## What PGPU is for
 
@@ -213,11 +220,31 @@ function pointer. Specifics that matter:
   `module->setup_local(ns, ...)` with the same tolerated-return contract.
   "Can only be called by a server from within an event."
 - **`pmix_pgpu_base_setup_fork(const pmix_proc_t *proc, char ***env)`** —
-  does **not** call any component. It looks up the proc's nspace in the
-  envar cache and, for each cached `pmix_envar_list_item_t`, calls
-  `PMIx_Setenv(...)` to inject it into `*env`. This is why the component
-  module has no `setup_fork`: the fork step just replays what
-  `setup_local` cached.
+  first looks up the proc's nspace in the envar cache and, for each
+  cached `pmix_envar_list_item_t`, calls `PMIx_Setenv(...)` to inject it
+  into `*env`; **then** calls each active module's `setup_fork`. The
+  split is the point: the cache is per *namespace*, so it can only carry
+  what every rank of the job shares, and a GPU assignment is per *rank*.
+  A module return of `PMIX_ERR_NOT_AVAILABLE` or
+  `PMIX_ERR_TAKE_NEXT_OPTION` means "nothing to say about this process",
+  which is the ordinary case; any other error aborts the fork rather than
+  launching a process that would use the wrong hardware.
+
+  Two things about this hook are worth knowing before touching it. It was
+  **unreachable until recently** — `PMIx_server_setup_fork` called
+  `pmix_pnet.setup_fork` and `pmix_pmdl.setup_fork` but never
+  `pmix_pgpu.setup_fork`, so `allocate` harvested envars, `setup_local`
+  cached them, and nothing ever replayed them into a child. And it is the
+  only pgpu hook that runs on the **daemon that will fork the process**,
+  which is why per-node truth belongs here: a device's vendor identity
+  differs from node to node, and the head node's copy of a topology may
+  belong to whichever node reported it first.
+
+  `pmix_pgpu_base_set_visible_devices()` is the shared implementation the
+  vendor modules call — it reads the proc's `PMIX_DEVICE_ID` out of the
+  local datastore, resolves each device against the local topology, keeps
+  the ones belonging to the caller's vendor, and joins their vendor
+  identities into the named variable.
 - **`pmix_pgpu_base_child_finalized` / `_local_app_finalized`** — loop and
   forward to any module implementing the hook (all current modules leave
   these `NULL`).
@@ -337,11 +364,11 @@ The framework **base** is always compiled into `libpmix` (via
 `libmca_pgpu.la` with `sources =` empty apart from the base. Each
 component ships a `configure.m4` and a `Makefile.am`:
 
-- The three **vendor** components (`amd`, `intel`, `nvd`) hard-disable
-  themselves (`AS_IF([test "yes" = "no"], ...)`), so they are not compiled
-  and `static-components.h` carries no vendor component. To enable one,
-  replace the placeholder gate with real vendor-runtime detection, then
-  regenerate: `./autogen.pl && ./configure ... && make`.
+- The three **vendor** components (`amd`, `intel`, `nvd`) build
+  unconditionally. Their `configure.m4` looks for nothing because there is
+  nothing to look for: no library, no SDK, no header. Keep it that way —
+  whether a component does any work is a property of the machine the
+  daemon runs on, and only `component_open` is in a position to know it.
 - The **`test`** component builds only when `--with-pgpu-test` is passed
   to `configure`, and never ships in a normal build. It is the way to
   exercise the launch path on a host with no GPU (select it at runtime
@@ -371,11 +398,15 @@ regenerate-the-help-content golden rule does not apply here.
   `pmix_util_harvest_envars`, pack as `PMIX_ENVAR`, compress via
   `pmix_compress`, and stash under a unique per-component blob key so
   `setup_local` can find and unpack it.
-- Give the component a real `configure.m4` gate (detect the vendor
-  runtime/library) instead of the placeholder `test "yes" = "no"`, and add
-  the `PMIX_SUMMARY_ADD` line so the configure summary reports it. The
-  `test` component's `configure.m4` (an `--with-pgpu-test` `AC_ARG_WITH`)
-  is the template for a real opt-in gate.
+- Do **not** invent a `configure.m4` gate unless the component genuinely
+  needs something at build time (a header, a library to link). A component
+  that only reads the topology and sets envars should build everywhere and
+  decline at run time in `component_open` — the build host is not the run
+  host, so a build-time gate answers the wrong question. Add the
+  `PMIX_SUMMARY_ADD` line either way so the configure summary reports it.
+  The `test` component's `--with-pgpu-test` `AC_ARG_WITH` is the template
+  for a deliberate opt-in, which is a different thing: it exists so a
+  component meant only for testing does not load on a real system.
 - The launch API calls (`pmix_pgpu.allocate` / `.setup_local` /
   `.setup_fork`) are already wired into the server the way `pnet` is; a
   new component inherits them for free. The `test` component is the

--- a/src/mca/pgpu/amd/configure.m4
+++ b/src/mca/pgpu/amd/configure.m4
@@ -22,14 +22,19 @@
 AC_DEFUN([MCA_pmix_pgpu_amd_CONFIG],[
     AC_CONFIG_FILES([src/mca/pgpu/amd/Makefile])
 
-    # No real AMD/ROCm-runtime detection exists yet, so this component
-    # only builds under --enable-test-build for compile coverage.
-    AS_IF([test "$pmix_testbuild" = "1"],
-          [$1
-           pmix_pgpu_amd_happy=yes],
-          [$2
-           pmix_pgpu_amd_happy=no])
+    # This component builds everywhere. It links nothing and needs no
+    # vendor SDK: all it does is read info attributes hwloc already
+    # recorded and set environment variables, so there is nothing here
+    # for configure to look for. Whether it does any work is settled at
+    # RUN time by its own component_open, which asks the local topology
+    # whether this vendor's hardware is present and declines if it is
+    # not - and that is the only place the question can be answered,
+    # since the machine that builds PMIx is routinely not the machine
+    # that runs it. Gating it at build time instead meant a cluster with
+    # AMD GPUs got no support unless somebody had thought to
+    # configure --enable-test-build.
+    $1
+    pmix_pgpu_amd_happy=yes
 
-    PMIX_SUMMARY_ADD([GPUs], [AMD], [],[$pmix_pgpu_amd_happy])
+    PMIX_SUMMARY_ADD([GPUs], [AMD], [], [$pmix_pgpu_amd_happy])
 ])
-

--- a/src/mca/pgpu/amd/pgpu_amd.c
+++ b/src/mca/pgpu/amd/pgpu_amd.c
@@ -51,6 +51,7 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
                               pmix_list_t *ilist);
 static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
                                  pmix_info_t info[], size_t ninfo);
+static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env);
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_list_t *inventory);
 static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
@@ -60,6 +61,7 @@ pmix_pgpu_module_t pmix_pgpu_amd_module = {
     .name = "amd",
     .allocate = allocate,
     .setup_local = setup_local,
+    .setup_fork = setup_fork,
     .collect_inventory = collect_inventory,
     .deliver_inventory = deliver_inventory
 };
@@ -222,6 +224,31 @@ static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
     }
 
     return rc;
+}
+
+/* Name this process's AMD GPUs in ROCR_VISIBLE_DEVICES.
+ *
+ * ROCR_VISIBLE_DEVICES accepts the vendor's own device identifier, and
+ * that is the only form used here.  The alternative it also accepts is an
+ * index into the runtime's own device ordering, which PMIx has no way to
+ * reproduce - and a value naming a device that is not there does not
+ * error, it silently shrinks the visible set - so an index is never
+ * guessed.  Nothing here touches the runtime's device-ordering variable
+ * either: the identifier does not depend on it, which is the whole reason
+ * for preferring it, and overriding an ordering the user may have chosen
+ * deliberately would renumber devices for the rest of their program.
+ *
+ * The variable is overwritten if already set.  A process asking to be
+ * mapped against a device has made the more specific request, and where a
+ * resource manager has already narrowed the visible set, the identifiers
+ * named here are drawn from the topology as seen through that same
+ * narrowing - so they are a subset of what is visible, and naming a subset
+ * composes correctly.  An index-based value would not.
+ */
+static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env)
+{
+    return pmix_pgpu_base_set_visible_devices(proc, "AMD",
+                                              "ROCR_VISIBLE_DEVICES", env);
 }
 
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,

--- a/src/mca/pgpu/base/base.h
+++ b/src/mca/pgpu/base/base.h
@@ -83,6 +83,20 @@ PMIX_EXPORT pmix_status_t pmix_pgpu_base_allocate(char *nspace,
 PMIX_EXPORT pmix_status_t pmix_pgpu_base_setup_local(char *nspace,
                                                      pmix_info_t info[], size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_pgpu_base_setup_fork(const pmix_proc_t *peer, char ***env);
+
+/* Set "vendor"'s visible-devices variable "envar" in *env from the devices
+ * this process was mapped against, naming them by the vendor's own
+ * identifier.  Shared by the components because every vendor spells this
+ * the same way at bottom; they differ only in whose devices are theirs and
+ * what the variable is called.
+ *
+ * Returns PMIX_ERR_TAKE_NEXT_OPTION when there is nothing to say - the
+ * process was not mapped against a device, or none of the devices it got
+ * belong to this vendor - which is the ordinary case and not an error. */
+PMIX_EXPORT pmix_status_t pmix_pgpu_base_set_visible_devices(const pmix_proc_t *proc,
+                                                             const char *vendor,
+                                                             const char *envar,
+                                                             char ***env);
 PMIX_EXPORT void pmix_pgpu_base_child_finalized(pmix_proc_t *peer);
 PMIX_EXPORT void pmix_pgpu_base_local_app_finalized(pmix_namespace_t *nptr);
 PMIX_EXPORT void pmix_pgpu_base_deregister_nspace(char *nspace);

--- a/src/mca/pgpu/base/pgpu_base_fns.c
+++ b/src/mca/pgpu/base/pgpu_base_fns.c
@@ -20,6 +20,8 @@
 #include "src/include/pmix_globals.h"
 
 #include "src/class/pmix_list.h"
+#include "src/hwloc/pmix_hwloc.h"
+#include "src/mca/gds/gds.h"
 #include "src/mca/preg/preg.h"
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
@@ -155,6 +157,8 @@ pmix_status_t pmix_pgpu_base_setup_fork(const pmix_proc_t *proc, char ***env)
 {
     pmix_nspace_env_cache_t *ns, *ns2;
     pmix_envar_list_item_t *ev;
+    pmix_pgpu_base_active_module_t *active;
+    pmix_status_t rc;
 
     pmix_output_verbose(2, pmix_pgpu_base_framework.framework_output, "pgpu: setup_fork called");
 
@@ -177,6 +181,130 @@ pmix_status_t pmix_pgpu_base_setup_fork(const pmix_proc_t *proc, char ***env)
         }
     }
 
+    /* Then let each module contribute anything that is specific to THIS
+     * process.  The cache above is per namespace, so it can carry only
+     * what every rank of the job shares; a device assignment is per rank
+     * and has nowhere else to be set.
+     *
+     * A module declining is the normal case - most processes are not
+     * mapped against a device at all - so only a genuine failure is
+     * propagated, and it aborts the fork rather than launching a process
+     * that would silently use the wrong hardware. */
+    PMIX_LIST_FOREACH (active, &pmix_pgpu_globals.actives, pmix_pgpu_base_active_module_t) {
+        if (NULL == active->module->setup_fork) {
+            continue;
+        }
+        rc = active->module->setup_fork(proc, env);
+        if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_AVAILABLE != rc
+            && PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+            return rc;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* Set a vendor's "visible devices" variable for one process from the
+ * devices it was mapped against.
+ *
+ * Every GPU vendor spells this the same way at bottom - a variable naming
+ * the subset of devices the process may use - so the loop belongs here and
+ * the components differ only in which vendor's devices are theirs and what
+ * the variable is called.
+ *
+ * Two things it deliberately does not do. It does not fall back to an
+ * index when the vendor identity is missing: the runtimes number devices
+ * in an order PMIx does not know (CUDA's default is fastest-first, not bus
+ * order), so an index would name a device other than the one that was
+ * assigned, and a wrong value in these variables truncates the visible set
+ * silently rather than failing. And it does not consult the mapper's
+ * decision - it reads what the process was told, so a process that was not
+ * mapped against a device is simply left alone.
+ *
+ * The identity is read from THIS node's topology, which is the reason this
+ * runs at fork time on the daemon rather than anywhere on the head node: a
+ * device's vendor identity differs between nodes, and the head node's copy
+ * of a topology may belong to whichever node reported it first.
+ */
+pmix_status_t pmix_pgpu_base_set_visible_devices(const pmix_proc_t *proc,
+                                                 const char *vendor,
+                                                 const char *envar,
+                                                 char ***env)
+{
+    pmix_cb_t cb;
+    pmix_kval_t *kv;
+    pmix_data_array_t *darray;
+    pmix_device_t *dev;
+    pmix_hwloc_device_t *devs;
+    size_t ndevs, n, d;
+    char **ids = NULL, *val;
+    pmix_status_t rc;
+
+    if (NULL == proc || NULL == vendor || NULL == envar || NULL == env) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* what device(s) was this process given?  Absent is the common case -
+     * the job was not mapped by device - and is not an error */
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    cb.proc = (pmix_proc_t *) proc;
+    cb.copy = true;
+    cb.key = PMIX_DEVICE_ID;
+    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+    cb.key = NULL;
+    if (PMIX_SUCCESS != rc || 1 != pmix_list_get_size(&cb.kvs)) {
+        PMIX_DESTRUCT(&cb);
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+    kv = (pmix_kval_t *) pmix_list_get_first(&cb.kvs);
+    if (NULL == kv->value || PMIX_DATA_ARRAY != kv->value->type
+        || NULL == kv->value->data.darray) {
+        PMIX_DESTRUCT(&cb);
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+    darray = kv->value->data.darray;
+    dev = (pmix_device_t *) darray->array;
+
+    for (n = 0; n < darray->size; n++) {
+        if (NULL == dev[n].osname) {
+            continue;
+        }
+        /* resolve the assignment against the local topology.  The name is
+         * the handle: it is what the enumerator called this device on this
+         * node, and it is what the mapper recorded */
+        devs = NULL;
+        ndevs = 0;
+        rc = pmix_hwloc_get_devices(&pmix_globals.topology, pmix_globals.hostname,
+                                    PMIX_DEVTYPE_GPU | PMIX_DEVTYPE_COPROC,
+                                    dev[n].osname, &devs, &ndevs);
+        if (PMIX_SUCCESS != rc) {
+            continue;
+        }
+        for (d = 0; d < ndevs; d++) {
+            /* a node may carry cards from more than one vendor, and each
+             * wants its own variable, so take only our own */
+            if (NULL == devs[d].vendor_id || NULL == devs[d].vendor
+                || 0 != strcasecmp(devs[d].vendor, vendor)) {
+                continue;
+            }
+            PMIx_Argv_append_nosize(&ids, devs[d].vendor_id);
+        }
+        pmix_hwloc_release_devices(devs, ndevs);
+    }
+    PMIX_DESTRUCT(&cb);
+
+    if (NULL == ids) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+    val = PMIx_Argv_join(ids, ',');
+    PMIx_Argv_free(ids);
+    if (NULL == val) {
+        return PMIX_ERR_NOMEM;
+    }
+    pmix_output_verbose(2, pmix_pgpu_base_framework.framework_output,
+                        "pgpu: %s=%s for %s", envar, val, PMIX_NAME_PRINT(proc));
+    PMIx_Setenv(envar, val, true, env);
+    free(val);
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/pgpu/intel/configure.m4
+++ b/src/mca/pgpu/intel/configure.m4
@@ -24,16 +24,19 @@
 AC_DEFUN([MCA_pmix_pgpu_intel_CONFIG],[
     AC_CONFIG_FILES([src/mca/pgpu/intel/Makefile])
 
-# eventually need to check for L0 library
-
-    # No real Intel L0-runtime detection exists yet, so this component
-    # only builds under --enable-test-build for compile coverage.
-    AS_IF([test "$pmix_testbuild" = "1"],
-          [$1
-          pmix_pgpu_intel_happy=yes],
-          [$2
-           pmix_pgpu_intel_happy=no])
+    # This component builds everywhere. It links nothing and needs no
+    # vendor SDK: all it does is read info attributes hwloc already
+    # recorded and set environment variables, so there is nothing here
+    # for configure to look for. Whether it does any work is settled at
+    # RUN time by its own component_open, which asks the local topology
+    # whether this vendor's hardware is present and declines if it is
+    # not - and that is the only place the question can be answered,
+    # since the machine that builds PMIx is routinely not the machine
+    # that runs it. Gating it at build time instead meant a cluster with
+    # Intel GPUs got no support unless somebody had thought to
+    # configure --enable-test-build.
+    $1
+    pmix_pgpu_intel_happy=yes
 
     PMIX_SUMMARY_ADD([GPUs], [Intel], [], [$pmix_pgpu_intel_happy])
 ])
-

--- a/src/mca/pgpu/intel/pgpu_intel.c
+++ b/src/mca/pgpu/intel/pgpu_intel.c
@@ -224,6 +224,20 @@ static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
     return rc;
 }
 
+/* No setup_fork here, and that is a decision rather than an omission.
+ *
+ * Intel's visible-devices variable, ZE_AFFINITY_MASK, takes device
+ * indices - there is no identifier form of the kind CUDA_VISIBLE_DEVICES
+ * and ROCR_VISIBLE_DEVICES accept.  PMIx cannot reproduce the runtime's
+ * device ordering, so any index it wrote would be a guess, and a wrong
+ * value in these variables does not fail - it silently narrows the set of
+ * devices the process can see.  Setting nothing leaves the process able to
+ * use every device it was given; setting a guess can quietly take devices
+ * away.  Until there is a way to name a Level Zero device that does not
+ * depend on an ordering we do not control, this module contributes no
+ * environment.
+ */
+
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_list_t *inventory)
 {

--- a/src/mca/pgpu/nvd/configure.m4
+++ b/src/mca/pgpu/nvd/configure.m4
@@ -22,14 +22,19 @@
 AC_DEFUN([MCA_pmix_pgpu_nvd_CONFIG],[
     AC_CONFIG_FILES([src/mca/pgpu/nvd/Makefile])
 
-    # No real NVIDIA-runtime detection exists yet, so this component
-    # only builds under --enable-test-build for compile coverage.
-    AS_IF([test "$pmix_testbuild" = "1"],
-          [$1
-           pmix_pgpu_nvd_happy=yes],
-          [$2
-           pmix_pgpu_nvd_happy=no])
+    # This component builds everywhere. It links nothing and needs no
+    # vendor SDK: all it does is read info attributes hwloc already
+    # recorded and set environment variables, so there is nothing here
+    # for configure to look for. Whether it does any work is settled at
+    # RUN time by its own component_open, which asks the local topology
+    # whether this vendor's hardware is present and declines if it is
+    # not - and that is the only place the question can be answered,
+    # since the machine that builds PMIx is routinely not the machine
+    # that runs it. Gating it at build time instead meant a cluster with
+    # NVIDIA GPUs got no support unless somebody had thought to
+    # configure --enable-test-build.
+    $1
+    pmix_pgpu_nvd_happy=yes
 
     PMIX_SUMMARY_ADD([GPUs], [NVIDIA], [], [$pmix_pgpu_nvd_happy])
 ])
-

--- a/src/mca/pgpu/nvd/pgpu_nvd.c
+++ b/src/mca/pgpu/nvd/pgpu_nvd.c
@@ -51,6 +51,7 @@ static pmix_status_t allocate(pmix_namespace_t *nptr, pmix_info_t info[], size_t
                               pmix_list_t *ilist);
 static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
                                  pmix_info_t info[], size_t ninfo);
+static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env);
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_list_t *inventory);
 static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
@@ -60,6 +61,7 @@ pmix_pgpu_module_t pmix_pgpu_nvd_module = {
     .name = "nvd",
     .allocate = allocate,
     .setup_local = setup_local,
+    .setup_fork = setup_fork,
     .collect_inventory = collect_inventory,
     .deliver_inventory = deliver_inventory
 };
@@ -222,6 +224,31 @@ static pmix_status_t setup_local(pmix_nspace_env_cache_t *ns,
     }
 
     return rc;
+}
+
+/* Name this process's NVIDIA GPUs in CUDA_VISIBLE_DEVICES.
+ *
+ * CUDA_VISIBLE_DEVICES accepts the vendor's own device identifier, and
+ * that is the only form used here.  The alternative it also accepts is an
+ * index into the runtime's own device ordering, which PMIx has no way to
+ * reproduce - and a value naming a device that is not there does not
+ * error, it silently shrinks the visible set - so an index is never
+ * guessed.  Nothing here touches the runtime's device-ordering variable
+ * either: the identifier does not depend on it, which is the whole reason
+ * for preferring it, and overriding an ordering the user may have chosen
+ * deliberately would renumber devices for the rest of their program.
+ *
+ * The variable is overwritten if already set.  A process asking to be
+ * mapped against a device has made the more specific request, and where a
+ * resource manager has already narrowed the visible set, the identifiers
+ * named here are drawn from the topology as seen through that same
+ * narrowing - so they are a subset of what is visible, and naming a subset
+ * composes correctly.  An index-based value would not.
+ */
+static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env)
+{
+    return pmix_pgpu_base_set_visible_devices(proc, "NVIDIA",
+                                              "CUDA_VISIBLE_DEVICES", env);
 }
 
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,

--- a/src/mca/pgpu/pgpu.h
+++ b/src/mca/pgpu/pgpu.h
@@ -67,6 +67,27 @@ typedef pmix_status_t (*pmix_pgpu_base_module_setup_local_fn_t)(pmix_nspace_env_
                                                                 size_t ninfo);
 
 /**
+ * Contribute environment variables to one process about to be forked.
+ *
+ * Called once per local child, from PMIx_server_setup_fork, after the
+ * namespace-wide envars cached by setup_local have been replayed. This is
+ * the only pgpu hook that sees an individual process, and therefore the
+ * only place a per-rank value can be set - a GPU assignment is per rank,
+ * while everything setup_local caches is per namespace.
+ *
+ * The module runs on the daemon that will fork the child, so the topology
+ * it reads (pmix_globals.topology) is that node's own. That matters: a
+ * device's vendor identity varies from node to node, and the copy the
+ * head node holds may belong to whichever node reported first.
+ *
+ * Return PMIX_SUCCESS having done nothing if this process is none of the
+ * module's business; only a real failure should return an error, which
+ * aborts the fork.
+ */
+typedef pmix_status_t (*pmix_pgpu_base_module_setup_fork_fn_t)(const pmix_proc_t *proc,
+                                                               char ***env);
+
+/**
  * Provide an opportunity to cleanup when a
  * local application process terminates
  */
@@ -141,6 +162,7 @@ typedef struct {
     pmix_pgpu_base_module_fini_fn_t finalize;
     pmix_pgpu_base_module_allocate_fn_t allocate;
     pmix_pgpu_base_module_setup_local_fn_t setup_local;
+    pmix_pgpu_base_module_setup_fork_fn_t setup_fork;
     pmix_pgpu_base_module_child_finalized_fn_t child_finalized;
     pmix_pgpu_base_module_local_app_finalized_fn_t local_app_finalized;
     pmix_pgpu_base_module_dregister_nspace_fn_t deregister_nspace;
@@ -192,7 +214,7 @@ typedef pmix_mca_base_component_t pmix_pgpu_base_component_t;
  * the same three by pasting its name, so the two cannot drift apart.
  * Bump it on any change to the module interface that a component built
  * against the previous one would not survive. */
-#define PMIX_MCA_pgpu_MAJOR_VERSION   1
+#define PMIX_MCA_pgpu_MAJOR_VERSION   2
 #define PMIX_MCA_pgpu_MINOR_VERSION   0
 #define PMIX_MCA_pgpu_RELEASE_VERSION 0
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1285,6 +1285,18 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char *
         return rc;
     }
 
+    /* get any GPU contribution.
+     *
+     * This call was missing, which made the whole pgpu envar path dead
+     * code: allocate() harvested the vendor's environment variables,
+     * setup_local() unpacked them into the namespace cache, and nothing
+     * ever replayed the cache into a child.  So a component could be
+     * selected, do its work, and have no effect anybody could observe. */
+    if (PMIX_SUCCESS != (rc = pmix_pgpu.setup_fork(proc, env))) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
     /* get any GDS contributions */
     if (PMIX_SUCCESS != (rc = pmix_gds_base_setup_fork(proc, env))) {
         PMIX_ERROR_LOG(rc);

--- a/test/topologies/Makefile.am
+++ b/test/topologies/Makefile.am
@@ -12,5 +12,21 @@
 # other than the one the tests happen to run on. Consumed by the
 # hwloc_datatype unit test (test/unit), which cycles over every file
 # named here. These fixtures were imported from PRRTE's test suite.
+#
+# nvml-4gpu.xml is the shape that matters to device enumeration and is
+# not synthetic: it is a reduced (16-PU) form of the machine reported in
+# Open MPI issue #14169, gathered by an hwloc built with the CUDA and
+# NVML backends. Each GPU function carries THREE OS devices - cuda0,
+# opencl0d0 and nvml0 - and the vendor uuid is on nvml0 while the
+# function is named by cuda0, so it is the fixture that proves the
+# vendor identity is found across the function rather than on the
+# device that names it.
+#
+# drm-4gpu.xml is that same machine again, reduced the same way, but as
+# a distro hwloc saw it: DRM card and render nodes only, no vendor
+# backend, no identity anywhere. It is the negative case - the GPUs are
+# still found and still placed, they simply cannot be named - and it
+# also carries a fifth card node (a BMC display adapter) that must NOT
+# be counted as a GPU.
 
-EXTRA_DIST = test-topo.xml test-topo2.xml
+EXTRA_DIST = test-topo.xml test-topo2.xml nvml-4gpu.xml drm-4gpu.xml

--- a/test/topologies/drm-4gpu.xml
+++ b/test/topologies/drm-4gpu.xml
@@ -1,0 +1,586 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" allowed_cpuset="0x0000ffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff" gp_index="1">
+    <info name="DMIProductName" value="ThinkSystem SD665-N V3"/>
+    <info name="DMIProductVersion" value="05"/>
+    <info name="DMIBoardVendor" value="Lenovo"/>
+    <info name="DMIBoardName" value="SB27C19718"/>
+    <info name="DMIBoardVersion" value="05"/>
+    <info name="DMIBoardAssetTag" value=""/>
+    <info name="DMIChassisVendor" value="Lenovo"/>
+    <info name="DMIChassisType" value="28"/>
+    <info name="DMIChassisVersion" value="None"/>
+    <info name="DMIChassisAssetTag" value=""/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/system.slice/slurmstepd.scope/job_9332563/step_interactive/user/task_0"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="5.14.0-611.55.1.el9_7.0.3.8z.x86_64"/>
+    <info name="OSVersion" value="#1 SMP PREEMPT_DYNAMIC Fri Jul 10 14:21:59 CEST 2026"/>
+    <info name="HostName" value="h200-1001"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.4.1"/>
+    <info name="ProcessName" value="hwloc-ls"/>
+    <object type="Package" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" gp_index="3">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="26"/>
+      <info name="CPUModelNumber" value="2"/>
+      <info name="CPUModel" value="AMD EPYC 9555 64-Core Processor                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="Group" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="812" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="804" local_memory="202483281920">
+          <page_type size="4096" count="49434395"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Die" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="4">
+          <object type="L3Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L2Cache" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+                    <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="12" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10">
+                    <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="18" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15">
+                    <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="24" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20">
+                    <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25">
+                    <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="30">
+                    <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35">
+                    <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="36"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="42" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40">
+                    <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Die" os_index="4" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46">
+          <object type="L3Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L2Cache" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="48" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="32" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45">
+                    <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="47"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="56" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="54" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="55" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="33" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52">
+                    <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="53"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="61" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="59" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="60" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="34" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="57">
+                    <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="58"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="66" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="64" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="65" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="35" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="62">
+                    <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="63"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="71" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="69" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="70" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="36" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="67">
+                    <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="68"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="76" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="74" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="75" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="37" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="72">
+                    <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="73"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="81" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="79" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="80" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="38" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="77">
+                    <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="78"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="86" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="84" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="85" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="39" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="82">
+                    <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="83"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="1009" bridge_type="0-1" depth="0" bridge_pci="0000:[50-54]">
+          <object type="Bridge" gp_index="961" bridge_type="1-1" depth="1" bridge_pci="0000:[51-51]" pci_busid="0000:50:03.4" pci_type="0604 [1022:1554] [1022:1453] 00" pci_link_speed="0.250000">
+            <object type="PCIDev" gp_index="949" pci_busid="0000:51:00.0" pci_type="0200 [8086:1533] [17aa:404d] 03" pci_link_speed="0.250000">
+              <info name="PCISlot" value="0"/>
+              <object type="OSDev" gp_index="1023" name="eno6" osdev_type="2">
+                <info name="Address" value="8c:3b:4a:fc:2f:d3"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="838" bridge_type="1-1" depth="1" bridge_pci="0000:[52-53]" pci_busid="0000:50:04.1" pci_type="0604 [1022:1554] [1022:1453] 00" pci_link_speed="0.250000">
+            <object type="Bridge" gp_index="921" bridge_type="1-1" depth="2" bridge_pci="0000:[53-53]" pci_busid="0000:52:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 06" pci_link_speed="0.250000">
+              <object type="PCIDev" gp_index="894" pci_busid="0000:53:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 52" pci_link_speed="0.000000">
+                <object type="OSDev" gp_index="1042" name="card0" osdev_type="1"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="1011" bridge_type="0-1" depth="0" bridge_pci="0000:[70-74]">
+          <object type="Bridge" gp_index="826" bridge_type="1-1" depth="1" bridge_pci="0000:[71-71]" pci_busid="0000:70:01.2" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="15.753846">
+            <object type="PCIDev" gp_index="873" pci_busid="0000:71:00.0" pci_type="0108 [144d:a900] [144d:ad06] 00" pci_link_speed="15.753846">
+              <info name="PCISlot" value="66"/>
+              <object type="OSDev" gp_index="1020" name="nvme0n1" subtype="Disk" osdev_type="0">
+                <info name="Size" value="15000928256"/>
+                <info name="SectorSize" value="512"/>
+                <info name="LinuxDeviceID" value="259:0"/>
+                <info name="Vendor" value="Samsung"/>
+                <info name="Model" value="SAMSUNG MZ3L615THBLF-00AW7"/>
+                <info name="Revision" value="LDDM5U2Q"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="908" bridge_type="1-1" depth="1" bridge_pci="0000:[72-72]" pci_busid="0000:70:01.3" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="15.753846">
+            <object type="PCIDev" gp_index="840" pci_busid="0000:72:00.0" pci_type="0108 [144d:a826] [144d:aa2a] 00" pci_link_speed="15.753846">
+              <info name="PCISlot" value="67"/>
+              <object type="OSDev" gp_index="1021" name="nvme1c1n1" subtype="Disk" osdev_type="0">
+                <info name="Size" value="1875374424"/>
+                <info name="SectorSize" value="512"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="863" bridge_type="1-1" depth="1" bridge_pci="0000:[74-74]" pci_busid="0000:70:07.2" pci_type="0604 [1022:1555] [1022:1555] 00" pci_link_speed="63.015385">
+            <object type="PCIDev" gp_index="967" pci_busid="0000:74:00.0" pci_type="0106 [1022:7901] [1022:7901] 93" pci_link_speed="63.015385"/>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="815" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="3" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="807" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1010" bridge_type="0-1" depth="0" bridge_pci="0000:[60-61]">
+          <object type="Bridge" gp_index="861" bridge_type="1-1" depth="1" bridge_pci="0000:[61-61]" pci_busid="0000:60:01.3" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="7.876923">
+            <object type="PCIDev" gp_index="1003" pci_busid="0000:61:00.0" pci_type="0200 [15b3:101f] [17aa:7827] 00" pci_link_speed="7.876923">
+              <info name="PCISlot" value="0-2"/>
+              <object type="OSDev" gp_index="1028" name="eno4np0" osdev_type="2">
+                <info name="Address" value="8c:3b:4a:fc:2f:d1"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" gp_index="1031" name="mlx5_1" osdev_type="3">
+                <info name="NodeGUID" value="8c3b:4a03:00fc:2fd1"/>
+                <info name="SysImageGUID" value="8c3b:4a03:00fc:2fd1"/>
+                <info name="Port1State" value="1"/>
+                <info name="Port1LID" value="0x0"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:8e3b:4aff:fefc:2fd1"/>
+                <info name="Port1GID1" value="fe80:0000:0000:0000:8e3b:4aff:fefc:2fd1"/>
+              </object>
+            </object>
+            <object type="PCIDev" gp_index="904" pci_busid="0000:61:00.1" pci_type="0200 [15b3:101f] [17aa:7827] 00" pci_link_speed="7.876923">
+              <info name="PCISlot" value="0-2"/>
+              <object type="OSDev" gp_index="1022" name="eno5np1" osdev_type="2">
+                <info name="Address" value="8c:3b:4a:fc:2f:d2"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" gp_index="1033" name="mlx5_2" osdev_type="3">
+                <info name="NodeGUID" value="8c3b:4a03:00fc:2fd2"/>
+                <info name="SysImageGUID" value="8c3b:4a03:00fc:2fd1"/>
+                <info name="Port1State" value="1"/>
+                <info name="Port1LID" value="0x0"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:8e3b:4aff:fefc:2fd2"/>
+                <info name="Port1GID1" value="fe80:0000:0000:0000:8e3b:4aff:fefc:2fd2"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="814" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="2" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="806" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1005" bridge_type="0-1" depth="0" bridge_pci="0000:[10-16]">
+          <object type="Bridge" gp_index="990" bridge_type="1-1" depth="1" bridge_pci="0000:[11-16]" pci_busid="0000:10:01.1" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="63.015385">
+            <object type="Bridge" gp_index="930" bridge_type="1-1" depth="2" bridge_pci="0000:[12-16]" pci_busid="0000:11:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+              <info name="PCISlot" value="9"/>
+              <object type="Bridge" gp_index="905" bridge_type="1-1" depth="3" bridge_pci="0000:[13-13]" pci_busid="0000:12:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <object type="PCIDev" gp_index="877" pci_busid="0000:13:00.0" pci_type="0207 [15b3:1021] [15b3:0055] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="9-1"/>
+                  <object type="OSDev" gp_index="1025" name="ib2x" osdev_type="2">
+                    <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:b8:e9:24:03:00:ba:a4:c4"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" gp_index="1030" name="mlx5_3" osdev_type="3">
+                    <info name="NodeGUID" value="b8e9:2403:00ba:a4c4"/>
+                    <info name="SysImageGUID" value="b8e9:2403:00ba:a4c4"/>
+                    <info name="Port1State" value="1"/>
+                    <info name="Port1LID" value="0xffff"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:b8e9:2403:00ba:a4c4"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Bridge" gp_index="976" bridge_type="1-1" depth="3" bridge_pci="0000:[14-16]" pci_busid="0000:12:02.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <object type="Bridge" gp_index="848" bridge_type="1-1" depth="4" bridge_pci="0000:[15-16]" pci_busid="0000:14:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="0-3"/>
+                  <object type="Bridge" gp_index="1000" bridge_type="1-1" depth="5" bridge_pci="0000:[16-16]" pci_busid="0000:15:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                    <object type="PCIDev" gp_index="972" pci_busid="0000:16:00.0" pci_type="0302 [10de:2335] [10de:18bf] a1" pci_link_speed="63.015385">
+                      <info name="PCISlot" value="5"/>
+                      <object type="OSDev" gp_index="1039" name="renderD129" osdev_type="1"/>
+                      <object type="OSDev" gp_index="1041" name="card2" osdev_type="1"/>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="813" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="1" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="805" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1004" bridge_type="0-1" depth="0" bridge_pci="0000:[00-07]">
+          <object type="Bridge" gp_index="935" bridge_type="1-1" depth="1" bridge_pci="0000:[01-06]" pci_busid="0000:00:01.1" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="63.015385">
+            <object type="Bridge" gp_index="881" bridge_type="1-1" depth="2" bridge_pci="0000:[02-06]" pci_busid="0000:01:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+              <info name="PCISlot" value="8"/>
+              <object type="Bridge" gp_index="853" bridge_type="1-1" depth="3" bridge_pci="0000:[03-03]" pci_busid="0000:02:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <object type="PCIDev" gp_index="823" pci_busid="0000:03:00.0" pci_type="0207 [15b3:1021] [15b3:0055] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="8-1"/>
+                  <object type="OSDev" gp_index="1024" name="ib3x" osdev_type="2">
+                    <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:b8:e9:24:03:00:ba:a4:c8"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" gp_index="1034" name="mlx5_0" osdev_type="3">
+                    <info name="NodeGUID" value="b8e9:2403:00ba:a4c8"/>
+                    <info name="SysImageGUID" value="b8e9:2403:00ba:a4c8"/>
+                    <info name="Port1State" value="1"/>
+                    <info name="Port1LID" value="0xffff"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:b8e9:2403:00ba:a4c8"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Bridge" gp_index="923" bridge_type="1-1" depth="3" bridge_pci="0000:[04-06]" pci_busid="0000:02:02.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <object type="Bridge" gp_index="979" bridge_type="1-1" depth="4" bridge_pci="0000:[05-06]" pci_busid="0000:04:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="0-1"/>
+                  <object type="Bridge" gp_index="946" bridge_type="1-1" depth="5" bridge_pci="0000:[06-06]" pci_busid="0000:05:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                    <object type="PCIDev" gp_index="919" pci_busid="0000:06:00.0" pci_type="0302 [10de:2335] [10de:18bf] a1" pci_link_speed="63.015385">
+                      <info name="PCISlot" value="6"/>
+                      <object type="OSDev" gp_index="1035" name="renderD128" osdev_type="1"/>
+                      <object type="OSDev" gp_index="1037" name="card1" osdev_type="1"/>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0x0" complete_cpuset="0x0" nodeset="0x000000f0" complete_nodeset="0x000000f0" gp_index="340">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="26"/>
+      <info name="CPUModelNumber" value="2"/>
+      <info name="CPUModel" value="AMD EPYC 9555 64-Core Processor                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="819" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="7" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="811" local_memory="202801766400">
+          <page_type size="4096" count="49512150"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1018" bridge_type="0-1" depth="0" bridge_pci="0000:[e0-e6]">
+          <object type="Bridge" gp_index="860" bridge_type="1-1" depth="1" bridge_pci="0000:[e1-e6]" pci_busid="0000:e0:01.1" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="63.015385">
+            <object type="Bridge" gp_index="988" bridge_type="1-1" depth="2" bridge_pci="0000:[e2-e6]" pci_busid="0000:e1:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+              <info name="PCISlot" value="11"/>
+              <object type="Bridge" gp_index="954" bridge_type="1-1" depth="3" bridge_pci="0000:[e3-e3]" pci_busid="0000:e2:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <object type="PCIDev" gp_index="928" pci_busid="0000:e3:00.0" pci_type="0207 [15b3:1021] [15b3:0055] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="11-1"/>
+                  <object type="OSDev" gp_index="1027" name="ib0" osdev_type="2">
+                    <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:b8:e9:24:03:00:ba:a4:bc"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" gp_index="1029" name="mlx5_5" osdev_type="3">
+                    <info name="NodeGUID" value="b8e9:2403:00ba:a4bc"/>
+                    <info name="SysImageGUID" value="b8e9:2403:00ba:a4bc"/>
+                    <info name="Port1State" value="4"/>
+                    <info name="Port1LID" value="0x199"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:b8e9:2403:00ba:a4bc"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Bridge" gp_index="847" bridge_type="1-1" depth="3" bridge_pci="0000:[e4-e6]" pci_busid="0000:e2:02.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <object type="Bridge" gp_index="899" bridge_type="1-1" depth="4" bridge_pci="0000:[e5-e6]" pci_busid="0000:e4:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="0-5"/>
+                  <object type="Bridge" gp_index="872" bridge_type="1-1" depth="5" bridge_pci="0000:[e6-e6]" pci_busid="0000:e5:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                    <object type="PCIDev" gp_index="839" pci_busid="0000:e6:00.0" pci_type="0302 [10de:2335] [10de:18bf] a1" pci_link_speed="63.015385">
+                      <info name="PCISlot" value="3"/>
+                      <object type="OSDev" gp_index="1040" name="card4" osdev_type="1"/>
+                      <object type="OSDev" gp_index="1043" name="renderD131" osdev_type="1"/>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="818" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="6" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="810" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1013" bridge_type="0-1" depth="0" bridge_pci="0000:[90-96]">
+          <object type="Bridge" gp_index="846" bridge_type="1-1" depth="1" bridge_pci="0000:[91-96]" pci_busid="0000:90:01.1" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="63.015385">
+            <object type="Bridge" gp_index="973" bridge_type="1-1" depth="2" bridge_pci="0000:[92-96]" pci_busid="0000:91:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+              <info name="PCISlot" value="10"/>
+              <object type="Bridge" gp_index="940" bridge_type="1-1" depth="3" bridge_pci="0000:[93-93]" pci_busid="0000:92:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <object type="PCIDev" gp_index="914" pci_busid="0000:93:00.0" pci_type="0207 [15b3:1021] [15b3:0055] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="10-1"/>
+                  <object type="OSDev" gp_index="1026" name="ib1x" osdev_type="2">
+                    <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:b8:e9:24:03:00:ba:a4:c0"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" gp_index="1032" name="mlx5_4" osdev_type="3">
+                    <info name="NodeGUID" value="b8e9:2403:00ba:a4c0"/>
+                    <info name="SysImageGUID" value="b8e9:2403:00ba:a4c0"/>
+                    <info name="Port1State" value="4"/>
+                    <info name="Port1LID" value="0x191"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:b8e9:2403:00ba:a4c0"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Bridge" gp_index="833" bridge_type="1-1" depth="3" bridge_pci="0000:[94-96]" pci_busid="0000:92:02.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <object type="Bridge" gp_index="887" bridge_type="1-1" depth="4" bridge_pci="0000:[95-96]" pci_busid="0000:94:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="0-4"/>
+                  <object type="Bridge" gp_index="859" bridge_type="1-1" depth="5" bridge_pci="0000:[96-96]" pci_busid="0000:95:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                    <object type="PCIDev" gp_index="830" pci_busid="0000:96:00.0" pci_type="0302 [10de:2335] [10de:18bf] a1" pci_link_speed="63.015385">
+                      <info name="PCISlot" value="4"/>
+                      <object type="OSDev" gp_index="1036" name="card3" osdev_type="1"/>
+                      <object type="OSDev" gp_index="1038" name="renderD130" osdev_type="1"/>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="817" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="5" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="809" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="816" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="4" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="808" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1019" bridge_type="0-1" depth="0" bridge_pci="0000:[f0-f2]">
+          <object type="Bridge" gp_index="837" bridge_type="1-1" depth="1" bridge_pci="0000:[f2-f2]" pci_busid="0000:f0:07.2" pci_type="0604 [1022:1555] [1022:1555] 00" pci_link_speed="63.015385">
+            <object type="PCIDev" gp_index="824" pci_busid="0000:f2:00.0" pci_type="0106 [1022:7901] [1022:7901] 93" pci_link_speed="63.015385"/>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+  <distances2 type="NUMANode" nbobjs="8" kind="5" name="NUMALatency" indexing="os">
+    <indexes length="16">0 1 2 3 4 5 6 7 </indexes>
+    <u64values length="30">10 12 12 12 32 32 32 32 12 10 </u64values>
+    <u64values length="30">12 12 32 32 32 32 12 12 10 12 </u64values>
+    <u64values length="30">32 32 32 32 12 12 12 10 32 32 </u64values>
+    <u64values length="30">32 32 32 32 32 32 10 12 12 12 </u64values>
+    <u64values length="30">32 32 32 32 12 10 12 12 32 32 </u64values>
+    <u64values length="30">32 32 12 12 10 12 32 32 32 32 </u64values>
+    <u64values length="12">12 12 12 10 </u64values>
+  </distances2>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.numa_memory"/>
+  <support name="discovery.disallowed_pu"/>
+  <support name="discovery.disallowed_numa"/>
+  <support name="cpubind.set_thisproc_cpubind"/>
+  <support name="cpubind.get_thisproc_cpubind"/>
+  <support name="cpubind.set_proc_cpubind"/>
+  <support name="cpubind.get_proc_cpubind"/>
+  <support name="cpubind.set_thisthread_cpubind"/>
+  <support name="cpubind.get_thisthread_cpubind"/>
+  <support name="cpubind.set_thread_cpubind"/>
+  <support name="cpubind.get_thread_cpubind"/>
+  <support name="cpubind.get_thisproc_last_cpu_location"/>
+  <support name="cpubind.get_proc_last_cpu_location"/>
+  <support name="cpubind.get_thisthread_last_cpu_location"/>
+  <support name="membind.set_thisthread_membind"/>
+  <support name="membind.get_thisthread_membind"/>
+  <support name="membind.set_area_membind"/>
+  <support name="membind.get_area_membind"/>
+  <support name="membind.alloc_membind"/>
+  <support name="membind.firsttouch_membind"/>
+  <support name="membind.bind_membind"/>
+  <support name="membind.interleave_membind"/>
+  <support name="membind.migrate_membind"/>
+  <support name="membind.get_area_memlocation"/>
+  <support name="custom.exported_support"/>
+  <memattr name="Bandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="804" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="805" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="806" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="807" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="808" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="809" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="810" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="811" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,,,0x0"/>
+  </memattr>
+  <memattr name="Latency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="804" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="805" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="806" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="807" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="808" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="809" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="810" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="811" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,,,0x0"/>
+  </memattr>
+  <cpukind cpuset="0x0000ffff">
+    <info name="FrequencyMaxMHz" value="3200"/>
+  </cpukind>
+</topology>

--- a/test/topologies/nvml-4gpu.xml
+++ b/test/topologies/nvml-4gpu.xml
@@ -1,0 +1,830 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" allowed_cpuset="0x0000ffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff" gp_index="1">
+    <info name="DMIProductName" value="ThinkSystem SD665-N V3"/>
+    <info name="DMIProductVersion" value="05"/>
+    <info name="DMIBoardVendor" value="Lenovo"/>
+    <info name="DMIBoardName" value="SB27C19718"/>
+    <info name="DMIBoardVersion" value="05"/>
+    <info name="DMIBoardAssetTag" value=""/>
+    <info name="DMIChassisVendor" value="Lenovo"/>
+    <info name="DMIChassisType" value="28"/>
+    <info name="DMIChassisVersion" value="None"/>
+    <info name="DMIChassisAssetTag" value=""/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/system.slice/slurmstepd.scope/job_9425229/step_interactive/user/task_0"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="5.14.0-687.34.1.el9_8.0.1.x86_64"/>
+    <info name="OSVersion" value="#1 SMP PREEMPT_DYNAMIC Tue Aug 4 15:16:18 UTC 2026"/>
+    <info name="HostName" value="h200-1001"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.13.0"/>
+    <info name="ProcessName" value="lstopo-no-graphics"/>
+    <object type="Package" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" gp_index="3">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="26"/>
+      <info name="CPUModelNumber" value="2"/>
+      <info name="CPUModel" value="AMD EPYC 9555 64-Core Processor                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="Group" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="940" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="932" local_memory="202483281920">
+          <page_type size="4096" count="49434395"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Die" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5">
+          <object type="L3Cache" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L2Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+                    <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11">
+                    <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17">
+                    <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23">
+                    <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29">
+                    <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35">
+                    <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41">
+                    <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="47">
+                    <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Die" os_index="4" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="55">
+          <object type="L3Cache" os_index="4" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="60" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L2Cache" os_index="32" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="59" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="32" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="57" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="32" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="58" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="32" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="53">
+                    <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="56"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="33" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="66" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="33" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="64" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="33" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="65" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="33" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="61">
+                    <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="63"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="34" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="72" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="34" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="70" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="34" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="71" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="34" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="67">
+                    <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="69"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="35" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="78" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="35" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="76" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="35" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="77" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="35" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="73">
+                    <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="75"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="36" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="84" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="36" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="82" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="36" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="83" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="36" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="79">
+                    <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="81"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="37" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="90" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="37" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="88" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="37" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="89" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="37" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="85">
+                    <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="87"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="38" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="96" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="38" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="94" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="38" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="95" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="38" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="91">
+                    <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="93"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+            <object type="L2Cache" os_index="39" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="102" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+              <info name="Inclusive" value="1"/>
+              <object type="L1Cache" os_index="39" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="100" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+                <info name="Inclusive" value="0"/>
+                <object type="L1iCache" os_index="39" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="101" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                  <info name="Inclusive" value="0"/>
+                  <object type="Core" os_index="39" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="97">
+                    <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="99"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="1108" bridge_type="0-1" depth="0" bridge_pci="0000:[50-54]">
+          <object type="Bridge" gp_index="1070" bridge_type="1-1" depth="1" bridge_pci="0000:[51-51]" pci_busid="0000:50:03.4" pci_type="0604 [1022:1554] [1022:1453] 00" pci_link_speed="0.250000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin GPP Bridge"/>
+            <object type="PCIDev" gp_index="1059" pci_busid="0000:51:00.0" pci_type="0200 [8086:1533] [17aa:404d] 03" pci_link_speed="0.250000">
+              <info name="PCISlot" value="0"/>
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I210 Gigabit Network Connection"/>
+              <object type="OSDev" gp_index="1121" name="eno6" osdev_type="2">
+                <info name="Address" value="8c:3b:4a:fc:2f:d3"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="965" bridge_type="1-1" depth="1" bridge_pci="0000:[52-53]" pci_busid="0000:50:04.1" pci_type="0604 [1022:1554] [1022:1453] 00" pci_link_speed="0.250000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin GPP Bridge"/>
+            <object type="Bridge" gp_index="1036" bridge_type="1-1" depth="2" bridge_pci="0000:[53-53]" pci_busid="0000:52:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 06" pci_link_speed="0.250000">
+              <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+              <info name="PCIDevice" value="AST1150 PCI-to-PCI Bridge"/>
+              <object type="PCIDev" gp_index="1013" pci_busid="0000:53:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 52" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+                <info name="PCIDevice" value="ASPEED Graphics Family"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="1110" bridge_type="0-1" depth="0" bridge_pci="0000:[70-74]">
+          <object type="Bridge" gp_index="954" bridge_type="1-1" depth="1" bridge_pci="0000:[71-71]" pci_busid="0000:70:01.2" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="15.753846">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin GPP Bridge"/>
+            <object type="PCIDev" gp_index="996" pci_busid="0000:71:00.0" pci_type="0108 [144d:a900] [144d:ad06] 00" pci_link_speed="15.753846">
+              <info name="PCISlot" value="66"/>
+              <info name="PCIVendor" value="Samsung Electronics Co Ltd"/>
+              <info name="PCIDevice" value="NVMe SSD Controller PM9DXa"/>
+              <object type="OSDev" gp_index="1120" name="nvme1n1" subtype="Disk" osdev_type="0">
+                <info name="Size" value="15000928256"/>
+                <info name="SectorSize" value="512"/>
+                <info name="LinuxDeviceID" value="259:0"/>
+                <info name="Vendor" value="Samsung"/>
+                <info name="Model" value="SAMSUNG MZ3L615THBLF-00AW7"/>
+                <info name="Revision" value="LDDM5U2Q"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="1026" bridge_type="1-1" depth="1" bridge_pci="0000:[72-72]" pci_busid="0000:70:01.3" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="15.753846">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin GPP Bridge"/>
+            <object type="PCIDev" gp_index="967" pci_busid="0000:72:00.0" pci_type="0108 [144d:a826] [144d:aa2a] 00" pci_link_speed="15.753846">
+              <info name="PCISlot" value="67"/>
+              <info name="PCIVendor" value="Samsung Electronics Co Ltd"/>
+              <info name="PCIDevice" value="NVMe SSD Controller PM174X"/>
+              <object type="OSDev" gp_index="1119" name="nvme0c0n1" subtype="Disk" osdev_type="0">
+                <info name="Size" value="1875374424"/>
+                <info name="SectorSize" value="512"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="988" bridge_type="1-1" depth="1" bridge_pci="0000:[74-74]" pci_busid="0000:70:07.2" pci_type="0604 [1022:1555] [1022:1555] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin Internal PCIe GPP Bridge to Bus [D:C]"/>
+            <object type="PCIDev" gp_index="1073" pci_busid="0000:74:00.0" pci_type="0106 [1022:7901] [1022:7901] 93" pci_link_speed="63.015385">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="943" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="3" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="935" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1109" bridge_type="0-1" depth="0" bridge_pci="0000:[60-61]">
+          <object type="Bridge" gp_index="986" bridge_type="1-1" depth="1" bridge_pci="0000:[61-61]" pci_busid="0000:60:01.3" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="7.876923">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin GPP Bridge"/>
+            <object type="PCIDev" gp_index="1102" pci_busid="0000:61:00.0" pci_type="0200 [15b3:101f] [17aa:7827] 00" pci_link_speed="7.876923">
+              <info name="PCISlot" value="0-2"/>
+              <info name="PCIVendor" value="Mellanox Technologies"/>
+              <info name="PCIDevice" value="MT2894 Family [ConnectX-6 Lx]"/>
+              <object type="OSDev" gp_index="1126" name="eno4np0" osdev_type="2">
+                <info name="Address" value="8c:3b:4a:fc:2f:d1"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" gp_index="1133" name="mlx5_1" osdev_type="3">
+                <info name="NodeGUID" value="8c3b:4a03:00fc:2fd1"/>
+                <info name="SysImageGUID" value="8c3b:4a03:00fc:2fd1"/>
+                <info name="Port1State" value="1"/>
+                <info name="Port1LID" value="0x0"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:8e3b:4aff:fefc:2fd1"/>
+                <info name="Port1GID1" value="fe80:0000:0000:0000:8e3b:4aff:fefc:2fd1"/>
+              </object>
+            </object>
+            <object type="PCIDev" gp_index="1022" pci_busid="0000:61:00.1" pci_type="0200 [15b3:101f] [17aa:7827] 00" pci_link_speed="7.876923">
+              <info name="PCISlot" value="0-2"/>
+              <info name="PCIVendor" value="Mellanox Technologies"/>
+              <info name="PCIDevice" value="MT2894 Family [ConnectX-6 Lx]"/>
+              <object type="OSDev" gp_index="1127" name="eno5np1" osdev_type="2">
+                <info name="Address" value="8c:3b:4a:fc:2f:d2"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" gp_index="1129" name="mlx5_2" osdev_type="3">
+                <info name="NodeGUID" value="8c3b:4a03:00fc:2fd2"/>
+                <info name="SysImageGUID" value="8c3b:4a03:00fc:2fd1"/>
+                <info name="Port1State" value="1"/>
+                <info name="Port1LID" value="0x0"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:8e3b:4aff:fefc:2fd2"/>
+                <info name="Port1GID1" value="fe80:0000:0000:0000:8e3b:4aff:fefc:2fd2"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="942" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="2" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="934" local_memory="202880688128">
+          <page_type size="4096" count="49531418"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1104" bridge_type="0-1" depth="0" bridge_pci="0000:[10-16]">
+          <object type="Bridge" gp_index="1092" bridge_type="1-1" depth="1" bridge_pci="0000:[11-16]" pci_busid="0000:10:01.1" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin GPP Bridge"/>
+            <object type="Bridge" gp_index="1045" bridge_type="1-1" depth="2" bridge_pci="0000:[12-16]" pci_busid="0000:11:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+              <info name="PCISlot" value="9"/>
+              <info name="PCIVendor" value="Mellanox Technologies"/>
+              <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+              <object type="Bridge" gp_index="1023" bridge_type="1-1" depth="3" bridge_pci="0000:[13-13]" pci_busid="0000:12:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <info name="PCIVendor" value="Mellanox Technologies"/>
+                <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                <object type="PCIDev" gp_index="1000" pci_busid="0000:13:00.0" pci_type="0207 [15b3:1021] [15b3:0055] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="9-1"/>
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT2910 Family [ConnectX-7]"/>
+                  <object type="OSDev" gp_index="1123" name="ib2x" osdev_type="2">
+                    <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:b8:e9:24:03:00:ba:a4:c4"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" gp_index="1132" name="mlx5_3" osdev_type="3">
+                    <info name="NodeGUID" value="b8e9:2403:00ba:a4c4"/>
+                    <info name="SysImageGUID" value="b8e9:2403:00ba:a4c4"/>
+                    <info name="Port1State" value="1"/>
+                    <info name="Port1LID" value="0xffff"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:b8e9:2403:00ba:a4c4"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Bridge" gp_index="1081" bridge_type="1-1" depth="3" bridge_pci="0000:[14-16]" pci_busid="0000:12:02.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <info name="PCIVendor" value="Mellanox Technologies"/>
+                <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                <object type="Bridge" gp_index="974" bridge_type="1-1" depth="4" bridge_pci="0000:[15-16]" pci_busid="0000:14:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="0-3"/>
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                  <object type="Bridge" gp_index="1099" bridge_type="1-1" depth="5" bridge_pci="0000:[16-16]" pci_busid="0000:15:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                    <info name="PCIVendor" value="Mellanox Technologies"/>
+                    <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                    <object type="PCIDev" gp_index="1078" pci_busid="0000:16:00.0" pci_type="0302 [10de:2335] [10de:18bf] a1" pci_link_speed="63.015385">
+                      <info name="PCISlot" value="5"/>
+                      <info name="PCIVendor" value="NVIDIA Corporation"/>
+                      <info name="PCIDevice" value="GH100 [H200 SXM 141GB]"/>
+                      <object type="OSDev" gp_index="1135" name="cuda1" subtype="CUDA" osdev_type="5">
+                        <info name="Backend" value="CUDA"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="CUDAGlobalMemorySize" value="146593728"/>
+                        <info name="CUDAL2CacheSize" value="61440"/>
+                        <info name="CUDAMultiProcessors" value="132"/>
+                        <info name="CUDACoresPerMP" value="128"/>
+                        <info name="CUDASharedMemorySizePerMP" value="48"/>
+                      </object>
+                      <object type="OSDev" gp_index="1139" name="opencl0d1" subtype="OpenCL" osdev_type="5">
+                        <info name="Backend" value="OpenCL"/>
+                        <info name="OpenCLDeviceType" value="GPU"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="OpenCLPlatformIndex" value="0"/>
+                        <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
+                        <info name="OpenCLPlatformDeviceIndex" value="1"/>
+                        <info name="OpenCLComputeUnits" value="132"/>
+                        <info name="OpenCLGlobalMemorySize" value="146593728"/>
+                      </object>
+                      <object type="OSDev" gp_index="1143" name="nvml1" subtype="NVML" osdev_type="1">
+                        <info name="Backend" value="NVML"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="NVIDIAUUID" value="GPU-32559d2f-bd80-6360-09ab-97af8614d541"/>
+                      </object>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="941" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="1" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="933" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1103" bridge_type="0-1" depth="0" bridge_pci="0000:[00-07]">
+          <object type="Bridge" gp_index="1048" bridge_type="1-1" depth="1" bridge_pci="0000:[01-06]" pci_busid="0000:00:01.1" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin GPP Bridge"/>
+            <object type="Bridge" gp_index="1004" bridge_type="1-1" depth="2" bridge_pci="0000:[02-06]" pci_busid="0000:01:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+              <info name="PCISlot" value="8"/>
+              <info name="PCIVendor" value="Mellanox Technologies"/>
+              <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+              <object type="Bridge" gp_index="979" bridge_type="1-1" depth="3" bridge_pci="0000:[03-03]" pci_busid="0000:02:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <info name="PCIVendor" value="Mellanox Technologies"/>
+                <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                <object type="PCIDev" gp_index="951" pci_busid="0000:03:00.0" pci_type="0207 [15b3:1021] [15b3:0055] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="8-1"/>
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT2910 Family [ConnectX-7]"/>
+                  <object type="OSDev" gp_index="1122" name="ib3x" osdev_type="2">
+                    <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:b8:e9:24:03:00:ba:a4:c8"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" gp_index="1130" name="mlx5_0" osdev_type="3">
+                    <info name="NodeGUID" value="b8e9:2403:00ba:a4c8"/>
+                    <info name="SysImageGUID" value="b8e9:2403:00ba:a4c8"/>
+                    <info name="Port1State" value="1"/>
+                    <info name="Port1LID" value="0xffff"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:b8e9:2403:00ba:a4c8"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Bridge" gp_index="1038" bridge_type="1-1" depth="3" bridge_pci="0000:[04-06]" pci_busid="0000:02:02.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <info name="PCIVendor" value="Mellanox Technologies"/>
+                <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                <object type="Bridge" gp_index="1083" bridge_type="1-1" depth="4" bridge_pci="0000:[05-06]" pci_busid="0000:04:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="0-1"/>
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                  <object type="Bridge" gp_index="1056" bridge_type="1-1" depth="5" bridge_pci="0000:[06-06]" pci_busid="0000:05:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                    <info name="PCIVendor" value="Mellanox Technologies"/>
+                    <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                    <object type="PCIDev" gp_index="1035" pci_busid="0000:06:00.0" pci_type="0302 [10de:2335] [10de:18bf] a1" pci_link_speed="63.015385">
+                      <info name="PCISlot" value="6"/>
+                      <info name="PCIVendor" value="NVIDIA Corporation"/>
+                      <info name="PCIDevice" value="GH100 [H200 SXM 141GB]"/>
+                      <object type="OSDev" gp_index="1134" name="cuda0" subtype="CUDA" osdev_type="5">
+                        <info name="Backend" value="CUDA"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="CUDAGlobalMemorySize" value="146593728"/>
+                        <info name="CUDAL2CacheSize" value="61440"/>
+                        <info name="CUDAMultiProcessors" value="132"/>
+                        <info name="CUDACoresPerMP" value="128"/>
+                        <info name="CUDASharedMemorySizePerMP" value="48"/>
+                      </object>
+                      <object type="OSDev" gp_index="1138" name="opencl0d0" subtype="OpenCL" osdev_type="5">
+                        <info name="Backend" value="OpenCL"/>
+                        <info name="OpenCLDeviceType" value="GPU"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="OpenCLPlatformIndex" value="0"/>
+                        <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
+                        <info name="OpenCLPlatformDeviceIndex" value="0"/>
+                        <info name="OpenCLComputeUnits" value="132"/>
+                        <info name="OpenCLGlobalMemorySize" value="146593728"/>
+                      </object>
+                      <object type="OSDev" gp_index="1142" name="nvml0" subtype="NVML" osdev_type="1">
+                        <info name="Backend" value="NVML"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="NVIDIAUUID" value="GPU-46f77619-68bf-8f9d-7cfb-61fa9c4ca692"/>
+                      </object>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0x0" complete_cpuset="0x0" nodeset="0x000000f0" complete_nodeset="0x000000f0" gp_index="404">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="26"/>
+      <info name="CPUModelNumber" value="2"/>
+      <info name="CPUModel" value="AMD EPYC 9555 64-Core Processor                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="947" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="7" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="939" local_memory="202849652736">
+          <page_type size="4096" count="49523841"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1117" bridge_type="0-1" depth="0" bridge_pci="0000:[e0-e6]">
+          <object type="Bridge" gp_index="985" bridge_type="1-1" depth="1" bridge_pci="0000:[e1-e6]" pci_busid="0000:e0:01.1" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin GPP Bridge"/>
+            <object type="Bridge" gp_index="1090" bridge_type="1-1" depth="2" bridge_pci="0000:[e2-e6]" pci_busid="0000:e1:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+              <info name="PCISlot" value="11"/>
+              <info name="PCIVendor" value="Mellanox Technologies"/>
+              <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+              <object type="Bridge" gp_index="1064" bridge_type="1-1" depth="3" bridge_pci="0000:[e3-e3]" pci_busid="0000:e2:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <info name="PCIVendor" value="Mellanox Technologies"/>
+                <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                <object type="PCIDev" gp_index="1043" pci_busid="0000:e3:00.0" pci_type="0207 [15b3:1021] [15b3:0055] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="11-1"/>
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT2910 Family [ConnectX-7]"/>
+                  <object type="OSDev" gp_index="1124" name="ib0" osdev_type="2">
+                    <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:b8:e9:24:03:00:ba:a4:bc"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" gp_index="1131" name="mlx5_5" osdev_type="3">
+                    <info name="NodeGUID" value="b8e9:2403:00ba:a4bc"/>
+                    <info name="SysImageGUID" value="b8e9:2403:00ba:a4bc"/>
+                    <info name="Port1State" value="4"/>
+                    <info name="Port1LID" value="0x199"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:b8e9:2403:00ba:a4bc"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Bridge" gp_index="973" bridge_type="1-1" depth="3" bridge_pci="0000:[e4-e6]" pci_busid="0000:e2:02.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <info name="PCIVendor" value="Mellanox Technologies"/>
+                <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                <object type="Bridge" gp_index="1017" bridge_type="1-1" depth="4" bridge_pci="0000:[e5-e6]" pci_busid="0000:e4:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="0-5"/>
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                  <object type="Bridge" gp_index="995" bridge_type="1-1" depth="5" bridge_pci="0000:[e6-e6]" pci_busid="0000:e5:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                    <info name="PCIVendor" value="Mellanox Technologies"/>
+                    <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                    <object type="PCIDev" gp_index="966" pci_busid="0000:e6:00.0" pci_type="0302 [10de:2335] [10de:18bf] a1" pci_link_speed="63.015385">
+                      <info name="PCISlot" value="3"/>
+                      <info name="PCIVendor" value="NVIDIA Corporation"/>
+                      <info name="PCIDevice" value="GH100 [H200 SXM 141GB]"/>
+                      <object type="OSDev" gp_index="1137" name="cuda3" subtype="CUDA" osdev_type="5">
+                        <info name="Backend" value="CUDA"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="CUDAGlobalMemorySize" value="146593728"/>
+                        <info name="CUDAL2CacheSize" value="61440"/>
+                        <info name="CUDAMultiProcessors" value="132"/>
+                        <info name="CUDACoresPerMP" value="128"/>
+                        <info name="CUDASharedMemorySizePerMP" value="48"/>
+                      </object>
+                      <object type="OSDev" gp_index="1141" name="opencl0d3" subtype="OpenCL" osdev_type="5">
+                        <info name="Backend" value="OpenCL"/>
+                        <info name="OpenCLDeviceType" value="GPU"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="OpenCLPlatformIndex" value="0"/>
+                        <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
+                        <info name="OpenCLPlatformDeviceIndex" value="3"/>
+                        <info name="OpenCLComputeUnits" value="132"/>
+                        <info name="OpenCLGlobalMemorySize" value="146593728"/>
+                      </object>
+                      <object type="OSDev" gp_index="1145" name="nvml3" subtype="NVML" osdev_type="1">
+                        <info name="Backend" value="NVML"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="NVIDIAUUID" value="GPU-81addb77-2337-6f9f-b0dd-696aa82969d1"/>
+                      </object>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="946" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="6" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="938" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1112" bridge_type="0-1" depth="0" bridge_pci="0000:[90-96]">
+          <object type="Bridge" gp_index="972" bridge_type="1-1" depth="1" bridge_pci="0000:[91-96]" pci_busid="0000:90:01.1" pci_type="0604 [1022:153e] [1022:1453] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin GPP Bridge"/>
+            <object type="Bridge" gp_index="1079" bridge_type="1-1" depth="2" bridge_pci="0000:[92-96]" pci_busid="0000:91:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+              <info name="PCISlot" value="10"/>
+              <info name="PCIVendor" value="Mellanox Technologies"/>
+              <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+              <object type="Bridge" gp_index="1053" bridge_type="1-1" depth="3" bridge_pci="0000:[93-93]" pci_busid="0000:92:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <info name="PCIVendor" value="Mellanox Technologies"/>
+                <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                <object type="PCIDev" gp_index="1030" pci_busid="0000:93:00.0" pci_type="0207 [15b3:1021] [15b3:0055] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="10-1"/>
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT2910 Family [ConnectX-7]"/>
+                  <object type="OSDev" gp_index="1125" name="ib1x" osdev_type="2">
+                    <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:b8:e9:24:03:00:ba:a4:c0"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" gp_index="1128" name="mlx5_4" osdev_type="3">
+                    <info name="NodeGUID" value="b8e9:2403:00ba:a4c0"/>
+                    <info name="SysImageGUID" value="b8e9:2403:00ba:a4c0"/>
+                    <info name="Port1State" value="4"/>
+                    <info name="Port1LID" value="0x191"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:b8e9:2403:00ba:a4c0"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Bridge" gp_index="960" bridge_type="1-1" depth="3" bridge_pci="0000:[94-96]" pci_busid="0000:92:02.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                <info name="PCIVendor" value="Mellanox Technologies"/>
+                <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                <object type="Bridge" gp_index="1008" bridge_type="1-1" depth="4" bridge_pci="0000:[95-96]" pci_busid="0000:94:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="0-4"/>
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                  <object type="Bridge" gp_index="984" bridge_type="1-1" depth="5" bridge_pci="0000:[96-96]" pci_busid="0000:95:00.0" pci_type="0604 [15b3:1979] [0000:0000] 00" pci_link_speed="63.015385">
+                    <info name="PCIVendor" value="Mellanox Technologies"/>
+                    <info name="PCIDevice" value="MT2910 Family [ConnectX-7 PCIe Bridge]"/>
+                    <object type="PCIDev" gp_index="958" pci_busid="0000:96:00.0" pci_type="0302 [10de:2335] [10de:18bf] a1" pci_link_speed="63.015385">
+                      <info name="PCISlot" value="4"/>
+                      <info name="PCIVendor" value="NVIDIA Corporation"/>
+                      <info name="PCIDevice" value="GH100 [H200 SXM 141GB]"/>
+                      <object type="OSDev" gp_index="1136" name="cuda2" subtype="CUDA" osdev_type="5">
+                        <info name="Backend" value="CUDA"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="CUDAGlobalMemorySize" value="146593728"/>
+                        <info name="CUDAL2CacheSize" value="61440"/>
+                        <info name="CUDAMultiProcessors" value="132"/>
+                        <info name="CUDACoresPerMP" value="128"/>
+                        <info name="CUDASharedMemorySizePerMP" value="48"/>
+                      </object>
+                      <object type="OSDev" gp_index="1140" name="opencl0d2" subtype="OpenCL" osdev_type="5">
+                        <info name="Backend" value="OpenCL"/>
+                        <info name="OpenCLDeviceType" value="GPU"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="OpenCLPlatformIndex" value="0"/>
+                        <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
+                        <info name="OpenCLPlatformDeviceIndex" value="2"/>
+                        <info name="OpenCLComputeUnits" value="132"/>
+                        <info name="OpenCLGlobalMemorySize" value="146593728"/>
+                      </object>
+                      <object type="OSDev" gp_index="1144" name="nvml2" subtype="NVML" osdev_type="1">
+                        <info name="Backend" value="NVML"/>
+                        <info name="GPUVendor" value="NVIDIA Corporation"/>
+                        <info name="GPUModel" value="NVIDIA H200"/>
+                        <info name="NVIDIAUUID" value="GPU-f62c37c9-47b3-35d9-91d2-b403ca0ef7ca"/>
+                      </object>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="945" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="5" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="937" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="944" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="4" cpuset="0x0" complete_cpuset="0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="936" local_memory="202928492544">
+          <page_type size="4096" count="49543089"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="Bridge" gp_index="1118" bridge_type="0-1" depth="0" bridge_pci="0000:[f0-f2]">
+          <object type="Bridge" gp_index="964" bridge_type="1-1" depth="1" bridge_pci="0000:[f2-f2]" pci_busid="0000:f0:07.2" pci_type="0604 [1022:1555] [1022:1555] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Turin Internal PCIe GPP Bridge to Bus [D:C]"/>
+            <object type="PCIDev" gp_index="952" pci_busid="0000:f2:00.0" pci_type="0106 [1022:7901] [1022:7901] 93" pci_link_speed="63.015385">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+  <distances2 type="NUMANode" nbobjs="8" kind="5" name="NUMALatency" indexing="os">
+    <indexes length="16">0 1 2 3 4 5 6 7 </indexes>
+    <u64values length="30">10 12 12 12 32 32 32 32 12 10 </u64values>
+    <u64values length="30">12 12 32 32 32 32 12 12 10 12 </u64values>
+    <u64values length="30">32 32 32 32 12 12 12 10 32 32 </u64values>
+    <u64values length="30">32 32 32 32 32 32 10 12 12 12 </u64values>
+    <u64values length="30">32 32 32 32 12 10 12 12 32 32 </u64values>
+    <u64values length="30">32 32 12 12 10 12 32 32 32 32 </u64values>
+    <u64values length="12">12 12 12 10 </u64values>
+  </distances2>
+  <distances2 type="OSDev" nbobjs="4" kind="9" name="NVLinkBandwidth" indexing="gp">
+    <indexes length="20">1142 1143 1144 1145 </indexes>
+    <u64values length="72">1000000 150000 150000 150000 150000 1000000 150000 150000 150000 150000 </u64values>
+    <u64values length="44">1000000 150000 150000 150000 150000 1000000 </u64values>
+  </distances2>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.numa_memory"/>
+  <support name="discovery.disallowed_pu"/>
+  <support name="discovery.disallowed_numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="cpubind.set_thisproc_cpubind"/>
+  <support name="cpubind.get_thisproc_cpubind"/>
+  <support name="cpubind.set_proc_cpubind"/>
+  <support name="cpubind.get_proc_cpubind"/>
+  <support name="cpubind.set_thisthread_cpubind"/>
+  <support name="cpubind.get_thisthread_cpubind"/>
+  <support name="cpubind.set_thread_cpubind"/>
+  <support name="cpubind.get_thread_cpubind"/>
+  <support name="cpubind.get_thisproc_last_cpu_location"/>
+  <support name="cpubind.get_proc_last_cpu_location"/>
+  <support name="cpubind.get_thisthread_last_cpu_location"/>
+  <support name="membind.set_thisthread_membind"/>
+  <support name="membind.get_thisthread_membind"/>
+  <support name="membind.set_area_membind"/>
+  <support name="membind.get_area_membind"/>
+  <support name="membind.alloc_membind"/>
+  <support name="membind.firsttouch_membind"/>
+  <support name="membind.bind_membind"/>
+  <support name="membind.interleave_membind"/>
+  <support name="membind.migrate_membind"/>
+  <support name="membind.get_area_memlocation"/>
+  <support name="custom.exported_support"/>
+  <memattr name="Bandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="932" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="933" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="934" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="935" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="936" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="937" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="938" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="939" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,,,0x0"/>
+  </memattr>
+  <memattr name="Latency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="932" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="933" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="934" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="935" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="936" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="937" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="938" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="939" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,,,0x0"/>
+  </memattr>
+  <memattr name="ReadBandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="932" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="933" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="934" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="935" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="936" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="937" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="938" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="939" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,,,0x0"/>
+  </memattr>
+  <memattr name="WriteBandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="932" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="933" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="934" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="935" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="936" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="937" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="938" value="115200" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="939" value="115200" initiator_cpuset="0xffff0000,,,,0xffff0000,,,0x0"/>
+  </memattr>
+  <memattr name="ReadLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="932" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="933" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="934" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="935" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="936" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="937" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="938" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="939" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,,,0x0"/>
+  </memattr>
+  <memattr name="WriteLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="932" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="933" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="934" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="935" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="936" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="937" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="938" value="110" initiator_cpuset="0x0000ffff,,,,0x0000ffff,,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="939" value="110" initiator_cpuset="0xffff0000,,,,0xffff0000,,,0x0"/>
+  </memattr>
+  <cpukind cpuset="0x0000ffff" forced_efficiency="1024">
+    <info name="FrequencyMaxMHz" value="3200"/>
+    <info name="LinuxCapacity" value="1024"/>
+  </cpukind>
+</topology>

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -55,9 +55,9 @@ noinst_SCRIPTS = run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_tools
 
 EXTRA_DIST = run_gds_fallback.pl.in run_simpcycle.pl.in run_toolcycle.pl.in run_toolswitch.pl.in run_grpmember.pl.in run_grpbadinfo.pl.in run_grpinvite.pl.in run_grpinviteendpts.pl.in run_grpinviteothers.pl.in run_grpinvitesuppress.pl.in run_grpinvitenb.pl.in run_grptimeout.pl.in run_grpdecline.pl.in run_grpabort.pl.in run_grpmemberfail.pl.in run_grpleader.pl.in run_grpcabort.pl.in run_grpctimeout.pl.in run_monitor.pl.in run_tools.pl.in
 
-check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_pending iof_inherit proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary event_forward
+check_PROGRAMS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback gds_datastore pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_pending iof_inherit proc_array_id get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary event_forward pgpu_visible_devices
 
-TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteendpts.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_pending iof_inherit proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary event_forward
+TESTS = client_api common_api compress compress_block preg bfrops_regex2 bfrops_alloc_inherit bfrops_darray bfrops_malformed bfrops_get_number bfrops_null_object bfrops_helpers nested_darray gds_fallback run_gds_fallback.pl run_simpcycle.pl run_toolcycle.pl run_toolswitch.pl run_grpmember.pl run_grpbadinfo.pl run_grpinvite.pl run_grpinviteendpts.pl run_grpinviteothers.pl run_grpinvitesuppress.pl run_grpinvitenb.pl run_grptimeout.pl run_grpdecline.pl run_grpabort.pl run_grpmemberfail.pl run_grpleader.pl run_grpcabort.pl run_grpctimeout.pl run_monitor.pl run_tools.pl pmix_log collective_status collect_job_info trk_complete tracker_match trk_peer_lost client_cycle tool_cycle event_chain hwloc_datatype hwloc_devices progress_threads info_support singleton_register rndz_stale iof_pattern iof_flow iof_output iof_pending iof_inherit proc_array_id gds_datastore get_perf ptl_uri ptl_handshake tool_nspace tool_rndz tool_api tool_evcache tool_relay runtime_init server_get resolve_api spawn_api server_control server_dmodex server_fabric server_fence server_connect server_resolve server_setup attr_dictionary event_forward pgpu_visible_devices
 
 client_api_SOURCES = \
         client_api.c
@@ -237,6 +237,13 @@ hwloc_devices_SOURCES = \
 hwloc_devices_CPPFLAGS = -DPMIX_TEST_TOPO_DIR=\"$(abs_top_srcdir)/test/topologies\"
 hwloc_devices_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 hwloc_devices_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+pgpu_visible_devices_SOURCES = \
+        pgpu_visible_devices.c
+pgpu_visible_devices_CPPFLAGS = -DPMIX_TEST_TOPO_DIR=\"$(abs_top_srcdir)/test/topologies\"
+pgpu_visible_devices_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+pgpu_visible_devices_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 runtime_init_SOURCES = \

--- a/test/unit/hwloc_devices.c
+++ b/test/unit/hwloc_devices.c
@@ -467,6 +467,89 @@ static void test_uuid_names_the_node(const char *dir)
     free_topo(&topo);
 }
 
+/* The vendor's own identity for a device, which is the only handle a GPU
+ * runtime will accept.
+ *
+ * Three properties, and the middle one is the whole reason this is not a
+ * one-line read off the named device:
+ *
+ *   - nvml-4gpu names each function by "cuda0" (the first vendor compute
+ *     node it meets) while NVIDIAUUID lives on the sibling "nvml0" of the
+ *     same PCI function.  A scan of the named device alone reports "no
+ *     identity" on exactly the machines that have one.
+ *   - test-topo2 is the other arrangement - AMDUUID sits on "rsmi0", which
+ *     is also the device that names the function - so both paths are
+ *     covered rather than just whichever one the first fixture happened to
+ *     use.
+ *   - drm-4gpu is the same machine as nvml-4gpu seen by an hwloc built
+ *     without the vendor backends.  Its GPUs are found and placed exactly
+ *     as well; they simply cannot be named, and NULL is the honest answer
+ *     rather than a failure.
+ */
+static void test_vendor_identity(const char *dir)
+{
+    struct {
+        const char *file;
+        const char *osname;   /* the device that names the function */
+        const char *prefix;   /* what its vendor id must start with, or NULL */
+        size_t ndevs;
+    } cases[] = {
+        {"nvml-4gpu.xml", "cuda0", "GPU-", 4},
+        {"test-topo2.xml", "rsmi0", "d364", 1},
+        {"drm-4gpu.xml", NULL, NULL, 4},
+    };
+    pmix_topology_t topo = PMIX_TOPOLOGY_STATIC_INIT;
+    pmix_hwloc_device_t *devs = NULL;
+    size_t ndevs = 0, i, c, nident;
+    char path[1024];
+    pmix_status_t rc;
+
+    for (c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
+        snprintf(path, sizeof(path), "%s/%s", dir, cases[c].file);
+        if (0 != load_topo_file(path, &topo)) {
+            fprintf(stderr, "FAIL: could not load %s\n", path);
+            ++failures;
+            continue;
+        }
+        rc = pmix_hwloc_get_devices(&topo, TESTHOST,
+                                    PMIX_DEVTYPE_GPU | PMIX_DEVTYPE_COPROC,
+                                    NULL, &devs, &ndevs);
+        ok(PMIX_SUCCESS == rc, "vendor: enumeration succeeds");
+        ok(cases[c].ndevs == ndevs, "vendor: the expected number of GPUs");
+
+        nident = 0;
+        for (i = 0; i < ndevs; i++) {
+            if (NULL != devs[i].vendor_id) {
+                ++nident;
+            }
+        }
+        if (NULL == cases[c].prefix) {
+            ok(0 == nident, "vendor: no backend means no identity, not a failure");
+        } else {
+            ok(nident == ndevs, "vendor: every GPU carries a vendor identity");
+            if (0 < ndevs) {
+                ok(NULL != devs[0].dev.osname
+                       && 0 == strcmp(devs[0].dev.osname, cases[c].osname),
+                   "vendor: the function is named as expected");
+                ok(NULL != devs[0].vendor_id
+                       && 0 == strncmp(devs[0].vendor_id, cases[c].prefix,
+                                       strlen(cases[c].prefix)),
+                   "vendor: the identity is the vendor's own, in its own grammar");
+            }
+            /* two GPUs on one machine are never the same GPU */
+            if (1 < ndevs) {
+                ok(NULL != devs[0].vendor_id && NULL != devs[1].vendor_id
+                       && 0 != strcmp(devs[0].vendor_id, devs[1].vendor_id),
+                   "vendor: distinct devices carry distinct identities");
+            }
+        }
+        pmix_hwloc_release_devices(devs, ndevs);
+        devs = NULL;
+        ndevs = 0;
+        free_topo(&topo);
+    }
+}
+
 int main(int argc, char **argv)
 {
     const char *dir;
@@ -491,6 +574,7 @@ int main(int argc, char **argv)
     test_topo1(dir);
     test_distances_agree(dir);
     test_uuid_names_the_node(dir);
+    test_vendor_identity(dir);
 
     fprintf(stderr, "%s: %d checks, %d failures\n",
             (0 == failures) ? "PASS" : "FAIL", checks, failures);

--- a/test/unit/hwloc_devices.c
+++ b/test/unit/hwloc_devices.c
@@ -45,6 +45,13 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* The node whose topology we claim to be reading.  Deliberately NOT the
+ * hostname this test process is running under: a device uuid names the node
+ * the device lives on, and the two are the same only when the topology is
+ * the local one.  Every enumeration below therefore says whose topology it
+ * has, exactly as a mapper reading another node's topology must. */
+#define TESTHOST "test-node-01"
+
 static int failures = 0;
 static int checks = 0;
 
@@ -131,7 +138,7 @@ static void test_topo2(const char *dir)
 
     /* THE case: one GPU, not two (the display controller) and not three or
      * four (the extra OS devices on the same function) */
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_GPU, NULL, &devs, &ndevs);
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_GPU, NULL, &devs, &ndevs);
     ok(PMIX_SUCCESS == rc, "topo2: gpu enumeration succeeds");
     ok(1 == ndevs, "topo2: exactly one compute GPU");
     if (1 == ndevs) {
@@ -151,13 +158,13 @@ static void test_topo2(const char *dir)
     ndevs = 0;
 
     /* lookup by name, and by a name that is not there */
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_GPU, "rsmi0", &devs, &ndevs);
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_GPU, "rsmi0", &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 1 == ndevs, "topo2: gpu by osname finds it");
     pmix_hwloc_release_devices(devs, ndevs);
     devs = NULL;
     ndevs = 0;
 
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_GPU, "no-such-device", &devs, &ndevs);
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_GPU, "no-such-device", &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 0 == ndevs,
        "topo2: an unknown device name is empty, not an error");
     pmix_hwloc_release_devices(devs, ndevs);
@@ -169,7 +176,7 @@ static void test_topo2(const char *dir)
      * either has to find it, or "--map-by device=mlx5_0" - the whole reason
      * a caller names a device - finds nothing on a machine where the
      * network device happened to sort first. */
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_UNKNOWN, "mlx5_0", &devs, &ndevs);
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_UNKNOWN, "mlx5_0", &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 1 == ndevs, "topo2: the fabric device is found by its own name");
     if (1 == ndevs) {
         ok(NULL != devs[0].dev.osname && 0 == strcmp(devs[0].dev.osname, "mlx5_0"),
@@ -179,20 +186,20 @@ static void test_topo2(const char *dir)
     devs = NULL;
     ndevs = 0;
 
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_UNKNOWN, "ib0", &devs, &ndevs);
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_UNKNOWN, "ib0", &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 1 == ndevs, "topo2: the network device on that same function too");
     pmix_hwloc_release_devices(devs, ndevs);
     devs = NULL;
     ndevs = 0;
 
     /* the fabric and network devices sit on different functions */
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_OPENFABRICS, NULL, &devs, &ndevs);
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_OPENFABRICS, NULL, &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 1 == ndevs, "topo2: one openfabrics device");
     pmix_hwloc_release_devices(devs, ndevs);
     devs = NULL;
     ndevs = 0;
 
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_NETWORK, NULL, &devs, &ndevs);
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_NETWORK, NULL, &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 2 == ndevs, "topo2: two network devices");
     pmix_hwloc_release_devices(devs, ndevs);
     devs = NULL;
@@ -202,7 +209,7 @@ static void test_topo2(const char *dir)
      * devices (ib0) shares its PCI function with the openfabrics device
      * (mlx5_0).  Asked for both types at once they are one device, so the
      * union is 2 rather than the 3 an OS-device count would give. */
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_NETWORK | PMIX_DEVTYPE_OPENFABRICS,
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_NETWORK | PMIX_DEVTYPE_OPENFABRICS,
                                 NULL, &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 2 == ndevs,
        "topo2: network+openfabrics dedup to one device per PCI function");
@@ -211,7 +218,7 @@ static void test_topo2(const char *dir)
     ndevs = 0;
 
     /* everything, in PCI order */
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_UNKNOWN, NULL, &devs, &ndevs);
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_UNKNOWN, NULL, &devs, &ndevs);
     ok(PMIX_SUCCESS == rc, "topo2: enumerating every type succeeds");
     ok(0 < ndevs, "topo2: every-type enumeration is non-empty");
     ok(ordered_by_busid(devs, ndevs), "topo2: devices come back in PCI bus order");
@@ -238,14 +245,14 @@ static void test_topo1(const char *dir)
     }
 
     /* this topology has no GPU at all - an empty result, not an error */
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_GPU, NULL, &devs, &ndevs);
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_GPU, NULL, &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 0 == ndevs, "topo1: no GPUs is empty, not an error");
     ok(NULL == devs, "topo1: an empty result hands back no array");
     pmix_hwloc_release_devices(devs, ndevs);
     devs = NULL;
     ndevs = 0;
 
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_UNKNOWN, NULL, &devs, &ndevs);
+    rc = pmix_hwloc_get_devices(&topo, TESTHOST, PMIX_DEVTYPE_UNKNOWN, NULL, &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 0 < ndevs, "topo1: devices are found");
     ok(ordered_by_busid(devs, ndevs), "topo1: devices come back in PCI bus order");
 
@@ -317,7 +324,12 @@ static void test_distances_agree(const char *dir)
     cpuset.source = strdup("hwloc");
     cpuset.bitmap = hwloc_bitmap_dup(hwloc_get_root_obj(t)->cpuset);
 
-    rc = pmix_hwloc_get_devices(&topo, PMIX_DEVTYPE_GPU | PMIX_DEVTYPE_NETWORK
+    /* pmix_globals.hostname, not TESTHOST, and that is the point: distances
+     * are only ever computed for the local node, so this is the one caller
+     * whose hostname is not a choice.  Handing the enumerator anything else
+     * here would make the two disagree on every uuid. */
+    rc = pmix_hwloc_get_devices(&topo, pmix_globals.hostname,
+                                PMIX_DEVTYPE_GPU | PMIX_DEVTYPE_NETWORK
                                        | PMIX_DEVTYPE_OPENFABRICS,
                                 NULL, &devs, &ndevs);
     ok(PMIX_SUCCESS == rc && 0 < ndevs, "agree: the enumerator finds devices");
@@ -359,6 +371,102 @@ static void test_distances_agree(const char *dir)
     free_topo(&topo);
 }
 
+/* A device uuid names the node the device is on, not the node doing the
+ * reading.
+ *
+ * This is the property that makes the uuid worth carrying at all: a process
+ * is handed the uuid of the device it was assigned, computes the same string
+ * locally from PMIX_DEVICE_DISTANCES, and correlates the two.  A caller
+ * reading a remote topology - the mapper on the head node, which is the only
+ * caller that reads one - therefore has to supply the node's name, because
+ * the alternative (this process's own hostname) would stamp the head node on
+ * every device in the job and nothing would ever correlate.  Enumerating one
+ * topology under two names is the whole test.
+ *
+ * Not every uuid moves, and that is correct rather than an exception to work
+ * around: a fabric or network device is named by its own GUIDs or MAC, which
+ * identify the card wherever it is plugged in.  Only the grammars that spell
+ * a hostname - gpu:// and blk:// - may differ between the two readings, and
+ * they must. */
+static void test_uuid_names_the_node(const char *dir)
+{
+    pmix_topology_t topo = PMIX_TOPOLOGY_STATIC_INIT;
+    pmix_hwloc_device_t *a = NULL, *b = NULL;
+    size_t na = 0, nb = 0, i, nhosted = 0;
+    char path[1024], expect[512];
+    const char *grammar;
+    pmix_status_t rc;
+    bool same_osname = true, moved = true, stable = true, named = true;
+
+    snprintf(path, sizeof(path), "%s/test-topo2.xml", dir);
+    if (0 != load_topo_file(path, &topo)) {
+        fprintf(stderr, "FAIL: could not load %s\n", path);
+        ++failures;
+        return;
+    }
+
+    /* a hostname is required, not defaulted: silently substituting the local
+     * one is precisely the bug this parameter exists to make impossible */
+    rc = pmix_hwloc_get_devices(&topo, NULL, PMIX_DEVTYPE_UNKNOWN, NULL, &a, &na);
+    ok(PMIX_ERR_BAD_PARAM == rc, "hostname: a NULL hostname is refused");
+    ok(NULL == a && 0 == na, "hostname: a refused call hands back nothing");
+
+    rc = pmix_hwloc_get_devices(&topo, "node-a", PMIX_DEVTYPE_UNKNOWN, NULL, &a, &na);
+    ok(PMIX_SUCCESS == rc && 0 < na, "hostname: enumeration as node-a succeeds");
+    rc = pmix_hwloc_get_devices(&topo, "node-b", PMIX_DEVTYPE_UNKNOWN, NULL, &b, &nb);
+    ok(PMIX_SUCCESS == rc && 0 < nb, "hostname: enumeration as node-b succeeds");
+    ok(na == nb, "hostname: one topology yields the same device count either way");
+
+    if (na == nb) {
+        for (i = 0; i < na; i++) {
+            if (NULL == a[i].dev.osname || NULL == b[i].dev.osname
+                || 0 != strcmp(a[i].dev.osname, b[i].dev.osname)) {
+                same_osname = false;
+            }
+            if (NULL == a[i].dev.uuid || NULL == b[i].dev.uuid) {
+                same_osname = false;
+                continue;
+            }
+            grammar = NULL;
+            if (0 == strncmp(a[i].dev.uuid, "gpu://", 6)) {
+                grammar = "gpu";
+            } else if (0 == strncmp(a[i].dev.uuid, "blk://", 6)) {
+                grammar = "blk";
+            }
+            if (NULL == grammar) {
+                /* named by the hardware itself - it must NOT move */
+                if (0 != strcmp(a[i].dev.uuid, b[i].dev.uuid)) {
+                    stable = false;
+                }
+                continue;
+            }
+            ++nhosted;
+            if (0 == strcmp(a[i].dev.uuid, b[i].dev.uuid)) {
+                moved = false;
+            }
+            snprintf(expect, sizeof(expect), "%s://node-a::%s", grammar, a[i].dev.osname);
+            if (0 != strcmp(a[i].dev.uuid, expect)) {
+                named = false;
+            }
+            snprintf(expect, sizeof(expect), "%s://node-b::%s", grammar, b[i].dev.osname);
+            if (0 != strcmp(b[i].dev.uuid, expect)) {
+                named = false;
+            }
+        }
+        ok(same_osname, "hostname: the devices themselves are unchanged");
+        /* without this the three checks below would pass on a topology
+         * carrying nothing the hostname reaches */
+        ok(0 < nhosted, "hostname: the topology has devices whose uuid names a node");
+        ok(moved, "hostname: no two nodes share a host-named device uuid");
+        ok(stable, "hostname: a device named by its own hardware ids does not move");
+        ok(named, "hostname: each uuid names the node it was asked about");
+    }
+
+    pmix_hwloc_release_devices(a, na);
+    pmix_hwloc_release_devices(b, nb);
+    free_topo(&topo);
+}
+
 int main(int argc, char **argv)
 {
     const char *dir;
@@ -373,7 +481,8 @@ int main(int argc, char **argv)
     dir = PMIX_TEST_TOPO_DIR;
 #endif
 
-    /* the gpu:// uuid embeds the hostname */
+    /* compute_distances() reads this for the local node it measures; the
+     * enumerator no longer reads it at all */
     if (NULL == pmix_globals.hostname) {
         pmix_globals.hostname = strdup("testhost");
     }
@@ -381,6 +490,7 @@ int main(int argc, char **argv)
     test_topo2(dir);
     test_topo1(dir);
     test_distances_agree(dir);
+    test_uuid_names_the_node(dir);
 
     fprintf(stderr, "%s: %d checks, %d failures\n",
             (0 == failures) ? "PASS" : "FAIL", checks, failures);

--- a/test/unit/pgpu_visible_devices.c
+++ b/test/unit/pgpu_visible_devices.c
@@ -1,0 +1,245 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the vendor "visible devices" environment a pgpu module
+ * contributes to a process it is about to fork.
+ *
+ * The thing under test is the whole chain, because every link of it was
+ * broken or absent until now: PMIx_server_setup_fork never called
+ * pmix_pgpu.setup_fork at all, so the framework's environment handling was
+ * unreachable; the module interface had no per-process hook, so a value
+ * that differs per rank had nowhere to be set; and the vendor's own device
+ * identifier - the only string a GPU runtime will accept - was not read out
+ * of the topology by anything.
+ *
+ * The test runs against nvml-4gpu.xml, handed to the server through the
+ * documented topo_file hook. That fixture is a real machine read by an
+ * hwloc with the CUDA and NVML backends, and it matters here for two
+ * reasons beyond carrying UUIDs at all: its PCI functions are NVIDIA
+ * display-class devices, so the nvd component's own open-time vendor check
+ * passes and the module really is selected on a machine that has no GPU;
+ * and each function exposes cuda0/opencl0d0/nvml0 with the identity on
+ * nvml0, so a value only appears if the identity was found across the
+ * function rather than on the device that names it.
+ */
+
+#include "src/include/pmix_config.h"
+#include "include/pmix.h"
+#include "include/pmix_server.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/pgpu/base/base.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/pmix_printf.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NPROCS 2
+#define TESTNS "pgpu-visdev"
+
+/* the first two GPUs of the fixture, and their NVIDIAUUIDs */
+static const char *osnames[NPROCS] = {"cuda0", "cuda1"};
+static const char *uuids[NPROCS] = {
+    "GPU-46f77619-68bf-8f9d-7cfb-61fa9c4ca692",
+    "GPU-32559d2f-bd80-6360-09ab-97af8614d541"
+};
+
+static int failures = 0;
+static int checks = 0;
+
+static void ok(bool cond, const char *what)
+{
+    ++checks;
+    if (!cond) {
+        ++failures;
+        fprintf(stderr, "FAIL: %s\n", what);
+    }
+}
+
+/* Register a namespace whose ranks were mapped against devices.  Rank 0
+ * gets cuda0, rank 1 gets cuda1, and rank NPROCS (registered but not
+ * mapped) gets none - which is what every ordinary job looks like. */
+static pmix_status_t register_nspace(void)
+{
+    pmix_info_t *info, *pdata;
+    pmix_data_array_t *array, *darray;
+    pmix_device_t *dev;
+    pmix_status_t rc;
+    pmix_proc_t p;
+    size_t ninfo, n = 0;
+    uint32_t nprocs = NPROCS + 1;
+    uint32_t m;
+    uint16_t lrank;
+    pmix_nspace_t ns;
+
+    ninfo = 2 + nprocs;
+    PMIX_INFO_CREATE(info, ninfo);
+
+    PMIX_INFO_LOAD(&info[n], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    ++n;
+    PMIX_INFO_LOAD(&info[n], PMIX_LOCAL_SIZE, &nprocs, PMIX_UINT32);
+    ++n;
+
+    for (m = 0; m < nprocs; m++) {
+        bool mapped = (m < NPROCS);
+        size_t k = 0;
+
+        pmix_strncpy(info[n].key, PMIX_PROC_INFO_ARRAY, PMIX_MAX_KEYLEN);
+        info[n].value.type = PMIX_DATA_ARRAY;
+        PMIX_DATA_ARRAY_CREATE(array, mapped ? 3 : 2, PMIX_INFO);
+        info[n].value.data.darray = array;
+        pdata = (pmix_info_t *) array->array;
+
+        PMIX_LOAD_PROCID(&p, TESTNS, (pmix_rank_t) m);
+        PMIX_INFO_LOAD(&pdata[k], PMIX_PROCID, &p, PMIX_PROC);
+        ++k;
+        lrank = (uint16_t) m;
+        PMIX_INFO_LOAD(&pdata[k], PMIX_LOCAL_RANK, &lrank, PMIX_UINT16);
+        ++k;
+
+        if (mapped) {
+            /* always an array of pmix_device_t, even for one device */
+            PMIX_DATA_ARRAY_CREATE(darray, 1, PMIX_DEVICE);
+            dev = (pmix_device_t *) darray->array;
+            PMIx_Device_construct(&dev[0]);
+            dev[0].osname = strdup(osnames[m]);
+            pmix_asprintf(&dev[0].uuid, "gpu://%s::%s",
+                          pmix_globals.hostname, osnames[m]);
+            dev[0].type = PMIX_DEVTYPE_GPU | PMIX_DEVTYPE_COPROC;
+            /* hand the array over rather than PMIX_INFO_LOAD-ing it: the
+             * info now owns it, which is how the shipped proc-array test
+             * builds one too */
+            pmix_strncpy(pdata[k].key, PMIX_DEVICE_ID, PMIX_MAX_KEYLEN);
+            pdata[k].value.type = PMIX_DATA_ARRAY;
+            pdata[k].value.data.darray = darray;
+        }
+        ++n;
+    }
+
+    /* No callback, which is what makes this call BLOCK - PMIx substitutes
+     * an internal lock when it is given none.  With a callback the call
+     * returns immediately and the info array below would be freed while
+     * the server was still reading it, which shows up as a value of some
+     * impossible type rather than as a use-after-free. */
+    PMIX_LOAD_NSPACE(ns, TESTNS);
+    rc = PMIx_server_register_nspace(ns, nprocs, info, ninfo, NULL, NULL);
+    PMIX_INFO_FREE(info, ninfo);
+    return rc;
+}
+
+/* the value of "var" in env, or NULL */
+static const char *envval(char **env, const char *var)
+{
+    size_t len = strlen(var);
+    int i;
+
+    for (i = 0; NULL != env && NULL != env[i]; i++) {
+        if (0 == strncmp(env[i], var, len) && '=' == env[i][len]) {
+            return &env[i][len + 1];
+        }
+    }
+    return NULL;
+}
+
+int main(int argc, char **argv)
+{
+    char **env = NULL;
+    const char *val;
+    pmix_proc_t proc;
+    pmix_status_t rc;
+    char path[1024];
+    size_t m;
+
+    (void) argc;
+    (void) argv;
+
+#ifndef PMIX_TEST_TOPO_DIR
+    fprintf(stderr, "SKIP: no topology directory configured\n");
+    return 77;
+#else
+    snprintf(path, sizeof(path), "%s/nvml-4gpu.xml", PMIX_TEST_TOPO_DIR);
+#endif
+
+    /* Hand the server the fixture as its own topology.  This is the
+     * documented testing hook, and it is what lets the nvd component's
+     * open-time NVIDIA check pass on a machine with no GPU in it. */
+    setenv("PMIX_MCA_pmix_hwloc_topo_file", path, 1);
+
+    rc = PMIx_server_init(NULL, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "SKIP: PMIx_server_init failed: %s\n", PMIx_Error_string(rc));
+        return 77;
+    }
+
+    rc = register_nspace();
+    /* a synchronous completion reports OPERATION_SUCCEEDED, not SUCCESS */
+    ok(PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc,
+       "the namespace registers");
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        goto done;
+    }
+
+    /* each mapped rank is told about its own GPU, by the vendor's name for
+     * it - which lives on a sibling of the device the assignment names */
+    for (m = 0; m < NPROCS; m++) {
+        PMIX_LOAD_PROCID(&proc, TESTNS, (pmix_rank_t) m);
+        env = NULL;
+        rc = pmix_pgpu_base_setup_fork(&proc, &env);
+        ok(PMIX_SUCCESS == rc, "setup_fork succeeds");
+        val = envval(env, "CUDA_VISIBLE_DEVICES");
+        ok(NULL != val && 0 == strcmp(val, uuids[m]),
+           "the rank is given its own GPU's vendor identity");
+        if (NULL != val && 0 != strcmp(val, uuids[m])) {
+            fprintf(stderr, "      rank %d: got %s, wanted %s\n",
+                    (int) m, val, uuids[m]);
+        }
+        /* never the vendor's ordering variable: the identity does not
+         * depend on it, and overriding it would renumber every device for
+         * the rest of the process's life */
+        ok(NULL == envval(env, "CUDA_DEVICE_ORDER"),
+           "the device ordering is left alone");
+        PMIx_Argv_free(env);
+    }
+
+    /* two ranks on one node never get the same GPU named */
+    ok(0 != strcmp(uuids[0], uuids[1]), "the fixture's GPUs are distinguishable");
+
+    /* a rank that was not mapped against a device gets nothing.  This is
+     * the ordinary case for every job that does not use --map-by device,
+     * so it has to be silent rather than an error */
+    PMIX_LOAD_PROCID(&proc, TESTNS, (pmix_rank_t) NPROCS);
+    env = NULL;
+    rc = pmix_pgpu_base_setup_fork(&proc, &env);
+    ok(PMIX_SUCCESS == rc, "an unmapped rank is not an error");
+    ok(NULL == envval(env, "CUDA_VISIBLE_DEVICES"),
+       "an unmapped rank is told nothing");
+    PMIx_Argv_free(env);
+
+    /* the vendor filter: asking for AMD's devices on a machine that has
+     * only NVIDIA ones must decline rather than name them.  A node can
+     * carry cards from two vendors and each wants its own variable */
+    PMIX_LOAD_PROCID(&proc, TESTNS, 0);
+    env = NULL;
+    rc = pmix_pgpu_base_set_visible_devices(&proc, "AMD",
+                                            "ROCR_VISIBLE_DEVICES", &env);
+    ok(PMIX_ERR_TAKE_NEXT_OPTION == rc, "another vendor's devices are declined");
+    ok(NULL == envval(env, "ROCR_VISIBLE_DEVICES"),
+       "and no value is written for them");
+    PMIx_Argv_free(env);
+
+done:
+    PMIx_server_finalize();
+    fprintf(stderr, "%s: %d checks, %d failures\n",
+            (0 == failures) ? "PASS" : "FAIL", checks, failures);
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
Groundwork in PMIx for `--map-by device=gpu` (PRRTE side in openpmix/prrte, opened alongside this; it needs this PR). Motivated by open-mpi/ompi#14169.

The theme is that a device assignment is only worth making if the process can act on it, and three separate things stood between "PMIx knows which GPU" and "the process can use it".

### The device uuid named the wrong machine

`build_device_uuid()` took the hostname from `pmix_globals.hostname` — the host of whatever process was doing the enumeration. That is right only when the topology is the local one, and the caller that matters is exactly the one for which it is not: PRRTE's mapper runs on the head node and enumerates every compute node's topology in turn, so every GPU in a job came back named `gpu://<head node>::cuda0`.

That defeats the reason the uuid travels instead of an ordinal. A process correlates the uuid it was handed against what it computes locally from `PMIX_DEVICE_DISTANCES`; the two agreed on exactly one node. Nothing detects it either — the strings are well-formed and unique per device, just consistently attributed to the wrong machine.

`pmix_hwloc_get_devices()` now takes the hostname as a **required** parameter (a NULL is `PMIX_ERR_BAD_PARAM`, because a default is how this happened). `pmix_hwloc_compute_distances()` is the one caller entitled to pass `pmix_globals.hostname`, since it measures against a cpuset of this machine's PUs.

### PMIx never reported the identity a GPU runtime accepts

PMIx names a device with a uuid of its own construction, which no GPU library has heard of. `pmix_hwloc_device_t` gains `vendor_id`/`vendor`, harvested from the key hwloc's vendor backends record (`NVIDIAUUID`, `AMDUUID`, `LevelZeroUUID`).

Harvested across the whole PCI **function**, not off the OS device that names it: with the CUDA and NVML backends both loaded a GPU exposes `cuda0`, `opencl0d0` and `nvml0` on one function, the enumerator names it `cuda0`, and the uuid is on `nvml0`. Reading only the named device reports "no identity" on precisely the machines that have one.

`NULL` is the ordinary answer — an hwloc built without the vendor backends describes the same GPUs with no way to name any of them — so what to do about it is left to the caller.

### The whole pgpu environment path was dead code

`PMIx_server_setup_fork` asked `ptl`, `pnet`, `gds` and `pmdl` for their contribution to a child's environment and never asked `pgpu`. So `allocate()` harvested the vendor's envars, the host shipped the blob, `setup_local()` cached it — and nothing ever replayed the cache into a process. A component could be selected, do all its work, and have no observable effect. There is no error and no empty result to notice, because the cache is written by one function and read by another that runs zero times.

On top of that, the `amd`/`intel`/`nvd` components disabled themselves in `configure` unless `--enable-test-build` was given. None of them links anything or needs a vendor SDK, and the machine that builds PMIx is routinely not the machine that runs it — detection belongs in `component_open`, which already asks the local topology whether the vendor's hardware is present. They build unconditionally now.

### Per-process environment

`pmix_pgpu_module_t` gains `setup_fork`, called after the namespace-wide envars. Everything `setup_local` caches is per namespace and replayed identically into every child; a GPU assignment is per rank and had nowhere to be set. Framework version → 2.0.0.

The shared work lives in the base as `pmix_pgpu_base_set_visible_devices()`, so a component is three lines. `nvd` sets `CUDA_VISIBLE_DEVICES`, `amd` sets `ROCR_VISIBLE_DEVICES`. `intel` deliberately sets nothing: `ZE_AFFINITY_MASK` takes indices in an ordering PMIx cannot reproduce, and a wrong value in these variables does not fail — it silently shrinks the visible set. For the same reason no index is ever guessed, and none of them touches the vendor's device-ordering variable.

Reading the identity from **this** node's topology is why the work happens at fork time on the daemon: the head node holds one topology for every node that reported identical hardware, so the identities in its copy belong to whichever node reported first.

### Testing

`make check` passes (78 tests). Two unit tests are new or extended:

- `hwloc_devices` enumerates one topology under two node names and checks the assignment moved with the node — and that uuids built from the *hardware's* own identifiers (fabric GUIDs, MACs) do **not** move, since those name the card wherever it is plugged in.
- `pgpu_visible_devices` drives the whole chain against a topology whose GPUs are named by `cuda0` while the identity sits on the sibling `nvml0`, so a value only appears if it was found across the function. It hands the server that topology through the documented `topo_file` hook, which also makes `nvd`'s own NVIDIA check pass on a machine with no GPU, so the module really is selected rather than simulated.

Three topology fixtures are added: the same real machine (from open-mpi/ompi#14169) reduced to 16 PUs and read by an hwloc with and without the vendor backends, plus the existing `test-topo2` whose `AMDUUID` sits on the device that names its function — so all three arrangements are covered rather than whichever one the first fixture happened to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
