### PR TITLE
Tell the host the group id of a publish or lookup

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -234,7 +234,7 @@ pmix_status_t pmix_server_publish(pmix_peer_t *peer, pmix_buffer_t *buf,
     int32_t cnt;
     size_t ninfo;
     pmix_proc_t proc;
-    uint32_t uid;
+    uint32_t uid, gid;
 
     pmix_output_verbose(2, pmix_server_globals.pub_output, "recvd PUBLISH");
 
@@ -249,6 +249,16 @@ pmix_status_t pmix_server_publish(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
+    /* ...and the effective group id, which access permissions are
+     * expressed in terms of just as much as the user id.  It does not come
+     * off the wire: the connection handshake already carried it, and the
+     * peer was refused at that point if it claimed a uid or gid other than
+     * the one it was registered with - so what the host told us is both
+     * available and more trustworthy than a per-command claim.  Adding a
+     * field to this message would also be unversionable, there being no
+     * version number that distinguishes a peer built before the field from
+     * one built after. */
+    gid = peer->info->gid;
     /* unpack the number of info objects */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
@@ -268,14 +278,14 @@ pmix_status_t pmix_server_publish(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    /* we will be adding one for the user id */
+    /* we will be adding two: the user id and the group id */
     cd = PMIX_NEW(pmix_setup_caddy_t);
     if (NULL == cd) {
         return PMIX_ERR_NOMEM;
     }
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
-    cd->ninfo = ninfo + 1;
+    cd->ninfo = ninfo + 2;
     PMIX_INFO_CREATE(cd->info, cd->ninfo);
     if (NULL == cd->info) {
         rc = PMIX_ERR_NOMEM;
@@ -293,9 +303,12 @@ pmix_status_t pmix_server_publish(pmix_peer_t *peer, pmix_buffer_t *buf,
             goto cleanup;
         }
     }
-    pmix_strncpy(cd->info[cd->ninfo - 1].key, PMIX_USERID, PMIX_MAX_KEYLEN);
+    pmix_strncpy(cd->info[cd->ninfo - 2].key, PMIX_USERID, PMIX_MAX_KEYLEN);
+    cd->info[cd->ninfo - 2].value.type = PMIX_UINT32;
+    cd->info[cd->ninfo - 2].value.data.uint32 = uid;
+    pmix_strncpy(cd->info[cd->ninfo - 1].key, PMIX_GRPID, PMIX_MAX_KEYLEN);
     cd->info[cd->ninfo - 1].value.type = PMIX_UINT32;
-    cd->info[cd->ninfo - 1].value.data.uint32 = uid;
+    cd->info[cd->ninfo - 1].value.data.uint32 = gid;
 
     /* call the local server */
     pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
@@ -342,7 +355,7 @@ pmix_status_t pmix_server_lookup(pmix_peer_t *peer, pmix_buffer_t *buf,
     char *sptr;
     size_t ninfo;
     pmix_proc_t proc;
-    uint32_t uid;
+    uint32_t uid, gid;
 
     pmix_output_verbose(2, pmix_server_globals.pub_output, "recvd LOOKUP");
 
@@ -357,6 +370,16 @@ pmix_status_t pmix_server_lookup(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
+    /* ...and the effective group id, which access permissions are
+     * expressed in terms of just as much as the user id.  It does not come
+     * off the wire: the connection handshake already carried it, and the
+     * peer was refused at that point if it claimed a uid or gid other than
+     * the one it was registered with - so what the host told us is both
+     * available and more trustworthy than a per-command claim.  Adding a
+     * field to this message would also be unversionable, there being no
+     * version number that distinguishes a peer built before the field from
+     * one built after. */
+    gid = peer->info->gid;
     /* unpack the number of keys */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &nkeys, &cnt, PMIX_SIZE);
@@ -401,8 +424,8 @@ pmix_status_t pmix_server_lookup(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
-    /* we will be adding one for the user id */
-    cd->ninfo = ninfo + 1;
+    /* we will be adding two: the user id and the group id */
+    cd->ninfo = ninfo + 2;
     PMIX_INFO_CREATE(cd->info, cd->ninfo);
     if (NULL == cd->info) {
         rc = PMIX_ERR_NOMEM;
@@ -417,9 +440,12 @@ pmix_status_t pmix_server_lookup(pmix_peer_t *peer, pmix_buffer_t *buf,
             goto cleanup;
         }
     }
-    pmix_strncpy(cd->info[cd->ninfo - 1].key, PMIX_USERID, PMIX_MAX_KEYLEN);
+    pmix_strncpy(cd->info[cd->ninfo - 2].key, PMIX_USERID, PMIX_MAX_KEYLEN);
+    cd->info[cd->ninfo - 2].value.type = PMIX_UINT32;
+    cd->info[cd->ninfo - 2].value.data.uint32 = uid;
+    pmix_strncpy(cd->info[cd->ninfo - 1].key, PMIX_GRPID, PMIX_MAX_KEYLEN);
     cd->info[cd->ninfo - 1].value.type = PMIX_UINT32;
-    cd->info[cd->ninfo - 1].value.data.uint32 = uid;
+    cd->info[cd->ninfo - 1].value.data.uint32 = gid;
 
     /* call the local server */
     pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
@@ -449,7 +475,7 @@ pmix_status_t pmix_server_unpublish(pmix_peer_t *peer, pmix_buffer_t *buf,
     size_t i, nkeys, ninfo;
     char *sptr;
     pmix_proc_t proc;
-    uint32_t uid;
+    uint32_t uid, gid;
 
     pmix_output_verbose(2, pmix_server_globals.pub_output, "recvd UNPUBLISH");
 
@@ -464,6 +490,16 @@ pmix_status_t pmix_server_unpublish(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
+    /* ...and the effective group id, which access permissions are
+     * expressed in terms of just as much as the user id.  It does not come
+     * off the wire: the connection handshake already carried it, and the
+     * peer was refused at that point if it claimed a uid or gid other than
+     * the one it was registered with - so what the host told us is both
+     * available and more trustworthy than a per-command claim.  Adding a
+     * field to this message would also be unversionable, there being no
+     * version number that distinguishes a peer built before the field from
+     * one built after. */
+    gid = peer->info->gid;
     /* unpack the number of keys */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &nkeys, &cnt, PMIX_SIZE);
@@ -508,8 +544,8 @@ pmix_status_t pmix_server_unpublish(pmix_peer_t *peer, pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
-    /* we will be adding one for the user id */
-    cd->ninfo = ninfo + 1;
+    /* we will be adding two: the user id and the group id */
+    cd->ninfo = ninfo + 2;
     PMIX_INFO_CREATE(cd->info, cd->ninfo);
     if (NULL == cd->info) {
         rc = PMIX_ERR_NOMEM;
@@ -524,9 +560,12 @@ pmix_status_t pmix_server_unpublish(pmix_peer_t *peer, pmix_buffer_t *buf,
             goto cleanup;
         }
     }
-    pmix_strncpy(cd->info[cd->ninfo - 1].key, PMIX_USERID, PMIX_MAX_KEYLEN);
+    pmix_strncpy(cd->info[cd->ninfo - 2].key, PMIX_USERID, PMIX_MAX_KEYLEN);
+    cd->info[cd->ninfo - 2].value.type = PMIX_UINT32;
+    cd->info[cd->ninfo - 2].value.data.uint32 = uid;
+    pmix_strncpy(cd->info[cd->ninfo - 1].key, PMIX_GRPID, PMIX_MAX_KEYLEN);
     cd->info[cd->ninfo - 1].value.type = PMIX_UINT32;
-    cd->info[cd->ninfo - 1].value.data.uint32 = uid;
+    cd->info[cd->ninfo - 1].value.data.uint32 = gid;
 
     /* call the local server */
     pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);


### PR DESCRIPTION
## The problem

The Standard requires the PMIx library to add **both** `PMIX_USERID` and
`PMIX_GRPID` to the info array it hands the host environment for
`PMIx_Publish`, `PMIx_Lookup` and `PMIx_Unpublish` (see the required-attributes
text for each of those APIs). We add only the user id.

That leaves a host unable to evaluate half of an access-permission list.
`PMIX_ACCESS_GRPIDS` names the effective group ids allowed to reach published
data, and nothing ever told the host what group the requestor was in — so the
attribute could be accepted and stored, but never enforced. It has been defined
since v4.1 and, as far as I can find, has no reader anywhere: not in this
library, not in PRRTE, not in Open MPI.

## The change

The server takes the gid from the peer's connection record and hands it up
beside the user id it already unpacks. Three call sites, no message change.

The first version of this PR did add a field to those three messages, and the
cross-version tests were right to segfault on it. The gid needs no wire field
and must not have one:

- The connection handshake **already carries the peer's uid and gid**
  (`ptl_base_connection_hdlr.c`), and the peer is refused right there if it
  claims either differently from what it was registered with. So
  `peer->info->gid` is not only available, it is more trustworthy than a
  per-command claim would be.
- A field here is unversionable. No version number distinguishes a peer built
  before it from one built after, which is exactly why `xversion (master)` —
  PR server against check-branch client — is entitled to run the two against
  each other, and a receiver expecting a field its sender never packed reads
  the rest of the message off by four bytes.

## Testing

Built with `--enable-devel-check`, warning-free. Reproduced the CI failure
locally first (old-linked client, new server → every operation
`PMIX_ERR_BAD_PARAM`), then confirmed the fix in the same shape: an application
linked against an **unpatched** libpmix publishes, looks up and unpublishes
against a patched server, which survives.

Exercised end-to-end from the consumer: openpmix/prrte#2689 implements the
access-permission rules on top of this. With it, a `PMIX_ACCESS_USERIDS` or
`PMIX_ACCESS_GRPIDS` list naming somebody else refuses a reader with
`PMIX_ERR_NO_PERMISSIONS`, while one naming the reader's own identity admits it
— and the gid-based half of that only discriminates because a real gid now
arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)