### PR TITLE
Actually drive the psensor monitors, and tear them down safely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,6 +240,9 @@ test/simple/simpjctrl
 test/simple/simpmonitor
 test/simple/simpio
 test/simple/data-*
+# left behind only if simpmonitor is killed before it unlinks its
+# file-monitor target
+test/simple/simpmon-*.watch
 test/simple/simpcoord
 test/python/run_bindings.sh
 test/python/run_sched.sh

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -89,6 +89,14 @@ each time somebody asks.
           ``psensor_base_use_separate_thread`` set, so the configuration
           that was silently dead is exercised by ``make check``.
 
+          The entry that replaced it below was **corrected the same day**.
+          It first recorded the unexpected-message ``show_help`` as a
+          beat arriving at a server with no posted recv; tracing the tag
+          showed the opposite -- the server matches it on its wildcard
+          recv and answers with an error the *client* cannot place.  The
+          diagnostic is fixed; the mis-delivery behind it is what stays
+          open.
+
 Review coverage
 ---------------
 
@@ -263,30 +271,36 @@ cover the whole of what the entry described.
   the only answer an application can act on.  Recorded here because it is
   the one behavior change in that group of fixes.
 
-A heartbeat with no monitor armed looks like a protocol error
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+An early heartbeat is delivered to the command switchyard
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``psensor/heartbeat`` posts the ``PMIX_PTL_TAG_HEARTBEAT`` receive
-lazily -- on the first ``start`` that claims a heartbeat monitor -- so a
-beat that arrives before any monitor has been armed finds no posted recv.
-The ``ptl`` base then prints its unexpected-message ``show_help``, which
-names the peer and the tag and asks the user to *report this error to
-the PMIx developers*.
+lazily -- on the first ``start`` that claims a heartbeat monitor.  A beat
+that arrives before that therefore finds no posted recv of its own, and
+on a *server* that does not mean it is dropped: the server holds a
+wildcard (``UINT_MAX``) recv for the command switchyard, which matches
+anything, so the beat is handed to ``server_switchyard`` as though it
+were a client command.  The switchyard cannot read a command out of a
+zero-byte buffer, fails, and queues its error status back to the client
+on tag 1 -- where nothing is waiting, because ``PMIx_Heartbeat()`` is
+one-way by construction and no client ever posts for that tag.
 
-Nothing is wrong.  ``PMIx_Heartbeat()`` is a client-side call that a
-process may legitimately make before -- or after -- its server holds a
-monitor for it, and the beat is correctly ignored either way; only the
-diagnostic is wrong.  ``test/unit/run_monitor.pl`` reproduces it on every
-run, because the observer rank sends its one test beat before the
-monitored rank has asked to be watched.
+Nothing is corrupted, and ``test/unit/run_monitor.pl`` reproduces it on
+every run: its observer rank sends its one test beat before the
+monitored rank has asked to be watched.  What used to make it look
+alarming -- the ``ptl`` base reporting the discarded reply with a
+``show_help`` that asked the user to report a bug to the PMIx
+developers -- is gone; that path is now a framework trace at verbosity
+2.
 
-The fix is a judgement call rather than a repair, which is why it is
-recorded rather than made.  Either the heartbeat tag stops being a
-lazily-posted recv (post it when the framework opens, and drop a beat
-that matches no tracker), or the ``ptl`` base learns that this one tag is
-allowed to arrive unclaimed.  The first spends a posted recv in every
-server that never monitors anything; the second puts component knowledge
-in the transport.
+The remaining defect is the mis-delivery itself, and the fix for it is a
+judgement call rather than a repair, which is why it is recorded here.
+Either the heartbeat tag stops being a lazily-posted recv -- post it when
+the framework opens, and drop a beat that matches no tracker -- or the
+switchyard learns to recognize the reserved tags that are not commands.
+The first spends a posted recv in every server that never monitors
+anything; the second puts component knowledge in the server's command
+dispatch.
 
 Coverage gaps
 -------------

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -89,13 +89,25 @@ each time somebody asks.
           ``psensor_base_use_separate_thread`` set, so the configuration
           that was silently dead is exercised by ``make check``.
 
-          The entry that replaced it below was **corrected the same day**.
-          It first recorded the unexpected-message ``show_help`` as a
-          beat arriving at a server with no posted recv; tracing the tag
-          showed the opposite -- the server matches it on its wildcard
-          recv and answers with an error the *client* cannot place.  The
-          diagnostic is fixed; the mis-delivery behind it is what stays
-          open.
+          A second entry was opened, corrected and closed the same day,
+          and the shape of the mistake is worth keeping.  The
+          unexpected-message ``show_help`` that ``run_monitor.pl``
+          printed on every run was first written down as a heartbeat
+          arriving at a server with no posted recv -- plausible, since
+          ``psensor/heartbeat`` really does post that recv lazily, and
+          wrong.  Tracing the tag showed the opposite: the server *does*
+          match the beat, on the wildcard recv the command switchyard
+          serves, and answers it with the error the switchyard gets for
+          trying to read a command out of a zero-byte buffer -- and it is
+          the *client* that then cannot place the reply, because
+          ``PMIx_Heartbeat`` is one-way and nobody posts for tag 1.  Both
+          halves are now fixed: ``pmix_server_message_handler`` drops
+          ``PMIX_PTL_TAG_HEARTBEAT`` instead of dispatching it, and an
+          unmatched message is a framework trace rather than a
+          ``show_help`` asking the user to report a bug.  The lesson is
+          the one this page keeps relearning -- an entry written from a
+          plausible reading of the code, rather than from watching it
+          run, is a lead and not a finding.
 
 Review coverage
 ---------------
@@ -270,37 +282,6 @@ cover the whole of what the entry described.
   ``refcb()`` entry in ``src/client/AGENTS.md`` for why all-or-nothing is
   the only answer an application can act on.  Recorded here because it is
   the one behavior change in that group of fixes.
-
-An early heartbeat is delivered to the command switchyard
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``psensor/heartbeat`` posts the ``PMIX_PTL_TAG_HEARTBEAT`` receive
-lazily -- on the first ``start`` that claims a heartbeat monitor.  A beat
-that arrives before that therefore finds no posted recv of its own, and
-on a *server* that does not mean it is dropped: the server holds a
-wildcard (``UINT_MAX``) recv for the command switchyard, which matches
-anything, so the beat is handed to ``server_switchyard`` as though it
-were a client command.  The switchyard cannot read a command out of a
-zero-byte buffer, fails, and queues its error status back to the client
-on tag 1 -- where nothing is waiting, because ``PMIx_Heartbeat()`` is
-one-way by construction and no client ever posts for that tag.
-
-Nothing is corrupted, and ``test/unit/run_monitor.pl`` reproduces it on
-every run: its observer rank sends its one test beat before the
-monitored rank has asked to be watched.  What used to make it look
-alarming -- the ``ptl`` base reporting the discarded reply with a
-``show_help`` that asked the user to report a bug to the PMIx
-developers -- is gone; that path is now a framework trace at verbosity
-2.
-
-The remaining defect is the mis-delivery itself, and the fix for it is a
-judgement call rather than a repair, which is why it is recorded here.
-Either the heartbeat tag stops being a lazily-posted recv -- post it when
-the framework opens, and drop a beat that matches no tracker -- or the
-switchyard learns to recognize the reserved tags that are not commands.
-The first spends a posted recv in every server that never monitors
-anything; the second puts component knowledge in the server's command
-dispatch.
 
 Coverage gaps
 -------------

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -74,6 +74,21 @@ each time somebody asks.
           has no answer at that moment, when the question that does have
           one is "does this output have to be formatted yet".
 
+.. note:: **2026-08-18.**  The ``psensor`` progress-thread entry that
+          stood under "Deferred work" is closed.  Both halves it called
+          for were made together: ``pmix_psensor_base_open`` now starts
+          the ``"PSENSOR"`` thread it creates, and
+          ``pmix_psensor_base_close`` pauses that thread before anything
+          is torn down and stops it only after the components -- which
+          own the trackers, and therefore the timers armed on the base --
+          have closed.  Both components' samplers were moved to
+          ``EV_PERSIST`` timers they no longer re-arm, for the reason
+          spelled out in ``src/mca/pstat/AGENTS.md``.
+          ``test/unit/run_monitor.pl`` now runs its heartbeat *and* file
+          scenario twice, once with
+          ``psensor_base_use_separate_thread`` set, so the configuration
+          that was silently dead is exercised by ``make check``.
+
 Review coverage
 ---------------
 
@@ -248,27 +263,30 @@ cover the whole of what the entry described.
   the only answer an application can act on.  Recorded here because it is
   the one behavior change in that group of fixes.
 
-``psensor`` never starts its own progress thread
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+A heartbeat with no monitor armed looks like a protocol error
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``pmix_psensor_base_open`` creates the ``"PSENSOR"`` event base with
-``pmix_progress_thread_init()`` and never calls
-``pmix_progress_thread_start()``, so with
-``psensor_base_use_separate_thread`` set the base exists and nothing
-drives it: trackers arm their timers and no heartbeat or monitor ever
-fires.  This is the same defect that was fixed for ``pstat`` in
-``pmix_pstat_base_open``, found while fixing it there.
+``psensor/heartbeat`` posts the ``PMIX_PTL_TAG_HEARTBEAT`` receive
+lazily -- on the first ``start`` that claims a heartbeat monitor -- so a
+beat that arrives before any monitor has been armed finds no posted recv.
+The ``ptl`` base then prints its unexpected-message ``show_help``, which
+names the peer and the tag and asks the user to *report this error to
+the PMIx developers*.
 
-It is deliberately **not** a one-line copy of that fix.
-``pmix_psensor_base_close`` destructs ``pmix_psensor_base.actives`` and
-then calls ``pmix_progress_thread_stop("PSENSOR")``, with no
-``pmix_progress_thread_pause()`` in between -- which is safe only for as
-long as the thread does not actually run.  Starting the thread without
-also correcting the teardown would introduce a destruct racing a live
-timer callback, which is precisely the class of bug the ``pstat`` change
-closed.  ``psensor`` needs the pair looked at together, and the arming
-discipline described under "Releasing an op from another thread" in
-``src/mca/pstat/AGENTS.md`` applies to its trackers as well.
+Nothing is wrong.  ``PMIx_Heartbeat()`` is a client-side call that a
+process may legitimately make before -- or after -- its server holds a
+monitor for it, and the beat is correctly ignored either way; only the
+diagnostic is wrong.  ``test/unit/run_monitor.pl`` reproduces it on every
+run, because the observer rank sends its one test beat before the
+monitored rank has asked to be watched.
+
+The fix is a judgement call rather than a repair, which is why it is
+recorded rather than made.  Either the heartbeat tag stops being a
+lazily-posted recv (post it when the framework opens, and drop a beat
+that matches no tracker), or the ``ptl`` base learns that this one tag is
+allowed to arrive unclaimed.  The first spends a posted recv in every
+server that never monitors anything; the second puts component knowledge
+in the transport.
 
 Coverage gaps
 -------------

--- a/src/mca/psensor/AGENTS.md
+++ b/src/mca/psensor/AGENTS.md
@@ -23,9 +23,10 @@ its own `AGENTS.md` with component-specific detail.
 
 There is no `docs/how-things-work/psensor.rst`; the closest companion
 reading is the sibling [`pstat`](../pstat/AGENTS.md) framework, which
-implements the *resource-usage* side of the `PMIx_Process_monitor` family
-and is where the monitor request path lands today (see "Current reality"
-below).
+implements the *resource-usage* side of the `PMIx_Process_monitor` family.
+The two split the job: `psensor` takes the liveness monitors and `pstat`
+takes the statistics, and `src/common/pmix_monitor.c` offers every
+request to `psensor` first.
 
 ## What PSENSOR does
 
@@ -76,34 +77,27 @@ new key without touching the others; the priority ordering is essentially
 vestigial today, much as the `ptl` role gates make its priorities
 vestigial.
 
-## Current reality: the start path is dormant
+## How a request reaches a component
 
-Read this before assuming `psensor` is on the hot monitor path. The
-public monitor API in
-[`src/common/pmix_monitor.c`](../../common/pmix_monitor.c) resolves a
-request's scope and, for local participation, calls **`pmix_pstat.query`**
-— *not* `pmix_psensor.start`. In the current tree there is **no live
-caller of `pmix_psensor.start`** (the framework's own
-`pmix_psensor_base_start` is wired into the `pmix_psensor.start` slot, but
-nothing invokes it). What *is* still called is **`pmix_psensor.stop`**:
+The public monitor API in
+[`src/common/pmix_monitor.c`](../../common/pmix_monitor.c) offers every
+request to **`pmix_psensor.start`** before anything else. A liveness
+monitor watches the *requesting* process itself, so it has no local/remote
+target to resolve; `pmix_monitor_processing` recovers the requestor's
+peer object and calls `start` with it. `PMIX_ERR_NOT_SUPPORTED` coming
+back means no component recognized the key, and the request falls through
+to the resource-usage (`pmix_pstat.query`) path. Anything else — success
+or a hard error — is the answer.
+
+**`pmix_psensor.stop`** is called from two more places, both teardown:
 
 - `src/server/pmix_server_registration.c` calls `pmix_psensor.stop(peer,
   NULL)` when a client departs, and
 - `src/mca/ptl/base/ptl_base_sendrecv.c` calls it from the
   lost-connection teardown.
 
-So the framework is presently in a transitional state: its teardown path
-is live (a defensive "stop any monitors this peer started" on
-disconnect), while its start path is not reached by the shipped monitor
-API. The heartbeat wire mechanism it depends on is, however, fully
-present — `PMIx_Heartbeat()` still sends `PMIX_PTL_TAG_HEARTBEAT` beacons,
-and the `heartbeat` component still knows how to receive and count them —
-so the monitors work end-to-end **if** something calls `start`. Do not
-delete the start machinery on the assumption that it is dead code; treat
-it as an intentionally-retained capability whose driver has moved. If you
-are wiring monitoring, understand that `pstat` and `psensor` split the job
-(statistics vs. liveness) and that the connective tissue on the psensor
-side is what is missing.
+So a monitor a client started is always torn down when that client goes
+away, whether it asked or not.
 
 ## Module interface (`pmix_psensor_base_module_t`)
 
@@ -156,12 +150,51 @@ dispatches.
     `pmix_globals.evbase` — monitors share the library's main progress
     thread.
   - **true:** a dedicated progress thread named `"PSENSOR"` is spun up via
-    `pmix_progress_thread_init`, so file `stat`s and heartbeat bookkeeping
-    cannot perturb the main thread. `close` stops it.
-  It then constructs the `actives` list and opens all components.
-- **`pmix_psensor_base_close`** clears `selected`, destructs `actives`,
-  stops the `"PSENSOR"` thread if one was started, and closes the
-  components.
+    `pmix_progress_thread_init` **and started** with
+    `pmix_progress_thread_start`, so file `stat`s and heartbeat
+    bookkeeping cannot perturb the main thread.
+  It then constructs the `actives` list and opens all components, undoing
+  its own setup if that fails (a framework whose open fails never has its
+  close called).
+- **`pmix_psensor_base_close`** clears `selected`, **pauses** the
+  `"PSENSOR"` thread, destructs `actives`, closes the components, and
+  only then **stops** the thread and clears `evbase`. The order is a
+  correctness requirement — see "Starting and stopping the monitor
+  thread" below.
+
+### Starting and stopping the monitor thread
+
+`pmix_progress_thread_init()` builds an event base and a thread object
+but leaves the engine parked; starting it is a separate call. Omitting
+that call does not fail loudly: the base exists, trackers arm timers on
+it quite happily, and nothing ever runs them. No window is ever checked,
+no file is ever sampled, and not even `add_tracker` runs — so a start
+returns success and the tracker never reaches its component's list. This
+was the state of `psensor` until it was fixed alongside the identical
+defect in `pstat`.
+
+Teardown is the other half of the same change, and it is why `close`
+pauses and stops in two separate places:
+
+- The tracker lists are destructed by the **component** close functions,
+  which run on the finalizing thread rather than on this base's. Every
+  live tracker carries a timer armed on the base, so tearing the trackers
+  down while the monitor thread still runs can free one out from under
+  the sampler executing on it. `pmix_progress_thread_pause` joins the
+  thread, so nothing is in flight once it returns.
+- The base cannot be freed before that, either: a tracker destructor
+  deletes its timer, and `pmix_event_del` reads the base out of the
+  event. So the stop — which drops the last reference to the `"PSENSOR"`
+  tracker, whose destructor frees the base — has to come *after* the
+  components have closed.
+
+`close` clears `pmix_psensor_base.evbase` either way, because
+`pmix_psensor.stop` stays callable after the framework closes (the server
+calls it from client teardown) and must not post a caddy to a freed base.
+
+In the default configuration there is no separate thread to pause:
+`evbase` is the library's shared base, which `PMIx_server_finalize` has
+already stopped before it closes any framework.
 
 ### `base/psensor_base_select.c` — priority-ordered activation
 
@@ -182,12 +215,13 @@ These are the two functions the `pmix_psensor` global points at:
 - **`pmix_psensor_base_start`** walks `actives` in priority order and
   calls each module's `start`. A module that returns neither
   `PMIX_SUCCESS` nor `PMIX_ERR_TAKE_NEXT_OPTION` aborts the walk and that
-  error is returned. Any module that *has* a `start` pointer sets an
-  internal `didit` flag; if **no** module has one, the function returns
-  `PMIX_ERR_NOT_SUPPORTED` so the server knows to ask the host RM instead.
-  Note the consequence of offering the request to *every* module: the
-  matching component claims it and the others cheaply decline with
-  `TAKE_NEXT_OPTION`.
+  error is returned. A module that returns `PMIX_SUCCESS` has *serviced*
+  the request; if none did — every module declined, or none has a `start`
+  pointer at all — the function returns `PMIX_ERR_NOT_SUPPORTED`, which
+  is what tells `pmix_monitor.c` to try the resource-usage path and, past
+  that, the host RM. Note the consequence of offering the request to
+  *every* module: the matching component claims it and the others cheaply
+  decline with `TAKE_NEXT_OPTION`.
 - **`pmix_psensor_base_stop`** walks `actives` and calls every module's
   `stop`, **continuing past errors** (it remembers the first non-success
   and keeps going) so that a stop reliably tears down monitors in *all*
@@ -210,7 +244,7 @@ follow the same shape, and understanding it once covers both:
    (`ft->cdev`) and firing it with `pmix_event_active(..., EV_WRITE, 1)`,
    preceded by `PMIX_POST_OBJECT`. The handler (`add_tracker`) runs on the
    monitor thread, appends the tracker to the component's `trackers` list,
-   and arms an `evtimer` (`file_sample` / `check_heartbeat`) at the
+   and arms a persistent timer (`file_sample` / `check_heartbeat`) at the
    sample interval.
 3. **`stop`** allocates a small caddy (`file_caddy_t` /
    `heartbeat_caddy_t` — each a `pmix_object_t` with its own `ev`,
@@ -227,6 +261,45 @@ cancel a monitor.
 All tracker-list access, timer fires, and (for heartbeat) beat counting
 happen **on `evbase`** — so the components touch shared state only on the
 monitor thread, exactly as the top-level thread-safety rules require.
+
+### The tracker timer is persistent
+
+Both components arm their sampler with `pmix_event_assign(...,
+PMIX_EV_PERSIST, ...)` plus `pmix_event_add`, and **neither sampler
+re-arms its own timer**. That is a correctness requirement rather than a
+style choice, and it is the same argument written out at greater length
+under "Releasing an op from another thread" in
+[`../pstat/AGENTS.md`](../pstat/AGENTS.md).
+
+A repeating timer can be built either way — a one-shot the sampler
+re-arms on its way out, or a persistent one libevent re-arms. They are
+not equivalent to a thread that wants to free the tracker. A tracker
+destructor ends with `pmix_event_del()`, and that can run on a thread
+that is *not* this base's: `check_heartbeat` retains the tracker across
+an asynchronous `PMIx_Notify_event`, and the completion callback that
+releases it runs on the library's own progress thread. `event_del`
+(with libevent threading on, which `pmix_init.c` enables) waits for a
+callback already running on the event — but it removes the event once,
+up front. A one-shot's re-arm happens *after* that removal and outside
+the base's lock, so `event_del` can return to a freshly armed timer and
+the tracker is freed with a live timer pointing into it.
+
+`EV_PERSIST` moves the re-arm into libevent's `event_persist_closure()`,
+made while it still holds the base lock and before the callback is
+entered, so a concurrent `event_del` either takes the lock first and
+removes the pending timeout or takes it afterwards and removes the
+re-armed one. Every interleaving returns disarmed.
+
+Two consequences to keep in mind when editing a sampler:
+
+- **Do not add a `pmix_event_evtimer_add` at the end of one**, and do not
+  "simplify" the arming back to `pmix_event_evtimer_set`, which asks for
+  flags 0.
+- **A sampler that is done monitoring must disarm explicitly.**
+  `file_sample` deletes its own timer before handing the tracker to the
+  notification, because a persistent timer is still armed while its
+  callback runs. That delete is safe precisely because it is made on the
+  base's own thread.
 
 ## Monitor directives the components honor
 
@@ -280,7 +353,10 @@ src/mca/psensor/
 
 Everything in `psensor` runs on a PMIx progress thread — either the main
 one or the dedicated `"PSENSOR"` thread, per
-`pmix_psensor_base_use_separate_thread`. The `start`/`stop` entry points
+`pmix_psensor_base_use_separate_thread`. Both configurations are
+exercised by `make check`: `test/unit/run_monitor.pl` runs its
+heartbeat-and-file scenario twice, once with the parameter set. The
+`start`/`stop` entry points
 may be entered from another thread, which is exactly why both components
 thread-shift onto `evbase` before touching their `trackers` list. The
 heartbeat receive callback (`pmix_psensor_heartbeat_recv_beats`) fires on
@@ -333,8 +409,13 @@ removing a *component directory* changes the build wiring resolved by
   a component with nothing to stop must simply do nothing and return
   success. This matters because `pmix_psensor.stop` runs on every client
   disconnect and lost connection.
-- **Don't assume `start` is on the hot path today** (see "Current
-  reality"). If you are re-connecting the monitor API to `psensor`, do it
-  in `src/common/pmix_monitor.c` alongside the existing `pmix_pstat.query`
-  call, and add a `make check` test that drives a real
-  `PMIx_Process_monitor` heartbeat/file request end-to-end.
+- **Never re-arm a sampler's own timer, and never start the monitor
+  thread without fixing the teardown to match.** See "The tracker timer
+  is persistent" and "Starting and stopping the monitor thread" above;
+  the two are a pair.
+- **Cover a new monitor end to end.** A `start` returns success whether
+  or not a sensor was actually armed, so only the arrival of the alert
+  proves anything. `test/simple/simpmonitor.c` and
+  `test/unit/run_monitor.pl` are the pattern: one rank asks to be
+  monitored and then does nothing, another waits for the alert and checks
+  its source.

--- a/src/mca/psensor/base/psensor_base_frame.c
+++ b/src/mca/psensor/base/psensor_base_frame.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,15 +64,54 @@ static int pmix_psensor_register(pmix_mca_base_register_flag_t flags)
 
 static int pmix_psensor_base_close(void)
 {
+    int rc;
+
     pmix_psensor_base.selected = false;
+
+    /* Quiesce the monitor thread before anything is torn down, but keep
+     * its event base alive until the components have let go of it. Both
+     * halves matter, and they are why this is a pause here and a stop
+     * further down rather than one call:
+     *
+     * - every live tracker carries a timer armed on this base, and the
+     *   trackers are destructed by the component close below - which runs
+     *   on the finalizing thread, not on this base's. pmix_event_del does
+     *   not wait for a callback it did not race, so tearing the trackers
+     *   down while the thread still runs can free one out from under the
+     *   sampler executing on it. Pausing joins the thread, so nothing is
+     *   in flight once it returns.
+     * - the base cannot be freed yet either, because the tracker
+     *   destructors delete their timers and pmix_event_del reads the base
+     *   out of the event.
+     *
+     * In the default configuration there is no separate thread to pause:
+     * evbase is the library's shared base, which PMIx_server_finalize has
+     * already stopped before it closes any framework. */
+    if (use_separate_thread && NULL != pmix_psensor_base.evbase) {
+        (void) pmix_progress_thread_pause("PSENSOR");
+    }
+
     PMIX_LIST_DESTRUCT(&pmix_psensor_base.actives);
 
+    /* Close all remaining available components. Each component's close
+     * destructs its tracker list, and a tracker destructor deletes the
+     * timer it armed on evbase - so this has to happen while the base is
+     * still there. */
+    rc = pmix_mca_base_framework_components_close(&pmix_psensor_base_framework, NULL);
+
+    /* Now the base can go. Do NOT free it here as well: this drops the
+     * last reference to the "PSENSOR" tracker, and the tracker's
+     * destructor is what calls pmix_event_base_free. */
     if (use_separate_thread && NULL != pmix_psensor_base.evbase) {
         (void) pmix_progress_thread_stop("PSENSOR");
     }
+    /* clear the pointer either way: pmix_psensor.stop remains callable
+     * after the framework closes (the server calls it from its client
+     * teardown paths), and it must not post a caddy to a base that has
+     * been freed, or to the library's base after finalize */
+    pmix_psensor_base.evbase = NULL;
 
-    /* Close all remaining available components */
-    return pmix_mca_base_framework_components_close(&pmix_psensor_base_framework, NULL);
+    return rc;
 }
 
 /**
@@ -81,6 +120,8 @@ static int pmix_psensor_base_close(void)
  */
 static int pmix_psensor_base_open(pmix_mca_base_open_flag_t flags)
 {
+    int rc;
+
     /* construct the list of modules */
     PMIX_CONSTRUCT(&pmix_psensor_base.actives, pmix_list_t);
 
@@ -88,7 +129,23 @@ static int pmix_psensor_base_open(pmix_mca_base_open_flag_t flags)
         /* create an event base and progress thread for us */
         pmix_psensor_base.evbase = pmix_progress_thread_init("PSENSOR");
         if (NULL == pmix_psensor_base.evbase) {
+            PMIX_LIST_DESTRUCT(&pmix_psensor_base.actives);
             return PMIX_ERROR;
+        }
+        /* and start it. init() builds the base and the thread object but
+         * leaves the engine parked - pmix_init.c starts the library's own
+         * thread in a separate step for the same reason. Without this the
+         * base exists and trackers arm their timers on it quite happily,
+         * and nothing ever runs them: no heartbeat window is ever checked
+         * and no file is ever sampled, so the monitors silently never
+         * fire. The tracker a start posted would not even reach its
+         * component's list, since add_tracker runs on this base too. */
+        rc = pmix_progress_thread_start("PSENSOR");
+        if (PMIX_SUCCESS != rc) {
+            (void) pmix_progress_thread_stop("PSENSOR");
+            pmix_psensor_base.evbase = NULL;
+            PMIX_LIST_DESTRUCT(&pmix_psensor_base.actives);
+            return rc;
         }
 
     } else {
@@ -96,7 +153,20 @@ static int pmix_psensor_base_open(pmix_mca_base_open_flag_t flags)
     }
 
     /* Open up all available components */
-    return pmix_mca_base_framework_components_open(&pmix_psensor_base_framework, flags);
+    rc = pmix_mca_base_framework_components_open(&pmix_psensor_base_framework, flags);
+    if (PMIX_SUCCESS != rc) {
+        /* Undo our own setup. When a framework's open fails, the base
+         * never sets the OPEN flag, and so never calls the framework's
+         * close function - leaving the progress thread, its event base
+         * and the actives list to leak. No component has run yet, so
+         * there are no trackers to race with here. */
+        PMIX_LIST_DESTRUCT(&pmix_psensor_base.actives);
+        if (use_separate_thread) {
+            (void) pmix_progress_thread_stop("PSENSOR");
+        }
+        pmix_psensor_base.evbase = NULL;
+    }
+    return rc;
 }
 
 PMIX_MCA_BASE_VERSIONED_FRAMEWORK_DECLARE(pmix, psensor, "PMIx Monitoring Sensors", pmix_psensor_register,

--- a/src/mca/psensor/file/AGENTS.md
+++ b/src/mca/psensor/file/AGENTS.md
@@ -62,8 +62,10 @@ unchanged checks), plus `range` and `info`/`ninfo` for the event.
    of the three watch flags is set, release the tracker and return
    `PMIX_ERR_BAD_PARAM`. A file monitor needs both *how often* to look and
    *what* to look at.
-4. Thread-shift to `add_tracker`, which appends the tracker and arms an
-   `evtimer` (`file_sample`) at `tv`.
+4. Thread-shift to `add_tracker`, which appends the tracker and arms a
+   **persistent** timer (`file_sample`) at `tv`. It is persistent for a
+   reason — see "The tracker timer is persistent" in the framework
+   [`AGENTS.md`](../AGENTS.md); `file_sample` must never re-arm it.
 
 The path itself is validated before the tracker is built: it arrives off
 the wire in `monitor->value`, so a value that is not a `PMIX_STRING`, or
@@ -75,8 +77,8 @@ to `strdup`.
 Fires every `tv` seconds:
 
 - `stat` the file. **If the `stat` fails** (file not present yet), it
-  re-arms the timer and returns — a not-yet-created file is not a fault,
-  the monitor simply waits for it to appear.
+  simply returns — a not-yet-created file is not a fault, and the
+  persistent timer brings us back to look again.
 - Compare the watched attribute to its last-seen value and update
   `nmisses`: unchanged ⇒ `nmisses++`; changed ⇒ `nmisses = 0` and the
   last-seen value is refreshed. **Only one attribute is checked per
@@ -88,9 +90,12 @@ Fires every `tv` seconds:
   verbosity >4 it emits the `file-stalled` `show_help`; it then **removes
   the tracker from the list** and raises `PMIX_MONITOR_FILE_ALERT` via
   `PMIx_Notify_event` (source = requestor, scope = `range`). The
-  completion callback (`opcbfunc`) releases the tracker. The timer is
-  **not** re-armed — a file monitor is one-shot: it fires once and is gone.
-- Otherwise it re-arms the timer for the next interval.
+  completion callback (`opcbfunc`) releases the tracker. Because the timer
+  is persistent it is **still armed** at that point — libevent re-armed it
+  before entering this callback — so `file_sample` **deletes it
+  explicitly** before letting go of the tracker. A file monitor is
+  one-shot: it fires once and is gone.
+- Otherwise it does nothing further; the timer brings it back on its own.
 
 ## Gotchas
 
@@ -104,8 +109,15 @@ Fires every `tv` seconds:
   mod, per the `if/else if` chain). This is easy to misread as "watch all
   three"; it is not.
 - **The monitor is one-shot.** Unlike `heartbeat`, `file` removes and
-  releases its tracker on the first alert and does not re-arm. If you need
-  ongoing monitoring after a stall, the caller must start a new monitor.
+  releases its tracker on the first alert. If you need ongoing monitoring
+  after a stall, the caller must start a new monitor.
+- **The sampler must not re-arm the timer, and must disarm before it
+  hands the tracker away.** Both halves come from the same argument in
+  the framework doc: re-arming a one-shot from the sampler races a
+  `pmix_event_del` made from another thread, and a persistent timer left
+  armed on a released tracker fires into freed memory. `make check` covers
+  this end to end — `test/simple/simpmonitor.c` watches a file it never
+  touches, which only alerts if the timer fires more than once.
 - **`stat` is a TOCTOU** (the source carries a `coverity[TOCTOU]`
   annotation): the file can change between the `stat` and any action.
   That is acceptable for a liveness heuristic — do not "harden" it into

--- a/src/mca/psensor/file/AGENTS.md
+++ b/src/mca/psensor/file/AGENTS.md
@@ -65,6 +65,11 @@ unchanged checks), plus `range` and `info`/`ninfo` for the event.
 4. Thread-shift to `add_tracker`, which appends the tracker and arms an
    `evtimer` (`file_sample`) at `tv`.
 
+The path itself is validated before the tracker is built: it arrives off
+the wire in `monitor->value`, so a value that is not a `PMIX_STRING`, or
+a `NULL` string, is rejected with `PMIX_ERR_BAD_PARAM` rather than handed
+to `strdup`.
+
 ## `file_sample` — the staleness check
 
 Fires every `tv` seconds:

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -193,6 +193,14 @@ static pmix_status_t start(pmix_peer_t *requestor, pmix_status_t error, const pm
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
 
+    /* the request names the file in the monitor's value, and it arrives
+     * off the wire from a client - so the type has to be checked and the
+     * string can be NULL. We claim the request (the key was ours) and
+     * reject it rather than handing strdup a NULL. */
+    if (PMIX_STRING != monitor->value.type || NULL == monitor->value.data.string) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* setup to track this monitoring operation */
     ft = PMIX_NEW(file_tracker_t);
     PMIX_RETAIN(requestor);

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -159,16 +159,24 @@ static void add_tracker(int sd, short flags, void *cbdata)
 {
     file_tracker_t *ft = (file_tracker_t *) cbdata;
 
-    PMIX_ACQUIRE_OBJECT(fd);
+    PMIX_ACQUIRE_OBJECT(ft);
 
     PMIX_HIDE_UNUSED_PARAMS(sd, flags);
 
     /* add the tracker to our list */
     pmix_list_append(&pmix_mca_psensor_file_component.trackers, &ft->super);
 
-    /* setup the timer event */
-    pmix_event_evtimer_set(pmix_psensor_base.evbase, &ft->ev, file_sample, ft);
-    pmix_event_evtimer_add(&ft->ev, &ft->tv);
+    /* Setup the timer event. The timer is PERSISTENT, and that is a
+     * correctness requirement rather than a convenience: the tracker can
+     * be released from a thread that is not this base's, so a one-shot
+     * that file_sample re-arms on its way out can be re-armed after the
+     * destructor's pmix_event_del has already removed it - leaving a live
+     * timer pointing at freed memory. See "The tracker timer is
+     * persistent" in ../AGENTS.md; do not simplify this back to
+     * pmix_event_evtimer_set(), which asks for flags 0. */
+    pmix_event_assign(&ft->ev, pmix_psensor_base.evbase, -1, PMIX_EV_PERSIST,
+                      file_sample, ft);
+    pmix_event_add(&ft->ev, &ft->tv);
     ft->event_active = true;
 }
 
@@ -309,8 +317,8 @@ static void file_sample(int sd, short args, void *cbdata)
         pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                              "[%s:%d] could not stat %s", pmix_globals.myid.nspace,
                              pmix_globals.myid.rank, ft->file);
-        /* re-add the timer, in case this file shows up */
-        pmix_event_evtimer_add(&ft->ev, &ft->tv);
+        /* the timer re-arms itself, so we simply come back and look
+         * again in case this file shows up */
         return;
     }
 
@@ -351,7 +359,17 @@ static void file_sample(int sd, short args, void *cbdata)
             pmix_show_help("help-pmix-psensor-file.txt", "file-stalled", true, ft->file,
                            ft->last_size, ctime(&ft->last_access), ctime(&ft->last_mod));
         }
-        /* stop monitoring this client */
+        /* stop monitoring this client. Disarm before we let go of the
+         * tracker: the timer is persistent, so it is still armed even
+         * though we are inside its callback, and the tracker is about to
+         * belong to the notification below. Deleting it here is safe
+         * because we are on the base's own thread - libevent re-armed
+         * the timeout under the base lock before entering us, so this
+         * removes that re-armed one. */
+        if (ft->event_active) {
+            pmix_event_del(&ft->ev);
+            ft->event_active = false;
+        }
         pmix_list_remove_item(&pmix_mca_psensor_file_component.trackers, &ft->super);
         /* generate an event - the source proc lives in the tracker (not
          * on the stack) because PMIx_Notify_event borrows the pointer and
@@ -366,6 +384,6 @@ static void file_sample(int sd, short args, void *cbdata)
         return;
     }
 
-    /* re-add the timer */
-    pmix_event_evtimer_add(&ft->ev, &ft->tv);
+    /* nothing to do - the timer re-arms itself. See the comment in
+     * add_tracker for why the sampler must not do it. */
 }

--- a/src/mca/psensor/heartbeat/AGENTS.md
+++ b/src/mca/psensor/heartbeat/AGENTS.md
@@ -126,6 +126,14 @@ more, re-alerted. This "latch then revive" behavior is deliberate.
   place (`recv_active` never resets, and `stop` does not un-post it). If
   you rework teardown, remember the recv outlives individual trackers by
   design.
+- **Being posted lazily leaves a window, and the server screens for it.**
+  A client may call `PMIx_Heartbeat()` before any monitor has been armed.
+  Until the recv exists, the server's *wildcard* recv matches the beat
+  and hands it to the command switchyard — so
+  `pmix_server_message_handler` drops `PMIX_PTL_TAG_HEARTBEAT` explicitly
+  rather than trying to read a command out of it and replying with the
+  error. If you ever make this recv eager, that screen becomes dead code
+  rather than wrong code, but say so when you remove it.
 - **This component depends on `ptl` internals** (`pmix_ptl_base.posted_recvs`,
   `PMIX_PTL_TAG_HEARTBEAT`, `pmix_ptl_posted_recv_t`). Beat delivery only
   works because `PMIx_Heartbeat()` sends on that reserved tag; the two

--- a/src/mca/psensor/heartbeat/AGENTS.md
+++ b/src/mca/psensor/heartbeat/AGENTS.md
@@ -71,8 +71,10 @@ peer, frees `id`/`info`, and deletes the timer if `event_active`.
    `pmix_ptl_base.posted_recvs`, and set `recv_active = true`. This is the
    one place `psensor` reaches directly into `ptl` internals — the recv is
    shared by *all* heartbeat trackers, not one per requestor.
-5. Thread-shift to `add_tracker`, which appends the tracker and arms an
-   `evtimer` (`check_heartbeat`) at `tv`.
+5. Thread-shift to `add_tracker`, which appends the tracker and arms a
+   **persistent** timer (`check_heartbeat`) at `tv`. It is persistent for
+   a reason — see "The tracker timer is persistent" in the framework
+   [`AGENTS.md`](../AGENTS.md); `check_heartbeat` must never re-arm it.
 
 ## Heartbeat reception: `recv_beats` → `add_beat`
 
@@ -96,7 +98,9 @@ Fires every `tv` seconds:
   `range`. The completion callback (`opcbfunc`) releases the retained
   tracker.
 - Otherwise it just logs the beat count.
-- Either way it resets `nbeats = 0` and re-arms the timer.
+- Either way it resets `nbeats = 0`. It does **not** re-arm the timer:
+  the timer is persistent and libevent re-armed it before this callback
+  was entered.
 
 Note the tracker is **not removed** on alert (unlike `file`): heartbeat
 monitoring persists, and a later beat via `add_beat` clears `stopped` so
@@ -110,6 +114,13 @@ more, re-alerted. This "latch then revive" behavior is deliberate.
   until a beat revives it. Do not "simplify" by removing the latch or by
   deleting the tracker on alert — you would either spam events every
   window or lose the ability to notice the process recovering.
+- **The sampler must not re-arm its own timer.** `check_heartbeat` hands
+  a *retained* tracker to an asynchronous `PMIx_Notify_event`, and the
+  completion callback that releases it runs on the library's progress
+  thread, not this one — so the tracker's `pmix_event_del` can race a
+  sample in flight. A one-shot re-armed from the end of the sampler
+  survives that delete; a persistent one does not. The full argument is
+  in the framework [`AGENTS.md`](../AGENTS.md).
 - **The PTL recv is shared and posted lazily.** It is prepended to
   `pmix_ptl_base.posted_recvs` on the first heartbeat `start` and left in
   place (`recv_active` never resets, and `stop` does not un-post it). If

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -155,9 +155,17 @@ static void add_tracker(int sd, short flags, void *cbdata)
     /* add the tracker to our list */
     pmix_list_append(&pmix_mca_psensor_heartbeat_component.trackers, &ft->super);
 
-    /* setup the timer event */
-    pmix_event_evtimer_set(pmix_psensor_base.evbase, &ft->ev, check_heartbeat, ft);
-    pmix_event_evtimer_add(&ft->ev, &ft->tv);
+    /* Setup the timer event. The timer is PERSISTENT, and that is a
+     * correctness requirement rather than a convenience: the tracker can
+     * be released from a thread that is not this base's, so a one-shot
+     * that check_heartbeat re-arms on its way out can be re-armed after
+     * the destructor's pmix_event_del has already removed it - leaving a
+     * live timer pointing at freed memory. See "The tracker timer is
+     * persistent" in ../AGENTS.md; do not simplify this back to
+     * pmix_event_evtimer_set(), which asks for flags 0. */
+    pmix_event_assign(&ft->ev, pmix_psensor_base.evbase, -1, PMIX_EV_PERSIST,
+                      check_heartbeat, ft);
+    pmix_event_add(&ft->ev, &ft->tv);
     ft->event_active = true;
 }
 
@@ -315,11 +323,9 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
                              pmix_globals.myid.nspace, pmix_globals.myid.rank, ft->nbeats,
                              ft->requestor->info->pname.nspace, ft->requestor->info->pname.rank);
     }
-    /* reset for next period */
+    /* reset for next period. The timer re-arms itself - see the comment
+     * in add_tracker for why the sampler must not do it. */
     ft->nbeats = 0;
-
-    /* reset the timer */
-    pmix_event_evtimer_add(&ft->ev, &ft->tv);
 }
 
 static void add_beat(int sd, short args, void *cbdata)

--- a/src/mca/ptl/AGENTS.md
+++ b/src/mca/ptl/AGENTS.md
@@ -263,9 +263,21 @@ region, reads the payload (resuming across `EAGAIN`), then
 **Matching.** `process_msg` walks `pmix_ptl_base.posted_recvs` looking for
 a recv whose `(peer, tag)` matches (with `UINT_MAX` as wildcard), loads
 the payload into a `pmix_buffer_t`, and fires the recv's `cbfunc`. A
-dynamic-tag recv is then removed and released. An unmatched message is an
-error (`unexpected-message` `show_help`) — by design this subsystem never
-receives anything it did not previously ask for.
+dynamic-tag recv is then removed and released. An unmatched message is
+**discarded with a framework trace** (verbosity 2) and a `PMIX_ERROR`
+event, not a `show_help`: it is unusual, but it is not necessarily a
+defect and it is never something a user can act on.
+
+Do not read the matching loop as "we only ever receive what we asked
+for". A server posts a **wildcard** (`UINT_MAX`) recv for the command
+switchyard, so on a server almost nothing is unmatched — a message on a
+tag nobody posted for is handed to `server_switchyard` as if it were a
+command. `PMIX_PTL_TAG_HEARTBEAT` is the live example: `psensor/heartbeat`
+posts its recv only when a heartbeat monitor is first armed, so a beat
+that arrives before that goes to the switchyard, which cannot read a
+command out of a zero-byte buffer and queues an error reply back on tag
+1 — and *that* reply is what ends up unmatched, on the client, since a
+heartbeat is one-way and no client posts for it.
 
 **Loopback.** A send whose peer is `pmix_globals.mypeer` skips the socket
 entirely: the buffer is handed straight to `PMIX_ACTIVATE_POST_MSG` and

--- a/src/mca/ptl/AGENTS.md
+++ b/src/mca/ptl/AGENTS.md
@@ -272,12 +272,17 @@ Do not read the matching loop as "we only ever receive what we asked
 for". A server posts a **wildcard** (`UINT_MAX`) recv for the command
 switchyard, so on a server almost nothing is unmatched — a message on a
 tag nobody posted for is handed to `server_switchyard` as if it were a
-command. `PMIX_PTL_TAG_HEARTBEAT` is the live example: `psensor/heartbeat`
-posts its recv only when a heartbeat monitor is first armed, so a beat
-that arrives before that goes to the switchyard, which cannot read a
-command out of a zero-byte buffer and queues an error reply back on tag
-1 — and *that* reply is what ends up unmatched, on the client, since a
-heartbeat is one-way and no client posts for it.
+command. That is why `pmix_server_message_handler` screens
+`PMIX_PTL_TAG_HEARTBEAT` before dispatching: `psensor/heartbeat` posts
+its recv only when a heartbeat monitor is first armed, and a beat that
+arrives before that would otherwise be read as a command, fail, and draw
+an error reply on tag 1 that no client can place — `PMIx_Heartbeat` is
+one-way and nobody posts for it. Heartbeat is the only reserved tag that
+can reach the switchyard today: `PMIX_PTL_TAG_IOF` and
+`PMIX_PTL_TAG_IOF_CONTROL` are posted at server init,
+`PMIX_PTL_TAG_DATA_DELETE` only ever travels server→client, and
+`PMIX_PTL_TAG_NOTIFY` is unused. **Any new reserved tag a client may send
+up needs either an eagerly-posted recv or a screen of its own.**
 
 **Loopback.** A send whose peer is `pmix_globals.mypeer` skips the socket
 entirely: the buffer is handed straight to `PMIX_ACTIVATE_POST_MSG` and

--- a/src/mca/ptl/base/help-ptl-base.txt
+++ b/src/mca/ptl/base/help-ptl-base.txt
@@ -122,15 +122,6 @@ interfaces were found after applying any include or exclude directives:
 Please adjust your include or exclude to allow selection of an
 available interface.
 #
-[unexpected-message]
-The PMIx messaging system has received an unexpected message:
-
-  Peer: %s
-  Tag:  %u
-
-The message cannot be processed and will be ignored. Please
-report this error to the PMIx developers.
-#
 [rndz-file-in-use]
 A PMIx server was unable to create the rendezvous file by which its
 peers locate it because that file already exists and belongs to a

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -824,15 +824,12 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
      * act on - so it is a framework trace rather than a show_help that
      * asks them to report a bug to the PMIx developers.
      *
-     * A reply to a one-way message is the ordinary way to get here, and
-     * it lands on the client rather than the server. psensor/heartbeat
-     * posts its PMIX_PTL_TAG_HEARTBEAT recv only when a heartbeat
-     * monitor is first armed; a beat arriving before that is matched
-     * instead by the server's wildcard recv, handed to the command
-     * switchyard, and answered with the error the switchyard gets for
-     * trying to read a command out of a zero-byte buffer. PMIx_Heartbeat
-     * is one-way, so no client ever posts for that tag and the reply has
-     * nowhere to go. Raise the framework verbosity to see these. */
+     * Note that on a server this is nearly unreachable: the command
+     * switchyard posts a wildcard (UINT_MAX) recv, which matches
+     * anything. So an unmatched message is almost always a *reply* that
+     * arrived after the recv expecting it was removed, or one sent on a
+     * reserved tag by a peer whose partner never posted for it. Raise
+     * the framework verbosity to see these. */
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "%s discarding unexpected message from %s on tag %u",
                         PMIX_NAME_PRINT(&pmix_globals.myid),

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -819,9 +819,24 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
         }
     }
 
-    /* we should never see an unexpected msg */
-    pmix_show_help("help-ptl-base.txt", "unexpected-message", true,
-                   PMIX_PEER_PRINT(msg->peer), msg->hdr.tag);
+    /* Nothing was waiting for this message. That is unusual, but it is
+     * not necessarily a defect, and it is never something the user can
+     * act on - so it is a framework trace rather than a show_help that
+     * asks them to report a bug to the PMIx developers.
+     *
+     * A reply to a one-way message is the ordinary way to get here, and
+     * it lands on the client rather than the server. psensor/heartbeat
+     * posts its PMIX_PTL_TAG_HEARTBEAT recv only when a heartbeat
+     * monitor is first armed; a beat arriving before that is matched
+     * instead by the server's wildcard recv, handed to the command
+     * switchyard, and answered with the error the switchyard gets for
+     * trying to read a command out of a zero-byte buffer. PMIx_Heartbeat
+     * is one-way, so no client ever posts for that tag and the reply has
+     * nowhere to go. Raise the framework verbosity to see these. */
+    pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                        "%s discarding unexpected message from %s on tag %u",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
+                        PMIX_PEER_PRINT(msg->peer), msg->hdr.tag);
     PMIX_REPORT_EVENT(PMIX_ERROR, msg->peer, PMIX_RANGE_NAMESPACE, _notify_complete);
     PMIX_RELEASE(msg);
 }

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -76,8 +76,19 @@ anything here. Inbound messages land in `pmix_server_message_handler`
 (a registered PTL receive callback,
 `pmix_server_switchyard.c:727`), which calls `server_switchyard`
 (`pmix_server_switchyard.c:258`). The switchyard unpacks the
-`pmix_cmd_t` and dispatches on it. **The return value of every command
-handler encodes who owns the reply and the caddy:**
+`pmix_cmd_t` and dispatches on it.
+
+The receive callback it is registered under is a **wildcard** one, so it
+sees every message that no more specific recv claimed — including
+messages that are not commands at all. `pmix_server_message_handler`
+therefore drops `PMIX_PTL_TAG_HEARTBEAT` before dispatching; see "An
+unmatched message" in [`../mca/ptl/AGENTS.md`](../mca/ptl/AGENTS.md) for
+why a beat can arrive with no recv of its own, and why letting it reach
+`server_switchyard` sent a bogus error reply to a client that was not
+listening for one.
+
+**The return value of every command handler encodes who owns the reply
+and the caddy:**
 
 - **Return `PMIX_SUCCESS`** ⇒ "I have taken ownership. I will (via my
   async callback) queue the client's reply and release the caddy."

--- a/src/server/pmix_server_switchyard.c
+++ b/src/server/pmix_server_switchyard.c
@@ -759,9 +759,28 @@ void pmix_server_message_handler(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     pmix_buffer_t *reply;
     pmix_status_t rc, ret;
 
+    PMIX_HIDE_UNUSED_PARAMS(cbdata);
+
+    /* A heartbeat is not a command, and it is the one reserved tag that
+     * can reach this handler. psensor/heartbeat posts a recv of its own
+     * for the tag, but only once the first heartbeat monitor is armed -
+     * so a beat sent before that is matched instead by the wildcard recv
+     * this handler serves. Passing it down would hand server_switchyard
+     * a zero-byte buffer it cannot read a command out of, and the error
+     * that comes back would be queued to the client on tag 1, where
+     * nothing is listening: PMIx_Heartbeat is one-way and no client ever
+     * posts for it. Drop it instead. Nothing is lost - there is no
+     * monitor to credit the beat to yet, which is precisely why the recv
+     * it belongs to has not been posted. */
+    if (PMIX_PTL_TAG_HEARTBEAT == hdr->tag) {
+        pmix_output_verbose(2, pmix_server_globals.base_output,
+                            "SWITCHYARD ignoring heartbeat from %s:%u with no monitor armed",
+                            peer->info->pname.nspace, peer->info->pname.rank);
+        return;
+    }
+
     pmix_output_verbose(2, pmix_server_globals.base_output, "SWITCHYARD for %s:%u:%d",
                         peer->info->pname.nspace, peer->info->pname.rank, peer->sd);
-    PMIX_HIDE_UNUSED_PARAMS(cbdata);
 
     ret = server_switchyard(peer, hdr->tag, buf);
     /* send the return, if there was an error returned */

--- a/test/simple/simpmonitor.c
+++ b/test/simple/simpmonitor.c
@@ -40,13 +40,23 @@
  * observer is a *different* rank. rank 1 receives the alert and checks
  * that its source is really rank 0, then prints "MONITOR TEST PASSED".
  *
- * This guards two things at once:
+ * rank 0 also asks for a *file* monitor on a file it creates and then
+ * never touches, so the other psensor component gets the same end-to-end
+ * treatment: the server's file monitor must notice the stale mtime and
+ * raise PMIX_MONITOR_FILE_ALERT. rank 1 waits for that too and prints
+ * "FILE MONITOR TEST PASSED".
+ *
+ * This guards three things at once:
  *   1. that the monitor API is wired to psensor at all - otherwise no
- *      alert is ever generated and rank 1 times out; and
+ *      alert is ever generated and rank 1 times out;
  *   2. that the alert carries the correct source - the source proc is
  *      passed to an asynchronous notify, so it must outlive the call that
  *      raised it. A stack-allocated source produces a garbage rank/nspace
- *      here.
+ *      here; and
+ *   3. that both monitors keep sampling on their own timer. Each tracker
+ *      arms a persistent timer, and the sampler must not re-arm it - so
+ *      an alert that never comes can mean the timer stopped after its
+ *      first fire, not just that the framework was never driven.
  */
 
 #include <errno.h>
@@ -66,7 +76,10 @@
 
 static pmix_proc_t myproc;
 static mylock_t alertlock;
+static mylock_t filelock;
 static volatile int alert_source_ok = 0;
+static volatile int file_alert_source_ok = 0;
+static char watchfile[1024] = {0};
 
 static void hide_unused_params(int x, ...)
 {
@@ -99,6 +112,31 @@ static void alert_handler(size_t evhdlr_registration_id, pmix_status_t status,
     }
     alertlock.status = status;
     DEBUG_WAKEUP_THREAD(&alertlock);
+}
+
+/* observer handler for PMIX_MONITOR_FILE_ALERT */
+static void file_alert_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                               const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                               pmix_info_t results[], size_t nresults,
+                               pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    int rc = 0;
+    hide_unused_params(rc, evhdlr_registration_id, info, ninfo, results, nresults);
+
+    if (NULL != source && PMIX_CHECK_NSPACE(source->nspace, myproc.nspace)
+        && MONITORED_RANK == (int) source->rank) {
+        file_alert_source_ok = 1;
+    }
+    fprintf(stderr, "Observer %s:%d FILE ALERT RECEIVED (%s) source=%s:%d source_ok=%d\n",
+            myproc.nspace, myproc.rank, PMIx_Error_string(status),
+            (NULL == source) ? "NULL" : source->nspace,
+            (NULL == source) ? -1 : (int) source->rank, file_alert_source_ok);
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+    filelock.status = status;
+    DEBUG_WAKEUP_THREAD(&filelock);
 }
 
 static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
@@ -188,6 +226,66 @@ static int run_monitored(void)
     return 0;
 }
 
+/* rank 0: create a file, ask the server to watch it for modification,
+ * and then never touch it again. The file monitor must notice that the
+ * mtime has stopped moving and alert. Note the drop count: the first
+ * sample only records the current mtime, so it takes ndrops+1 samples to
+ * trip - which is exactly what proves the tracker's timer kept firing. */
+static int run_file_monitored(void)
+{
+    int rc;
+    pmix_info_t *monitor, *info;
+    mylock_t mylock;
+    uint32_t n;
+    FILE *fp;
+    bool flag = true;
+
+    if (NULL == getcwd(watchfile, sizeof(watchfile) - 32)) {
+        fprintf(stderr, "Monitored %s:%d: getcwd failed\n", myproc.nspace, myproc.rank);
+        return 1;
+    }
+    snprintf(watchfile + strlen(watchfile), 32, "/simpmon-%lu.watch",
+             (unsigned long) getpid());
+    fp = fopen(watchfile, "w");
+    if (NULL == fp) {
+        fprintf(stderr, "Monitored %s:%d: cannot create %s\n", myproc.nspace, myproc.rank,
+                watchfile);
+        return 1;
+    }
+    fprintf(fp, "watch me\n");
+    fclose(fp);
+
+    PMIX_INFO_CREATE(monitor, 1);
+    PMIX_INFO_LOAD(&monitor[0], PMIX_MONITOR_FILE, watchfile, PMIX_STRING);
+
+    PMIX_INFO_CREATE(info, 4);
+    PMIX_INFO_LOAD(&info[0], PMIX_MONITOR_ID, "SIMPMONITOR-FILE", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_MONITOR_FILE_MODIFY, &flag, PMIX_BOOL);
+    n = 1; /* stat it every second */
+    PMIX_INFO_LOAD(&info[2], PMIX_MONITOR_FILE_CHECK_TIME, &n, PMIX_UINT32);
+    n = 1; /* tolerate one unchanged check */
+    PMIX_INFO_LOAD(&info[3], PMIX_MONITOR_FILE_DROPS, &n, PMIX_UINT32);
+
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    rc = PMIx_Process_monitor_nb(monitor, PMIX_MONITOR_FILE_ALERT, info, 4, infocbfunc,
+                                 (void *) &mylock);
+    if (PMIX_SUCCESS == rc) {
+        DEBUG_WAIT_THREAD(&mylock);
+        rc = mylock.status;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(monitor, 1);
+    PMIX_INFO_FREE(info, 4);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(stderr, "Monitored %s:%d: file monitor request rejected: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        return 1;
+    }
+    fprintf(stderr, "Monitored %s:%d: file monitoring started on %s\n", myproc.nspace,
+            myproc.rank, watchfile);
+    return 0;
+}
+
 /* The blocking form of PMIx_Process_monitor with PMIX_SEND_HEARTBEAT
  * used to hang forever: the _nb entry point fired the beat and returned
  * success without ever invoking the callback, so the blocking wrapper
@@ -218,7 +316,7 @@ static int send_one_heartbeat(void)
     return 0;
 }
 
-/* rank 1: watch for the alert the server raises about rank 0 */
+/* rank 1: watch for the alerts the server raises about rank 0 */
 static int run_observer(void)
 {
     pmix_status_t code = PMIX_MONITOR_HEARTBEAT_ALERT;
@@ -235,6 +333,19 @@ static int run_observer(void)
         return 1;
     }
     DEBUG_DESTRUCT_LOCK(&mylock);
+
+    code = PMIX_MONITOR_FILE_ALERT;
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, file_alert_handler, evhandler_reg_callbk,
+                                (void *) &mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    if (PMIX_SUCCESS != mylock.status) {
+        fprintf(stderr, "Observer %s:%d: file alert handler registration failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(mylock.status));
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        return 1;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
     return 0;
 }
 
@@ -247,6 +358,7 @@ int main(int argc, char **argv)
     hide_unused_params(rc, argc, argv);
 
     DEBUG_CONSTRUCT_LOCK(&alertlock);
+    DEBUG_CONSTRUCT_LOCK(&filelock);
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
@@ -273,6 +385,9 @@ int main(int argc, char **argv)
 
     if (MONITORED_RANK == (int) myproc.rank) {
         result = run_monitored();
+        if (0 == result) {
+            result = run_file_monitored();
+        }
     } else if (OBSERVER_RANK == (int) myproc.rank) {
         /* the blocking heartbeat call must return before we go on to
          * wait for the alert - if it hangs, this whole test hangs and
@@ -282,9 +397,16 @@ int main(int argc, char **argv)
         }
         if (0 == wait_for_alert(&alertlock, 30) && alert_source_ok) {
             fprintf(stderr, "Observer %s:%d: MONITOR TEST PASSED\n", myproc.nspace, myproc.rank);
-            result = 0;
         } else {
             fprintf(stderr, "Observer %s:%d: MONITOR TEST FAILED - no valid heartbeat alert\n",
+                    myproc.nspace, myproc.rank);
+            result = 1;
+        }
+        if (0 == wait_for_alert(&filelock, 30) && file_alert_source_ok) {
+            fprintf(stderr, "Observer %s:%d: FILE MONITOR TEST PASSED\n", myproc.nspace,
+                    myproc.rank);
+        } else {
+            fprintf(stderr, "Observer %s:%d: FILE MONITOR TEST FAILED - no valid file alert\n",
                     myproc.nspace, myproc.rank);
             result = 1;
         }
@@ -300,7 +422,11 @@ int main(int argc, char **argv)
     }
 
 done:
+    if (MONITORED_RANK == (int) myproc.rank && '\0' != watchfile[0]) {
+        unlink(watchfile);
+    }
     DEBUG_DESTRUCT_LOCK(&alertlock);
+    DEBUG_DESTRUCT_LOCK(&filelock);
     if (PMIX_SUCCESS != PMIx_Finalize(NULL, 0)) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Finalize failed\n", myproc.nspace, myproc.rank);
     }

--- a/test/unit/run_monitor.pl.in
+++ b/test/unit/run_monitor.pl.in
@@ -19,6 +19,15 @@
 # was actually armed, so only the arrival of the alert proves the monitor
 # is live. If the monitor path is not wired to psensor, no alert is ever
 # generated and the client times out waiting - failing this test.
+#
+# The whole run is repeated with psensor_base_use_separate_thread set,
+# which moves every monitor timer off the library's progress thread and
+# onto a dedicated "PSENSOR" one. That configuration is otherwise never
+# exercised, and it was silently dead: the framework created the event
+# base but never started the thread, so trackers armed timers that
+# nothing ever ran and no alert was ever raised. It also runs the
+# framework's teardown against a live sampling thread, so a crash or hang
+# here is as meaningful as a missing alert.
 
 use strict;
 
@@ -62,78 +71,115 @@ foreach my $p (@paths) {
 
 # Prefix the external timeout(1)/gtimeout(1) when we found one; otherwise
 # arm a Perl alarm so a wedged run can never hang "make check" forever.
-my @cmd = ("./simptest", "-n", "2", "-e", "./simpmonitor");
+my @basecmd = ("./simptest", "-n", "2", "-e", "./simpmonitor");
 my $use_alarm = 0;
 if ("" ne $timeout_cmd) {
-    unshift(@cmd, split(' ', $timeout_cmd));
+    unshift(@basecmd, split(' ', $timeout_cmd));
 } else {
     $use_alarm = 1;
 }
-print "@cmd\n";
 
-# Run the server in a child we control, merging stderr into stdout, and
-# slurp the output. The alarm (when armed) bounds the wait.
-my $pid = open(my $fh, "-|");
-defined($pid) or die "cannot fork: $!";
-if (0 == $pid) {
-    open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
-    exec(@cmd) or die "cannot exec simptest: $!";
-}
-my $output = "";
-my $timed_out = 0;
-eval {
-    local $SIG{ALRM} = sub { die "alarm\n"; };
-    alarm(600) if $use_alarm;
-    local $/;            # slurp the whole stream
-    $output = <$fh>;
-    alarm(0);
-};
-if ($@) {
-    $timed_out = 1;
-    kill('KILL', $pid);
-}
-close($fh);
-$output = "" unless defined($output);
-my $status = $timed_out ? 1 : ($? >> 8);
-if ($timed_out) {
-    $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
-}
-print $output . "\n";
-print "CODE $status\n";
+# Run one scenario and check it. Returns 0 on success, non-zero on
+# failure, having printed the reason.
+sub run_scenario {
+    my ($label, $separate_thread) = @_;
 
-# The server must exit 0: a crash anywhere in the monitor/psensor path
-# drives a non-zero exit.
-if (0 != $status) {
-    print "FAIL: simptest did not complete (exit $status)\n";
-    exit($status == 0 ? 1 : $status);
+    print "\n=== $label ===\n";
+    if ($separate_thread) {
+        $ENV{'PMIX_MCA_psensor_base_use_separate_thread'} = "1";
+    } else {
+        delete $ENV{'PMIX_MCA_psensor_base_use_separate_thread'};
+    }
+
+    my @cmd = @basecmd;
+    print "@cmd\n";
+
+    # Run the server in a child we control, merging stderr into stdout, and
+    # slurp the output. The alarm (when armed) bounds the wait.
+    my $pid = open(my $fh, "-|");
+    defined($pid) or die "cannot fork: $!";
+    if (0 == $pid) {
+        open(STDERR, ">&", \*STDOUT) or die "cannot redirect stderr: $!";
+        exec(@cmd) or die "cannot exec simptest: $!";
+    }
+    my $output = "";
+    my $timed_out = 0;
+    eval {
+        local $SIG{ALRM} = sub { die "alarm\n"; };
+        alarm(600) if $use_alarm;
+        local $/;            # slurp the whole stream
+        $output = <$fh>;
+        alarm(0);
+    };
+    if ($@) {
+        $timed_out = 1;
+        kill('KILL', $pid);
+    }
+    close($fh);
+    $output = "" unless defined($output);
+    my $status = $timed_out ? 1 : ($? >> 8);
+    if ($timed_out) {
+        $output .= "\nFAIL: simptest exceeded the 600s time limit\n";
+    }
+    print $output . "\n";
+    print "CODE $status\n";
+
+    # The server must exit 0: a crash anywhere in the monitor/psensor path
+    # drives a non-zero exit.
+    if (0 != $status) {
+        print "FAIL[$label]: simptest did not complete (exit $status)\n";
+        return ($status == 0 ? 1 : $status);
+    }
+
+    # The client explicitly reports failure if it never received the alert.
+    if ($output =~ /MONITOR TEST FAILED/) {
+        print "FAIL[$label]: client did not receive the heartbeat alert\n";
+        return 1;
+    }
+
+    # Confirm the alert actually fired rather than passing vacuously: the
+    # client prints this line only from inside its heartbeat-alert handler.
+    if ($output !~ /MONITOR TEST PASSED/) {
+        print "FAIL[$label]: client did not confirm heartbeat monitoring\n";
+        return 1;
+    }
+
+    # The observer also makes one blocking PMIx_Process_monitor call with
+    # PMIX_SEND_HEARTBEAT. That form used to return from the _nb layer
+    # without ever invoking the callback the blocking wrapper was waiting
+    # on, so it hung forever - which here shows up as the whole run hitting
+    # the time limit above. This line proves it came back.
+    if ($output =~ /HEARTBEAT TEST FAILED/) {
+        print "FAIL[$label]: blocking PMIx_Process_monitor(SEND_HEARTBEAT) reported an error\n";
+        return 1;
+    }
+    if ($output !~ /HEARTBEAT TEST PASSED/) {
+        print "FAIL[$label]: blocking PMIx_Process_monitor(SEND_HEARTBEAT) never completed\n";
+        return 1;
+    }
+    # The file monitor is the other psensor component, watching a file
+    # rank 0 creates and never touches. It has to survive its own first
+    # sample: the tracker's timer is persistent and the sampler must not
+    # re-arm it, so a timer that stops after one fire never trips.
+    if ($output =~ /FILE MONITOR TEST FAILED/) {
+        print "FAIL[$label]: client did not receive the file alert\n";
+        return 1;
+    }
+    if ($output !~ /FILE MONITOR TEST PASSED/) {
+        print "FAIL[$label]: client did not confirm file monitoring\n";
+        return 1;
+    }
+    print "PASS[$label]: heartbeat monitor raised the expected alert\n";
+    print "PASS[$label]: file monitor raised the expected alert\n";
+    print "PASS[$label]: blocking PMIx_Process_monitor(SEND_HEARTBEAT) returned\n";
+    return 0;
 }
 
-# The client explicitly reports failure if it never received the alert.
-if ($output =~ /MONITOR TEST FAILED/) {
-    print "FAIL: client did not receive the heartbeat alert\n";
-    exit(1);
-}
+my $rc = run_scenario("shared progress thread", 0);
+exit($rc) if (0 != $rc);
 
-# Confirm the alert actually fired rather than passing vacuously: the
-# client prints this line only from inside its heartbeat-alert handler.
-if ($output !~ /MONITOR TEST PASSED/) {
-    print "FAIL: client did not confirm heartbeat monitoring\n";
-    exit(1);
-}
+# Same test, with the monitors on their own progress thread.
+$rc = run_scenario("dedicated PSENSOR thread", 1);
+exit($rc) if (0 != $rc);
 
-# The observer also makes one blocking PMIx_Process_monitor call with
-# PMIX_SEND_HEARTBEAT. That form used to return from the _nb layer
-# without ever invoking the callback the blocking wrapper was waiting
-# on, so it hung forever - which here shows up as the whole run hitting
-# the time limit above. This line proves it came back.
-if ($output =~ /HEARTBEAT TEST FAILED/) {
-    print "FAIL: blocking PMIx_Process_monitor(SEND_HEARTBEAT) reported an error\n";
-    exit(1);
-}
-if ($output !~ /HEARTBEAT TEST PASSED/) {
-    print "FAIL: blocking PMIx_Process_monitor(SEND_HEARTBEAT) never completed\n";
-    exit(1);
-}
-print "PASS: heartbeat monitor raised the expected alert\n";
-print "PASS: blocking PMIx_Process_monitor(SEND_HEARTBEAT) returned\n";
 exit(0);


### PR DESCRIPTION
The `psensor` framework created its `"PSENSOR"` event base with
`pmix_progress_thread_init()` and never called
`pmix_progress_thread_start()`. With
`psensor_base_use_separate_thread` set, the base existed and nothing
drove it: a monitor `start` returned success, and no heartbeat window
was ever checked and no file ever sampled. This is the same defect that
was fixed for `pstat` in `pmix_pstat_base_open`, and was recorded in
`docs/todo.rst` at the time as needing its teardown looked at in the
same pass.

It does. Starting the thread is only half the change:

* **Teardown ran in the wrong order.** `close()` destructed `actives`,
  stopped the thread — which *frees* the base — and only then closed the
  components. It is the component close functions that destruct the
  tracker lists, and a tracker destructor deletes the timer it armed on
  that base. So it deleted events out of a freed base, from the
  finalizing thread, while the monitor thread was still running samplers
  on those same trackers. `close()` now pauses the thread first (joining
  it, so nothing is in flight), destructs `actives`, closes the
  components while the base is still there, and stops the thread last.

* **Both samplers re-armed their own one-shot timers.** This is the
  pattern the `pstat` `EV_PERSIST` change closed, and it bites here for
  a different reason: `check_heartbeat` retains its tracker across an
  asynchronous `PMIx_Notify_event`, and the completion callback that
  releases it runs on the library's progress thread, not the monitor's.
  A `pmix_event_del` from there can race a sample in flight, and a
  one-shot's re-arm lands after the delete. Both components now arm
  `EV_PERSIST` timers and neither sampler re-arms; `file_sample` disarms
  explicitly before handing the tracker to the notification.

While validating the fix end to end, two more things turned up and are
included as separate commits.

**The file monitor's path was not screened.** `psensor/file`'s
`start()` fed `monitor->value.data.string` straight to `strdup`. That
value arrives off the wire from a client, so a malformed
`PMIX_MONITOR_FILE` request was a server crash a client could ask for.

**An early heartbeat was delivered to the command switchyard.**
`pmix_server_message_handler` is registered under a wildcard
(`UINT_MAX`) receive, so it sees every message no more specific recv
claimed. `psensor/heartbeat` posts its `PMIX_PTL_TAG_HEARTBEAT` recv
only when the first monitor is armed, so a beat sent before that was
matched by the wildcard and handed to `server_switchyard`, which cannot
read a `pmix_cmd_t` out of a zero-byte buffer. The error it returned was
packed into a reply and queued back on tag 1 — where nothing is
listening, because `PMIx_Heartbeat` is one-way and no client posts for
that tag. The client then reported it through the `unexpected-message`
`show_help`, which asks the user to report a bug to the PMIx developers.

Both halves are fixed: the switchyard drops the tag, and an unmatched
message in the `ptl` base is now a framework trace at verbosity 2
rather than a `show_help`. Nothing is lost by dropping the beat — there
is no monitor to credit it to yet, which is exactly why the recv it
belongs to has not been posted.

Heartbeat is the only reserved tag that can reach the switchyard today:
`PMIX_PTL_TAG_IOF` and `PMIX_PTL_TAG_IOF_CONTROL` are posted at server
init, `PMIX_PTL_TAG_DATA_DELETE` only travels server→client, and
`PMIX_PTL_TAG_NOTIFY` is unused. The standing rule — a new reserved tag
a client may send *up* needs either an eagerly-posted recv or a screen
of its own — is recorded in the `ptl` and `server` guides.

### Testing

`test/unit/run_monitor.pl` covered one monitor in one configuration.
It now runs its scenario twice, the second time with
`psensor_base_use_separate_thread` set, and `test/simple/simpmonitor.c`
also drives the **file** monitor, which had no end-to-end coverage at
all. The file case is a real regression test for the arming rule rather
than just for the wiring: the first sample only records the mtime, so
the monitor trips only if its timer fires more than once.

I confirmed the new coverage catches the original defect by temporarily
removing the `thread_start` call — the second scenario fails, the first
still passes.

Full `make check` passes (153 PASS, 0 FAIL, 2 SKIP). Library and docs
build warning-free.
