### PR TITLE
Review src/mca/preg, and record it

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -112,9 +112,10 @@ each time somebody asks.
 Review coverage
 ---------------
 
-Assessed on **2026-08-15** from the commit history.  Move an entry out of
-"Not yet reviewed" as its review lands, and refresh the churn figures in
-"Reviewed, but changed materially since" when a re-review closes one.
+Assessed on **2026-08-15** from the commit history, and refreshed on
+**2026-08-19** when the ``src/mca/pnet`` review landed.  Move an entry out
+of "Not yet reviewed" as its review lands, and refresh the churn figures
+in "Reviewed, but changed materially since" when a re-review closes one.
 
 .. note:: **An** ``AGENTS.md`` **is not evidence of a review.**  Every
           directory under ``src/`` has one; most were written in the July
@@ -129,7 +130,8 @@ Reviewed and current
 ``src/class``, ``src/common``, ``src/event``, ``src/include``,
 ``src/runtime``, ``src/tool``, ``src/tools``, ``src/mca/base``,
 ``src/mca/bfrops``, ``src/mca/gds/base``, ``src/mca/gds/hash``,
-``src/mca/pstat``, ``src/mca/ptl``, and ``bindings/python``.
+``src/mca/pnet``, ``src/mca/pstat``, ``src/mca/ptl``, and
+``bindings/python``.
 ``src/client``, ``src/server``, ``src/hwloc``, ``src/util`` and
 ``src/mca/gds/shmem3`` were reviewed too, but have moved since — see
 below.
@@ -141,9 +143,6 @@ Each of these has an orientation guide and nothing else: no findings were
 ever recorded in it, and only drive-by fixes have landed.  Ordered by
 size, which is a rough proxy for how much there is to find.
 
-* ``src/mca/pnet`` (with ``base``, ``tcp``, ``opa``, ``nvd``,
-  ``simptest``) — 4064 lines.  Revived on 2026-07-15 and not looked at
-  since.
 * ``src/mca/preg`` (with ``raw``, ``compress``) — 1324 lines.  It parses
   regular expressions arriving off the wire, which makes it the
   highest-risk member of this list.  Halved on 2026-08-17 by dropping the
@@ -257,6 +256,36 @@ See :ref:`Delta Exchange and Data Deletion <modex-delta>` in
 :doc:`how-things-work/modex`, tracked as `openpmix#4087
 <https://github.com/openpmix/openpmix/issues/4087>`_.
 
+A fabric plane claimed asynchronously is not recorded
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Found in the ``src/mca/pnet`` review (2026-08-19).
+``pmix_pnet_base_register_fabric`` records a tracker for a plane only when
+a module answers ``PMIX_OPERATION_SUCCEEDED`` — the "already done, inline"
+status.  A module that claims the plane the *asynchronous* way, returning
+plain ``PMIX_SUCCESS`` and calling back later, is never recorded, yet both
+callers — ``src/server/pmix_server_fabric.c`` and
+``PMIx_Fabric_register_nb`` — read ``PMIX_SUCCESS`` as "claimed, wait for
+the callback".  A later update or deregister on that plane then answers
+``PMIX_ERR_BAD_PARAM``, because the scan finds nothing.
+
+Which half is wrong is the decision, and it cannot be settled by reading
+the tree: **no shipped component implements** ``register_fabric`` **at
+all** — grep the four component directories and the slots are unset — so
+there is nothing to test a change against, and choosing the async
+contract now pins down the interface a real fabric component would have
+to meet.  Two loose ends belong to the same decision.  ``fabric->module``
+is deliberately never set, so the branches in ``update_fabric`` and
+``deregister_fabric`` that cast it back to a ``pmix_pnet_fabric_t *`` are
+dead and every lookup goes through the index/name scan — a tracker
+pointer parked in a caller's object would dangle the moment the fabric
+was deregistered.  And nothing frees ``pmix_pnet_fabric_t.payload``:
+``ftdes`` releases only ``name``, and the base never tells a component
+its tracker died, so a component that parks an allocation there must free
+it from its own ``deregister_fabric``.
+
+See "The fabric path is scaffolding" in ``src/mca/pnet/AGENTS.md``.
+
 Deferred work
 -------------
 
@@ -282,6 +311,27 @@ cover the whole of what the entry described.
   ``refcb()`` entry in ``src/client/AGENTS.md`` for why all-or-nothing is
   the only answer an application can act on.  Recorded here because it is
   the one behavior change in that group of fixes.
+
+Fabric inventory collection is a stub
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Found in the ``src/mca/pnet`` review (2026-08-19).  No pnet component
+collects inventory.  ``opa``'s ``collect_inventory`` carries a comment
+about searching the topology for OPA NICs and then returns
+``PMIX_SUCCESS`` having added nothing; ``deliver_inventory`` returns
+``PMIX_SUCCESS``.  ``nvd``'s goes one step further — it confirms that a
+matching NIC exists on the node — but still reports no contents.  The
+plumbing is real, so a host that asks for fabric inventory gets a
+successful, empty answer rather than an error; treat the capability as
+unfinished rather than working.
+
+Finishing it needs a decision the review was not entitled to make: what a
+fabric inventory record contains, and how a component that has nothing to
+report says so.  The base has **no decline convention** on this path —
+unlike ``allocate`` and ``setup_fork``, it ``PMIX_ERROR_LOG``\ s any
+non-``PMIX_SUCCESS`` return and abandons the fan-out to every component
+behind it — so today "nothing here" and "collected everything" are the
+same answer.
 
 Coverage gaps
 -------------
@@ -324,6 +374,23 @@ Coverage gaps
 * **``pps`` has never been validated against a live process-table
   server.**  Its no-connect paths are covered by the tools smoke test;
   the proc-table rendering is not.
+* **Nothing exercises the pnet fabric calls.**  ``register_fabric``,
+  ``update_fabric`` and ``deregister_fabric`` are wired all the way
+  through ``src/mca/pnet/base``, but no shipped component implements any
+  of them, so ``pmix_pnet_globals.fabrics`` is never populated in a stock
+  build and every base fabric call ends in ``PMIX_ERR_NOT_SUPPORTED`` /
+  ``PMIX_ERR_NOT_FOUND`` / ``PMIX_ERR_BAD_PARAM``.  Covering it means
+  writing a component that claims a plane, which is the decision recorded
+  above.  (``test/unit/server_fabric`` covers the server-side
+  ``PMIx_Compute_distances`` handler, not this path.)
+* **``pnet/simptest``'s end-to-end launch path is not in** ``make check``.
+  ``test/unit/pnet_simptest_map`` drives ``allocate`` through
+  ``PMIx_server_setup_application`` against a topology file it writes, but
+  the other half — a client fetching ``PMIX_FABRIC_ENDPT`` by rank and
+  ``PMIX_FABRIC_COORDINATES`` at the node level — still has to be run by
+  hand, because ``test/simple/simptest`` generates its node map from the
+  local host and so needs a topology file naming that host.  See
+  "Running it" in ``src/mca/pnet/simptest/AGENTS.md``.
 
 Not defects — by design
 -----------------------
@@ -385,6 +452,35 @@ not "fixed" by a later reader.
   is intentional.**  A job-control request may name a job this server has
   not been told about yet, and the epilog directives need somewhere to
   hang; the entry is reused when registration arrives.
+* **``pnet/opa`` and ``pnet/nvd`` ship no ``configure.m4``, on purpose.**
+  A component with no ``configure.m4`` is configured by the MCA machinery
+  itself and therefore builds unconditionally, which is what these two
+  want: neither links anything nor needs an SDK — they read info
+  attributes hwloc already recorded and set environment variables — and
+  whether there is work to do is a property of the machine the *daemon*
+  runs on, which only ``component_open`` is in a position to know.  The
+  files they used to have asked that question at build time and got it
+  wrong in both directions (``nvd``'s was hardwired off, ``opa``'s always
+  succeeded).  The one visible consequence is that ``configure``'s summary
+  no longer prints ``Transports / NVIDIA|OmniPath`` lines.  Do not restore
+  them.
+* **``transports_print`` in ``pnet/opa`` type-puns a ``uint64_t`` through
+  ``unsigned int *``.**  That is undefined behavior in general and is not
+  a live defect here: the whole tree is built ``-fno-strict-aliasing``
+  (``config/pmix_setup_cc.m4`` adds it wherever the compiler takes it).
+  The surrounding arithmetic is deliberately width-independent, and the
+  byte-order dependence of the result does not matter because the key is
+  generated once on the lead server and shipped as a string.  Do not copy
+  the idiom into new code, and do not "fix" it as a bug.
+* **A node in ``pnet/simptest``'s topology file that the job's node map
+  does not name is silently skipped.**  ``allocate`` matches each config
+  line against the ``PMIX_NODE_MAP`` by exact name, which is intrinsic to
+  a file that describes the real nodes the RM placed the job on.  The
+  converse is *not* silent: a node the job was placed on that the file
+  fails to describe draws a ``node-not-found`` ``show_help`` naming it and
+  the request is then declined — declined, rather than failed, because a
+  hard error out of ``allocate`` aborts the base's fan-out for every other
+  component too.
 * **The bare ``atomic_bool`` fields in ``pmix_globals_t``** are correct,
   merely inconsistent with the typedefs used elsewhere, and the
   ``PMIX_C_HAVE_*`` defines in the installed ``pmix_config.h`` are now

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -113,7 +113,8 @@ Review coverage
 ---------------
 
 Assessed on **2026-08-15** from the commit history, and refreshed on
-**2026-08-19** when the ``src/mca/pnet`` review landed.  Move an entry out
+**2026-08-19** when the ``src/mca/pnet`` and ``src/mca/preg`` reviews
+landed.  Move an entry out
 of "Not yet reviewed" as its review lands, and refresh the churn figures
 in "Reviewed, but changed materially since" when a re-review closes one.
 
@@ -130,8 +131,8 @@ Reviewed and current
 ``src/class``, ``src/common``, ``src/event``, ``src/include``,
 ``src/runtime``, ``src/tool``, ``src/tools``, ``src/mca/base``,
 ``src/mca/bfrops``, ``src/mca/gds/base``, ``src/mca/gds/hash``,
-``src/mca/pnet``, ``src/mca/pstat``, ``src/mca/ptl``, and
-``bindings/python``.
+``src/mca/pnet``, ``src/mca/preg``, ``src/mca/pstat``, ``src/mca/ptl``,
+and ``bindings/python``.
 ``src/client``, ``src/server``, ``src/hwloc``, ``src/util`` and
 ``src/mca/gds/shmem3`` were reviewed too, but have moved since — see
 below.
@@ -143,11 +144,6 @@ Each of these has an orientation guide and nothing else: no findings were
 ever recorded in it, and only drive-by fixes have landed.  Ordered by
 size, which is a rough proxy for how much there is to find.
 
-* ``src/mca/preg`` (with ``raw``, ``compress``) — 1324 lines.  It parses
-  regular expressions arriving off the wire, which makes it the
-  highest-risk member of this list.  Halved on 2026-08-17 by dropping the
-  ``native`` component and moving the deprecated ``char*`` API into the
-  base, but that was a restructure, not a review.
 * ``src/mca/pgpu`` (with ``amd``, ``intel``, ``nvd``, ``test``) — 2467
   lines.  The 2026-07-15 "repair the stale components" work was not a
   review.
@@ -333,6 +329,27 @@ non-``PMIX_SUCCESS`` return and abandons the fan-out to every component
 behind it — so today "nothing here" and "collected everything" are the
 same answer.
 
+The deprecated regex API cannot carry a length
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Found in the ``src/mca/preg`` review (2026-08-19), and narrowed rather
+than closed by it.  ``pmix_preg_base_legacy_decode`` bounds every read
+against an ``avail`` argument, but only ``unpack`` can supply a real one:
+it knows how many bytes are left in the buffer.  Every other caller holds
+a bare ``char *`` and passes ``SIZE_MAX``, because
+``pmix_preg.parse_nodes(regexp, &names)`` has nowhere to put a length
+without changing a signature that predates the current API.  ``gds/hash``
+has the length in ``val->data.bo.size`` and still cannot hand it over.
+
+The review made the tag test exact, which removed the case that a host
+could trigger with ordinary data — a plain node list whose first node
+begins with ``blob`` is no longer taken for a blob and walked past its
+end.  What is left needs a caller-owned string that really does carry the
+``"blob:"`` tag and is truncated behind it, which is not something a peer
+can produce (those arrive through the bounded ``unpack``).  Closing it
+properly means plumbing a length through the deprecated signatures, and a
+caller that can do that is better off moving to ``pmix_regex2_t``.
+
 Coverage gaps
 -------------
 
@@ -374,6 +391,18 @@ Coverage gaps
 * **``pps`` has never been validated against a live process-table
   server.**  Its no-connect paths are covered by the tools smoke test;
   the proc-table rendering is not.
+* **The compressed half of ``preg`` is invisible to a build with no
+  compression library.**  ``preg/compress`` disables itself when
+  ``pcompress`` has no module, so on such a build — a stock macOS
+  developer tree among them — ``raw`` wins every encode, and neither the
+  ``blob:`` framing in ``preg_base_legacy.c`` nor the ``compress``
+  component is ever reached by a round trip.  ``test/unit/preg`` covers
+  the framing with hand-built vectors, which is what a bounded decoder
+  can be tested with, but the encode-decode pair only meet on a build
+  that can compress: ``test_legacy_large`` says which encoding it got, so
+  a thin run reports itself rather than passing quietly.  The real round
+  trip was run under ``contrib/dockerswarm`` (Linux, all four
+  compressors), where the 5000-node case does take the blob path.
 * **Nothing exercises the pnet fabric calls.**  ``register_fabric``,
   ``update_fabric`` and ``deregister_fabric`` are wired all the way
   through ``src/mca/pnet/base``, but no shipped component implements any

--- a/src/mca/pcompress/zlib/compress_zlib.c
+++ b/src/mca/pcompress/zlib/compress_zlib.c
@@ -218,6 +218,16 @@ static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len)
     bool rc;
     uint8_t *input;
 
+    /* the caller's length is a claim about bytes that generally came off
+     * a peer's wire, and the four-byte prefix read below is the first
+     * thing that trusts it - as is the subtraction that sizes the
+     * payload, which underflows for anything shorter. zstd and lz4 screen
+     * this the same way; so does get_decompressed_size, just below. */
+    if (NULL == inbytes || len < sizeof(uint32_t)) {
+        *outstring = NULL;
+        return false;
+    }
+
     /* the first 4 bytes contains the uncompressed size */
     memcpy(&len2, inbytes, sizeof(uint32_t));
     if (len2 == UINT32_MAX) {

--- a/src/mca/pcompress/zlibng/compress_zlibng.c
+++ b/src/mca/pcompress/zlibng/compress_zlibng.c
@@ -219,6 +219,16 @@ static bool decompress_string(char **outstring, uint8_t *inbytes, size_t len)
     bool rc;
     uint8_t *input;
 
+    /* the caller's length is a claim about bytes that generally came off
+     * a peer's wire, and the four-byte prefix read below is the first
+     * thing that trusts it - as is the subtraction that sizes the
+     * payload, which underflows for anything shorter. zstd and lz4 screen
+     * this the same way; so does get_decompressed_size, just below. */
+    if (NULL == inbytes || len < sizeof(uint32_t)) {
+        *outstring = NULL;
+        return false;
+    }
+
     /* the first 4 bytes contains the uncompressed size */
     memcpy(&len2, inbytes, sizeof(uint32_t));
     if (len2 == UINT32_MAX) {

--- a/src/mca/pnet/nvd/AGENTS.md
+++ b/src/mca/pnet/nvd/AGENTS.md
@@ -145,7 +145,7 @@ prints a `Transports / NVIDIA` line.
   transfers the packed bytes to a `pmix_byte_object_t` without freeing
   anything, so when compression succeeds — and the `pmix_kval_t` therefore
   owns the *compressed* copy — the uncompressed block has to be freed by
-  hand. `pgpu/{nvd,intel}` are the reference; `pnet/opa` still leaks it.
+  hand. `pgpu/{nvd,intel}` and `pnet/opa` all do this.
 - **`collect_inventory` reports presence but not contents.** It confirms a
   matching NIC exists but does not populate inventory; treat inventory
   support as unfinished.

--- a/src/mca/preg/AGENTS.md
+++ b/src/mca/preg/AGENTS.md
@@ -206,6 +206,48 @@ two. Their failure behavior is worth knowing:
   pointer carries no recognizable framing. Nothing in the tree currently
   calls it.
 
+### The decoder validates the framing byte for byte, and must
+
+`pmix_preg_base_legacy_decode` reads bytes a peer supplied, so it treats
+every field of the layout as something to *confirm* rather than to step
+over: the tag must be the literal `"blob:"` and nothing longer, the label
+must be there, `"size="` must be there, and the digits must be followed by
+`":"` and a NUL. Each of those checks earns its place — none is
+defensive decoration:
+
+- **The tag test is exact, not a prefix test.** A prefix test also claims
+  a plain node list whose first node happens to begin with `blob`, and
+  everything after the tag is then read looking for a label that is not
+  there — off the end of a string the caller owns, in the `SIZE_MAX` case
+  where there is no bound to stop it. A genuine blob always carries the
+  tag verbatim, so exactness costs nothing.
+- **The bound on the payload is a subtraction.** Written the natural way,
+  `payload_offset + len > avail`, it is the *peer's* declared length that
+  overflows the sum: a `size=` near `SIZE_MAX` wraps it back to a small
+  number, the value is accepted, and `SIZE_MAX` reaches
+  `pmix_compress.decompress_string` as the byte count of a buffer a few
+  dozen bytes long. `len > avail - offset` cannot wrap, and the offset is
+  known to be within `avail` because it was reached by stepping over a NUL
+  the code had already found inside the bound.
+- **The colon and NUL after the digits are checked before being stepped
+  over.** Skipping two bytes that are something else leaves the payload
+  pointer inside the framing, and the value is then accepted with a
+  payload nobody wrote.
+
+`test/unit/preg.c` holds the vectors for all of these
+(`test_legacy_malformed`, `test_legacy_blob_prefixed_list`,
+`test_legacy_truncated`). Keep the encoder and the decoder exact mirrors
+of each other: anything the encoder writes as a literal, the decoder
+should insist on.
+
+`legacy_encode` reads `regex->bytes` as a C string on the `raw` path,
+which is the one place the framework's "never `strlen` a `regex->bytes`"
+rule is broken on purpose. The deprecated `raw` layout is *defined* as a
+NUL-terminated string, and the only producer of a `raw` regex2 is the
+`raw` module, whose `generate_regex` is a `strdup`. A component that
+emits embedded NULs simply has no deprecated form, which is the
+documented fallback.
+
 ### The one wart the deprecated form cannot shed
 
 `pmix_preg_base_legacy_decode` takes an `avail` bound and honors it, but
@@ -216,14 +258,15 @@ the buffer. Every other caller holds a bare `char *` and passes
 a signature that predates the current API. `gds/hash` has the length
 right there in `val->data.bo.size` and still cannot hand it over.
 
-The practical consequence is that a caller-owned string claiming to be a
-`blob` but truncated before its framing completes can be read a few bytes
-past its end. This is not new — it is what the per-component parsers did
-before — and it is bounded in the direction that matters, since values
-arriving from a peer come through `unpack`, which *is* bounded. Do not
-"fix" it by removing the bound from `unpack`; if you want it fixed
-properly, the length has to be plumbed through the deprecated signatures,
-and at that point you are better off moving the caller to `pmix_regex2_t`.
+What is left of that, now that the tag test is exact, is narrow: a string
+that really does carry the `"blob:"` tag but was truncated before its
+framing completes can be read a few bytes past its end. It takes a
+caller-owned value that claims to be a blob and is not one — not an
+ordinary list, and not anything that arrived from a peer, since those come
+through `unpack`, which *is* bounded. Do not "fix" it by removing the
+bound from `unpack`; if you want it fixed properly, the length has to be
+plumbed through the deprecated signatures, and at that point you are
+better off moving the caller to `pmix_regex2_t`.
 
 ## Selection and lifecycle
 

--- a/src/mca/preg/AGENTS.md
+++ b/src/mca/preg/AGENTS.md
@@ -285,7 +285,8 @@ better off moving the caller to `pmix_regex2_t`.
 ## Selection and lifecycle
 
 - **`preg_base_frame.c`** declares the framework
-  (`PMIX_MCA_BASE_FRAMEWORK_DECLARE`), instantiates the global `pmix_preg`
+  (`PMIX_MCA_BASE_VERSIONED_FRAMEWORK_DECLARE`), instantiates the global
+  `pmix_preg`
   API (pointing every slot at the base functions), and defines the
   `PMIX_CLASS_INSTANCE` for the active-module wrapper. `pmix_preg_open`
   constructs the `actives` list and opens all components;

--- a/src/mca/preg/AGENTS.md
+++ b/src/mca/preg/AGENTS.md
@@ -200,11 +200,25 @@ two. Their failure behavior is worth knowing:
   rather than splitting the payload. Do not "restore" a fallback there:
   splitting an encoded blob on commas yields plausible-looking garbage
   node names instead of an error, which is far worse than failing.
-- `copy` / `pack` / `unpack` treat an unrecognized value as a plain
-  string (`strdup`, or bfrops `PMIX_STRING`).
-- `release` has no fallback — it returns `PMIX_ERR_BAD_PARAM` if the
-  pointer carries no recognizable framing. Nothing in the tree currently
-  calls it.
+- **"Unrecognized" and "malformed" are different answers, and every
+  fallback here turns on the difference.** `parse_nodes`/`parse_procs`,
+  `copy`, `pack` and `unpack` all fall back to treating the value as a
+  plain string — but only on `PMIX_ERR_TAKE_NEXT_OPTION`, which the
+  decoder returns when the input carries no tag of ours at all. A
+  `PMIX_ERR_BAD_PARAM` means the value *does* carry our tag and is
+  malformed behind it, and each of them returns it: splitting such a
+  value hands back framing bytes dressed as node names, copying it stops
+  at the first embedded NUL and silently shortens it, and reading it as a
+  bfrops string takes a length prefix out of the middle of the framing.
+- `release` frees what it is given, whatever shape it is in. It is the
+  destructor for a `PMIX_REGEX` value — the bfrops value and darray
+  teardown (`bfrop_base_tma.h`) call it on every one of them — so it is
+  emphatically *not* uncalled, and it must not screen its argument. It
+  used to decode the framing first and refuse anything that carried none,
+  which leaked exactly the values that are allowed to carry none: `unpack`
+  hands back a plain string whenever a peer sent one, and
+  `generate_node_regex` does the same whenever no component could encode
+  the list.
 
 ### The decoder validates the framing byte for byte, and must
 

--- a/src/mca/preg/AGENTS.md
+++ b/src/mca/preg/AGENTS.md
@@ -368,6 +368,12 @@ help-content golden rule does not usually bite here.
   form.
 - Your encoding may contain embedded NUL bytes; that is what `len` is
   for. Never `strlen` a `regex->bytes`.
+- **Validate the `pmix_regex2_t` you are handed before you use it.** It
+  is a peer's claim about a peer's bytes: `bfrops` copies exactly `len`
+  bytes off the buffer, appends no terminator, and leaves `bytes` NULL
+  when `len` is zero. Whatever your encoding needs to be true of a
+  payload — a minimum length, a terminator, a magic number — check it in
+  `parse_regex` rather than in whatever you hand the bytes to.
 - Preserve value ordering across generate→parse, and remember the
   encoding must be indifferent to the delimiter: the same code path
   encodes a node list and a process map. Test round-trips with both.

--- a/src/mca/preg/base/base.h
+++ b/src/mca/preg/base/base.h
@@ -101,7 +101,14 @@ PMIX_EXPORT pmix_status_t pmix_preg_base_parse_regex(const pmix_regex2_t *regex,
  * returned pmix_regex2_t points into the caller's buffer and must not be
  * destructed, and "avail" bounds the read (SIZE_MAX for a string the
  * caller owns, the bytes remaining when reading off the wire). "total"
- * receives the length of the serialized form, including its framing. */
+ * receives the length of the serialized form, including its framing.
+ *
+ * The decode fails in two ways that callers must tell apart:
+ * PMIX_ERR_TAKE_NEXT_OPTION says the input carries no serialized regex at
+ * all, which is the ordinary answer for the plain delimited list a host
+ * supplies and which the caller should then use as-is;
+ * PMIX_ERR_BAD_PARAM says it carries our tag and is malformed behind it,
+ * and must not be fallen back on as a plain list. */
 PMIX_EXPORT pmix_status_t pmix_preg_base_legacy_encode(const pmix_regex2_t *regex,
                                                         char **output, size_t *outlen);
 

--- a/src/mca/preg/base/preg_base_legacy.c
+++ b/src/mca/preg/base/preg_base_legacy.c
@@ -123,7 +123,16 @@ pmix_status_t pmix_preg_base_legacy_encode(const pmix_regex2_t *regex, char **ou
 /* Decode in place: the returned pmix_regex2_t points into the caller's
  * buffer and must not be destructed. avail bounds the read - pass
  * SIZE_MAX for a NULL-terminated string the caller owns, or the number
- * of bytes remaining when reading off the wire. */
+ * of bytes remaining when reading off the wire.
+ *
+ * Two failures, and callers must tell them apart. PMIX_ERR_TAKE_NEXT_OPTION
+ * means "this is not a serialized regex at all" - the ordinary answer for
+ * the plain delimited list a host hands us, which the caller should go on
+ * to use as-is. PMIX_ERR_BAD_PARAM means "this carries our tag and is
+ * malformed behind it", which a caller must not fall back on: treating a
+ * corrupt blob as a plain list splits framing bytes into node names that
+ * look plausible and are not. The tag is what separates the two, which is
+ * the other reason it is matched exactly. */
 pmix_status_t pmix_preg_base_legacy_decode(const char *input, size_t avail,
                                            pmix_regex2_t *regex, size_t *total)
 {
@@ -149,7 +158,14 @@ pmix_status_t pmix_preg_base_legacy_decode(const char *input, size_t avail,
         return PMIX_SUCCESS;
     }
 
-    if (0 != strncmp(input, PREG_LEGACY_BLOB_TAG, strlen(PREG_LEGACY_BLOB_TAG))) {
+    /* the tag stands alone in its own NULL-terminated field, so this test
+     * has to be exact. A prefix test also claims a plain list whose first
+     * node happens to begin with "blob", and everything below then reads
+     * on looking for framing that is not there - past the end of the
+     * string, in the SIZE_MAX case where the caller had no bound to give
+     * us. A genuine blob always carries the tag verbatim; see encode. */
+    if (taglen != strlen(PREG_LEGACY_BLOB_TAG ":") ||
+        0 != memcmp(input, PREG_LEGACY_BLOB_TAG ":", taglen)) {
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
     idx = taglen + 1; // step over the NULL terminator
@@ -158,30 +174,53 @@ pmix_status_t pmix_preg_base_legacy_decode(const char *input, size_t avail,
      * wrote the blob - see the note at the top of this file */
     if (idx + strlen(PREG_LEGACY_BLOB_LABEL) >= avail ||
         0 != strncmp(&input[idx], PREG_LEGACY_BLOB_LABEL, strlen(PREG_LEGACY_BLOB_LABEL))) {
-        return PMIX_ERR_TAKE_NEXT_OPTION;
+        return PMIX_ERR_BAD_PARAM;
     }
     idx += strlen(PREG_LEGACY_BLOB_LABEL) + 1; // step over the NULL terminator
 
+    /* the size field is "size=" then decimal digits then ":" and a NULL.
+     * Confirm the label instead of stepping blindly over five bytes, and
+     * confirm a NULL lies ahead so strtoul cannot run off the end of a
+     * truncated buffer */
+    if (idx + strlen("size=") >= avail ||
+        0 != strncmp(&input[idx], "size=", strlen("size="))) {
+        return PMIX_ERR_BAD_PARAM;
+    }
     idx += strlen("size=");
-    /* the length is decimal digits followed by a colon and a NULL, so
-     * refuse to run strtoul off the end of a truncated buffer */
-    if (idx >= avail || strnlen(&input[idx], avail - idx) == avail - idx) {
-        return PMIX_ERR_TAKE_NEXT_OPTION;
+    if (strnlen(&input[idx], avail - idx) == avail - idx) {
+        return PMIX_ERR_BAD_PARAM;
     }
     len = strtoul(&input[idx], &ptr, 10);
     if (ptr == &input[idx]) {
         /* no digits where the length belongs */
-        return PMIX_ERR_TAKE_NEXT_OPTION;
+        return PMIX_ERR_BAD_PARAM;
+    }
+    /* the digits are followed by a colon and a NULL. Verify that rather
+     * than assume it: stepping over two bytes that are something else
+     * leaves the payload pointer inside the framing, and the value is
+     * then accepted with a payload nobody wrote. Reading ptr[1] is safe
+     * only once ptr[0] is known not to be the NULL the check above
+     * guarantees is there. */
+    if (':' != ptr[0] || '\0' != ptr[1]) {
+        return PMIX_ERR_BAD_PARAM;
     }
     ptr += 2; // step over the colon and its NULL terminator
+    idx = (size_t) (ptr - input);
 
-    if ((size_t) (ptr - input) + len > avail) {
-        return PMIX_ERR_TAKE_NEXT_OPTION;
+    /* the payload has to fit in what is left. This must be a subtraction:
+     * written as "idx + len > avail" it is the length the *peer* declared
+     * that overflows the sum - a declared length near SIZE_MAX wraps it
+     * back to a small number, the value is accepted, and SIZE_MAX then
+     * reaches pmix_compress.decompress_string as the byte count of a
+     * buffer that is a few dozen bytes long. idx <= avail here because
+     * the NULL it steps over was found within the bound. */
+    if (len > avail - idx) {
+        return PMIX_ERR_BAD_PARAM;
     }
 
     regex->type = (char *) PREG_LEGACY_BLOB_TYPE;
     regex->bytes = (uint8_t *) ptr;
     regex->len = len;
-    *total = (size_t) (ptr - input) + len;
+    *total = idx + len;
     return PMIX_SUCCESS;
 }

--- a/src/mca/preg/base/preg_base_legacy.c
+++ b/src/mca/preg/base/preg_base_legacy.c
@@ -124,6 +124,16 @@ pmix_status_t pmix_preg_base_legacy_encode(const pmix_regex2_t *regex, char **ou
  * SIZE_MAX for a NULL-terminated string the caller owns, or the number
  * of bytes remaining when reading off the wire.
  *
+ * SIZE_MAX warrants that a value carrying the blob tag owns its whole
+ * framing, and the deprecated char* entry points have no way to warrant
+ * anything narrower: the blob layout puts a NULL after the tag, so a
+ * blob and the plain string "blob:" are the same five characters up to
+ * their first NULL. Nothing readable through a char* tells them apart,
+ * which is why the exact tag test below is the last line of defense
+ * rather than a complete one - it rules out every plain list except that
+ * one string. Bytes off the wire always arrive with a real bound, so
+ * this gap is confined to the deprecated interface.
+ *
  * Two failures, and callers must tell them apart. PMIX_ERR_TAKE_NEXT_OPTION
  * means "this is not a serialized regex at all" - the ordinary answer for
  * the plain delimited list a host hands us, which the caller should go on

--- a/src/mca/preg/base/preg_base_legacy.c
+++ b/src/mca/preg/base/preg_base_legacy.c
@@ -67,8 +67,7 @@ pmix_status_t pmix_preg_base_legacy_encode(const pmix_regex2_t *regex, char **ou
                                            size_t *outlen)
 {
     char *result, *slen;
-    size_t total;
-    int idx;
+    size_t total, idx;
 
     if (NULL == regex || NULL == regex->type || NULL == regex->bytes) {
         return PMIX_ERR_BAD_PARAM;

--- a/src/mca/preg/base/preg_base_select.c
+++ b/src/mca/preg/base/preg_base_select.c
@@ -87,6 +87,9 @@ int pmix_preg_base_select(void)
         nmodule = (pmix_preg_module_t *) module;
         /* add to the list of selected modules */
         newmodule = PMIX_NEW(pmix_preg_base_active_module_t);
+        if (NULL == newmodule) {
+            return PMIX_ERR_NOMEM;
+        }
         newmodule->pri = priority;
         newmodule->module = nmodule;
         newmodule->component = (pmix_mca_base_component_t *) cli->cli_component;

--- a/src/mca/preg/base/preg_base_select.c
+++ b/src/mca/preg/base/preg_base_select.c
@@ -34,14 +34,15 @@
 
 /* Function for selecting a prioritized list of components
  * from all those that are available. */
-int pmix_preg_base_select(void)
+pmix_status_t pmix_preg_base_select(void)
 {
     pmix_mca_base_component_list_item_t *cli = NULL;
     pmix_mca_base_component_t *component = NULL;
     pmix_mca_base_module_t *module = NULL;
     pmix_preg_module_t *nmodule;
     pmix_preg_base_active_module_t *newmodule, *mod;
-    int rc, priority;
+    pmix_status_t rc;
+    int priority;
     bool inserted;
 
     if (pmix_preg_globals.selected) {
@@ -126,5 +127,4 @@ int pmix_preg_base_select(void)
     }
 
     return PMIX_SUCCESS;
-    ;
 }

--- a/src/mca/preg/base/preg_base_stubs.c
+++ b/src/mca/preg/base/preg_base_stubs.c
@@ -82,6 +82,11 @@ static pmix_status_t parse_legacy(const char *regexp, char ***result, int delimi
          * encoding - splitting the payload would yield nonsense */
         return PMIX_ERR_NOT_SUPPORTED;
     }
+    if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+        /* it carries our tag and is malformed behind it. Splitting that
+         * hands back framing bytes dressed as node names */
+        return rc;
+    }
 
     /* not an encoded regex at all, so it must be the plain list */
     *result = PMIx_Argv_split(regexp, delimiter);
@@ -111,9 +116,16 @@ pmix_status_t pmix_preg_base_parse_procs(const char *regexp, char ***procs)
 pmix_status_t pmix_preg_base_copy(char **dest, size_t *len, const char *input)
 {
     pmix_regex2_t r2 = PMIX_REGEX2_STATIC_INIT;
+    pmix_status_t rc;
     size_t total;
 
-    if (PMIX_SUCCESS != pmix_preg_base_legacy_decode(input, SIZE_MAX, &r2, &total)) {
+    rc = pmix_preg_base_legacy_decode(input, SIZE_MAX, &r2, &total);
+    if (PMIX_SUCCESS != rc) {
+        if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+            /* ours and malformed - copying it as a string would stop at
+             * the first embedded NULL and silently shorten it */
+            return rc;
+        }
         /* it must just be a string */
         *dest = strdup(input);
         if (NULL == *dest) {
@@ -139,7 +151,13 @@ pmix_status_t pmix_preg_base_pack(pmix_buffer_t *buffer, const char *input)
     size_t total;
     char *ptr;
 
-    if (PMIX_SUCCESS != pmix_preg_base_legacy_decode(input, SIZE_MAX, &r2, &total)) {
+    rc = pmix_preg_base_legacy_decode(input, SIZE_MAX, &r2, &total);
+    if (PMIX_SUCCESS != rc) {
+        if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+            /* ours and malformed - refuse it rather than put a truncated
+             * copy of it on the wire for a peer to puzzle over */
+            return rc;
+        }
         /* just pack it as a string */
         PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buffer, input, 1, PMIX_STRING);
         return rc;
@@ -171,8 +189,20 @@ pmix_status_t pmix_preg_base_unpack(pmix_buffer_t *buffer, char **regex)
     }
     avail = (size_t) (buffer->pack_ptr - buffer->unpack_ptr);
 
-    if (0 == avail ||
-        PMIX_SUCCESS != pmix_preg_base_legacy_decode(buffer->unpack_ptr, avail, &r2, &total)) {
+    /* an empty buffer is left to the string unpack, whose
+     * PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER is what a caller reading
+     * until the buffer runs dry is waiting for */
+    rc = (0 == avail) ? PMIX_ERR_TAKE_NEXT_OPTION
+                      : pmix_preg_base_legacy_decode(buffer->unpack_ptr, avail, &r2, &total);
+    if (PMIX_SUCCESS != rc) {
+        if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+            /* these are a peer's bytes and they carry our tag with
+             * something malformed behind it. Reading them as a string
+             * would take the bfrops length prefix out of the middle of
+             * the framing */
+            *regex = NULL;
+            return rc;
+        }
         /* must just be a string */
         PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, buffer, regex, &cnt, PMIX_STRING);
         return rc;
@@ -191,15 +221,18 @@ pmix_status_t pmix_preg_base_unpack(pmix_buffer_t *buffer, char **regex)
 
 pmix_status_t pmix_preg_base_release(char *regexp)
 {
-    pmix_regex2_t r2 = PMIX_REGEX2_STATIC_INIT;
-    size_t total;
-
     if (NULL == regexp) {
         return PMIX_SUCCESS;
     }
-    if (PMIX_SUCCESS != pmix_preg_base_legacy_decode(regexp, SIZE_MAX, &r2, &total)) {
-        return PMIX_ERR_BAD_PARAM;
-    }
+    /* This is the destructor for a PMIX_REGEX value - the bfrops value
+     * and darray teardown call it on every one of them - so it frees
+     * what it is given without asking what shape it is in. It used to
+     * decode the framing first and refuse anything that carried none,
+     * which leaked precisely the values that are allowed to carry none:
+     * pmix_preg_base_unpack hands back a plain string whenever a peer
+     * sent one, and generate_node_regex does the same whenever no
+     * component could encode the list. Either way the value is one
+     * allocation, and its owner is done with it. */
     free(regexp);
     return PMIX_SUCCESS;
 }
@@ -233,6 +266,12 @@ pmix_status_t pmix_preg_base_generate_regex(const char *input,
             continue;
         }
         if (PMIX_SUCCESS != active->module->generate_regex(input, info, ninfo, &candidate)) {
+            /* the interface says nothing about what a module leaves in
+             * the struct when it declines, so take back anything it put
+             * there rather than carry it into the next call - which
+             * would overwrite the pointers and lose them */
+            PMIx_Regex2_destruct(&candidate);
+            candidate = (pmix_regex2_t) PMIX_REGEX2_STATIC_INIT;
             continue;
         }
         /* keep this result if it is the first or smaller than the current best */

--- a/src/mca/preg/compress/AGENTS.md
+++ b/src/mca/preg/compress/AGENTS.md
@@ -53,7 +53,8 @@ active list — everything downstream is written to degrade to `raw` when
   or fails. Because it produces the smallest encoding for any non-trivial
   list, it almost always wins the framework's **smallest-wins** contest.
 - **`parse_regex`** — gates on `regex->type == "compress"` (returning
-  `PMIX_ERR_TAKE_NEXT_OPTION` otherwise), then
+  `PMIX_ERR_TAKE_NEXT_OPTION` otherwise), **screens out a NULL or
+  zero-length payload**, then
   `decompress_string(&tmp, regex->bytes, regex->len)` and returns the
   decompressed list. The caller splits it on whichever delimiter it
   supplied.
@@ -96,6 +97,14 @@ see it in packet dumps:
   `PMIX_ERR_TAKE_NEXT_OPTION`; keep that "decline, don't hard-error"
   behavior so a corrupt or foreign blob can still be retried by another
   scheme.
+- **What is on the other side of `decompress_string` reads the blob's
+  length prefix out of the first four bytes.** A peer may legitimately
+  declare a length of zero, in which case `bfrops` unpacked nothing and
+  left `bytes` NULL, or a length shorter than that prefix. `zstd` and
+  `lz4` screen for both; `zlib` and `zlibng` did not until recently, and
+  the payload-sizing subtraction underflows for anything shorter than
+  four bytes. Screening here means this component does not depend on
+  which `pcompress` component answered.
 - The module name `"compress"` is the on-the-wire type tag, and
   `preg_base_legacy.c` keys its `blob:` serialization on that exact
   string. Renaming the component breaks both.

--- a/src/mca/preg/compress/preg_compress.c
+++ b/src/mca/preg/compress/preg_compress.c
@@ -17,28 +17,10 @@
 #ifdef HAVE_STRING_H
 #    include <string.h>
 #endif
-#include <fcntl.h>
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
-#ifdef HAVE_SYS_TYPES_H
-#    include <sys/types.h>
-#endif
-#include <ctype.h>
 
-#include "include/pmix.h"
 #include "pmix_common.h"
 
-#include "src/class/pmix_list.h"
-#include "src/client/pmix_client_ops.h"
 #include "src/include/pmix_globals.h"
-#include "src/include/pmix_socket_errno.h"
-#include "src/mca/bfrops/base/base.h"
-#include "src/mca/gds/gds.h"
-#include "src/util/pmix_argv.h"
-#include "src/util/pmix_error.h"
-#include "src/util/pmix_output.h"
-#include "src/util/pmix_printf.h"
 
 #include "preg_compress.h"
 #include "src/mca/pcompress/pcompress.h"

--- a/src/mca/preg/compress/preg_compress.c
+++ b/src/mca/preg/compress/preg_compress.c
@@ -68,6 +68,15 @@ static pmix_status_t parse_regex(const pmix_regex2_t *regex, pmix_info_t info[],
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
 
+    /* a peer is free to declare a length of zero, in which case bfrops
+     * unpacked no bytes and left the pointer NULL. Screen that here: what
+     * is on the other side of this call is a decompressor that reads the
+     * blob's length prefix out of the first four bytes, and not all of
+     * them check first */
+    if (NULL == regex->bytes || 0 == regex->len) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     if (!pmix_compress.decompress_string(&tmp, regex->bytes, regex->len)) {
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }

--- a/src/mca/preg/compress/preg_compress_component.c
+++ b/src/mca/preg/compress/preg_compress_component.c
@@ -57,12 +57,12 @@ pmix_mca_base_component_t pmix_mca_preg_compress_component = {
 };
 PMIX_MCA_BASE_COMPONENT_INIT(pmix, preg, compress)
 
-static int component_open(void)
+static pmix_status_t component_open(void)
 {
     return PMIX_SUCCESS;
 }
 
-static int component_query(pmix_mca_base_module_t **module, int *priority)
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
 {
     if (NULL == pmix_compress.compress_string) {
         return PMIX_ERROR;
@@ -73,7 +73,7 @@ static int component_query(pmix_mca_base_module_t **module, int *priority)
     return PMIX_SUCCESS;
 }
 
-static int component_close(void)
+static pmix_status_t component_close(void)
 {
     return PMIX_SUCCESS;
 }

--- a/src/mca/preg/raw/AGENTS.md
+++ b/src/mca/preg/raw/AGENTS.md
@@ -33,9 +33,11 @@ guaranteed fallback encoder.
   must beat. For inputs too small or too random for `compress` to shrink,
   `raw` legitimately wins.
 - **`parse_regex`** — gates on `regex->type == "raw"`, returning
-  `PMIX_ERR_TAKE_NEXT_OPTION` otherwise, and returns
-  `strdup(regex->bytes)`. Because `raw`'s bytes are just the original
-  NUL-terminated list, no expansion is needed.
+  `PMIX_ERR_TAKE_NEXT_OPTION` otherwise, then **confirms the bytes end in
+  a NUL** before returning `strdup(regex->bytes)`. Because `raw`'s bytes
+  are just the original NUL-terminated list, no expansion is needed — but
+  see the gotcha below for why the terminator has to be checked rather
+  than assumed.
 
 Both ignore their `info`/`ninfo` attribute arrays
 (`PMIX_HIDE_UNUSED_PARAMS`); the parameters exist only to satisfy the
@@ -61,6 +63,16 @@ regex2 as `raw:<string>` when a caller comes in through
 
 ## Gotchas
 
+- **A `pmix_regex2_t` reaching `parse_regex` is a claim, not a fact.**
+  Off the wire it is a type, a length, and that many bytes: `bfrops`
+  copies exactly `len` bytes out of the buffer, appends no NUL, and
+  leaves `bytes` NULL when the peer declared `len` of zero. `raw`'s own
+  `generate_regex` counts the terminator into `len`, so a well-formed
+  value carries one — but a peer's need not, and `strdup` on bytes that
+  do not is a read off the end of the unpacked allocation. It segfaults
+  in practice, not in theory: `test/unit/preg.c`'s
+  `test_regex2_from_the_wire` crashed the library outright before the
+  check existed. The same reasoning applies to any component added here.
 - Do not add "cleverness" to `raw`. Its whole value is that it is a
   transparent, always-available identity transform. If you want smarter
   encoding, add a new component with a new tag.

--- a/src/mca/preg/raw/preg_raw.c
+++ b/src/mca/preg/raw/preg_raw.c
@@ -59,7 +59,22 @@ static pmix_status_t parse_regex(const pmix_regex2_t *regex, pmix_info_t info[],
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
 
+    /* the bytes came off a peer's wire, where a pmix_regex2_t is a length
+     * and that many bytes - nothing puts a NULL at the end of them. Our
+     * generate counts the terminator into len, so a well-formed raw value
+     * carries one; confirm it rather than let strdup go looking, which on
+     * a value that does not is a read past the end of the unpacked
+     * allocation. A zero length is the same question with no bytes at
+     * all: bfrops leaves the pointer NULL when the peer declared none. */
+    if (NULL == regex->bytes || 0 == regex->len ||
+        '\0' != (char) regex->bytes[regex->len - 1]) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     *output = strdup((const char *) regex->bytes);
+    if (NULL == *output) {
+        return PMIX_ERR_NOMEM;
+    }
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/preg/raw/preg_raw.c
+++ b/src/mca/preg/raw/preg_raw.c
@@ -17,22 +17,10 @@
 #ifdef HAVE_STRING_H
 #    include <string.h>
 #endif
-#include <fcntl.h>
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
-#ifdef HAVE_SYS_TYPES_H
-#    include <sys/types.h>
-#endif
-#include <ctype.h>
 
-#include "include/pmix.h"
 #include "pmix_common.h"
 
-#include "src/mca/bfrops/base/base.h"
-#include "src/util/pmix_argv.h"
-#include "src/util/pmix_error.h"
-#include "src/util/pmix_printf.h"
+#include "src/include/pmix_globals.h"
 
 #include "preg_raw.h"
 #include "src/mca/preg/base/base.h"

--- a/src/mca/preg/raw/preg_raw_component.c
+++ b/src/mca/preg/raw/preg_raw_component.c
@@ -56,19 +56,19 @@ pmix_mca_base_component_t pmix_mca_preg_raw_component = {
 };
 PMIX_MCA_BASE_COMPONENT_INIT(pmix, preg, raw)
 
-static int component_open(void)
+static pmix_status_t component_open(void)
 {
     return PMIX_SUCCESS;
 }
 
-static int component_query(pmix_mca_base_module_t **module, int *priority)
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
 {
     *priority = 50;
     *module = (pmix_mca_base_module_t *) &pmix_preg_raw_module;
     return PMIX_SUCCESS;
 }
 
-static int component_close(void)
+static pmix_status_t component_close(void)
 {
     return PMIX_SUCCESS;
 }

--- a/test/unit/preg.c
+++ b/test/unit/preg.c
@@ -533,6 +533,72 @@ static void test_legacy_decode_exact(void)
     report("blob ending flush with the buffer is accepted", ok);
 }
 
+/* A pmix_regex2_t that arrived from a peer is a type, a length, and that
+ * many bytes - bfrops puts no NULL after them and leaves the pointer NULL
+ * when the peer declared a length of zero. A component must therefore
+ * treat what it was handed as a claim rather than a fact. Build the
+ * values a peer can legitimately send and hand them to the public
+ * parser. Each allocation is exact so that valgrind sees a read past its
+ * end; without valgrind these cases still prove nothing was accepted. */
+static void test_regex2_from_the_wire(void)
+{
+    pmix_regex2_t r2 = PMIX_REGEX2_STATIC_INIT;
+    char *out = NULL;
+    int ok = 1;
+
+    /* "raw" bytes with no terminator anywhere in them - strdup would run
+     * off the end of the allocation looking for one */
+    r2.type = strdup("raw");
+    r2.len = 3;
+    r2.bytes = (uint8_t *) malloc(3);
+    memcpy(r2.bytes, "abc", 3);
+    if (PMIX_SUCCESS == PMIx_parse_regex2(&r2, NULL, 0, &out)) {
+        fprintf(stdout, "    unterminated raw bytes were accepted\n");
+        ok = 0;
+        free(out);
+        out = NULL;
+    }
+    PMIx_Regex2_destruct(&r2);
+
+    /* a declared length of zero, which leaves bfrops with nothing to
+     * unpack and the pointer NULL - for either component */
+    r2 = (pmix_regex2_t) PMIX_REGEX2_STATIC_INIT;
+    r2.type = strdup("raw");
+    if (PMIX_SUCCESS == PMIx_parse_regex2(&r2, NULL, 0, &out)) {
+        fprintf(stdout, "    an empty raw value was accepted\n");
+        ok = 0;
+        free(out);
+        out = NULL;
+    }
+    PMIx_Regex2_destruct(&r2);
+
+    r2 = (pmix_regex2_t) PMIX_REGEX2_STATIC_INIT;
+    r2.type = strdup("compress");
+    if (PMIX_SUCCESS == PMIx_parse_regex2(&r2, NULL, 0, &out)) {
+        fprintf(stdout, "    an empty compressed value was accepted\n");
+        ok = 0;
+        free(out);
+        out = NULL;
+    }
+    PMIx_Regex2_destruct(&r2);
+
+    /* a compressed blob shorter than the four-byte length prefix its
+     * decompressor reads out of the front of it */
+    r2 = (pmix_regex2_t) PMIX_REGEX2_STATIC_INIT;
+    r2.type = strdup("compress");
+    r2.len = 2;
+    r2.bytes = (uint8_t *) malloc(2);
+    memcpy(r2.bytes, "\x01\x02", 2);
+    if (PMIX_SUCCESS == PMIx_parse_regex2(&r2, NULL, 0, &out)) {
+        fprintf(stdout, "    a two-byte compressed value was accepted\n");
+        ok = 0;
+        free(out);
+    }
+    PMIx_Regex2_destruct(&r2);
+
+    report("a regex2 from the wire is checked, not trusted", ok);
+}
+
 /* release() is the destructor the bfrops value and darray teardown call
  * on every PMIX_REGEX value, so it has to free whatever a PMIX_REGEX
  * value is allowed to hold - and an unframed plain string is allowed:
@@ -661,6 +727,7 @@ int main(int argc, char **argv)
 
     /* Structural checks */
     test_type_field_set();
+    test_regex2_from_the_wire();
 
     /* The deprecated char* form, which the base synthesizes from the
      * regex2 operations above */

--- a/test/unit/preg.c
+++ b/test/unit/preg.c
@@ -533,6 +533,64 @@ static void test_legacy_decode_exact(void)
     report("blob ending flush with the buffer is accepted", ok);
 }
 
+/* release() is the destructor the bfrops value and darray teardown call
+ * on every PMIX_REGEX value, so it has to free whatever a PMIX_REGEX
+ * value is allowed to hold - and an unframed plain string is allowed:
+ * unpack hands one back whenever a peer sent one, and generate_node_regex
+ * does the same whenever no component could encode the list. It used to
+ * decode the framing first and return PMIX_ERR_BAD_PARAM without freeing
+ * anything, which is a leak per value on exactly those two paths. The
+ * status is what this can assert in-process; run it under valgrind for
+ * the half that matters. */
+static void test_legacy_release(void)
+{
+    char *plain = strdup("nodeA,nodeB,nodeC");
+    char *encoded = NULL;
+    int ok = 1;
+
+    if (PMIX_SUCCESS != pmix_preg.release(NULL)) {
+        fprintf(stdout, "    NULL was not accepted\n");
+        ok = 0;
+    }
+    if (PMIX_SUCCESS != pmix_preg.release(plain)) {
+        fprintf(stdout, "    an unframed value was refused, and so leaked\n");
+        ok = 0;
+        free(plain);
+    }
+    if (PMIX_SUCCESS == PMIx_generate_regex("nodeA,nodeB,nodeC", &encoded) &&
+        NULL != encoded) {
+        if (PMIX_SUCCESS != pmix_preg.release(encoded)) {
+            fprintf(stdout, "    an encoded value was refused\n");
+            ok = 0;
+            free(encoded);
+        }
+    } else {
+        ok = 0;
+    }
+    report("release frees a value of either shape", ok);
+}
+
+/* A value that carries our tag and is malformed behind it must not be
+ * split as though it were a plain list: the caller would get framing
+ * bytes dressed as node names, which is worse than an error because
+ * nothing downstream can tell they are wrong. */
+static void test_legacy_malformed_not_split(void)
+{
+    char **names = NULL;
+    pmix_status_t rc;
+    int ok;
+
+    /* the tag is exact and complete; everything behind it is missing */
+    rc = pmix_preg.parse_nodes("blob:", &names);
+    ok = (PMIX_SUCCESS != rc);
+    if (!ok) {
+        fprintf(stdout, "    accepted, first name is \"%s\"\n",
+                (NULL != names && NULL != names[0]) ? names[0] : "(none)");
+        PMIx_Argv_free(names);
+    }
+    report("a malformed blob is not split into node names", ok);
+}
+
 /* A large, highly-compressible list takes the compressed encoding, and so
  * exercises the blob serialization rather than the raw one - which is the
  * half of preg_base_legacy.c with real framing in it. Say out loud which
@@ -615,6 +673,8 @@ int main(int argc, char **argv)
     test_legacy_malformed();
     test_legacy_blob_prefixed_list();
     test_legacy_decode_exact();
+    test_legacy_release();
+    test_legacy_malformed_not_split();
     test_legacy_large();
 
     fprintf(stdout, "\nResults: %d passed, %d failed, %d skipped\n\n", npass, nfail, nskip);

--- a/test/unit/preg.c
+++ b/test/unit/preg.c
@@ -449,6 +449,71 @@ static void test_legacy_truncated(void)
     report("truncated blob is declined, not read past", ok);
 }
 
+/* Framing that is not truncated but is wrong. Every one of these arrives
+ * as bytes from a peer, so "declined" is the only acceptable answer -
+ * an accepted value hands its declared length straight to a decompressor.
+ * The SIZE_MAX case is the one that matters most: the declared length is
+ * added to the offset of the payload, so a length near SIZE_MAX wraps the
+ * sum back to a small number and sails through a bounds check written as
+ * an addition. */
+static void test_legacy_malformed(void)
+{
+    static const char m1[] = "blob:\0component=zlib:\0size=18446744073709551615:\0abc";
+    static const char m2[] = "blob:\0component=zlib:\0size=3xyz\0abc";
+    static const char m3[] = "blob:\0component=zlib:\0size=3\0abc";
+    static const struct {
+        const char *bytes;
+        size_t len;
+    } cases[] = {
+        {m1, sizeof(m1) - 1},  // length wraps the bounds arithmetic
+        {m2, sizeof(m2) - 1},  // digits not followed by the colon
+        {m3, sizeof(m3) - 1},  // colon missing entirely
+    };
+    pmix_regex2_t r2 = PMIX_REGEX2_STATIC_INIT;
+    size_t total, n;
+    int ok = 1;
+
+    for (n = 0; n < sizeof(cases) / sizeof(cases[0]); n++) {
+        r2 = (pmix_regex2_t) PMIX_REGEX2_STATIC_INIT;
+        total = 0;
+        if (PMIX_SUCCESS == pmix_preg_base_legacy_decode(cases[n].bytes, cases[n].len,
+                                                         &r2, &total)) {
+            fprintf(stdout, "    case %lu was accepted, len=%lu total=%lu\n",
+                    (unsigned long) n, (unsigned long) r2.len, (unsigned long) total);
+            ok = 0;
+        }
+    }
+    report("malformed blob framing is declined", ok);
+}
+
+/* A plain list whose first node happens to begin with "blob" is not a
+ * blob. The tag test has to be exact for that to be true: a prefix test
+ * accepts it, and everything after the tag is then read looking for a
+ * label that is not there - past the end of a string the caller owns and
+ * whose length this entry point has no way to learn. Run this one under
+ * valgrind; without it, the test only proves the value was declined. */
+static void test_legacy_blob_prefixed_list(void)
+{
+    char *list = strdup("blobfish,node02");
+    pmix_regex2_t r2 = PMIX_REGEX2_STATIC_INIT;
+    size_t total = 0;
+    char **names = NULL;
+    int ok;
+
+    ok = (PMIX_SUCCESS != pmix_preg_base_legacy_decode(list, SIZE_MAX, &r2, &total));
+
+    /* and the whole point of declining it: the list still splits */
+    if (PMIX_SUCCESS == pmix_preg.parse_nodes(list, &names)) {
+        ok = ok && (NULL != names && NULL != names[0] &&
+                    0 == strcmp(names[0], "blobfish"));
+        PMIx_Argv_free(names);
+    } else {
+        ok = 0;
+    }
+    free(list);
+    report("a plain list beginning with \"blob\" is not a blob", ok);
+}
+
 /* The bounded decoder must still accept a well-formed value that ends
  * exactly at the end of the buffer - the bounds checks are there to
  * reject short reads, not to demand slack. */
@@ -547,6 +612,8 @@ int main(int argc, char **argv)
     test_legacy_copy();
     test_legacy_pack_unpack();
     test_legacy_truncated();
+    test_legacy_malformed();
+    test_legacy_blob_prefixed_list();
     test_legacy_decode_exact();
     test_legacy_large();
 

--- a/test/unit/preg.c
+++ b/test/unit/preg.c
@@ -639,15 +639,23 @@ static void test_legacy_release(void)
 /* A value that carries our tag and is malformed behind it must not be
  * split as though it were a plain list: the caller would get framing
  * bytes dressed as node names, which is worse than an error because
- * nothing downstream can tell they are wrong. */
+ * nothing downstream can tell they are wrong.
+ *
+ * The value has to carry bytes behind the tag. parse_nodes takes a char*
+ * and so decodes unbounded, which - see the contract on
+ * pmix_preg_base_legacy_decode - warrants that a tagged value owns its
+ * whole framing. A bare "blob:" would violate that, and no decoder can
+ * catch it: a genuine blob is "blob:" up to its first NULL too, so the
+ * two are the same string. */
 static void test_legacy_malformed_not_split(void)
 {
+    static const char malformed[] = "blob:\0component=zip:\0size=3:\0abc";
     char **names = NULL;
     pmix_status_t rc;
     int ok;
 
-    /* the tag is exact and complete; everything behind it is missing */
-    rc = pmix_preg.parse_nodes("blob:", &names);
+    /* the tag is exact; the label behind it is not ours */
+    rc = pmix_preg.parse_nodes(malformed, &names);
     ok = (PMIX_SUCCESS != rc);
     if (!ok) {
         fprintf(stdout, "    accepted, first name is \"%s\"\n",


### PR DESCRIPTION
The deep review of `src/mca/preg`, plus the bookkeeping for it and for
the `src/mca/pnet` review that landed just before it.

`preg` decodes node and process maps that arrive from a peer, and the
decoder was stepping over most of its own framing rather than confirming
it. Four of the fixes are reachable from data a peer controls:

* The bound on a blob's payload was written `offset + len > avail`. The
  length is the peer's, so the peer decides whether that sum overflows:
  a value declaring `size=18446744073709551615` wraps it back to 28,
  is accepted, and `regex->len` reaches `pmix_compress.decompress_string`
  as `SIZE_MAX`. Written as a subtraction it cannot wrap.
* `preg/raw`'s `parse_regex` called `strdup` on bytes that bfrops copies
  off the wire without appending a NUL. The new test case crashes an
  unfixed library with a SIGSEGV; it now requires the terminator inside
  the declared length, which is what its own generate always writes.
* The blob tag was matched as a four-byte prefix, so a plain node list
  whose first node begins with `blob` was taken for a blob and read past
  the end of a string this entry point has no way to measure.
* `preg/compress` handed a NULL or too-short payload straight to a
  decompressor. `zlib` and `zlibng` did not screen for that either,
  though `zstd` and `lz4` do - the drive-by commit makes the four agree.

One leak, on a path that repeats per value: `pmix_preg_base_release` is
the destructor bfrops calls for every `PMIX_REGEX` value, and it decoded
the framing first and freed nothing when it found none. The values that
carry no framing are the ordinary ones - `unpack` hands back a plain
string whenever a peer sent one, and `generate_node_regex` does the same
whenever no component could encode the list.

Because a value carrying our tag is ours, a failure behind that tag is
now `PMIX_ERR_BAD_PARAM` rather than `PMIX_ERR_TAKE_NEXT_OPTION`, and
the parse/copy/pack/unpack fallbacks act on the difference: treating a
corrupt blob as a plain list splits framing bytes into node names that
look plausible and are not.

Testing: `test/unit/preg` grows from 20 cases to 24, including the
overflowing length, the malformed framing, the four shapes a peer can
legitimately send in a `pmix_regex2_t`, and a plain list beginning with
`blob` that is worth running under valgrind. Each new case was watched
failing against the unfixed code first.

`make check` is clean (148 tests). Since a build with no compression
library never selects `preg/compress` - so `raw` wins every encode and
the blob framing is never produced - the compressed round trip was run
under `contrib/dockerswarm` on Linux with all four compressors: the gds
suite passes 49/49 across 2, 4 and 8 servers, and `test/unit/preg`
passes 24/24 there with the 5000-node case reporting that it did take
the blob path. That gap, and the residual one where the deprecated
`char*` signatures have nowhere to put a length, are recorded in
`docs/todo.rst`.