### PR TITLE
Install the missing PMIx_server_IOF_flow_control man page

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -363,6 +363,7 @@ PMIX_MAN3 = \
 	PMIx_server_deliver_inventory.3 \
 	PMIx_server_collect_job_info.3 \
 	PMIx_server_IOF_deliver.3 \
+	PMIx_server_IOF_flow_control.3 \
 	PMIx_server_generate_cpuset.3 \
 	PMIx_server_generate_cpuset_string.3 \
 	PMIx_server_generate_locality_string.3 \

--- a/docs/how-things-work/regex.rst
+++ b/docs/how-things-work/regex.rst
@@ -91,10 +91,24 @@ Declared in ``include/pmix_deprecated.h``::
     pmix_status_t PMIx_generate_ppn(const char *input, char **ppn);
 
 These return the encoded form as a plain ``char *`` and use the
-deprecated ``PMIX_REGEX`` data type (value ``49``). They remain because
-production launchers built against older releases still call them, and
-because the per-node process map is still carried internally in the string
-form. New code should prefer ``PMIx_generate_regex2``.
+deprecated ``PMIX_REGEX`` data type (value ``49``). They remain purely for
+backward compatibility: production launchers built against older releases
+still call them, and still register namespaces with ``PMIX_REGEX``-typed
+node and process maps, so both the symbols and the parsing path have to
+stay.
+
+New code should use ``PMIx_generate_regex2`` for **both** maps.
+``PMIx_generate_ppn`` has no successor of its own because it never needed
+one — the encoding is agnostic to what the values represent, so passing
+the process-map string (``"0,1,2;3,4,5"``: nodes delimited by ``;``, the
+ranks on each node by ``,``) to ``PMIx_generate_regex2`` produces a
+``pmix_regex2_t`` that is loaded as the ``PMIX_PROC_MAP`` value exactly as
+the node list is loaded as ``PMIX_NODE_MAP``. The two paths do not
+necessarily pick the same scheme — the legacy generators are
+first-success in descending priority, while the regex2 path is
+smallest-wins among the components that implement it (``native`` does not)
+— but that is invisible to the consumer, because every encoding tags
+itself with the scheme that produced it.
 
 All four entry points are thin wrappers in ``src/server/pmix_server_setup.c``
 that check ``pmix_globals.initialized`` and forward to the corresponding

--- a/docs/how-things-work/regex.rst
+++ b/docs/how-things-work/regex.rst
@@ -251,6 +251,20 @@ outrank ``native``, the *legacy* generate path is claimed by ``compress``
 shadowed in a default build. ``native`` still serves as the **parser** of
 the ``pmix[...]`` format, which external launchers produce.
 
+In other words, ``native`` only *generates* anything if the higher-priority
+components are kept out of the running, which in practice means asking for
+it explicitly with the framework's component-selection parameter::
+
+    PMIX_MCA_preg=native            # open only native
+    PMIX_MCA_preg=^compress         # open everything except compress
+
+Be aware of what the first form costs: with ``native`` the only active
+component, ``PMIx_generate_regex2`` has no implementer at all
+(``native.generate_regex`` is ``NULL``), so the smallest-wins stub finds no
+candidate and the call fails with ``PMIX_ERR_NOT_SUPPORTED``. Restricting
+the framework to ``native`` is therefore a debugging aid for the
+``pmix[...]`` encoding, not a supported production configuration.
+
 
 ``preg`` Components
 -------------------

--- a/docs/man/man3/PMIx_generate_regex2.3.rst
+++ b/docs/man/man3/PMIx_generate_regex2.3.rst
@@ -79,6 +79,17 @@ encoding is implementation specific; the leading colon-delimited ``type``
 string (e.g., ``"pmix"``, ``"raw"``, or ``"blob"``) identifies the method
 used so that a decoder can select the correct expansion algorithm.
 
+``PMIx_generate_regex2`` also replaces the deprecated
+``PMIx_generate_ppn``, which encoded the per-node process map |mdash| a
+semicolon-delimited list of nodes, each holding a comma-delimited list of
+the ranks on that node (e.g., ``"0,1,2;3,4,5"``). No separate API is
+required for that case: the encoding is agnostic to what the values
+represent, so the same call is used for both maps. Pass the process-map
+string as ``input`` and hand the resulting ``pmix_regex2_t`` to
+:ref:`PMIx_server_register_nspace(3) <man3-PMIx_server_register_nspace>`
+as the ``PMIX_PROC_MAP`` value with type ``PMIX_REGEX2``, just as the node
+list is passed as ``PMIX_NODE_MAP``.
+
 The operation is performed synchronously in the caller's thread; it does
 not thread-shift into the PMIx progress engine and does not invoke a
 callback.


### PR DESCRIPTION
`PMIx_server_IOF_flow_control` had a man page written and added to the
section 3 index when the API landed, so it renders in the HTML docs — but
it was never added to `PMIX_MAN3` in `docs/Makefile.am`. Since `docs/conf.py`
discovers page sources by walking `man/`, Sphinx was generating the nroff
page all along and then throwing it away: `PMIX_MAN3` only drives
`man3_MANS`, i.e. install/uninstall. `man PMIx_server_IOF_flow_control`
found nothing.

It was the only one of the 280 section 3 page sources missing from that
list. I checked the whole surface while I was there: all 305 `PMIX_EXPORT`
declarations in `pmix.h`, `pmix_server.h`, and `pmix_tool.h` are covered,
the 25 `*_nb` variants are all documented on their blocking counterpart's
page, and `PMIX_MAN3_NB_ALIASES` matches that set exactly.

Two follow-on doc fixes came out of the same pass:

* `PMIx_generate_ppn` was the one deprecated API mentioned on no man page
  at all — `PMIx_generate_regex` and `PMIx_tool_connect_to_server` are
  each described on their successor's page, but `generate_ppn` has no
  successor of its own. It is now covered on the `PMIx_generate_regex2`
  page, including the shape of the process-map string and how to pass the
  result as `PMIX_PROC_MAP`. Verified against `gds_utils.c:parse_map()`
  that `PMIX_PROC_MAP` really does accept a `PMIX_REGEX2` value.

* `docs/how-things-work/regex.rst` said the deprecated generators survive
  partly "because the per-node process map is still carried internally in
  the string form". That is not the reason — a process map travels as a
  `PMIX_REGEX2` just as happily as a node map does. They remain for
  backward compatibility alone. Corrected, and the page now says how one
  would actually reach the `native` generator and what that costs.

Verification: `sphinx-build -W` clean for both the `man` and `html`
targets.