### PR TITLE
Make psensor honor the directives it was handed

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -109,13 +109,54 @@ each time somebody asks.
           plausible reading of the code, rather than from watching it
           run, is a lead and not a finding.
 
+.. note:: **2026-08-20.**  The ``src/mca/psensor`` review found one
+          shape repeated five times, and it is worth naming because it
+          passes every test anyone would think to write: a directive
+          parsed out of the request, stored in the tracker, and then
+          never read again.  ``PMIX_MONITOR_HEARTBEAT_DROPS`` set
+          ``ndrops`` and nothing consulted it, so a request asking to
+          tolerate missed beats alerted on the very first empty window.
+          ``PMIX_MONITOR_ID`` was never parsed at all, so the ``id``
+          argument to ``stop()`` — the whole cancel handle — could never
+          match anything.  ``PMIX_MONITOR_CANCEL`` was recognized by
+          neither component, so it fell through to the resource-usage
+          path, which answers ``PMIX_SUCCESS`` for an id it has never
+          held: a client's cancel reported success and the monitor kept
+          firing forever.  The ``error`` argument, which
+          ``PMIx_Process_monitor(3)`` documents as "the code the monitor
+          is to use", was discarded in favour of a hardcoded alert.  And
+          the ``file`` sampler checked only the first of the three
+          attributes a request named.
+
+          Each of those looked like working code, and the framework's
+          own end-to-end test passed throughout — because a test that
+          waits for an alert cannot tell an honored directive from an
+          ignored one.  ``test/unit/run_monitor.pl`` now arms a capped
+          monitor and a cancelled one under a status code of their own
+          and fails if *either* fires, which is the only shape that
+          distinguishes them.  Each of the three fixes was verified by
+          re-breaking it and watching the new check catch it.
+
+          Two lifetime defects came out of the same pass.
+          ``PMIx_Notify_event`` returns ``PMIX_ERR_NOT_AVAILABLE``
+          without reaching its callback once the progress thread has
+          stopped — which ``PMIx_server_finalize`` does well before it
+          closes this framework — so both samplers stranded a tracker
+          and the peer it retained.  And ``psensor/heartbeat`` never
+          un-posted the PTL recv it posts lazily, nor cleared the flag
+          saying it had: ``ptl`` closes after ``psensor``, so a DSO build
+          left the ptl list naming a function in an unloaded plugin, and
+          a second ``PMIx_server_init`` in one process would have found
+          the flag set, the recv gone, and declared every monitored
+          client dead on its first window.
+
 Review coverage
 ---------------
 
 Assessed on **2026-08-15** from the commit history, and refreshed on
 **2026-08-20** when the ``src/mca/pnet``, ``src/mca/preg``,
-``src/mca/pgpu``, ``src/mca/pmdl``, ``src/mca/pcompress`` and
-``src/mca/plog`` reviews landed.  Move an entry out
+``src/mca/pgpu``, ``src/mca/pmdl``, ``src/mca/pcompress``,
+``src/mca/plog`` and ``src/mca/psensor`` reviews landed.  Move an entry out
 of "Not yet reviewed" as its review lands, and refresh the churn figures
 in "Reviewed, but changed materially since" when a re-review closes one.
 
@@ -133,8 +174,8 @@ Reviewed and current
 ``src/runtime``, ``src/tool``, ``src/tools``, ``src/mca/base``,
 ``src/mca/bfrops``, ``src/mca/gds/base``, ``src/mca/gds/hash``,
 ``src/mca/pcompress``, ``src/mca/pgpu``, ``src/mca/plog``,
-``src/mca/pmdl``, ``src/mca/pnet``, ``src/mca/preg``, ``src/mca/pstat``,
-``src/mca/ptl``, and ``bindings/python``.
+``src/mca/pmdl``, ``src/mca/pnet``, ``src/mca/preg``, ``src/mca/psensor``,
+``src/mca/pstat``, ``src/mca/ptl``, and ``bindings/python``.
 ``src/client``, ``src/server``, ``src/hwloc``, ``src/util`` and
 ``src/mca/gds/shmem3`` were reviewed too, but have moved since — see
 below.
@@ -151,7 +192,6 @@ size, which is a rough proxy for how much there is to find.
 * ``src/mca/psec`` (with ``native``, ``none``, ``munge``,
   ``dummy_handshake``) — 1901 lines.  This is the connection-handshake
   code; two small fixes on 2026-07-14/15 are all it has had.
-* ``src/mca/psensor`` (with ``file``, ``heartbeat``) — 1398 lines.
 * ``src/mca/pdl``, ``src/mca/pinstalldirs``, ``src/mca/pif`` — about
   3200 lines between them, and the lowest risk of the group.
 * ``src/threads`` — 737 lines.  The 2026-07-17 cleanup fixed a TSD key
@@ -526,6 +566,17 @@ Coverage gaps
   a thin run reports itself rather than passing quietly.  The real round
   trip was run under ``contrib/dockerswarm`` (Linux, all four
   compressors), where the 5000-node case does take the blob path.
+* **The ``psensor/file`` drop-count and baseline semantics have no
+  automated check.**  The fix stops a monitor from alerting before it has
+  ever recorded a miss — a request with no ``PMIX_MONITOR_FILE_DROPS``
+  used to trip on the first sample of a perfectly healthy file.
+  Distinguishing the fixed behavior from the broken one takes a monitor
+  with a *zero* drop allowance watching a file that is being kept fresh,
+  and zero tolerance means any scheduling hiccup or coarse filesystem
+  timestamp granularity fails it.  The heartbeat drop allowance is
+  covered instead (``run_monitor.pl``'s capped monitor), because a
+  request can be given an allowance no run can spend; there is no
+  equivalent for "must not alert on the first look".
 * **The plog ``smtp`` component has never been run.**  It builds only
   where libesmtp is present, and exercising it needs a reachable SMTP
   server on top of that, so the fixes from the ``src/mca/plog`` review

--- a/src/mca/psensor/AGENTS.md
+++ b/src/mca/psensor/AGENTS.md
@@ -38,16 +38,16 @@ and *notifying* someone. It ships two monitors:
 
 - **`heartbeat`** — the requestor promises to send periodic
   `PMIx_Heartbeat()` beacons to its server. `psensor/heartbeat` counts the
-  beats arriving in each time window; if a window passes with **no** beat,
-  it raises `PMIX_MONITOR_HEARTBEAT_ALERT`. This is dropped-heartbeat
-  detection: the process is presumed stalled or dead.
+  beats arriving in each time window; once more consecutive windows have
+  passed with **no** beat than the requestor said it would tolerate, it
+  alerts. This is dropped-heartbeat detection: the process is presumed
+  stalled or dead.
 - **`file`** — the requestor names a file that a healthy application is
   expected to keep touching (growing it, or updating its access or
   modification time). `psensor/file` `stat`s the file on an interval; if
-  the watched attribute has not changed across a configured number of
-  checks, it raises `PMIX_MONITOR_FILE_ALERT`. This is staleness
-  detection for applications that write progress to a file rather than
-  emit heartbeats.
+  none of the watched attributes has changed across a configured number
+  of checks, it alerts. This is staleness detection for applications that
+  write progress to a file rather than emit heartbeats.
 
 Like `pstat`, `psensor` only ever runs **inside a PMIx server** — it is
 opened and selected during server startup in
@@ -68,6 +68,21 @@ and either claims it or declines by returning
 - `heartbeat` claims a request whose `monitor->key` is
   `PMIX_MONITOR_HEARTBEAT`.
 - `file` claims a request whose `monitor->key` is `PMIX_MONITOR_FILE`.
+
+`PMIX_MONITOR_CANCEL` is the exception to the claim/decline shape, and it
+is worth understanding before adding a component. Both components act on
+a cancel — each hands the id in `monitor->value` to its own `stop()`,
+which is already the right matcher — and then **still return
+`PMIX_ERR_TAKE_NEXT_OPTION`**. Claiming it would be wrong: the id may
+name a `pstat` op rather than a `psensor` tracker, and
+`pmix_psensor_base_start` stops walking the moment a module returns
+success, so `pmix_monitor.c` would never offer the cancel to the
+resource-usage path. Every cancel target is tolerant of an id it does not
+hold, so offering the request to everyone costs nothing and strands
+nothing. A `monitor->value` that is a `PMIX_STRING` with a `NULL` string
+means "cancel every monitor this requestor started"; a value of any other
+type is a malformed request, and the components leave it alone rather
+than reading it as a request to cancel everything.
 
 Because the two components gate on **mutually exclusive** keys, their
 priorities (`file` = 20, `heartbeat` = 5 — both commented "irrelevant" in
@@ -107,7 +122,7 @@ supply both):
 
 | Field | Signature | Purpose |
 |-------|-----------|---------|
-| `start` | `(pmix_peer_t *requestor, pmix_status_t error, const pmix_info_t *monitor, const pmix_info_t directives[], size_t ndirs)` | Begin a monitor for `requestor`. Inspect `monitor->key`; if it is not this component's key, return `PMIX_ERR_TAKE_NEXT_OPTION`. Otherwise build a tracker from `directives` and arm a timer. `error` is the status code the caller wants raised if the monitor trips. |
+| `start` | `(pmix_peer_t *requestor, pmix_status_t error, const pmix_info_t *monitor, const pmix_info_t directives[], size_t ndirs)` | Begin a monitor for `requestor`. Inspect `monitor->key`; if it is not this component's key, return `PMIX_ERR_TAKE_NEXT_OPTION`. Otherwise build a tracker from `directives` and arm a timer. `error` is the status code the caller wants raised if the monitor trips — see "Events raised" below. |
 | `stop` | `(pmix_peer_t *requestor, char *id)` | Tear down monitors. A `NULL` `id` means "stop **all** monitors this requestor started"; a non-`NULL` `id` matches the caller-supplied `PMIX_MONITOR_ID` handle. |
 
 The component data structure is just a typedef of the standard
@@ -188,9 +203,27 @@ pauses and stops in two separate places:
   tracker, whose destructor frees the base — has to come *after* the
   components have closed.
 
-`close` clears `pmix_psensor_base.evbase` either way, because
-`pmix_psensor.stop` stays callable after the framework closes (the server
-calls it from client teardown) and must not post a caddy to a freed base.
+`close` clears `pmix_psensor_base.evbase` either way. Note what actually
+makes a post-close `pmix_psensor.stop` harmless, because it is *not* that
+pointer: nothing checks it, and `event_assign()` silently substitutes
+libevent's `current_base` for a `NULL` one, so a caddy posted after close
+would land on a base that is no longer looping and simply leak. What
+saves it is that `close` destructs `actives` first — so
+`pmix_psensor_base_stop` walks an empty list and never reaches a module's
+`stop` at all. The same argument covers `start`. Do not "fix" this by
+adding a `NULL` check without also explaining why the empty-list argument
+stopped holding; and do not reorder `close` so the `actives` destruct
+comes after the components close.
+
+**`heartbeat_close` also un-posts the PTL recv it lazily posted.** That
+recv names a function in the component, and `ptl` closes *after* this
+framework, so between the two the ptl list would otherwise hold a
+callback into a component that has been closed — and, in a DSO build,
+unloaded. Clearing the component's `recv_active` flag alongside it is the
+other half: the flag lives in a file-scope struct that outlives the
+library, so a second `PMIx_server_init` in the same process would find it
+still set, never re-post, count no beats, and declare every monitored
+client dead on its first window.
 
 In the default configuration there is no separate thread to pause:
 `evbase` is the library's shared base, which `PMIx_server_finalize` has
@@ -207,6 +240,15 @@ here — there is no `no-plugins` `show_help` and no error return; an empty
 `actives` list simply means `pmix_psensor_base_start` will later report
 `PMIX_ERR_NOT_SUPPORTED`. At verbosity >4 it prints the resolved priority
 list.
+
+Two skips guard the walk, and both matter for a component that does not
+yet exist: a component need not supply a query function at all, and one
+that does may decline by handing back `PMIX_SUCCESS` and no module. The
+first is called unconditionally without the guard; the second lands a
+`NULL` module on `actives`, where `pmix_psensor_base_start` dereferences
+it on the next monitor request — it checks `mod->module->start` for
+`NULL`, which is one level too late. `preg`, the other multi-select
+framework, screens for both, and this is the pattern to copy.
 
 ### `base/psensor_base_stubs.c` — the dispatch functions
 
@@ -310,16 +352,20 @@ The `monitor` argument's **key** selects the component (above); its
 | Directive | Consumed by | Effect |
 |-----------|-------------|--------|
 | `PMIX_MONITOR_HEARTBEAT_TIME` | heartbeat | uint32 seconds per heartbeat window (**required**; 0 ⇒ `PMIX_ERR_BAD_PARAM`) |
-| `PMIX_MONITOR_HEARTBEAT_DROPS` | heartbeat | (parsed into `ndrops`) |
-| `PMIX_MONITOR_FILE_SIZE` / `PMIX_MONITOR_FILE_ACCESS` / `PMIX_MONITOR_FILE_MODIFY` | file | which `stat` attribute signals life (at least one **required**) |
+| `PMIX_MONITOR_HEARTBEAT_DROPS` | heartbeat | consecutive empty windows tolerated before alerting (`ndrops`; default 0 ⇒ alert on the first) |
+| `PMIX_MONITOR_FILE_SIZE` / `PMIX_MONITOR_FILE_ACCESS` / `PMIX_MONITOR_FILE_MODIFY` | file | which `stat` attributes signal life (at least one **required**; **all** of the ones given are watched, and any one moving counts as alive) |
 | `PMIX_MONITOR_FILE_CHECK_TIME` | file | uint32 seconds between `stat`s (**required**; 0 ⇒ `PMIX_ERR_BAD_PARAM`) |
-| `PMIX_MONITOR_FILE_DROPS` | file | number of unchanged checks tolerated before alerting (`ndrops`) |
+| `PMIX_MONITOR_FILE_DROPS` | file | unchanged checks tolerated before alerting (`ndrops`; default 0 ⇒ alert on the first check that shows no change) |
+| `PMIX_MONITOR_ID` | both | caller-supplied string handle for this monitor; the cancel key. Must be a non-`NULL` `PMIX_STRING` or the request is `PMIX_ERR_BAD_PARAM`. Naming a monitor twice keeps the first name |
 | `PMIX_RANGE` | both | `pmix_data_range_t` scope for the raised event (default `PMIX_RANGE_NAMESPACE`) |
 
-The requestor's `PMIX_MONITOR_ID` string (the cancel handle used by
-`stop`) is part of the tracker contract but is not itself parsed in the
-current component `start` routines — a caller cancels by requestor peer,
-optionally narrowed by `id`, in `stop`.
+**Read numeric directives through `PMIx_Value_get_number`, not out of the
+union.** Every one of these arrives off the wire from a client, which is
+free to send the wrong type; reaching straight for `.data.uint32` reads
+whatever bits happen to be there and turns a malformed request into a
+monitor that quietly never fires. Both components convert, and hand back
+the conversion's error. `PMIX_MONITOR_ID` and `PMIX_RANGE` are
+type-checked outright for the same reason.
 
 ## Events raised
 
@@ -328,12 +374,31 @@ When a monitor trips, the component calls the **public**
 uses — with a `source` of the monitored requestor and the tracker's
 `range`:
 
-| Component | Status code raised |
-|-----------|--------------------|
+**The status raised is the `error` the requestor supplied**, exactly as
+[`PMIx_Process_monitor(3)`](../../../docs/man/man3/PMIx_Process_monitor.3.rst)
+promises ("the code the monitor is to use when generating an event
+notification"). A requestor that passed `PMIX_SUCCESS` expressed no
+preference, and then the component's own code stands:
+
+| Component | Default status code |
+|-----------|---------------------|
 | `heartbeat` | `PMIX_MONITOR_HEARTBEAT_ALERT` (`-109`) |
 | `file` | `PMIX_MONITOR_FILE_ALERT` (`-110`) |
 
 (Both codes live in [`include/pmix_common.h.in`](../../../include/pmix_common.h.in).)
+`pstat` does the same thing with its `op->eventcode`, so the two halves
+of the monitor API agree.
+
+**`PMIx_Notify_event` does not always reach the callback.** It rejects a
+request outright — `PMIX_ERR_INIT`, `PMIX_ERR_NOMEM`, and
+`PMIX_ERR_NOT_AVAILABLE` once `pmix_globals.progress_thread_stopped` is
+set — and returns before the caddy that would fire `opcbfunc` exists. A
+sampler that handed the notification its tracker's last reference must
+therefore release it on the error path, or the tracker and the peer it
+retains are stranded. The `NOT_AVAILABLE` case is not hypothetical:
+`PMIx_server_finalize` stops the progress thread well before it closes
+this framework, and in the separate-thread configuration the samplers go
+on firing across that gap.
 
 ## Directory layout
 
@@ -408,7 +473,14 @@ removing a *component directory* changes the build wiring resolved by
   requestor," and the base deliberately calls `stop` on *every* component;
   a component with nothing to stop must simply do nothing and return
   success. This matters because `pmix_psensor.stop` runs on every client
-  disconnect and lost connection.
+  disconnect and lost connection — and because a `PMIX_MONITOR_CANCEL` is
+  offered to every component too.
+- **Honor what the request asked for, or reject it.** A directive parsed
+  into a tracker field and then never read is the failure mode this
+  framework keeps producing: the drop allowance, the cancel handle and
+  the requestor's own status code were each stored and ignored, and every
+  one of them looked like working code. If a new directive cannot be
+  supported, return `PMIX_ERR_BAD_PARAM` — do not accept it silently.
 - **Never re-arm a sampler's own timer, and never start the monitor
   thread without fixing the teardown to match.** See "The tracker timer
   is persistent" and "Starting and stopping the monitor thread" above;
@@ -418,4 +490,7 @@ removing a *component directory* changes the build wiring resolved by
   proves anything. `test/simple/simpmonitor.c` and
   `test/unit/run_monitor.pl` are the pattern: one rank asks to be
   monitored and then does nothing, another waits for the alert and checks
-  its source.
+  its source. Cover the *negative* direction too — that test also arms a
+  capped monitor and a cancelled one under a status code of their own, so
+  that "this must not alert" is checked rather than assumed. A directive
+  that is silently ignored passes every positive test there is.

--- a/src/mca/psensor/base/psensor_base_frame.c
+++ b/src/mca/psensor/base/psensor_base_frame.c
@@ -17,9 +17,6 @@
 
 #include "pmix_common.h"
 
-#include <pthread.h>
-#include <event.h>
-
 #include "src/class/pmix_list.h"
 #include "src/include/pmix_types.h"
 #include "src/mca/base/pmix_base.h"

--- a/src/mca/psensor/base/psensor_base_select.c
+++ b/src/mca/psensor/base/psensor_base_select.c
@@ -110,5 +110,4 @@ int pmix_psensor_base_select(void)
     }
 
     return PMIX_SUCCESS;
-    ;
 }

--- a/src/mca/psensor/base/psensor_base_select.c
+++ b/src/mca/psensor/base/psensor_base_select.c
@@ -56,8 +56,25 @@ int pmix_psensor_base_select(void)
                             "mca:psensor:select: checking available component %s",
                             component->pmix_mca_component_name);
 
-        /* get the module for this component */
-        if (PMIX_SUCCESS != component->pmix_mca_query_component(&mod, &pri)) {
+        /* A component is not obliged to offer a query function, and one
+         * that does may decline by handing back no module - so check both
+         * before calling and before keeping the answer. Neither is
+         * hypothetical bookkeeping: without the first this crashes on any
+         * component built without a query, and without the second a NULL
+         * module lands on the actives list, where pmix_psensor_base_start
+         * dereferences it on the next monitor request. This matches what
+         * preg, the other multi-select framework, does. */
+        if (NULL == component->pmix_mca_query_component) {
+            pmix_output_verbose(5, pmix_psensor_base_framework.framework_output,
+                                "mca:psensor:select: skipping component %s - no query function",
+                                component->pmix_mca_component_name);
+            continue;
+        }
+        mod = NULL;
+        if (PMIX_SUCCESS != component->pmix_mca_query_component(&mod, &pri) || NULL == mod) {
+            pmix_output_verbose(5, pmix_psensor_base_framework.framework_output,
+                                "mca:psensor:select: skipping component %s - returned no module",
+                                component->pmix_mca_component_name);
             continue;
         }
 

--- a/src/mca/psensor/file/AGENTS.md
+++ b/src/mca/psensor/file/AGENTS.md
@@ -11,8 +11,8 @@
 # AGENTS.md: The PSENSOR `file` Component
 
 `file` is the `psensor` component that watches a file for signs of life —
-changes to its size, access time, or modification time — and raises
-`PMIX_MONITOR_FILE_ALERT` when the file goes stale. Read the framework
+changes to its size, access time, or modification time — and raises an
+alert when the file goes stale. Read the framework
 [`AGENTS.md`](../AGENTS.md) first; this file covers only what is specific
 to `file`. It claims a start request whose `monitor->key` is
 `PMIX_MONITOR_FILE`, with the file path carried in `monitor->value`.
@@ -33,6 +33,11 @@ to `file`. It claims a start request whose `monitor->key` is
 chosen for a request: `start` returns `PMIX_ERR_TAKE_NEXT_OPTION` unless
 `monitor->key == PMIX_MONITOR_FILE`.
 
+`PMIX_MONITOR_CANCEL` is handled before that gate — `start` passes the id
+in `monitor->value` to `stop()` and then declines anyway, so the cancel
+goes on to `pstat`. The framework
+[`AGENTS.md`](../AGENTS.md) explains why declining is the right answer.
+
 ## The component and tracker structs
 
 The component wraps the base struct to hold its tracker list
@@ -46,10 +51,22 @@ typedef struct {
 ```
 
 Each `file_tracker_t` records the retained `requestor`, the `file` path,
-the sample interval `tv`, the three watch flags `file_size` /
-`file_access` / `file_mod`, the last-seen `last_size` / `last_access` /
-`last_mod`, the counters `ndrops` (tolerance) and `nmisses` (consecutive
-unchanged checks), plus `range` and `info`/`ninfo` for the event.
+the caller's `id` (the `PMIX_MONITOR_ID` cancel handle) and `error` (the
+status to raise), the sample interval `tv`, the three watch flags
+`file_size` / `file_access` / `file_mod`, the last-seen `last_size` /
+`last_access` / `last_mod`, the `sampled` baseline latch, the counters
+`ndrops` (tolerance) and `nmisses` (consecutive unchanged checks), plus
+`range` and `info`/`ninfo` for the event.
+
+`last_size` is an `off_t`, not a `size_t`: it holds `st_size`, and the
+two are not the same width wherever large-file support is on and pointers
+are 32 bits. It used to be a `size_t` compared through an `(int64_t)`
+cast, which is the shape a truncating assignment leaves behind.
+
+**The constructor must initialize every pointer field.** `PMIX_NEW`
+mallocs and runs the constructor; it does not zero. `file` was set only
+in `start`, which happens to assign it before any path that could release
+the tracker — a property no one is required to preserve.
 
 ## `start` — validating and arming
 
@@ -57,7 +74,12 @@ unchanged checks), plus `range` and `info`/`ninfo` for the event.
    path from `monitor->value.data.string`.
 2. Parse directives: `PMIX_MONITOR_FILE_SIZE` / `_ACCESS` / `_MODIFY` set
    the corresponding watch flag; `PMIX_MONITOR_FILE_DROPS` → `ndrops`;
-   `PMIX_MONITOR_FILE_CHECK_TIME` → `tv.tv_sec`; `PMIX_RANGE` → `range`.
+   `PMIX_MONITOR_FILE_CHECK_TIME` → `tv.tv_sec`; `PMIX_MONITOR_ID` →
+   `id`; `PMIX_RANGE` → `range`. The two numbers go through
+   `PMIx_Value_get_number` and the other two are type-checked, because
+   all four arrive off the wire; a directive that will not convert takes
+   the whole request down with `PMIX_ERR_BAD_PARAM` rather than leaving a
+   tracker built from whatever the union happened to hold.
 3. **Reject an incomplete request:** if the interval is zero **or** none
    of the three watch flags is set, release the tracker and return
    `PMIX_ERR_BAD_PARAM`. A file monitor needs both *how often* to look and
@@ -78,19 +100,29 @@ Fires every `tv` seconds:
 
 - `stat` the file. **If the `stat` fails** (file not present yet), it
   simply returns — a not-yet-created file is not a fault, and the
-  persistent timer brings us back to look again.
-- Compare the watched attribute to its last-seen value and update
-  `nmisses`: unchanged ⇒ `nmisses++`; changed ⇒ `nmisses = 0` and the
-  last-seen value is refreshed. **Only one attribute is checked per
-  sample**, chosen by an `if / else if / else if` chain in the order
-  size → access → mod. So if `file_size` is set, the access/mod flags are
-  effectively ignored; watch exactly one attribute per monitor to avoid
-  surprise.
-- **Alert when `nmisses == ndrops`:** the file is declared stalled. At
+  persistent timer brings us back to look again. Note the consequence: a
+  file that is *deleted* after being watched also stops the count rather
+  than tripping it. That is deliberate, not an oversight.
+- **The first sample only records a baseline** (`sampled`) and returns.
+  There is nothing to compare against yet, and the constructor's zeroes
+  are values a real file can genuinely have — a monitor watching the size
+  of a legitimately empty file used to score a miss on its very first
+  look.
+- Afterwards, compare **every** watched attribute to its last-seen value.
+  Any one of them moving means the application is alive: `nmisses = 0`.
+  Only if none moved does `nmisses++`. (An `if / else if / else if` chain
+  used to check just the first flag that was set, so a request naming
+  both a size and a modification time silently got one of them.)
+- **Alert when `0 < nmisses` and `nmisses >= ndrops`:** the file is
+  declared stalled. At
   verbosity >4 it emits the `file-stalled` `show_help`; it then **removes
-  the tracker from the list** and raises `PMIX_MONITOR_FILE_ALERT` via
-  `PMIx_Notify_event` (source = requestor, scope = `range`). The
-  completion callback (`opcbfunc`) releases the tracker. Because the timer
+  the tracker from the list** and raises the alert via
+  `PMIx_Notify_event` (source = requestor, scope = `range`, status =
+  the requestor's `error`, or `PMIX_MONITOR_FILE_ALERT` if they asked for
+  `PMIX_SUCCESS`). The completion callback (`opcbfunc`) releases the
+  tracker — **unless `PMIx_Notify_event` returns an error**, in which case
+  it never runs and the sampler has to release the tracker itself; by
+  then that reference is the last one. Because the timer
   is persistent it is **still armed** at that point — libevent re-armed it
   before entering this callback — so `file_sample` **deletes it
   explicitly** before letting go of the tracker. A file monitor is
@@ -99,15 +131,21 @@ Fires every `tv` seconds:
 
 ## Gotchas
 
-- **`ndrops` is an equality threshold, not a "≥".** The alert fires the
-  moment `nmisses` *equals* `ndrops`. With the default `ndrops == 0`, that
-  means the very first sample can alert: `last_size` starts at 0, so a
-  freshly-created non-empty file registers a *change* (`nmisses` reset to
-  0), and `0 == 0` trips immediately. Callers who want N tolerated misses
-  must pass `PMIX_MONITOR_FILE_DROPS` explicitly.
-- **Only the first-listed attribute is watched** (size beats access beats
-  mod, per the `if/else if` chain). This is easy to misread as "watch all
-  three"; it is not.
+- **`ndrops` counts misses, and a miss is not the same as a sample.** The
+  baseline sample scores nothing, and the alert needs `0 < nmisses` as
+  well as `nmisses >= ndrops`. Both halves are load-bearing: an equality
+  test against a default `ndrops` of 0 fired on the first sample of a
+  perfectly healthy file, because a `nmisses` of 0 means "nothing has
+  been missed", not "the tolerance is exhausted". So a request with no
+  `PMIX_MONITOR_FILE_DROPS` alerts on the first check that shows no
+  change — which is what asking to tolerate zero misses means.
+- **Two `ctime()` calls in one argument list return the same buffer.**
+  Both the verbose sample line and the `file-stalled` topic print an
+  access time and a modification time; done with `ctime()` they printed
+  the same timestamp twice, and scribbled on any `ctime`/`asctime` result
+  the application held on another thread. `render_time()` wraps
+  `ctime_r`, and deliberately keeps the trailing newline `ctime` emits —
+  the help topic runs its next label straight up against it.
 - **The monitor is one-shot.** Unlike `heartbeat`, `file` removes and
   releases its tracker on the first alert. If you need ongoing monitoring
   after a stall, the caller must start a new monitor.

--- a/src/mca/psensor/file/help-pmix-psensor-file.txt
+++ b/src/mca/psensor/file/help-pmix-psensor-file.txt
@@ -15,5 +15,5 @@
 A specified file is not changing, indicating a possibly stalled application:
 
 File:              %s
-Last size:         %lu
+Last size:         %llu
 Last access:       %sLast modification: %s

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -45,6 +45,7 @@
 #include "src/include/pmix_globals.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
 
 #include "psensor_file.h"
@@ -72,10 +73,11 @@ typedef struct {
     struct timeval tv;
     int tick;
     char *file;
+    bool sampled;
     bool file_size;
     bool file_access;
     bool file_mod;
-    size_t last_size;
+    off_t last_size;
     time_t last_access;
     time_t last_mod;
     uint32_t ndrops;
@@ -94,6 +96,8 @@ static void ft_constructor(file_tracker_t *ft)
     ft->tv.tv_sec = 0;
     ft->tv.tv_usec = 0;
     ft->tick = 0;
+    ft->file = NULL;
+    ft->sampled = false;
     ft->file_size = false;
     ft->file_access = false;
     ft->file_mod = false;
@@ -188,13 +192,32 @@ static pmix_status_t start(pmix_peer_t *requestor, pmix_status_t error, const pm
 {
     file_tracker_t *ft;
     size_t n;
-
-    PMIX_HIDE_UNUSED_PARAMS(error);
+    uint32_t u32;
+    pmix_status_t rc;
 
     pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] checking file monitoring for requestor %s:%d",
                          pmix_globals.myid.nspace, pmix_globals.myid.rank,
                          requestor->info->pname.nspace, requestor->info->pname.rank);
+
+    /* A cancel names the monitor by the id its original request carried,
+     * and our stop() already does exactly that matching - so service it
+     * here, but still decline. The id may name a pstat op rather than one
+     * of ours, and pmix_psensor_base_start stops walking the moment a
+     * module claims a request: claiming a cancel we know nothing about
+     * would strand it. Both ends are tolerant of an id they do not hold,
+     * so offering it to everyone is the right shape. PMIX_MONITOR_CANCEL
+     * is a char*, and a NULL one means "cancel everything this requestor
+     * started" - which is what stop() already does with a NULL id. A
+     * value of some other type is a malformed request rather than a
+     * request to cancel everything, so leave it alone and let the pstat
+     * path reject it. */
+    if (0 == strcmp(monitor->key, PMIX_MONITOR_CANCEL)) {
+        if (PMIX_STRING == monitor->value.type) {
+            (void) stop(requestor, monitor->value.data.string);
+        }
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
 
     /* if they didn't ask to monitor a file, then nothing for us to do */
     if (0 != strcmp(monitor->key, PMIX_MONITOR_FILE)) {
@@ -214,8 +237,15 @@ static pmix_status_t start(pmix_peer_t *requestor, pmix_status_t error, const pm
     PMIX_RETAIN(requestor);
     ft->requestor = requestor;
     ft->file = strdup(monitor->value.data.string);
+    /* the status the requestor wants raised when this trips - see
+     * PMIx_Process_monitor(3). PMIX_SUCCESS means they expressed no
+     * preference, and then the framework's own alert code stands. */
+    ft->error = error;
 
-    /* check the directives to see if what they want monitored */
+    /* Check the directives to see what they want monitored. Every value
+     * here arrives off the wire from a client, so read the numbers
+     * through PMIx_Value_get_number rather than reaching into the union
+     * for a type the sender never promised to have sent. */
     for (n = 0; n < ndirs; n++) {
         if (0 == strcmp(directives[n].key, PMIX_MONITOR_FILE_SIZE)) {
             ft->file_size = PMIX_INFO_TRUE(&directives[n]);
@@ -224,10 +254,36 @@ static pmix_status_t start(pmix_peer_t *requestor, pmix_status_t error, const pm
         } else if (0 == strcmp(directives[n].key, PMIX_MONITOR_FILE_MODIFY)) {
             ft->file_mod = PMIX_INFO_TRUE(&directives[n]);
         } else if (0 == strcmp(directives[n].key, PMIX_MONITOR_FILE_DROPS)) {
-            ft->ndrops = directives[n].value.data.uint32;
+            rc = PMIx_Value_get_number(&directives[n].value, (void *) &u32, PMIX_UINT32);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_RELEASE(ft);
+                return rc;
+            }
+            ft->ndrops = u32;
         } else if (0 == strcmp(directives[n].key, PMIX_MONITOR_FILE_CHECK_TIME)) {
-            ft->tv.tv_sec = directives[n].value.data.uint32;
+            rc = PMIx_Value_get_number(&directives[n].value, (void *) &u32, PMIX_UINT32);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_RELEASE(ft);
+                return rc;
+            }
+            ft->tv.tv_sec = u32;
+        } else if (0 == strcmp(directives[n].key, PMIX_MONITOR_ID)) {
+            /* the cancel handle. Nothing stops a caller from naming the
+             * monitor twice; the first name wins, as overwriting would
+             * lose the string we already took */
+            if (PMIX_STRING != directives[n].value.type ||
+                NULL == directives[n].value.data.string) {
+                PMIX_RELEASE(ft);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            if (NULL == ft->id) {
+                ft->id = strdup(directives[n].value.data.string);
+            }
         } else if (0 == strcmp(directives[n].key, PMIX_RANGE)) {
+            if (PMIX_DATA_RANGE != directives[n].value.type) {
+                PMIX_RELEASE(ft);
+                return PMIX_ERR_BAD_PARAM;
+            }
             ft->range = directives[n].value.data.range;
         }
     }
@@ -296,11 +352,31 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(ft);
 }
 
+/* Render a time_t the way ctime() would, but into the caller's buffer.
+ * ctime() hands back a process-wide static, so the two calls this file
+ * used to make in one argument list both pointed at the same bytes and
+ * printed the same timestamp twice - and, with the monitors on their own
+ * "PSENSOR" thread, they also scribbled on any ctime/asctime result the
+ * application was holding elsewhere. The trailing newline ctime() emits
+ * is deliberately kept: help-pmix-psensor-file.txt runs the next label
+ * straight up against this conversion and relies on it. */
+static const char *render_time(time_t when, char *buf, size_t sz)
+{
+    if (NULL == ctime_r(&when, buf)) {
+        /* ctime_r is allowed to decline a time it cannot represent */
+        pmix_snprintf(buf, sz, "unknown\n");
+    }
+    return buf;
+}
+
 static void file_sample(int sd, short args, void *cbdata)
 {
     file_tracker_t *ft = (file_tracker_t *) cbdata;
     struct stat buf;
     pmix_status_t rc;
+    time_t atime, mtime;
+    char atod[32], mtod[32];
+    bool changed;
 
     PMIX_ACQUIRE_OBJECT(ft);
 
@@ -322,42 +398,71 @@ static void file_sample(int sd, short args, void *cbdata)
         return;
     }
 
+    atime = buf.st_atime;
+    mtime = buf.st_mtime;
     pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
-                         "[%s:%d] size %lu access %s\tmod %s", pmix_globals.myid.nspace,
-                         pmix_globals.myid.rank, (unsigned long) buf.st_size, ctime(&buf.st_atime),
-                         ctime(&buf.st_mtime));
+                         "[%s:%d] size %llu access %s\tmod %s", pmix_globals.myid.nspace,
+                         pmix_globals.myid.rank, (unsigned long long) buf.st_size,
+                         render_time(atime, atod, sizeof(atod)),
+                         render_time(mtime, mtod, sizeof(mtod)));
 
-    if (ft->file_size) {
-        if (buf.st_size == (int64_t) ft->last_size) {
-            ft->nmisses++;
-        } else {
-            ft->nmisses = 0;
-            ft->last_size = buf.st_size;
-        }
-    } else if (ft->file_access) {
-        if (buf.st_atime == ft->last_access) {
-            ft->nmisses++;
-        } else {
-            ft->nmisses = 0;
-            ft->last_access = buf.st_atime;
-        }
-    } else if (ft->file_mod) {
-        if (buf.st_mtime == ft->last_mod) {
-            ft->nmisses++;
-        } else {
-            ft->nmisses = 0;
-            ft->last_mod = buf.st_mtime;
-        }
+    /* The first sample has nothing to compare against - it establishes
+     * the baseline and nothing more. Without this the constructor's
+     * zeroes stand in for "what the file looked like last time", which is
+     * a value a real file can genuinely have: a monitor watching the size
+     * of a file that is legitimately empty counted a miss on its very
+     * first look. */
+    if (!ft->sampled) {
+        ft->sampled = true;
+        ft->last_size = buf.st_size;
+        ft->last_access = atime;
+        ft->last_mod = mtime;
+        return;
+    }
+
+    /* Every attribute the request named is watched, and any one of them
+     * moving means the application is alive. An if/else-if chain used to
+     * check only the first flag that was set, so a request naming both a
+     * size and a modification time silently got one of them - and would
+     * report a stall in a file whose mtime was moving all along. */
+    changed = false;
+    if (ft->file_size && buf.st_size != ft->last_size) {
+        ft->last_size = buf.st_size;
+        changed = true;
+    }
+    if (ft->file_access && atime != ft->last_access) {
+        ft->last_access = atime;
+        changed = true;
+    }
+    if (ft->file_mod && mtime != ft->last_mod) {
+        ft->last_mod = mtime;
+        changed = true;
+    }
+    if (changed) {
+        ft->nmisses = 0;
+    } else {
+        ft->nmisses++;
     }
 
     pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] sampled file %s misses %d", pmix_globals.myid.nspace,
                          pmix_globals.myid.rank, ft->file, ft->nmisses);
 
-    if (ft->nmisses == ft->ndrops) {
+    /* Alert once the watched attribute has sat still for as many checks
+     * as the requestor said it would tolerate. The miss count has to be
+     * non-zero for this to mean anything: a request that named no
+     * PMIX_MONITOR_FILE_DROPS leaves ndrops at 0, and the first sample of
+     * a perfectly healthy file also leaves nmisses at 0 - so an equality
+     * test alerted immediately on a file that had just been written. */
+    if (0 < ft->nmisses && ft->nmisses >= ft->ndrops) {
         if (4 < pmix_output_get_verbosity(pmix_psensor_base_framework.framework_output)) {
+            /* the topic renders the size with %llu; off_t is 64 bits
+             * wherever large-file support is on, and varargs will not
+             * widen it for us */
             pmix_show_help("help-pmix-psensor-file.txt", "file-stalled", true, ft->file,
-                           ft->last_size, ctime(&ft->last_access), ctime(&ft->last_mod));
+                           (unsigned long long) ft->last_size,
+                           render_time(ft->last_access, atod, sizeof(atod)),
+                           render_time(ft->last_mod, mtod, sizeof(mtod)));
         }
         /* stop monitoring this client. Disarm before we let go of the
          * tracker: the timer is persistent, so it is still armed even
@@ -376,10 +481,18 @@ static void file_sample(int sd, short args, void *cbdata)
          * processes the event asynchronously, after we return */
         pmix_strncpy(ft->source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
         ft->source.rank = ft->requestor->info->pname.rank;
-        rc = PMIx_Notify_event(PMIX_MONITOR_FILE_ALERT, &ft->source, ft->range, ft->info, ft->ninfo,
+        rc = PMIx_Notify_event((PMIX_SUCCESS == ft->error) ? PMIX_MONITOR_FILE_ALERT : ft->error,
+                               &ft->source, ft->range, ft->info, ft->ninfo,
                                opcbfunc, ft);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            /* opcbfunc is not going to run - PMIx_Notify_event rejects a
+             * request outright (PMIX_ERR_NOT_AVAILABLE once the progress
+             * thread has stopped, which finalize does while our sampler
+             * may still be firing) without ever reaching the callback.
+             * The tracker has just left the list, so the reference we
+             * handed the notification is its last one. */
+            PMIX_RELEASE(ft);
         }
         return;
     }

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -20,21 +20,8 @@
 #include "src/include/pmix_config.h"
 #include "pmix_common.h"
 
-#include <ctype.h>
 #include <stddef.h>
-#include <stdio.h>
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
-#ifdef HAVE_NETDB_H
-#    include <netdb.h>
-#endif
-#ifdef HAVE_SYS_PARAM_H
-#    include <sys/param.h>
-#endif
-#include <errno.h>
-#include <fcntl.h>
-#include <signal.h>
+#include <string.h>
 #ifdef HAVE_TIME_H
 #    include <time.h>
 #endif
@@ -71,7 +58,6 @@ typedef struct {
     pmix_event_t ev;
     pmix_event_t cdev;
     struct timeval tv;
-    int tick;
     char *file;
     bool sampled;
     bool file_size;
@@ -95,7 +81,6 @@ static void ft_constructor(file_tracker_t *ft)
     ft->event_active = false;
     ft->tv.tv_sec = 0;
     ft->tv.tv_usec = 0;
-    ft->tick = 0;
     ft->file = NULL;
     ft->sampled = false;
     ft->file_size = false;
@@ -445,7 +430,7 @@ static void file_sample(int sd, short args, void *cbdata)
     }
 
     pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
-                         "[%s:%d] sampled file %s misses %d", pmix_globals.myid.nspace,
+                         "[%s:%d] sampled file %s misses %u", pmix_globals.myid.nspace,
                          pmix_globals.myid.rank, ft->file, ft->nmisses);
 
     /* Alert once the watched attribute has sat still for as many checks

--- a/src/mca/psensor/heartbeat/AGENTS.md
+++ b/src/mca/psensor/heartbeat/AGENTS.md
@@ -11,8 +11,8 @@
 # AGENTS.md: The PSENSOR `heartbeat` Component
 
 `heartbeat` is the `psensor` component that watches for periodic
-`PMIx_Heartbeat()` beacons from a monitored process and raises
-`PMIX_MONITOR_HEARTBEAT_ALERT` when they stop arriving. Read the framework
+`PMIx_Heartbeat()` beacons from a monitored process and alerts when they
+stop arriving. Read the framework
 [`AGENTS.md`](../AGENTS.md) first; this file covers only what is specific
 to `heartbeat`. It claims a start request whose `monitor->key` is
 `PMIX_MONITOR_HEARTBEAT`.
@@ -33,6 +33,11 @@ to `heartbeat`. It claims a start request whose `monitor->key` is
 `PMIX_ERR_TAKE_NEXT_OPTION` unless `monitor->key == PMIX_MONITOR_HEARTBEAT`,
 so it only ever acts on heartbeat requests.
 
+`PMIX_MONITOR_CANCEL` is handled before that gate — `heartbeat_start`
+passes the id in `monitor->value` to `heartbeat_stop()` and then declines
+anyway, so the cancel goes on to `pstat`. The framework
+[`AGENTS.md`](../AGENTS.md) explains why declining is the right answer.
+
 ## The component and module structs
 
 The component wraps the base struct to hang two pieces of per-component
@@ -51,8 +56,10 @@ The module is the usual `{ .start, .stop }` pair.
 ## The tracker (`pmix_heartbeat_trkr_t`)
 
 One per monitored requestor, held on `component.trackers`. Key fields:
-`requestor` (retained peer), `tv` (window length), `nbeats` (beats seen
-this window), `ndrops`, `error`, `range`, `info`/`ninfo` (payload for the
+`requestor` (retained peer), `id` (the `PMIX_MONITOR_ID` cancel handle),
+`tv` (window length), `nbeats` (beats seen this window), `nmissed`
+(consecutive empty windows), `ndrops` (how many of those are tolerated),
+`error` (the status to raise), `range`, `info`/`ninfo` (payload for the
 event), and **`stopped`** (latch, see below). Its destructor releases the
 peer, frees `id`/`info`, and deletes the timer if `event_active`.
 
@@ -61,7 +68,11 @@ peer, frees `id`/`info`, and deletes the timer if `event_active`.
 1. Decline unless `monitor->key == PMIX_MONITOR_HEARTBEAT`.
 2. Allocate the tracker, retain the requestor, and parse directives:
    `PMIX_MONITOR_HEARTBEAT_TIME` → `tv.tv_sec`,
-   `PMIX_MONITOR_HEARTBEAT_DROPS` → `ndrops`, `PMIX_RANGE` → `range`.
+   `PMIX_MONITOR_HEARTBEAT_DROPS` → `ndrops`, `PMIX_MONITOR_ID` → `id`,
+   `PMIX_RANGE` → `range`. The two numbers go through
+   `PMIx_Value_get_number` and the other two are type-checked, because
+   all four arrive off the wire; a directive that will not convert takes
+   the whole request down with `PMIX_ERR_BAD_PARAM`.
 3. If `tv.tv_sec == 0` (no window given), release and return
    `PMIX_ERR_BAD_PARAM`.
 4. **Post the heartbeat receive once.** If
@@ -83,21 +94,31 @@ peer, frees `id`/`info`, and deletes the timer if `event_active`.
 from a peer. It does the minimum — retain the sending `peer` into a small
 `pmix_psensor_beat_t` caddy and thread-shift onto `pmix_psensor_base.evbase`
 — then `add_beat` (on the monitor thread) finds the tracker whose
-`requestor == peer`, increments `nbeats`, and clears `stopped` (a beat
-proves the process is alive again). The caddy is released.
+`requestor == peer`, increments `nbeats`, and clears both `stopped` and
+`nmissed` (a beat proves the process is alive again, and gives back the
+whole drop allowance). The caddy is released.
+
+Note `add_beat` stops at the **first** tracker matching the peer, so a
+requestor holding two heartbeat monitors credits only one of them per
+beat.
 
 ## The window check: `check_heartbeat`
 
 Fires every `tv` seconds:
 
-- If `nbeats == 0` **and** `!stopped`: no beat arrived in the window →
-  the process appears dead. It builds a `source` proc from the requestor,
+- If `nbeats == 0` **and** `!stopped`: no beat arrived in this window, so
+  `nmissed++`. While `nmissed <= ndrops` the requestor's drop allowance
+  still covers it and the sampler simply returns. Past that the process
+  is declared dead: it builds a `source` proc from the requestor,
   **retains the tracker** (to keep it alive across the async notify), sets
   `stopped = true` so it will **not** re-report every window, and raises
-  `PMIX_MONITOR_HEARTBEAT_ALERT` via `PMIx_Notify_event` scoped to
-  `range`. The completion callback (`opcbfunc`) releases the retained
-  tracker.
-- Otherwise it just logs the beat count.
+  the alert via `PMIx_Notify_event` scoped to `range` — with the status
+  the requestor asked for, or `PMIX_MONITOR_HEARTBEAT_ALERT` if they
+  passed `PMIX_SUCCESS`. The completion callback (`opcbfunc`) releases the
+  retained tracker; if `PMIx_Notify_event` returns an error it never runs,
+  so the sampler gives that reference back itself.
+- Otherwise it just logs the beat count. `add_beat` is what clears
+  `nmissed`, which is what makes the count *consecutive*.
 - Either way it resets `nbeats = 0`. It does **not** re-arm the timer:
   the timer is persistent and libevent re-armed it before this callback
   was entered.
@@ -121,11 +142,16 @@ more, re-alerted. This "latch then revive" behavior is deliberate.
   sample in flight. A one-shot re-armed from the end of the sampler
   survives that delete; a persistent one does not. The full argument is
   in the framework [`AGENTS.md`](../AGENTS.md).
-- **The PTL recv is shared and posted lazily.** It is prepended to
-  `pmix_ptl_base.posted_recvs` on the first heartbeat `start` and left in
-  place (`recv_active` never resets, and `stop` does not un-post it). If
-  you rework teardown, remember the recv outlives individual trackers by
-  design.
+- **The PTL recv is shared, posted lazily, and retired by
+  `heartbeat_close`.** It is prepended to `pmix_ptl_base.posted_recvs` on
+  the first heartbeat `start` and outlives individual trackers by design —
+  `stop` does not un-post it. Component close is the one place that does,
+  and it must, for two separate reasons: the recv names a function in this
+  component while `ptl` closes *after* `psensor` (so a DSO build would
+  leave the ptl list pointing into an unloaded plugin), and `recv_active`
+  lives in a file-scope struct that outlives the library, so a second
+  `PMIx_server_init` in the same process would find the flag set, the
+  recv gone, and never count another beat.
 - **Being posted lazily leaves a window, and the server screens for it.**
   A client may call `PMIx_Heartbeat()` before any monitor has been armed.
   Until the recv exists, the server's *wildcard* recv matches the beat

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -15,23 +15,14 @@
 #include "src/include/pmix_config.h"
 #include "pmix_common.h"
 
-#include <errno.h>
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif /* HAVE_UNISTD_H */
 #ifdef HAVE_STRING_H
 #    include <string.h>
 #endif /* HAVE_STRING_H */
-#include <pthread.h>
-#include <stdio.h>
-#include <event.h>
 
 #include "src/include/pmix_globals.h"
 #include "src/mca/ptl/base/base.h"
-#include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
-#include "src/util/pmix_show_help.h"
 
 #include "psensor_heartbeat.h"
 #include "src/mca/psensor/base/base.h"
@@ -339,7 +330,6 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(ft);
     PMIX_HIDE_UNUSED_PARAMS(fd, dummy);
-
 
     pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] sensor:check_heartbeat for proc %s:%d", pmix_globals.myid.nspace,

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -175,12 +175,33 @@ static pmix_status_t heartbeat_start(pmix_peer_t *requestor, pmix_status_t error
 {
     pmix_heartbeat_trkr_t *ft;
     size_t n;
+    uint32_t u32;
+    pmix_status_t rc;
     pmix_ptl_posted_recv_t *rcv;
 
     pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] checking heartbeat monitoring for requestor %s:%d",
                          pmix_globals.myid.nspace, pmix_globals.myid.rank,
                          requestor->info->pname.nspace, requestor->info->pname.rank);
+
+    /* A cancel names the monitor by the id its original request carried,
+     * and our stop() already does exactly that matching - so service it
+     * here, but still decline. The id may name a pstat op rather than one
+     * of ours, and pmix_psensor_base_start stops walking the moment a
+     * module claims a request: claiming a cancel we know nothing about
+     * would strand it. Both ends are tolerant of an id they do not hold,
+     * so offering it to everyone is the right shape. PMIX_MONITOR_CANCEL
+     * is a char*, and a NULL one means "cancel everything this requestor
+     * started" - which is what stop() already does with a NULL id. A
+     * value of some other type is a malformed request rather than a
+     * request to cancel everything, so leave it alone and let the pstat
+     * path reject it. */
+    if (0 == strcmp(monitor->key, PMIX_MONITOR_CANCEL)) {
+        if (PMIX_STRING == monitor->value.type) {
+            (void) heartbeat_stop(requestor, monitor->value.data.string);
+        }
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
 
     /* if they didn't ask for heartbeats, then nothing for us to do */
     if (0 != strcmp(monitor->key, PMIX_MONITOR_HEARTBEAT)) {
@@ -193,13 +214,42 @@ static pmix_status_t heartbeat_start(pmix_peer_t *requestor, pmix_status_t error
     ft->requestor = requestor;
     ft->error = error;
 
-    /* check the directives to see what they want monitored */
+    /* Check the directives to see what they want monitored. Every value
+     * here arrives off the wire from a client, so read the numbers
+     * through PMIx_Value_get_number rather than reaching into the union
+     * for a type the sender never promised to have sent. */
     for (n = 0; n < ndirs; n++) {
         if (0 == strcmp(directives[n].key, PMIX_MONITOR_HEARTBEAT_TIME)) {
-            ft->tv.tv_sec = directives[n].value.data.uint32;
+            rc = PMIx_Value_get_number(&directives[n].value, (void *) &u32, PMIX_UINT32);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_RELEASE(ft);
+                return rc;
+            }
+            ft->tv.tv_sec = u32;
         } else if (0 == strcmp(directives[n].key, PMIX_MONITOR_HEARTBEAT_DROPS)) {
-            ft->ndrops = directives[n].value.data.uint32;
+            rc = PMIx_Value_get_number(&directives[n].value, (void *) &u32, PMIX_UINT32);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_RELEASE(ft);
+                return rc;
+            }
+            ft->ndrops = u32;
+        } else if (0 == strcmp(directives[n].key, PMIX_MONITOR_ID)) {
+            /* the cancel handle. Nothing stops a caller from naming the
+             * monitor twice; the first name wins, as overwriting would
+             * lose the string we already took */
+            if (PMIX_STRING != directives[n].value.type ||
+                NULL == directives[n].value.data.string) {
+                PMIX_RELEASE(ft);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            if (NULL == ft->id) {
+                ft->id = strdup(directives[n].value.data.string);
+            }
         } else if (0 == strcmp(directives[n].key, PMIX_RANGE)) {
+            if (PMIX_DATA_RANGE != directives[n].value.type) {
+                PMIX_RELEASE(ft);
+                return PMIX_ERR_BAD_PARAM;
+            }
             ft->range = directives[n].value.data.range;
         }
     }
@@ -298,10 +348,24 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
 
     if (0 == ft->nbeats && !ft->stopped) {
         /* no heartbeat recvd in last window */
+        ++ft->nmissed;
         pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
-                             "[%s:%d] sensor:check_heartbeat failed for proc %s:%d",
+                             "[%s:%d] sensor:check_heartbeat missed %u of %u allowed for proc %s:%d",
                              pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                             ft->nmissed, ft->ndrops,
                              ft->requestor->info->pname.nspace, ft->requestor->info->pname.rank);
+        /* PMIX_MONITOR_HEARTBEAT_DROPS says how many windows the
+         * requestor is willing to have go by empty before we call the
+         * process dead. It was parsed and then thrown away, so a request
+         * that asked for slack got none: the very first empty window
+         * alerted. Leaving ndrops at its default of 0 keeps that
+         * behavior, which is what a request that never named the
+         * attribute is asking for. add_beat clears the count, so this
+         * counts *consecutive* empty windows. */
+        if (ft->nmissed <= ft->ndrops) {
+            ft->nbeats = 0;
+            return;
+        }
         /* generate an event - the source proc lives in the tracker (not
          * on the stack) because PMIx_Notify_event borrows the pointer and
          * processes the event asynchronously, after we return */
@@ -312,10 +376,19 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
         /* mark that the process appears stopped so we don't
          * continue to report it */
         ft->stopped = true;
-        rc = PMIx_Notify_event(PMIX_MONITOR_HEARTBEAT_ALERT, &ft->source, ft->range, ft->info,
+        rc = PMIx_Notify_event((PMIX_SUCCESS == ft->error) ? PMIX_MONITOR_HEARTBEAT_ALERT
+                                                            : ft->error,
+                               &ft->source, ft->range, ft->info,
                                ft->ninfo, opcbfunc, ft);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            /* opcbfunc is not going to run - PMIx_Notify_event rejects a
+             * request outright (PMIX_ERR_NOT_AVAILABLE once the progress
+             * thread has stopped, which finalize does while our sampler
+             * may still be firing) without ever reaching the callback.
+             * Give back the reference we just took; the list still holds
+             * the tracker's own. */
+            PMIX_RELEASE(ft);
         }
     } else {
         pmix_output_verbose(1, pmix_psensor_base_framework.framework_output,
@@ -343,6 +416,9 @@ static void add_beat(int sd, short args, void *cbdata)
             ++ft->nbeats;
             /* ensure we know that the proc is alive */
             ft->stopped = false;
+            /* the drop allowance is spent on *consecutive* empty
+             * windows, so a beat gives it all back */
+            ft->nmissed = 0;
             break;
         }
     }

--- a/src/mca/psensor/heartbeat/psensor_heartbeat_component.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat_component.c
@@ -15,6 +15,7 @@
 
 #include "src/mca/psensor/base/base.h"
 #include "src/mca/psensor/heartbeat/psensor_heartbeat.h"
+#include "src/mca/ptl/base/base.h"
 #include "src/mca/ptl/ptl.h"
 
 /*
@@ -65,7 +66,31 @@ static int heartbeat_query(pmix_mca_base_module_t **module, int *priority)
 
 static int heartbeat_close(void)
 {
+    pmix_ptl_posted_recv_t *rcv, *rnext;
+
     PMIX_LIST_DESTRUCT(&pmix_mca_psensor_heartbeat_component.trackers);
+
+    /* Retire the beat recv the first heartbeat_start posted, and clear
+     * the flag that says one is posted. Both halves matter, and neither
+     * happens on its own:
+     *
+     * - the recv names pmix_psensor_heartbeat_recv_beats, which lives in
+     *   this component. The ptl framework closes after we do, so between
+     *   the two the list holds a callback pointing into a component that
+     *   has been closed - and, in a DSO build, unloaded.
+     * - recv_active is a field of a file-scope component struct, so it
+     *   outlives the library. The ptl's own close frees the recv object
+     *   but knows nothing about our flag, so a second PMIx_server_init
+     *   in the same process would find recv_active still set and never
+     *   re-post. No beat would ever be counted, and the first window
+     *   would declare every monitored client dead. */
+    PMIX_LIST_FOREACH_SAFE (rcv, rnext, &pmix_ptl_base.posted_recvs, pmix_ptl_posted_recv_t) {
+        if (pmix_psensor_heartbeat_recv_beats == rcv->cbfunc) {
+            pmix_list_remove_item(&pmix_ptl_base.posted_recvs, &rcv->super);
+            PMIX_RELEASE(rcv);
+        }
+    }
+    pmix_mca_psensor_heartbeat_component.recv_active = false;
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/psensor/psensor.h
+++ b/src/mca/psensor/psensor.h
@@ -84,4 +84,4 @@ PMIX_EXPORT extern pmix_psensor_base_module_t pmix_psensor; /* holds API functio
 
 END_C_DECLS
 
-#endif /* MCA_SENSOR_H */
+#endif /* PMIX_PSENSOR_H_ */

--- a/test/simple/simpmonitor.c
+++ b/test/simple/simpmonitor.c
@@ -46,17 +46,47 @@
  * raise PMIX_MONITOR_FILE_ALERT. rank 1 waits for that too and prints
  * "FILE MONITOR TEST PASSED".
  *
- * This guards three things at once:
+ * The heartbeat request names its own status code (MONITOR_TEST_CODE)
+ * rather than PMIX_MONITOR_HEARTBEAT_ALERT, and the file request names
+ * none at all (PMIX_SUCCESS). Between them they cover both halves of the
+ * "error" argument PMIx_Process_monitor(3) documents: the code the
+ * requestor asked for is what gets raised, and asking for nothing leaves
+ * the framework's own alert code standing. psensor used to hardcode its
+ * alert either way, so the first request would have produced the wrong
+ * status.
+ *
+ * rank 0 also starts two more monitors that must never fire, and that is
+ * the point of them. They raise a status of their own
+ * (MONITOR_SILENT_CODE) so that the observer can tell them apart from
+ * the two above, which name the same source:
+ *
+ *   - a heartbeat monitor with a drop allowance far larger than the run.
+ *     rank 0 never beats at all, so an implementation that parses
+ *     PMIX_MONITOR_HEARTBEAT_DROPS and then ignores it alerts within a
+ *     second. One that honors it stays silent for the whole test.
+ *   - a file monitor, given a PMIX_MONITOR_ID and then cancelled with
+ *     PMIX_MONITOR_CANCEL before it can trip. The cancel only works if
+ *     the id was recorded when the monitor was started *and* the cancel
+ *     key reaches psensor rather than falling through to the
+ *     resource-usage path, which answers success without stopping
+ *     anything.
+ *
+ * Either failure shows up as a MONITOR_SILENT_CODE event at the
+ * observer, and the run prints "SILENCE TEST FAILED".
+ *
+ * This guards several things at once:
  *   1. that the monitor API is wired to psensor at all - otherwise no
  *      alert is ever generated and rank 1 times out;
  *   2. that the alert carries the correct source - the source proc is
  *      passed to an asynchronous notify, so it must outlive the call that
  *      raised it. A stack-allocated source produces a garbage rank/nspace
- *      here; and
+ *      here;
  *   3. that both monitors keep sampling on their own timer. Each tracker
  *      arms a persistent timer, and the sampler must not re-arm it - so
  *      an alert that never comes can mean the timer stopped after its
- *      first fire, not just that the framework was never driven.
+ *      first fire, not just that the framework was never driven; and
+ *   4. that a monitor honors the status code, the drop allowance and the
+ *      cancel handle it was given, as described above.
  */
 
 #include <errno.h>
@@ -74,12 +104,27 @@
 #define MONITORED_RANK 0
 #define OBSERVER_RANK  1
 
+/* The status the heartbeat monitor is asked to raise. Host-defined codes
+ * are supposed to be built off PMIX_EXTERNAL_ERR_BASE so they cannot
+ * collide with the library's own, and using one here means the alert we
+ * receive can only have come from the code we supplied. */
+#define MONITOR_TEST_CODE (PMIX_EXTERNAL_ERR_BASE - 1)
+
+/* The status raised by the two monitors that are supposed to stay quiet.
+ * They watch the same process as the two above, so the source proc
+ * cannot tell them apart - only the code can. */
+#define MONITOR_SILENT_CODE (PMIX_EXTERNAL_ERR_BASE - 2)
+
 static pmix_proc_t myproc;
 static mylock_t alertlock;
 static mylock_t filelock;
 static volatile int alert_source_ok = 0;
 static volatile int file_alert_source_ok = 0;
+/* set if the observer ever sees a MONITOR_SILENT_CODE event - the two
+ * monitors that raise it are supposed to stay quiet */
+static volatile int silent_alert_seen = 0;
 static char watchfile[1024] = {0};
+static char obs_watchfile[1024] = {0};
 
 static void hide_unused_params(int x, ...)
 {
@@ -137,6 +182,26 @@ static void file_alert_handler(size_t evhdlr_registration_id, pmix_status_t stat
     }
     filelock.status = status;
     DEBUG_WAKEUP_THREAD(&filelock);
+}
+
+/* observer handler for MONITOR_SILENT_CODE - reaching this at all is a
+ * failure, so it records the fact and returns */
+static void silent_alert_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                                 const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                                 pmix_info_t results[], size_t nresults,
+                                 pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    int rc = 0;
+    hide_unused_params(rc, evhdlr_registration_id, info, ninfo, results, nresults);
+
+    silent_alert_seen = 1;
+    fprintf(stderr, "Observer %s:%d UNEXPECTED ALERT (%d) source=%s:%d\n", myproc.nspace,
+            myproc.rank, (int) status, (NULL == source) ? "NULL" : source->nspace,
+            (NULL == source) ? -1 : (int) source->rank);
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
 }
 
 static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
@@ -205,7 +270,7 @@ static int run_monitored(void)
     PMIX_INFO_LOAD(&info[2], PMIX_MONITOR_HEARTBEAT_DROPS, &n, PMIX_UINT32);
 
     DEBUG_CONSTRUCT_LOCK(&mylock);
-    rc = PMIx_Process_monitor_nb(monitor, PMIX_MONITOR_HEARTBEAT_ALERT, info, 3, infocbfunc,
+    rc = PMIx_Process_monitor_nb(monitor, MONITOR_TEST_CODE, info, 3, infocbfunc,
                                  (void *) &mylock);
     if (PMIX_SUCCESS == rc) {
         DEBUG_WAIT_THREAD(&mylock);
@@ -267,7 +332,7 @@ static int run_file_monitored(void)
     PMIX_INFO_LOAD(&info[3], PMIX_MONITOR_FILE_DROPS, &n, PMIX_UINT32);
 
     DEBUG_CONSTRUCT_LOCK(&mylock);
-    rc = PMIx_Process_monitor_nb(monitor, PMIX_MONITOR_FILE_ALERT, info, 4, infocbfunc,
+    rc = PMIx_Process_monitor_nb(monitor, PMIX_SUCCESS, info, 4, infocbfunc,
                                  (void *) &mylock);
     if (PMIX_SUCCESS == rc) {
         DEBUG_WAIT_THREAD(&mylock);
@@ -283,6 +348,120 @@ static int run_file_monitored(void)
     }
     fprintf(stderr, "Monitored %s:%d: file monitoring started on %s\n", myproc.nspace,
             myproc.rank, watchfile);
+    return 0;
+}
+
+/* rank 0: arm two more monitors on itself that must never fire. Both
+ * raise MONITOR_SILENT_CODE, which nothing else in this test uses, so
+ * the observer can tell them from the two that are supposed to alert.
+ *
+ * The heartbeat one is given a drop allowance no run can exhaust. rank 0
+ * never beats at all, so a heartbeat monitor that ignores
+ * PMIX_MONITOR_HEARTBEAT_DROPS alerts within a window.
+ *
+ * The file one is given a PMIX_MONITOR_ID and then cancelled. A cancel
+ * has to reach psensor - the resource-usage path answers success for an
+ * id it has never heard of, so a cancel that falls through looks like it
+ * worked - and psensor has to have recorded the id when the monitor was
+ * started, or nothing matches it. The cancel names only this monitor, so
+ * the real ones armed above must survive it.
+ *
+ * Returns 0 if both requests (and the cancel) were accepted. */
+static int arm_silent_monitors(void)
+{
+    int rc;
+    pmix_info_t *monitor, *info;
+    mylock_t mylock;
+    uint32_t n;
+    FILE *fp;
+    bool flag = true;
+
+    /* --- heartbeat, with a drop allowance we cannot spend --- */
+    PMIX_INFO_CREATE(monitor, 1);
+    PMIX_INFO_LOAD(&monitor[0], PMIX_MONITOR_HEARTBEAT, NULL, PMIX_POINTER);
+    PMIX_INFO_CREATE(info, 3);
+    PMIX_INFO_LOAD(&info[0], PMIX_MONITOR_ID, "SIMPMONITOR-CAPPED", PMIX_STRING);
+    n = 1;
+    PMIX_INFO_LOAD(&info[1], PMIX_MONITOR_HEARTBEAT_TIME, &n, PMIX_UINT32);
+    n = 100000; /* far more empty windows than this test can produce */
+    PMIX_INFO_LOAD(&info[2], PMIX_MONITOR_HEARTBEAT_DROPS, &n, PMIX_UINT32);
+
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    rc = PMIx_Process_monitor_nb(monitor, MONITOR_SILENT_CODE, info, 3, infocbfunc,
+                                 (void *) &mylock);
+    if (PMIX_SUCCESS == rc) {
+        DEBUG_WAIT_THREAD(&mylock);
+        rc = mylock.status;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(monitor, 1);
+    PMIX_INFO_FREE(info, 3);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(stderr, "Monitored %s:%d: drop-allowance monitor rejected: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* --- file, cancelled before it can trip --- */
+    if (NULL == getcwd(obs_watchfile, sizeof(obs_watchfile) - 32)) {
+        fprintf(stderr, "Monitored %s:%d: getcwd failed\n", myproc.nspace, myproc.rank);
+        return 1;
+    }
+    snprintf(obs_watchfile + strlen(obs_watchfile), 32, "/simpmon-obs-%lu.watch",
+             (unsigned long) getpid());
+    fp = fopen(obs_watchfile, "w");
+    if (NULL == fp) {
+        fprintf(stderr, "Monitored %s:%d: cannot create %s\n", myproc.nspace, myproc.rank,
+                obs_watchfile);
+        return 1;
+    }
+    fprintf(fp, "watch me too\n");
+    fclose(fp);
+
+    PMIX_INFO_CREATE(monitor, 1);
+    PMIX_INFO_LOAD(&monitor[0], PMIX_MONITOR_FILE, obs_watchfile, PMIX_STRING);
+    PMIX_INFO_CREATE(info, 4);
+    PMIX_INFO_LOAD(&info[0], PMIX_MONITOR_ID, "SIMPMONITOR-CANCEL", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_MONITOR_FILE_MODIFY, &flag, PMIX_BOOL);
+    n = 1;
+    PMIX_INFO_LOAD(&info[2], PMIX_MONITOR_FILE_CHECK_TIME, &n, PMIX_UINT32);
+    n = 0; /* alert on the first check that shows no change */
+    PMIX_INFO_LOAD(&info[3], PMIX_MONITOR_FILE_DROPS, &n, PMIX_UINT32);
+
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    rc = PMIx_Process_monitor_nb(monitor, MONITOR_SILENT_CODE, info, 4, infocbfunc,
+                                 (void *) &mylock);
+    if (PMIX_SUCCESS == rc) {
+        DEBUG_WAIT_THREAD(&mylock);
+        rc = mylock.status;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(monitor, 1);
+    PMIX_INFO_FREE(info, 4);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(stderr, "Monitored %s:%d: cancellable file monitor rejected: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* now take it back */
+    PMIX_INFO_CREATE(monitor, 1);
+    PMIX_INFO_LOAD(&monitor[0], PMIX_MONITOR_CANCEL, "SIMPMONITOR-CANCEL", PMIX_STRING);
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    rc = PMIx_Process_monitor_nb(monitor, PMIX_SUCCESS, NULL, 0, infocbfunc, (void *) &mylock);
+    if (PMIX_SUCCESS == rc) {
+        DEBUG_WAIT_THREAD(&mylock);
+        rc = mylock.status;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(monitor, 1);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(stderr, "Monitored %s:%d: monitor cancel rejected: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        return 1;
+    }
+    fprintf(stderr, "Monitored %s:%d: silent monitors armed (%s cancelled)\n", myproc.nspace,
+            myproc.rank, obs_watchfile);
     return 0;
 }
 
@@ -319,7 +498,7 @@ static int send_one_heartbeat(void)
 /* rank 1: watch for the alerts the server raises about rank 0 */
 static int run_observer(void)
 {
-    pmix_status_t code = PMIX_MONITOR_HEARTBEAT_ALERT;
+    pmix_status_t code = MONITOR_TEST_CODE;
     mylock_t mylock;
 
     DEBUG_CONSTRUCT_LOCK(&mylock);
@@ -341,6 +520,19 @@ static int run_observer(void)
     DEBUG_WAIT_THREAD(&mylock);
     if (PMIX_SUCCESS != mylock.status) {
         fprintf(stderr, "Observer %s:%d: file alert handler registration failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(mylock.status));
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        return 1;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+
+    code = MONITOR_SILENT_CODE;
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, silent_alert_handler, evhandler_reg_callbk,
+                                (void *) &mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    if (PMIX_SUCCESS != mylock.status) {
+        fprintf(stderr, "Observer %s:%d: silent alert handler registration failed: %s\n",
                 myproc.nspace, myproc.rank, PMIx_Error_string(mylock.status));
         DEBUG_DESTRUCT_LOCK(&mylock);
         return 1;
@@ -388,6 +580,9 @@ int main(int argc, char **argv)
         if (0 == result) {
             result = run_file_monitored();
         }
+        if (0 == result) {
+            result = arm_silent_monitors();
+        }
     } else if (OBSERVER_RANK == (int) myproc.rank) {
         /* the blocking heartbeat call must return before we go on to
          * wait for the alert - if it hangs, this whole test hangs and
@@ -410,6 +605,18 @@ int main(int argc, char **argv)
                     myproc.nspace, myproc.rank);
             result = 1;
         }
+        /* Both alerts about rank 0 have now been waited out, which means
+         * the monitors have been running long enough for our own two to
+         * have tripped had they been going to. */
+        if (silent_alert_seen) {
+            fprintf(stderr,
+                    "Observer %s:%d: SILENCE TEST FAILED - alerted on a monitor that should "
+                    "not have fired\n",
+                    myproc.nspace, myproc.rank);
+            result = 1;
+        } else {
+            fprintf(stderr, "Observer %s:%d: SILENCE TEST PASSED\n", myproc.nspace, myproc.rank);
+        }
     }
 
     /* second barrier: keeps the monitored proc connected until the
@@ -424,6 +631,9 @@ int main(int argc, char **argv)
 done:
     if (MONITORED_RANK == (int) myproc.rank && '\0' != watchfile[0]) {
         unlink(watchfile);
+    }
+    if (MONITORED_RANK == (int) myproc.rank && '\0' != obs_watchfile[0]) {
+        unlink(obs_watchfile);
     }
     DEBUG_DESTRUCT_LOCK(&alertlock);
     DEBUG_DESTRUCT_LOCK(&filelock);

--- a/test/unit/run_monitor.pl.in
+++ b/test/unit/run_monitor.pl.in
@@ -169,9 +169,25 @@ sub run_scenario {
         print "FAIL[$label]: client did not confirm file monitoring\n";
         return 1;
     }
+    # rank 0 arms two more monitors that must never fire: a heartbeat one
+    # whose drop allowance cannot be spent in this run, and a file one it
+    # cancels by PMIX_MONITOR_ID. Both used to trip -
+    # PMIX_MONITOR_HEARTBEAT_DROPS was parsed and discarded, and a cancel
+    # fell past psensor to the resource-usage path, which reports success
+    # for an id it has never held. Waiting out the two alerts above gives
+    # them well past their one-second windows to have gone off.
+    if ($output =~ /SILENCE TEST FAILED/) {
+        print "FAIL[$label]: a monitor that was capped or cancelled alerted anyway\n";
+        return 1;
+    }
+    if ($output !~ /SILENCE TEST PASSED/) {
+        print "FAIL[$label]: observer never reported on the capped/cancelled monitors\n";
+        return 1;
+    }
     print "PASS[$label]: heartbeat monitor raised the expected alert\n";
     print "PASS[$label]: file monitor raised the expected alert\n";
     print "PASS[$label]: blocking PMIx_Process_monitor(SEND_HEARTBEAT) returned\n";
+    print "PASS[$label]: capped and cancelled monitors stayed silent\n";
     return 0;
 }
 


### PR DESCRIPTION
Deep review of `src/mca/psensor` (the framework as one unit — base, `file`
and `heartbeat`, 7 `.c` files).

## The dominant finding

Five separate qualifiers on a monitor request were parsed out of the
directives array, stored in the tracker, and then never read again. Each
looked like working code, and the framework's end-to-end test passed
throughout.

- **`PMIX_MONITOR_HEARTBEAT_DROPS`** set `ndrops` and nothing consulted
  it, so a request asking to tolerate a few missed beats alerted on the
  very first empty window. `check_heartbeat` now counts consecutive empty
  windows in `nmissed` — a field that was also already there and unused —
  and a beat gives the whole allowance back. A request that named no
  drops keeps today's behavior.
- **`PMIX_MONITOR_ID`** was not parsed at all, which made the `id`
  argument to `stop()` — the entire cancel handle described in
  `psensor.h` — unable to match anything.
- **`PMIX_MONITOR_CANCEL`** was recognized by neither component, so it
  fell past `psensor` to the resource-usage path, which answers
  `PMIX_SUCCESS` for an id it has never held. **A client's cancel
  reported success while the monitor went on firing forever.** Both
  components now hand the id to their own `stop()` and then still
  decline, so the request also reaches `pstat`: the id may name one of
  its ops, and the base stops walking the moment a module claims a
  request.
- **The `error` argument**, which `PMIx_Process_monitor(3)` documents as
  "the code the monitor is to use when generating an event
  notification", was discarded in favour of a hardcoded alert — `file`
  did not even store it. Both now raise it, falling back to their own
  alert code when the requestor passed `PMIX_SUCCESS`, which is what
  `pstat` does with `op->eventcode`.
- **`file_sample` checked only the first** of the three attributes a
  request named, through an `if`/`else if` chain, so a monitor watching
  both a size and a modification time silently got one of them.

## Two lifetime defects

`PMIx_Notify_event` returns without reaching its callback in three
cases, one of which — `PMIX_ERR_NOT_AVAILABLE` once the progress thread
has stopped — is reachable during finalize, which stops that thread well
before it closes this framework and leaves the samplers running in
between. Both components handed the notification a tracker reference the
callback was supposed to give back, and stranded the tracker and its
retained peer when it never ran.

`psensor/heartbeat` never un-posted the PTL recv it posts lazily, nor
cleared the flag saying it had. `ptl` closes after `psensor`, so a DSO
build left the ptl list naming a function in an unloaded plugin, and a
second `PMIx_server_init` in one process would have found the flag set,
the recv gone, no beats counted, and every monitored client declared
dead on its first window.

## Smaller items

The file tracker's constructor did not initialize its `file` pointer,
which `PMIX_NEW` does not zero; `last_size` was a `size_t` holding an
`st_size`, compared through an `(int64_t)` cast; two `ctime()` calls in
one argument list returned the same static buffer, so the access and
modification times printed identically and raced any other thread's
conversion; the `show_help` topic read a `size_t` with `%lu`; and the
select loop called a component's query function without checking it
exists and kept a `NULL` module, which the dispatcher then dereferences
— `preg`, the other multi-select framework, screens for both.

## Testing

Every one of the ignored directives passed the existing end-to-end test,
because a test that *waits for an alert* cannot distinguish an honored
directive from an ignored one. `test/unit/run_monitor.pl` now also arms
a capped monitor and a cancelled one under a status code of their own
and fails if either fires — the only shape that separates the two.

Worth noting for anyone writing a similar test: a proc is never notified
of an event naming *itself* as source, so the silent monitors have to be
armed by the monitored rank and told apart from the real alerts by
status code, not by source rank. The first version of this check had the
observer monitor itself and was silently vacuous. Each of the three
fixes it covers was verified by re-breaking it and watching the check
catch it.

Both `psensor` thread configurations are exercised, as before.

## Verification

- `make -j` clean and warning-free (`--enable-devel-check`).
- `make check`: 152/152 across all five suites.
- `docs` build clean under `-W --keep-going`.

`AGENTS.md` updated for the framework and both components — including
what was *refuted*: the post-close `evbase` is `NULL` but unguarded, and
is harmless only because `close` destructs `actives` first, so no
module's `stop` is ever reached. `event_assign()` silently substitutes
libevent's `current_base` for a `NULL` one, so the guard the old comment
implied does not exist.

One coverage gap is recorded in `docs/todo.rst`: the `file`
drop-count/baseline fix has no automated check, because distinguishing
it needs a zero-tolerance monitor on a file being kept fresh, and zero
tolerance means any scheduling hiccup or coarse filesystem timestamp
granularity fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)