### PR TITLE
Explain the delta exchange and key deletion in the docs

### DIFF
--- a/docs/how-things-work/modex.rst
+++ b/docs/how-things-work/modex.rst
@@ -488,10 +488,11 @@ one section because the two halves are one problem: **the mechanism that
 lets a modex carry only what changed is the same mechanism that lets a key
 be deleted**, and neither can be built without the other.
 
-The exchange half is implemented — the commit delta, the server's fence
-delta behind ``pmix_server_fence_delta_modex``, and the ``shmem3``
-generation chain that makes a non-self-contained modex readable. The
-deletion half, described at the end, is not.
+Both halves are implemented — the commit delta, the server's fence delta
+behind ``pmix_server_fence_delta_modex``, the ``shmem3`` generation chain
+that makes a non-self-contained modex readable, and the ``PMIX_DEL_*``
+scopes with the propagation that carries a removal to the other clients
+of a server and, through a collecting fence, to the other nodes.
 
 Why deletion needs this
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -552,9 +553,10 @@ set of peers would contribute nothing to a later fence over a different set,
 and the servers holding only the second set's processes would never learn its
 keys — two sub-communicators fencing independently is enough to reach it.
 Each process is therefore stamped with the participant set of the fence it
-last contributed to, and a delta is sent only when the current fence's set is
-contained in that stamp. Otherwise the contribution is cumulative and the
-stamp is replaced.
+last contributed to, and a delta is sent only when the current fence's set
+matches that stamp exactly. Otherwise the contribution is cumulative and the
+stamp is replaced. Equality rather than containment is deliberate: it can
+only cost an unnecessary cumulative contribution, never a short one.
 
 Telling a delta from a full contribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -745,24 +747,6 @@ acknowledgement, so a removal reaches the other processes on the node
 *promptly* rather than *synchronously*. A reader that raced it can see
 the old value once more.
 
-The two datastores then diverge, exactly as the deletion problem always
-predicted:
-
-* ``hash`` removes the key outright and the server messages each local
-  client to do the same in its own tables.
-* ``shmem3`` writes a **tombstone** — the key with a ``PMIX_UNDEF`` value —
-  into a new segment in the chain. A lookup walking newest to oldest that
-  reaches a tombstone stops and reports the key as not found, without any
-  published segment ever being written.
-
-.. warning::
-
-   The tombstone walk has to be consulted by the **job-data** lookup, not
-   only the modex one. ``deregister_resources`` targets job-level
-   information, which lives in the job segment rather than the modex
-   segment — so a chain that covers only the modex closes none of the
-   problem this work exists to solve.
-
 An older server silently discards a scope it does not recognize rather than
 reporting an error, so a delete issued against one would appear to succeed
 and do nothing. ``PMIx_Put`` therefore checks the server's version and
@@ -788,12 +772,13 @@ Summary
   its numbering once at initialization, and for modex data by giving each
   modex segment its own key index, written by the one process that owns
   the segment.
-* Both the commit and the fence contribution are **cumulative today**. The
-  planned delta exchange keeps the cumulative path as a resync fallback,
-  marks a delta in the envelope's existing flag byte so a mixed-version job
-  fails loudly, and turns ``shmem3``'s modex generations into a chain that
-  is searched newest to oldest.
+* The commit sends only what changed; the fence contribution does too when
+  ``pmix_server_fence_delta_modex`` is set. Both keep the cumulative path
+  as a resync fallback, a delta is marked in the envelope's existing flag
+  byte so a mixed-version job fails loudly, and ``shmem3``'s modex
+  generations become a chain that is searched newest to oldest.
 * **Deleting a key is the same mechanism seen from the other side**: a
-  tombstone in a newer segment, found by that same search — which is what
-  finally lets a deregistration retract information a running job already
-  holds.
+  ``PMIX_DEL_*`` scope on ``PMIx_Put``, stated in the commit and in the
+  next collecting fence, and answered by a removal in ``hash`` and a
+  tombstone in ``shmem3`` — which is what finally lets a deregistration
+  retract information a running job already holds.

--- a/docs/man/man3/PMIx_Commit.3.rst
+++ b/docs/man/man3/PMIx_Commit.3.rst
@@ -41,14 +41,33 @@ A PMIx implementation may locally cache non-reserved keys in the client library
 until they are committed. ``PMIx_Commit`` initiates the operation of making those
 staged key-value pairs available; depending on the implementation, this may
 involve transmitting the entire collection of data posted by the process to the
-local PMIx server. ``PMIx_Commit`` is an asynchronous operation: it returns to the
-caller immediately while the data is staged to the server in the background.
+local PMIx server. In this implementation the call returns once the local server
+has received and acknowledged the data |mdash| which is not the same as the data
+being available to peers, as the note below explains.
 
-This implementation ordinarily transmits only what has been posted since the
-previous ``PMIx_Commit``, falling back to the entire collection where that is
-not sufficient. Either way the effect on the caller is the same, and a key
-posted more than once between two commits is transmitted once, carrying the
-value it had when ``PMIx_Commit`` was called.
+**Only what changed is sent.** This implementation ordinarily transmits just
+what has been posted since the previous ``PMIx_Commit``, falling back to the
+entire collection where that is not sufficient |mdash| for instance when a
+qualified value is involved (it is stored under the reserved
+``PMIX_QUALIFIED_VALUE`` key, so there is no key to ask for it back by), or on
+the first commit made to a server that has not seen anything this process
+published, such as after a tool repoints at another server. Either way the effect on the caller is the
+same, and a key posted more than once between two commits is transmitted once,
+carrying the value it had when ``PMIx_Commit`` was called. The saving matters
+because the older behavior re-sent everything published so far on every call,
+so *n* put/commit cycles moved O(*n*\ :sup:`2`) bytes.
+
+**Deletions are carried too.** A key removed by one of the ``PMIX_DEL_*``
+scopes of :ref:`PMIx_Put(3) <man3-PMIx_Put>` cannot simply be left out of the
+next transmission |mdash| the server accumulates what it is sent, so omitting a
+key removes nothing. The removals requested since the previous commit are
+therefore stated explicitly, and are applied by the server ahead of the values
+sent with them; see the discussion of ordering in
+:ref:`PMIx_Put(3) <man3-PMIx_Put>`. A commit that carries a removal sends the
+full collection rather than a delta, since the record a delta is built from
+names keys to be fetched back and a deleted key is precisely the one that will
+not be found. Passing the removal on to the *other nodes* is the collecting
+:ref:`PMIx_Fence(3) <man3-PMIx_Fence>`'s business, not the commit's.
 
 .. note::
    Users are advised to always include the call to ``PMIx_Commit`` in case the
@@ -95,4 +114,5 @@ the peers issue :ref:`PMIx_Get(3) <man3-PMIx_Get>`.
    :ref:`PMIx_Put(3) <man3-PMIx_Put>`,
    :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
    :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
-   :ref:`pmix_status_t(5) <man5-pmix_status_t>`
+   :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
+   :doc:`Modex: Exchanging Process Data </how-things-work/modex>`

--- a/docs/man/man3/PMIx_Fence.3.rst
+++ b/docs/man/man3/PMIx_Fence.3.rst
@@ -99,6 +99,40 @@ locally available to each participant at the end of the operation. Collected dat
 is cached at the server to reduce memory footprint and is retrieved as needed via
 :ref:`PMIx_Get(3) <man3-PMIx_Get>`.
 
+**What a collecting fence carries.** Each PMIx server contributes, on behalf
+of each of its local participants, the data that process staged with
+:ref:`PMIx_Put(3) <man3-PMIx_Put>` and committed with
+:ref:`PMIx_Commit(3) <man3-PMIx_Commit>`. That contribution is *cumulative* by
+default: everything the process has published so far is sent on every
+collecting fence, so a job that fences repeatedly re-sends the same data each
+time. Setting the ``pmix_server_fence_delta_modex`` MCA parameter (see
+`MCA PARAMETERS`_) instead has each server send only what its processes have
+committed since they last took part in a collecting fence.
+
+The delta changes only what is put on the wire, not what a participant can
+retrieve afterwards: the servers keep what earlier fences delivered, and a
+contribution reverts to the full published set whenever a delta could not
+express it |mdash| in particular when the participants of this fence are not
+exactly the set the process last contributed to (two sub-communicators fencing
+independently, for example), when a local participant has not yet taken part in
+a collecting fence, or when data was published on that process's behalf by some
+path other than a commit, such as
+:ref:`PMIx_server_register_resources(3) <man3-PMIx_server_register_resources>`
+or a group collective.
+
+A fence that does not collect data exchanges nothing, and therefore does not
+move that boundary: whatever is owed is still carried by the next collecting
+fence.
+
+**Deletions travel with a collecting fence.** A key removed with one of the
+``PMIX_DEL_*`` scopes of :ref:`PMIx_Put(3) <man3-PMIx_Put>` cannot be retracted
+from a remote node by simply omitting it |mdash| the exchange is additive, so a
+contribution that stops naming a key removes nothing at the far end. The
+removal is therefore stated explicitly in the next collecting fence, and
+processes on other nodes stop seeing the key once that fence completes.
+Processes on the deleting process's own node are corrected when the deletion is
+committed and do not wait for a fence.
+
 ``PMIx_Fence`` and ``PMIx_Fence_nb`` are *collective* operations. The PMIx server
 library aggregates the participation of its local clients, passing a single request
 to the host environment once all local participants have called the API; the host
@@ -135,6 +169,31 @@ depend on the implementation and host environment.
    and should not be used in new code.
 
 
+MCA PARAMETERS
+--------------
+
+The following MCA parameter influences the behavior of a collecting
+``PMIx_Fence``. It is read by the PMIx **server** library, so it must be set in
+the environment of the servers (e.g.,
+``PMIX_MCA_pmix_server_fence_delta_modex=1``) and not in that of the
+application processes. The complete, authoritative list of parameters (with
+current values) can be displayed with ``pmix_info``.
+
+* ``pmix_server_fence_delta_modex=<true|false>`` (default: ``false``). When
+  ``true``, a server contributes only the data its processes have committed
+  since they last took part in a collecting fence, rather than everything they
+  have published. See the description above for the cases that fall back to the
+  full set regardless.
+
+.. caution::
+   Every node in the job must be running a PMIx release that understands a
+   delta contribution before this is enabled. A server that does not understand
+   one rejects the entire collective rather than storing a contribution it
+   cannot interpret, so a job whose nodes run mixed releases fails the fence
+   with ``PMIX_ERR_BAD_PARAM`` |mdash| loudly, on both sides, rather than
+   silently losing keys. That is why the parameter defaults to ``false``.
+
+
 RETURN VALUE
 ------------
 
@@ -150,7 +209,9 @@ accepted for processing and the final status will be delivered to ``cbfunc``.
 * ``PMIX_ERR_NOT_A_MEMBER`` |mdash| the calling process is not among the named
   participants.
 * ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied (e.g., a ``NULL``
-  ``procs`` array with a non-zero ``nprocs``).
+  ``procs`` array with a non-zero ``nprocs``), or the servers contributing to a
+  collecting fence did not agree on the kind of contribution they sent |mdash|
+  see `MCA PARAMETERS`_.
 * ``PMIX_ERR_UNREACH`` |mdash| the local PMIx server could not be reached.
 * ``PMIX_ERR_NOT_AVAILABLE`` |mdash| the operation cannot be serviced because the
   library's progress engine has been stopped.
@@ -186,4 +247,5 @@ constants are defined in ``pmix_common.h``.
    :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
    :ref:`pmix_status_t(5) <man5-pmix_status_t>`,
-   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`,
+   :doc:`Modex: Exchanging Process Data </how-things-work/modex>`

--- a/docs/man/man3/PMIx_Get.3.rst
+++ b/docs/man/man3/PMIx_Get.3.rst
@@ -313,7 +313,9 @@ returned in the manner requested. For the non-blocking form, a return of
 final status and value are delivered to ``cbfunc``.
 
 * ``PMIX_SUCCESS`` |mdash| the requested data has been returned.
-* ``PMIX_ERR_NOT_FOUND`` |mdash| the requested data was not available.
+* ``PMIX_ERR_NOT_FOUND`` |mdash| the requested data was not available. This
+  includes a key that *was* available earlier and has since been deleted
+  |mdash| see `NOTES`_.
 * ``PMIX_ERR_EXISTS_OUTSIDE_SCOPE`` |mdash| the requested key exists, but was
   posted in a scope that does not include the requester.
 * ``PMIX_ERR_BAD_PARAM`` |mdash| an invalid argument was supplied |mdash| for
@@ -343,6 +345,27 @@ typically via a :ref:`PMIx_Fence(3) <man3-PMIx_Fence>` |mdash| unless the
 desired qualifiers in the ``info`` array to select among the values stored under
 that key. ``PMIx_Get`` returns the primary value of the matching entry; the
 qualifiers themselves are used only for matching and are not returned.
+
+**A key that was there can go away.** Published data used only to
+accumulate, so a key that was once retrievable stayed retrievable. That is no
+longer true: a process can retract one of its own keys with the ``PMIX_DEL_*``
+scopes of :ref:`PMIx_Put(3) <man3-PMIx_Put>`, and a host environment can
+retract job-level information it registered with
+:ref:`PMIx_server_deregister_resources(3) <man3-PMIx_server_deregister_resources>`.
+A call that succeeded for a key can therefore return ``PMIX_ERR_NOT_FOUND``
+later in the same job, and callers that cannot tolerate that must be prepared
+for it.
+
+The removal reaches this process as a notification from its local PMIx server,
+which drops the cached copy the caller was given. For a key belonging to a
+process on another node it arrives with the collecting
+:ref:`PMIx_Fence(3) <man3-PMIx_Fence>` that carries the removal. The
+notification is one-way and unacknowledged, so it arrives promptly rather than
+synchronously: a ``PMIx_Get`` that races it can return the old value once more.
+Once it has landed, a request for the key behaves exactly like one for a key
+that was never published |mdash| for a non-reserved key that means the call
+blocks until someone publishes it, unless ``PMIX_OPTIONAL`` or
+``PMIX_IMMEDIATE`` bounds the search.
 
 **Values from another process are cached, and a later exchange does not
 refresh them.** Once a process's data has been retrieved, subsequent calls for
@@ -374,6 +397,7 @@ updates the caller's whole view of that process.
    :ref:`PMIx_Put(3) <man3-PMIx_Put>`,
    :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`,
    :ref:`PMIx_Fence(3) <man3-PMIx_Fence>`,
+   :ref:`PMIx_server_deregister_resources(3) <man3-PMIx_server_deregister_resources>`,
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
    :ref:`pmix_value_t(5) <man5-pmix_value_t>`,
    :ref:`pmix_status_t(5) <man5-pmix_status_t>`,

--- a/docs/man/man3/PMIx_Put.3.rst
+++ b/docs/man/man3/PMIx_Put.3.rst
@@ -137,6 +137,22 @@ by itself invalidate it. Such a peer must ask for the update with
 ``PMIX_GET_REFRESH_CACHE`` |mdash| see
 :ref:`PMIx_Get(3) <man3-PMIx_Get>`.
 
+**Deleting a key.** The removal requested by a ``PMIX_DEL_*`` scope is applied
+to the calling process at once. The local PMIx server, and every other client
+of that server that had already been handed the key, are corrected when the
+removal is committed with :ref:`PMIx_Commit(3) <man3-PMIx_Commit>`; the server
+tells them with a one-way notification that carries no acknowledgement, so
+that correction arrives promptly rather than synchronously and a peer that
+races it can see the old value once more. Processes on *other* nodes stop
+seeing the key at the next collecting
+:ref:`PMIx_Fence(3) <man3-PMIx_Fence>` |mdash| the exchange is additive, so the
+removal has to be stated there, and a barrier-only fence does not carry it.
+
+Within a single commit interval the server applies the removals before the
+values published alongside them, so a key that is deleted and then posted
+again before the next ``PMIx_Commit`` ends up **present**, while one that is
+posted and then deleted ends up **absent**.
+
 **Qualified values.** A value may be posted together with one or more qualifiers
 that scope its later retrieval by using the reserved key
 ``PMIX_QUALIFIED_VALUE``. In that case ``val`` must be a ``pmix_value_t`` of type

--- a/docs/man/man3/PMIx_server_deregister_resources.3.rst
+++ b/docs/man/man3/PMIx_server_deregister_resources.3.rst
@@ -156,13 +156,30 @@ its normal finalize operations. Deregistration is needed only when the host
 environment determines that client processes should no longer have access to the
 information.
 
-.. important:: Deregistration takes effect for namespaces registered
-               **after** the call. Non-namespace resource information is copied
-               into a namespace's data store when that namespace is registered,
-               so a namespace already registered |mdash| and any client already
-               running under it |mdash| retains the information. A host that
-               needs the data withheld from a running job cannot achieve that
-               with this call alone.
+.. important:: Deregistration reaches the namespaces this server has
+               **already** registered, not only those registered after the
+               call. Non-namespace resource information is copied into a
+               namespace's data store when that namespace is registered, so
+               removing an entry from the server's cache also takes the key
+               back from every namespace holding a copy of it, and the server
+               tells its local clients to drop the copies they were handed. A
+               subsequent :ref:`PMIx_Get(3) <man3-PMIx_Get>` for that key
+               therefore returns ``PMIX_ERR_NOT_FOUND`` where it previously
+               returned the value. The notification to the clients carries no
+               acknowledgement, so it reaches them promptly rather than
+               synchronously: a client that races it can read the old value
+               once more.
+
+               This governs the information held by **this** server and its
+               clients. A host that wants the data withdrawn across the job
+               makes the call on every server holding it.
+
+One case is deliberately excluded from that retraction: a *qualified* request
+that prunes elements out of an entry rather than removing the entry outright.
+There the host has asked for part of a value to go, so the correct propagation
+is the pruned value, not a deletion |mdash| pushing a removal would take more
+away from a running namespace than was asked for. A pruning therefore still
+governs only the namespaces registered **after** the call.
 
 
 .. include:: /man/no-blocking-in-progress-thread.rst
@@ -172,5 +189,6 @@ information.
    :ref:`PMIx_server_init(3) <man3-PMIx_server_init>`,
    :ref:`PMIx_server_register_resources(3) <man3-PMIx_server_register_resources>`,
    :ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`,
+   :ref:`PMIx_Get(3) <man3-PMIx_Get>`,
    :ref:`pmix_info_t(5) <man5-pmix_info_t>`,
    :ref:`pmix_status_t(5) <man5-pmix_status_t>`


### PR DESCRIPTION
The delta commit/fence work and the `PMIX_DEL_*` scopes changed behavior
that applications and host environments can see, but only `PMIx_Put` and
`PMIx_Commit` picked up the documentation as those pieces landed.

**Man pages**

- `PMIx_Fence` said nothing about either, though the fence is where a
  delta actually saves wire traffic and where a removal reaches the other
  nodes. It now describes what a collecting fence carries (cumulative by
  default, delta under `pmix_server_fence_delta_modex`, and the cases that
  fall back to the full set regardless), gains an MCA PARAMETERS section
  saying why that parameter defaults off, and states that a deletion is
  announced in the fence because the exchange is additive.
- `PMIx_Get` now documents that published data no longer only
  accumulates: a call that succeeded for a key can later return
  `PMIX_ERR_NOT_FOUND`, how the removal arrives, and what a caller can
  see while one is in flight.
- `PMIx_server_deregister_resources` no longer tells the host it cannot
  withdraw data from a running job - it now reaches the namespaces
  already registered and their clients. The one exclusion, a qualified
  request that prunes an entry rather than removing it, is called out.

Two smaller corrections on the pages already touched: `PMIx_Commit` does
not return before the server has acknowledged, and the fallback to a
cumulative commit is not driven by a failed send.

**Design document**

`docs/how-things-work/modex.rst` kept its forward-looking phrasing after
the deletion half landed: it announced deletion as unimplemented,
described the design's shmem3 answer rather than the one built, and
summarized both contributions as cumulative. Also corrects the
participant-set rule - the code requires an exact match to the stamp, not
containment.

Documentation only; the docs build is warning-free with `-W`.