### PR TITLE
Fix a double free of a pfexec child

### DIFF
--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -507,6 +507,24 @@ execs — and carries hazards the request files do not:
 - **`wait_signal_callback` reaps every child of the process**
   (`waitpid(-1, ...)`), not just pfexec's — keep that in mind if you add
   another `waitpid` consumer.
+- **A `pmix_pfexec_child_t` has more than one owner, and the
+  `children` list is only one of them.** The list holds a reference; so
+  does every caddy that carries the child across an event boundary —
+  `pmix_pfexec_cmpl_caddy_t` (retained by `PMIX_PFEXEC_CHK_COMPLETE`) and
+  `pmix_pfexec_signal_caddy_t` (retained by `kill_proc`, which then holds
+  the child for the *seconds* its SIGCONT/SIGTERM/SIGKILL timers take).
+  Two independent paths take a child off the list — the completion path
+  and the kill sequence — both are posted to the event base, and either
+  can be dispatched first. So **never assume you are the one doing the
+  removal**: go through `child_delist()`, which drops the list's
+  reference exactly once and is a no-op the second time. It keys off the
+  child's `onlist` flag rather than `pmix_list_remove_item`'s return,
+  because that function only reports a missing item under
+  `PMIX_ENABLE_DEBUG` — in a release build it splices the list using the
+  item's stale pointers and decrements the length again, which silently
+  corrupts the list this file's SIGCHLD early-out reads (see below).
+  Getting this wrong is not a leak, it is a double free plus a kill
+  sequence reading `->pid` out of freed memory to decide what to signal.
 
 ## What the August 2026 sweep changed
 
@@ -541,8 +559,8 @@ before the `fork()` that can generate its `SIGCHLD`, so the count cannot be
 stale for a child we care about, and removing the guard would make pfexec
 `waitpid(-1)` on every `SIGCHLD` in a process that currently has no
 children of its own. If you do restructure it, replace the read with a
-counter maintained across all six add/remove sites rather than deleting
-the check.
+counter maintained rather than deleting the check — the removals are all
+funnelled through `child_delist()` now, so there is one place to do it.
 
 ## Building and testing
 

--- a/src/common/pmix_pfexec.c
+++ b/src/common/pmix_pfexec.c
@@ -123,6 +123,26 @@ int pmix_pfexec_base_close(void)
     return PMIX_SUCCESS;
 }
 
+/* Take a child off the children list if it is still on it, and drop the
+ * reference the list was holding.
+ *
+ * Both the completion path and the kill sequence remove children, and
+ * either can reach a given child first: a completion posted by the IOF
+ * read handler or by child_reaped sits queued on the event base, and the
+ * kill sequence the tool's finalize drives can be dispatched in between.
+ * Whoever gets here first does the removal and drops the list reference;
+ * the second call is a no-op. Callers must hold a reference of their own
+ * - this may drop the last one. */
+static void child_delist(pmix_pfexec_child_t *child)
+{
+    if (!child->onlist) {
+        return;
+    }
+    child->onlist = false;
+    pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
+    PMIX_RELEASE(child);
+}
+
 static void _ntfy_done(pmix_status_t status, void *cbdata)
 {
     pmix_pfexec_cmpl_caddy_t *cd = (pmix_pfexec_cmpl_caddy_t*)cbdata;
@@ -141,7 +161,7 @@ void pmix_pfexec_check_complete(int sd, short args, void *cbdata)
     pmix_proc_t wildcard;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    pmix_list_remove_item(&pmix_pfexec_globals.children, &cd->child->super);
+    child_delist(cd->child);
     /* see if any more children from this nspace are alive */
     PMIX_LIST_FOREACH (child, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
         if (PMIX_CHECK_NSPACE(child->proc.nspace, cd->child->proc.nspace)) {
@@ -401,13 +421,13 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
             PMIX_LOAD_PROCID(&child->proc, nspace, rank);
             ++rank;
             pmix_list_append(&pmix_pfexec_globals.children, &child->super);
+            child->onlist = true;
 
             /* setup any IOF */
             child->opts.usepty = PMIX_ENABLE_PTY_SUPPORT;
             if (PMIX_SUCCESS != (rc = setup_prefork(child))) {
                 PMIX_ERROR_LOG(rc);
-                pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
-                PMIX_RELEASE(child);
+                child_delist(child);
                 goto complete;
             }
 
@@ -418,8 +438,7 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
             info = PMIX_NEW(pmix_rank_info_t);
             if (NULL == info) {
                 rc = PMIX_ERR_NOMEM;
-                pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
-                PMIX_RELEASE(child);
+                child_delist(child);
                 goto complete;
             }
             info->pname.nspace = strdup(child->proc.nspace);
@@ -459,8 +478,7 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
             /* get any PTL contribution such as tmpdir settings for session files */
             if (PMIX_SUCCESS != (rc = pmix_ptl.setup_fork(&child->proc, &env))) {
                 PMIX_ERROR_LOG(rc);
-                pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
-                PMIX_RELEASE(child);
+                child_delist(child);
                 goto complete;
             }
 
@@ -475,8 +493,7 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
                 rc = pipe(child->keepalive);
                 if (0 != rc) {
                     PMIX_ERROR_LOG(PMIX_ERR_SYS_OTHER);
-                    pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
-                    PMIX_RELEASE(child);
+                    child_delist(child);
                     goto complete;
                 }
                 pmix_snprintf(sock, 10, "%d", child->keepalive[1]);
@@ -492,8 +509,7 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
             env = NULL;
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
-                pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
-                PMIX_RELEASE(child);
+                child_delist(child);
                 goto complete;
             }
             PMIX_IOF_READ_ACTIVATE(child->stdoutev);
@@ -604,12 +620,15 @@ void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata)
         return;
     }
 
-    /* remove the child from the list so waitpid callback won't
-     * find it as this induces unmanageable race
-     * conditions when we are deliberately killing the process
-     */
-    pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
+    /* Take the child off the list so the waitpid callback won't find it -
+     * that induces unmanageable race conditions when we are deliberately
+     * killing the process - but take a reference of our own first. The
+     * caddy holds this child across two evtimers, and a completion posted
+     * before we got here is still queued behind us with a reference of
+     * its own; whichever of the two runs last is the one that frees it. */
+    PMIX_RETAIN(child);
     scd->child = child;
+    child_delist(child);
 
     /* First send a SIGCONT in case the process is in stopped state.
        If it is in a stopped state and we do not first change it to
@@ -617,7 +636,9 @@ void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata)
        value. */
     pmix_output_verbose(5, pmix_client_globals.spawn_output, "%s SENDING SIGCONT",
                          PMIX_NAME_PRINT(&pmix_globals.myid));
-    sigproc(child->pid, SIGCONT);
+    /* through the caddy, which is the reference that keeps this alive
+     * now that the list's is gone */
+    sigproc(scd->child->pid, SIGCONT);
 
     /* wait a little to give the proc a chance to wakeup, then continue
      * to the SIGTERM stage */
@@ -1337,6 +1358,7 @@ static void chcon(pmix_pfexec_child_t *p)
     PMIX_LOAD_PROCID(&p->proc, NULL, PMIX_RANK_UNDEF);
     p->pid = 0;
     p->completed = false;
+    p->onlist = false;
     /* objects are malloc'd, not calloc'd - a child that completes
      * through a path that never records an exit status must report
      * zero, not whatever was on the heap */

--- a/src/common/pmix_pfexec.h
+++ b/src/common/pmix_pfexec.h
@@ -54,6 +54,15 @@ typedef struct {
     pmix_proc_t proc;
     pid_t pid;
     bool completed;
+    /* whether this child is currently on pmix_pfexec_globals.children,
+     * and therefore whether the list's reference is still outstanding.
+     * Two independent paths take a child off that list - the completion
+     * path and the kill sequence - and either can get there first, so
+     * neither may assume it is the one doing the removal. Not derived
+     * from pmix_list_remove_item's return: that only reports a missing
+     * item under PMIX_ENABLE_DEBUG, and in a release build it splices
+     * the list using the item's stale pointers instead. */
+    bool onlist;
     int exitcode;
     int keepalive[2];
     pmix_pfexec_base_io_conf_t opts;
@@ -148,9 +157,15 @@ typedef struct {
 } pmix_pfexec_cmpl_caddy_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_cmpl_caddy_t);
 
+/* The caddy carries the child across an event boundary, so it takes its
+ * own reference: between the post and the callback the kill sequence can
+ * take this same child off the list and park it for the length of a
+ * SIGCONT/SIGTERM/SIGKILL sequence. Released again by
+ * pmix_pfexec_check_complete or _ntfy_done. */
 #define PMIX_PFEXEC_CHK_COMPLETE(c)                                        \
     do {                                                                   \
         pmix_pfexec_cmpl_caddy_t *pc = PMIX_NEW(pmix_pfexec_cmpl_caddy_t); \
+        PMIX_RETAIN((c));                                                  \
         pc->child = (c);                                                   \
         pmix_event_assign(&((pc)->ev), pmix_globals.evbase, -1, EV_WRITE,  \
                           pmix_pfexec_check_complete, (pc));               \

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1611,7 +1611,9 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     struct timeval tv = {5, 0};
     int n, i;
     pmix_peer_t *peer;
-    pmix_pfexec_child_t *child, *nxt;
+    pmix_pfexec_child_t *child;
+    pmix_proc_t *dying = NULL;
+    size_t ndying = 0, nd;
     pmix_dmdx_local_t *dlcd, *dnxt;
     pmix_lock_t lock;
     bool myserver_is_mypeer;
@@ -1708,11 +1710,36 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
             pmix_event_del(pmix_pfexec_globals.handler);
             pmix_pfexec_globals.active = false;
         }
-        PMIX_LIST_FOREACH_SAFE (child, nxt, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
+        /* Snapshot the identities before killing anything. Each kill parks
+         * this thread on the lock for the whole SIGCONT/SIGTERM/SIGKILL
+         * sequence - seconds - and the progress thread keeps running
+         * underneath: it can complete and release other children while we
+         * wait, so a pointer into the list cannot be carried across the
+         * wait. That is what the "next" pointer of a list traversal is.
+         * kill_proc looks its target up by identity anyway, so an identity
+         * is all this loop ever needed. */
+        ndying = pmix_list_get_size(&pmix_pfexec_globals.children);
+        if (0 < ndying) {
+            dying = (pmix_proc_t *) malloc(ndying * sizeof(pmix_proc_t));
+        }
+        if (NULL == dying) {
+            ndying = 0;
+        } else {
+            nd = 0;
+            PMIX_LIST_FOREACH (child, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
+                memcpy(&dying[nd++], &child->proc, sizeof(pmix_proc_t));
+            }
+        }
+        for (nd = 0; nd < ndying; nd++) {
             PMIX_CONSTRUCT_LOCK(&lock);
-            PMIX_PFEXEC_KILL(&child->proc, &lock);
+            /* the caddy holds this pointer until the sequence ends, which
+             * is why the array outlives the loop */
+            PMIX_PFEXEC_KILL(&dying[nd], &lock);
             PMIX_WAIT_THREAD(&lock);
             PMIX_DESTRUCT_LOCK(&lock);
+        }
+        if (NULL != dying) {
+            free(dying);
         }
         pmix_pfexec_base_close();
     }

--- a/test/unit/tool_relay.c
+++ b/test/unit/tool_relay.c
@@ -64,6 +64,12 @@
 #define SPAWNEE "/usr/bin/true"
 #define SPAWNEE_ALT "/bin/true"
 
+/* and something that does NOT exit, so the launcher still has a pfexec
+ * child when it finalizes - see the two-app comment in run_downstream().
+ * "cat" with no argument blocks forever on the stdin pipe pfexec hands
+ * it, and exits on the SIGTERM the kill sequence sends. */
+#define LINGERER "/bin/cat"
+
 static int npass = 0;
 static int nfail = 0;
 
@@ -144,16 +150,36 @@ static int run_downstream(int urifd)
         return D_INITFAIL;
     }
 
-    PMIX_APP_CREATE(app, 1);
+    /* Two apps, deliberately.
+     *
+     * The first exits at once, which is all the relay itself needs. The
+     * second outlives us, so that when the upstream launcher finalizes it
+     * still has a child on pmix_pfexec_globals.children and therefore
+     * actually runs the kill sequence - kill_proc, SIGCONT, SIGTERM,
+     * SIGKILL, kill_finish.
+     *
+     * That path is where a child is taken off the children list while a
+     * completion for it may still be queued behind, and it used to
+     * release the child twice (see child_delist() in pmix_pfexec.c). With
+     * only the fast-exiting app the launcher usually had nothing left to
+     * kill by the time it finalized, so the path ran in roughly one run
+     * in fifteen and the double free surfaced as a rare abort in this
+     * test rather than as a reproducible failure. */
+    PMIX_APP_CREATE(app, 2);
     app[0].cmd = strdup((0 == access(SPAWNEE, X_OK)) ? SPAWNEE : SPAWNEE_ALT);
     app[0].argv = (char **) malloc(2 * sizeof(char *));
     app[0].argv[0] = strdup(app[0].cmd);
     app[0].argv[1] = NULL;
     app[0].maxprocs = 1;
+    app[1].cmd = strdup(LINGERER);
+    app[1].argv = (char **) malloc(2 * sizeof(char *));
+    app[1].argv[0] = strdup(app[1].cmd);
+    app[1].argv[1] = NULL;
+    app[1].maxprocs = 1;
 
     memset(child, 0, sizeof(child));
-    rc = PMIx_Spawn(NULL, 0, app, 1, child);
-    PMIX_APP_FREE(app, 1);
+    rc = PMIx_Spawn(NULL, 0, app, 2, child);
+    PMIX_APP_FREE(app, 2);
 
     if (PMIX_ERR_UNREACH == rc) {
         /* this is the defect: our upstream tool has no server of its own,


### PR DESCRIPTION
Fixes an intermittent `tool_relay` abort that turned out to be a **double
free of a `pmix_pfexec_child_t`**, plus the test gap that let it hide.

## The race

`pmix_pfexec_globals.children` holds **one** reference to each child.
Two independent paths remove a child from that list and release it, each
written as though it were the only one:

- **completion** — `pmix_pfexec_check_complete`, posted by
  `child_reaped` on reap, or by the IOF read handler on stdout/stderr
  EOF;
- **kill** — `pmix_pfexec_base_kill_proc`, which `PMIx_tool_finalize`
  drives for every surviving child, then parks the bare pointer in its
  caddy across two evtimers for SIGCONT → SIGTERM → SIGKILL.

Both arrive as events, so either can be dispatched first. When the kill
wins, the completion queued behind it runs against a child no longer on
the list, and its release takes the refcount to zero. The kill sequence
then spends the next couple of seconds dereferencing freed memory — it
reads `->pid` out of it to decide what to signal — and `kill_finish`
releases it a second time:

```
Warning :: pmix_list_remove_item - the item 0x... is not on the list
Assertion failed: (PMIX_OBJ_MAGIC_ID == _obj->obj_magic_id),
                  function kill_finish, file pmix_pfexec.c, line 581
```

## It is worse without `--enable-debug`

Both diagnostics above are debug-only. In a release build the assertion
is gone, so the second release runs `pmix_obj_update` on freed memory;
and `pmix_list_remove_item`'s membership check is gone too, so rather
than declining it splices the list using the item's **stale** pointers
and decrements `pmix_list_length` a second time. Once that length is
wrong, `wait_signal_callback`'s `0 == pmix_list_get_size(children)`
early-out can stop reaping children altogether. The `pid` handed to
`kill()` is by then whatever the allocator has put in that memory.

## The fix

Every holder that carries a child across an event boundary takes its own
reference. A new `child_delist()` drops the list's reference exactly
once, keyed off a new `onlist` flag rather than
`pmix_list_remove_item`'s return value — that return only reports a
missing item under `--enable-debug`. The five spawn error paths that did
the same remove-then-release by hand go through it too, so there is now
one place that takes a child off that list.

`PMIx_tool_finalize`'s kill loop had a **second instance of the same
problem**: it walked the list with `PMIX_LIST_FOREACH_SAFE`, whose
cached "next" pointer only protects against the *current* item being
removed — but the loop blocks on a lock for the whole kill sequence, and
the progress thread can complete and release some *other* child while it
waits. It now snapshots the identities up front, which is all it needed,
since `kill_proc` looks its target up by identity.

## Verification

The race is microsecond-wide, so it was forced rather than waited for:
post the competing completion at the point `kill_proc` delists the
child, and remove the variability that stops the path being reached at
all. With the forcer held constant, the unfixed code aborts on **every**
run with exactly the warning and assertion above; the fixed code
completes cleanly **10 times out of 10**. The forcer is not part of this
PR.

`make check` 151/151, warning-free build. The ownership rule is written
into `src/common/AGENTS.md`'s pfexec-hazards section.

## The second commit

`tool_relay` reached the kill path in roughly **one run in fifteen** —
its spawnee is `/bin/true`, so the child had usually completed and been
delisted before the launcher finalized, leaving nothing to kill. That is
most of the reason this survived. The spawn now carries a second app
that does not exit, so the path is taken 10/10. The first app and every
assertion are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
