### PR TITLE
Describe the spawn tree in a job-end notification

### DIFF
--- a/contrib/dictionary_ids.txt
+++ b/contrib/dictionary_ids.txt
@@ -690,3 +690,5 @@ pmix.pthrdnm           659   PMIX_PROGRESS_THREAD_NAME
 pmix.qry.supqual       660   PMIX_QUERY_SUPPORTED_QUALIFIERS
 pmix.jctrl.ckpttime    661   PMIX_JOB_CTRL_CHECKPOINT_TIMEOUT
 pmix.fabdev.coord      662   PMIX_FABRIC_DEVICE_COORDINATES
+pmix.spwn.root         663   PMIX_SPAWN_TREE_ROOT
+pmix.spwn.actv         664   PMIX_SPAWN_TREE_ACTIVE

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -336,6 +336,23 @@ Completion and termination notification:
   :ref:`PMIx_Notify_event(3) <man3-PMIx_Notify_event>` for the notification-side
   description of this attribute.
 
+A spawned job outlives the job that spawned it, so a tool watching a job it
+launched cannot tell from that job's ``PMIX_EVENT_JOB_END`` whether anything it
+spawned is still running |mdash| nor, when some later job ends, whether that job
+was one of its descendants or somebody else's work sharing the same session.
+Host environments are therefore encouraged to describe the *spawn tree* in each
+``PMIX_EVENT_JOB_END`` notification:
+
+* ``PMIX_SPAWN_TREE_ROOT`` (char*) |mdash| namespace of the process or tool from
+  which the terminating job descends by one or more spawns. A job nobody spawned
+  is the root of its own tree and so names itself. Two jobs carrying the same
+  value belong to the same tree.
+* ``PMIX_SPAWN_TREE_ACTIVE`` (uint32_t) |mdash| number of jobs in that tree which
+  have yet to terminate, not counting the one being reported. Because a job can
+  only be spawned by a process that is still running, a value of zero means the
+  reported job is the last of its tree and no further job can join it |mdash|
+  which is what lets a launcher know it has seen everything it started.
+
 Output forwarding:
 
 These attributes control which of the spawned job's streams are forwarded and how

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -362,6 +362,15 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_PARENT_ID                      "pmix.parent"           // (pmix_proc_t*) identifier of the process that called PMIx_Spawn
                                                                     //                to launch this proc's application
 #define PMIX_EXIT_CODE                      "pmix.exit.code"        // (int) exit code returned when proc terminated
+#define PMIX_SPAWN_TREE_ROOT                "pmix.spwn.root"        // (char*) namespace of the process or tool from which the specified
+                                                                    //         job descends by one or more calls to PMIx_Spawn - i.e., the
+                                                                    //         root of the spawn tree it belongs to. A job nobody spawned
+                                                                    //         is the root of its own tree, and so names itself.
+#define PMIX_SPAWN_TREE_ACTIVE              "pmix.spwn.actv"        // (uint32_t) number of jobs in the spawn tree named by
+                                                                    //            PMIX_SPAWN_TREE_ROOT that have yet to terminate, not
+                                                                    //            counting the job whose termination is being reported.
+                                                                    //            Zero means the reported job is the last of that tree,
+                                                                    //            and therefore that no further job can be spawned into it.
 
 /* size info */
 #define PMIX_UNIV_SIZE                      "pmix.univ.size"        // (uint32_t) #slots in this session


### PR DESCRIPTION
### The problem

A tool that launches a job and watches for its `PMIX_EVENT_JOB_END` learns nothing about what that job spawned. A spawned job outlives the job that spawned it by default, so the parent's termination is not the end of the work the tool started — and when some later job's `JOB_END` arrives, the notification carries no way to tell whether that job descended from the tool or belongs to somebody else sharing the same session.

Two questions a launcher needs answered, and neither is answerable today:

* **Is this one of mine?** On a shared, persistent server every job end looks alike.
* **Am I done?** A tool is told when a job *ends*, never when one *starts*, so at the moment its own job ends it cannot know whether anything it started is still running.

The practical consequence is openpmix/prrte#2682: `prterun`, which runs its own server and shuts it down only once every job has terminated, waits for the whole spawn tree and reports its status; `prun`, driving a persistent DVM, could do neither — it abandoned the spawned job's output and exit status the moment the parent finished.

### The change

Two informational attributes, provided by the host with each `PMIX_EVENT_JOB_END`:

* `PMIX_SPAWN_TREE_ROOT` (char*) — namespace of the process or tool the terminating job descends from by one or more spawns. A job nobody spawned is the root of its own tree and so names itself; two jobs in one tree carry the same value, which lets a tool recognize its own descendants with a string compare against a namespace it already holds.
* `PMIX_SPAWN_TREE_ACTIVE` (uint32_t) — how many jobs in that tree have yet to terminate, not counting the one being reported.

A count rather than a flag, because it is no harder for the host to produce and it lets a tool report progress. Zero is the terminal condition, and it is sound rather than merely likely: a job can only be spawned by a process that is still running, so a tree with no live job left cannot acquire one.

Nothing requests these — they are informational, and a host that does not supply them leaves a tool exactly where it is today. Both are documented on `PMIx_Spawn(3)` beside the completion-notification directives, which is where a reader looking for what happens when a spawned job ends will be.

### Testing

`make check` clean; docs build warning-free; the attributes carry dictionary ids 663/664 (`make update-dictionary`). Exercised end to end by the PRRTE side, on a single host and across a ten-node container swarm.

Consumed by openpmix/prrte#2685.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

