### PR TITLE
Keep a shmem3 read and the progress thread out of each other's way

### DIFF
--- a/contrib/dockerswarm/run-gds-tests.sh
+++ b/contrib/dockerswarm/run-gds-tests.sh
@@ -205,6 +205,15 @@ run_across_nodes() {
             bad "$prog $label, $np servers: only $nok/$np ranks confirmed the deletion"
             return 1
         fi
+        # ...and the key comes back when rank 0 publishes it again. Under
+        # shmem3 the removal is a dated record rather than a removal, so
+        # this is what says the date is honored: a record that shadowed
+        # every later generation would bury the new value too.
+        nok=$(echo "$out" | grep -c 're-published key came back' || true)
+        if [ "$nok" -lt "$np" ]; then
+            bad "$prog $label, $np servers: only $nok/$np ranks saw the key return"
+            return 1
+        fi
     elif [ "$prog" = modex_twice ]; then
         # rank 0 prints one line per fence, and every rank exits non-zero
         # if any peer's value was missing or wrong. Both lines are needed:
@@ -551,12 +560,12 @@ test_linux() {
     for geom in $GEOMETRIES; do
         hosts="${geom%|*}"; np="${geom#*|}"
         run_across_nodes delete_key "$hosts" "$np" "" "(default)" \
-            && ok "$np servers: deleted key gone everywhere, others kept"
+            && ok "$np servers: deleted key gone everywhere, others kept, and it came back"
     done
     for geom in $GEOMETRIES; do
         hosts="${geom%|*}"; np="${geom#*|}"
         run_across_nodes delete_key "$hosts" "$np" "PMIX_MCA_gds=hash" "(hash)" \
-            && ok "$np servers on hash: deleted key gone everywhere, others kept"
+            && ok "$np servers on hash: deleted key gone everywhere, others kept, and it came back"
     done
 
     banner "every get through the progress thread (fast path disabled)"

--- a/examples/delete_key.c
+++ b/examples/delete_key.c
@@ -34,6 +34,12 @@
  * because the modex is additive - a contribution that merely stops
  * naming a key removes nothing at the far end.
  *
+ * Finally rank 0 publishes the key again and every rank must see it
+ * come back, carrying the new value. A deletion is not permanent, and
+ * under gds/shmem3 the record of it is dated with the modex generation
+ * it was made at precisely so that a later generation is not shadowed by
+ * it.
+ *
  * NOTE ON TIMING. Once a server has the removal, passing it to its own
  * clients is a one-way push with no acknowledgement, so it lands
  * promptly rather than synchronously. A reader that races it can
@@ -58,6 +64,9 @@ static int nerrs = 0;
 
 #define DELKEY  "delete_key.victim"
 #define KEEPKEY "delete_key.keeper"
+/* what rank 0 re-publishes DELKEY as, chosen so it cannot be mistaken
+ * for the rank number the first round put there */
+#define REPUBVAL 4242u
 
 /* how long to allow for the removal to reach us, and how often to look */
 #define WAIT_USEC  5000000
@@ -109,6 +118,68 @@ static bool readable(uint32_t peer, const char *key)
         PMIX_VALUE_RELEASE(val);
     }
     return got;
+}
+
+/* As readable(), but hands back what was read. */
+static bool read_u32(uint32_t peer, const char *key, uint32_t *out)
+{
+    pmix_value_t *val = NULL;
+    pmix_proc_t proc;
+    pmix_info_t tmo;
+    pmix_status_t rc;
+    int secs = GET_TIMEOUT_SEC;
+    bool got = false;
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, peer);
+    PMIX_INFO_LOAD(&tmo, PMIX_TIMEOUT, &secs, PMIX_INT);
+    rc = PMIx_Get(&proc, key, &tmo, 1, &val);
+    PMIX_INFO_DESTRUCT(&tmo);
+    if (PMIX_SUCCESS == rc && NULL != val && PMIX_UINT32 == val->type) {
+        *out = val->data.uint32;
+        got = true;
+    }
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+    }
+    return got;
+}
+
+/* Wait for the key to become readable again AND carry the given value.
+ *
+ * Both halves matter. A re-published key arriving is one thing; a
+ * re-published key that still reads as the value it had before the
+ * delete would mean a stale generation answered. */
+static void expect_value(uint32_t peer, const char *key, uint32_t want,
+                         const char *what)
+{
+    int waited = 0;
+    uint32_t got = 0;
+
+    for (;;) {
+        if (read_u32(peer, key, &got)) {
+            if (got == want) {
+                return;
+            }
+            fprintf(stderr,
+                    "delete_key: rank %u: %s from rank %u reads %u, wanted "
+                    "%u [%s]\n",
+                    (unsigned) myproc.rank, key, (unsigned) peer,
+                    (unsigned) got, (unsigned) want, what);
+            nerrs++;
+            return;
+        }
+        if (waited >= WAIT_USEC) {
+            fprintf(stderr,
+                    "delete_key: rank %u: %s from rank %u never came back "
+                    "after %d ms [%s]\n",
+                    (unsigned) myproc.rank, key, (unsigned) peer,
+                    WAIT_USEC / 1000, what);
+            nerrs++;
+            return;
+        }
+        usleep(POLL_USEC);
+        waited += POLL_USEC;
+    }
 }
 
 static void expect_readable(uint32_t peer, const char *key, const char *what)
@@ -243,8 +314,53 @@ int main(int argc, char **argv)
         }
     }
 
+    /* And now put it back.
+     *
+     * A deletion is not permanent - nothing in the Standard says a key
+     * may only be published once - so a rank that publishes the same key
+     * again must be readable again. Under gds/shmem3 that is the one
+     * thing a removal record must NOT outlast: the data still sits in a
+     * segment that is never rewritten, so the module answers by
+     * remembering that it stopped answering, and a record that never
+     * expired would bury the new value along with the old one. Each
+     * record is therefore dated with the modex generation it was made
+     * at, and only shadows generations up to that one.
+     *
+     * The value differs from the original so that "it came back" and
+     * "the old copy was never really gone" are distinguishable. */
+    if (0 == myproc.rank) {
+        if (PMIX_SUCCESS != (rc = put_u32(DELKEY, REPUBVAL))) {
+            fprintf(stderr, "delete_key: rank 0: re-publish failed: %s\n",
+                    PMIx_Error_string(rc));
+            exit(1);
+        }
+        if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+            fprintf(stderr, "delete_key: rank 0: third commit failed: %s\n",
+                    PMIx_Error_string(rc));
+            exit(1);
+        }
+    }
+
+    flag = true;
+    PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+    rc = PMIx_Fence(&wildcard, 1, &info, 1);
+    PMIX_INFO_DESTRUCT(&info);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "delete_key: rank %u: third fence failed: %s\n",
+                (unsigned) myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    expect_value(0, DELKEY, REPUBVAL, "after the re-publish");
+    /* and nothing that survived the delete may be lost to the return */
+    for (n = 0; n < nprocs; n++) {
+        expect_readable(n, KEEPKEY, "after the re-publish");
+    }
+
     if (0 == nerrs) {
         fprintf(stderr, "delete_key: rank %u: deleted key gone, others kept\n",
+                (unsigned) myproc.rank);
+        fprintf(stderr, "delete_key: rank %u: re-published key came back\n",
                 (unsigned) myproc.rank);
     }
 

--- a/src/mca/gds/AGENTS.md
+++ b/src/mca/gds/AGENTS.md
@@ -388,7 +388,14 @@ golden rule does not usually bite here.
   exist precisely to keep that working.
 - **Everything runs on the progress thread.** No new path may call a `gds`
   entry point without first thread-shifting, unless the module's `is_tsafe`
-  says otherwise.
+  says otherwise. `shmem3` does say otherwise, and that is not theoretical:
+  `try_local_fetch()` in `src/client/pmix_client_get.c` consults
+  `PMIX_GDS_FETCH_IS_TSAFE` on every keyed `PMIx_Get` and
+  `pmix_client_globals.fast_get` is on by default, so on a client that
+  module's `fetch` runs on the application's own thread. A module that
+  sets `is_tsafe` owns the synchronization for any process-local state its
+  `fetch` walks — see the `is_tsafe` section in
+  [`shmem3/AGENTS.md`](shmem3/AGENTS.md).
 - **Treat every job-level value as untrusted.** The `pmix_info_t` array a
   module is handed comes from a host environment (which is not this
   project) or off the wire from a peer (which may be a different release).
@@ -438,10 +445,16 @@ golden rule does not usually bite here.
 Neither component ever removes a session tracker. A session legitimately
 outlives the jobs in it — that is what a session is — and there is no
 "session has ended" signal for either component to act on, so
-`pmix_mca_gds_hash_component.mysessions` and
-`pmix_mca_gds_shmem3_component.sessions` only shrink when the module
+`pmix_mca_gds_hash_component.mysessions` only shrinks when the module
 finalizes. `del_nspace` drops the *job* and its reference to the session;
 the session itself stays.
+
+`pmix_mca_gds_shmem3_component.sessions` is a different story: nothing
+ever appends to it, so it is permanently empty and a `shmem3` session
+object lives and dies with the one job that created it. The searches
+`pmix_gds_shmem3_get_session_tracker()` runs against that list are
+unreachable. Sharing a session across jobs there is unfinished, not
+merely uncleaned — see [`shmem3/AGENTS.md`](shmem3/AGENTS.md).
 
 Closing that needs a **`deregister_session` entry point** — a host-facing
 call that says a session is over, paired with a `del_session` slot on

--- a/src/mca/gds/shmem3/AGENTS.md
+++ b/src/mca/gds/shmem3/AGENTS.md
@@ -685,12 +685,20 @@ so it was documented and treated as server-only. But it is *also* what
 dates a tombstone, and `del_key()` runs on the client too. A client that
 left it at zero stamped every tombstone with generation zero, and
 `generation <= t->generation` then held for every generation it ever
-mapped: a key deleted and re-published in a later fence stayed invisible
-to that client for the rest of the run. A keyed `PMIx_Get` merely lost
-its fast path and went to the server; a **NULL-key** fetch returned a
-list with the key silently missing and reported success, so nothing
-looked further. `advance_modex_generation()` is called from both sides
-now. The two counters are never compared with each other — each only has
+mapped: on that client the removal never expired.
+
+Be accurate about what that cost, because the fallbacks hide most of it.
+A keyed `PMIx_Get` filters the key out here, misses, and goes to the
+server - which advanced *its* counter and answers correctly - so the
+caller gets the right value and pays a round trip. What is genuinely
+wrong is a NULL-key read that reaches the modex at all: `modex_fetch()`
+drops the re-published key and `shmem3_fetch_from_job()` reports success
+because the list is not empty, so nothing looks further. That needs the
+local table to miss for the rank, or an explicit `PMIX_REMOTE` scope -
+an unqualified NULL-key get of a rank the job data describes is answered
+out of the job segment and never consults the modex. So: a real
+inconsistency with a narrow blast radius, not a common wrong answer.
+`advance_modex_generation()` is called from both sides now. The two counters are never compared with each other — each only has
 to advance whenever *its* process takes on a new generation.
 
 Two shapes of read, two filters. A keyed lookup that finds only

--- a/src/mca/gds/shmem3/AGENTS.md
+++ b/src/mca/gds/shmem3/AGENTS.md
@@ -159,9 +159,54 @@ needs to own the *bulk job/modex data* path; individual `put`/`get` traffic
 falls back. `cache_job_info` also returns `PMIX_ERR_NOT_SUPPORTED`: unlike
 `hash`, `shmem3` does not pre-cache — it fetches the fully-assembled
 job data lazily inside `register_job_info` when the first client connects.
-Unlike `hash`, it is `is_tsafe = true`: a fetch holds a reference on the
-job tracker and reads only data that is never written again, so it may
-run off the progress thread.
+Unlike `hash`, it is `is_tsafe = true`, which is why the next section
+exists.
+
+## `is_tsafe` is real: a fetch runs on the application's thread
+
+`pmix_shmem3_module.is_tsafe` is `true`, and that is not decorative.
+`try_local_fetch()` in [`src/client/pmix_client_get.c`](../../../client/pmix_client_get.c)
+tests it on every keyed `PMIx_Get`, and `pmix_client_globals.fast_get`
+defaults **on** — so on a client, `pmix_gds_shmem3_fetch()` normally runs
+on whatever thread called `PMIx_Get`, while the progress thread carries
+on underneath it.
+
+Two things make that safe, and they are not the same thing:
+
+- **What is in a segment needs nothing.** It is written once, before any
+  client can see it, and never again. No lock, no copy, no barrier.
+- **The process-local bookkeeping alongside it needs a lock**, because
+  the progress thread rewrites it while a read is in flight. That is
+  `job->datalock`, held across the whole of `shmem3_fetch_from_job()`,
+  and taken by every writer of the two things a read walks:
+
+  | written by | what changes |
+  |---|---|
+  | `retire_modex_segment()` | `job->smmodex` goes NULL; the chain gains a member |
+  | `release_modex_segment()` | the current generation is **unmapped** |
+  | `drop_modex_priors()` | every retired generation is **unmapped** |
+  | `del_key()` | the tombstone list gains a member |
+  | `advance_modex_generation()` | the number a tombstone is dated against |
+
+The reference a reader holds on the job tracker is often mistaken for
+covering this. It does not: it keeps the *tracker* alive, and with it the
+job and session segments, which are released only by `job_destruct()`. A
+modex generation is released independently of the tracker's refcount, on
+the progress thread, as each fence completes. Before the lock existed, a
+`PMIx_Fence_nb` concurrent with a `PMIx_Get` of a remote rank's key could
+put an application thread inside `pmix_hash_fetch()` on a table that had
+just been `munmap`ped - and the ordinary single-threaded case was only
+safe by accident, because a blocking `PMIx_Fence` parks the app thread
+until the modex-complete has been processed.
+
+The lock protects nothing in shared memory, so it does not belong to a
+segment and does not appear in `PMIX_GDS_SHMEM3_LAYOUT_ID`:
+`pmix_gds_shmem3_job_t` is an ordinary heap object.
+
+**Do not take it while holding anything else.** `joblock` is released
+before it is acquired (see `pmix_gds_shmem3_acquire_job_tracker()`), and
+no writer holds it across a segment create or attach - those do file I/O
+and would block a reader for the duration.
 
 ## The shared-segment model
 
@@ -460,10 +505,19 @@ Four things about it are load-bearing:
   slot. Deriving it rather than keeping a tally means no path that
   releases a generation can leave the accounting stale. A generation
   arriving when all slots are taken places itself outside the arena.
-- **The session segment is deliberately outside the arena.** A session
-  outlives the job that first described it (`component.sessions` holds a
-  reference), and `job_destruct()` releases the whole arena, so a shared
-  session's segment inside it would be unmapped under a live holder.
+- **The session segment is deliberately outside the arena.** The design
+  is that a session outlives the job that first described it, and
+  `job_destruct()` releases the whole arena, so a shared session's
+  segment inside it would be unmapped under a live holder.
+
+  Be aware that the sharing this guards against **cannot happen today**:
+  nothing ever appends to `pmix_mca_gds_shmem3_component.sessions`, so
+  the list is permanently empty, both searches in
+  `pmix_gds_shmem3_get_session_tracker()` are unreachable, and a job's
+  session object is created by `job_construct()` and dies with it. The
+  placement is still the right one - it is what the code would need the
+  moment a session really were shared - but do not read it as evidence
+  that sharing works.
 
 If the arena cannot be reserved, or a modex does not fit its slot, every
 segment places itself independently exactly as before — degraded, never
@@ -624,6 +678,21 @@ own number as it walks, and a tombstone shadows only generations up to
 the one it was made at — a key deleted and then published again in a
 later fence is alive again.
 
+**Both ends have to advance that counter, and only the server's names
+anything.** `job->modex_generation` was introduced to name the next
+backing file, which is a server-side job — a client is told the path —
+so it was documented and treated as server-only. But it is *also* what
+dates a tombstone, and `del_key()` runs on the client too. A client that
+left it at zero stamped every tombstone with generation zero, and
+`generation <= t->generation` then held for every generation it ever
+mapped: a key deleted and re-published in a later fence stayed invisible
+to that client for the rest of the run. A keyed `PMIx_Get` merely lost
+its fast path and went to the server; a **NULL-key** fetch returned a
+list with the key silently missing and reported success, so nothing
+looked further. `advance_modex_generation()` is called from both sides
+now. The two counters are never compared with each other — each only has
+to advance whenever *its* process takes on a new generation.
+
 Two shapes of read, two filters. A keyed lookup that finds only
 tombstoned entries in a generation keeps walking rather than reporting a
 hit; a NULL-key lookup — "everything this process published" — has its
@@ -711,6 +780,43 @@ as success.
   wholesale. If you find yourself needing to reconcile two dictionaries
   across a process boundary, put the index next to the data instead.
 
+## Things that look like bugs and are not
+
+Recorded so the next review does not re-derive them.
+
+- **`PMIX_RELEASE(x)` sets `x` to `NULL`** when the refcount reaches
+  zero — the assignment is inside the macro, in both the debug and the
+  default definition. So `cache_connection_info_for_job_shmem3()`
+  releasing `job->conni` on its error path does not leave a dangling
+  pointer for the next `register_job_info()` to copy from, and
+  `newkval()`'s `PMIX_RELEASE(kv); return kv;` returns `NULL` rather
+  than the block it just freed. Both read like defects and are not.
+- **`modex_fetch()` reports `PMIX_ERR_NOT_FOUND` after a *successful*
+  NULL-key read of the current generation** — it falls through to
+  `rc = PMIX_ERR_NOT_FOUND` on the way to walking the retired ones, and
+  when `job->modex_prior` is empty (the ordinary case) that is what it
+  returns. Harmless only because `shmem3_fetch_from_job()` ends with
+  `if (0 == pmix_list_get_size(kvs)) ... else rc = PMIX_SUCCESS;`, which
+  overrides it. Fragile, but not currently wrong: if you ever make that
+  final check narrower, fix this first.
+- **`assign_module()` keeps its default bid for a `PMIX_GDS_MODULE` that
+  splits to nothing.** The comment says so and the code agrees, but only
+  because `PMIx_Argv_split()` returns `NULL` — not an empty array — for
+  `""` or `",,,"`, and the `NULL == options` arm breaks out before
+  `specified` is set. Covered by `test/unit/gds_datastore`.
+- **Nothing in `gds` checks `darray->type` before casting an array to
+  `pmix_info_t *`.** Neither component does, for any of the `*_INFO_ARRAY`
+  keys: the key is taken to imply the element type. That is a project-wide
+  convention, not an oversight here. `get_local_job_data_info()` was a
+  genuinely different case and is now guarded — it probed element zero of
+  **every** data array, whatever its key, looking for a session id, so a
+  host-supplied array of some other type was read as a `pmix_info_t`.
+  `PMIx_Check_key()` stops at the first differing byte, so most such
+  arrays are read one byte past their start and no further; it takes an
+  array whose leading bytes actually spell `pmix.session.id` to carry the
+  read on into `info[0].value`, 512 bytes into what may be a 16-byte
+  allocation. `test/unit/gds_datastore` sends exactly that.
+
 ## Testing
 
 `shmem3` gets **no coverage at all on macOS** — `configure.m4` gates it on
@@ -725,3 +831,17 @@ cross-node fetches that reach the modex.
 `test/unit/gds_datastore` covers the *framework* contracts this component
 has to honor — notably the modex callback contract above — but runs against
 whichever module is assigned, which on a developer's Mac is `hash`.
+
+Its last case, `test_shmem3_job_segment()`, is the exception: it asks
+`pmix_gds_base_assign_module()` for `shmem3` by name and, when it gets
+it, drives this component end to end in one process — register an nspace,
+build the job and session segments through `PMIX_GDS_REGISTER_JOB_INFO`
+against a peer bound to this module, read a job-level key and the whole
+job back out of the segment, and deregister. Where the component is not
+available it prints `SKIP` and passes, so the case is honest on macOS
+rather than absent.
+
+That is as far as one process goes: a fence, a second modex generation, a
+client attach at a fixed address, and every cross-node path still belong
+to `run-gds-tests.sh`. But the segment build itself, and the untrusted
+job-level input that reaches it, now run in `make check` on Linux.

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -752,19 +752,6 @@ job_destruct(
     PMIX_DESTRUCT(&job->datalock);
 }
 
-/**
- * Let go of this job's current modex segment.
- *
- * Releasing our handle does not pull the segment out from under anyone:
- * the backing file carries a reference count, so a client that has it
- * mapped keeps a valid mapping and the file survives until the last
- * holder lets go. That is what makes handing one generation off and
- * starting the next safe.
- *
- * Mirrors what job_destruct() does for this segment; keep the two in
- * step. Order matters - the allocator context is reached through
- * job->smmodex, so it has to go before that pointer is cleared.
- */
 static void
 tombstone_construct(
     pmix_gds_shmem3_tombstone_t *t
@@ -895,6 +882,19 @@ drop_modex_priors(
     pmix_mutex_unlock(&job->datalock);
 }
 
+/**
+ * Let go of this job's current modex segment.
+ *
+ * Releasing our handle does not pull the segment out from under anyone:
+ * the backing file carries a reference count, so a client that has it
+ * mapped keeps a valid mapping and the file survives until the last
+ * holder lets go. That is what makes handing one generation off and
+ * starting the next safe.
+ *
+ * Mirrors what job_destruct() does for this segment; keep the two in
+ * step. Order matters - the allocator context is reached through
+ * job->smmodex, so it has to go before that pointer is cleared.
+ */
 static void
 release_modex_segment(
     pmix_gds_shmem3_job_t *job
@@ -1261,8 +1261,8 @@ fetch_base_tmpdir(
     }
     // Didn't find a specific temp basedir, so just use a general one.
     if (!fetched_kv) {
-        static const char *tmpdir = NULL;
-        if (NULL == (tmpdir = getenv("TMPDIR"))) {
+        const char *tmpdir = getenv("TMPDIR");
+        if (NULL == tmpdir) {
             tmpdir = "/tmp";
         }
         return tmpdir;
@@ -2541,7 +2541,7 @@ unpack_shmem3_connection_info(
              * so it does exactly what it did before they existed. */
             PMIX_GDS_SHMEM3_VOUT(
                 "%s: ignoring unrecognized seg blob key=%s",
-                __func__, kv.key
+                __func__, (NULL == kv.key) ? "(null)" : kv.key
             );
         }
         // Done with this one.
@@ -3173,7 +3173,8 @@ client_connect_to_shmem3_from_buffi(
         }
         else {
             PMIX_GDS_SHMEM3_VOUT(
-                "%s:ERROR unexpected key=%s", __func__, kval.key
+                "%s:ERROR unexpected key=%s", __func__,
+                (NULL == kval.key) ? "(null)" : kval.key
             );
             rc = PMIX_ERR_BAD_PARAM;
             PMIX_ERROR_LOG(rc);
@@ -3287,9 +3288,6 @@ get_modex_sizing_data(
     return result;
 }
 
-/**
- * This gets called for each process participating in the modex.
- */
 /**
  * Stop answering for this key.
  *

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -591,6 +591,7 @@ job_construct(
     job->modex_is_delta = false;
     PMIX_CONSTRUCT(&job->modex_prior, pmix_list_t);
     PMIX_CONSTRUCT(&job->tombstones, pmix_list_t);
+    PMIX_CONSTRUCT(&job->datalock, pmix_mutex_t);
     // Address-space arena
     job->arena_base = 0;
     job->arena_size = 0;
@@ -709,8 +710,13 @@ job_destruct(
         pmix_shmem_t *shmem3;
         rc = pmix_gds_shmem3_get_job_shmem3_by_id(job, sid, &shmem3);
         if (PMIX_UNLIKELY(rc != PMIX_SUCCESS)) {
+            /* Only one id can fail here - SESSION, on a job whose
+             * construction did not get as far as its session object.
+             * Skip that segment; returning abandoned the rest of the
+             * teardown, which is where the arena reservation and the
+             * session reference are given back. */
             PMIX_ERROR_LOG(rc);
-            return;
+            continue;
         }
         if (pmix_gds_shmem3_has_status(job, sid, PMIX_GDS_SHMEM3_MINE)) {
             // Emit usage status before we potentially destroy the segment.
@@ -741,6 +747,9 @@ job_destruct(
     if (job->session) {
         PMIX_RELEASE(job->session);
     }
+    /* Last: nothing can still be reading this tracker - a reader holds a
+     * reference and we are the destructor. */
+    PMIX_DESTRUCT(&job->datalock);
 }
 
 /**
@@ -844,6 +853,11 @@ retire_modex_segment(
     if (PMIX_UNLIKELY(NULL == seg)) {
         return PMIX_ERR_NOMEM;
     }
+    /* A read may be walking this chain on another thread - see
+     * job->datalock. Nothing is unmapped here, but job->smmodex goes NULL
+     * and the list gains a member, and a reader must not see either
+     * half-done. */
+    pmix_mutex_lock(&job->datalock);
     seg->status = job->modex_shmem3_status;
     seg->shmem3 = job->modex_shmem3;
     seg->smmodex = job->smmodex;
@@ -853,6 +867,7 @@ retire_modex_segment(
     job->modex_shmem3 = PMIX_NEW(pmix_shmem_t);
     job->smmodex = NULL;
     pmix_gds_shmem3_clearall_status(job, PMIX_GDS_SHMEM3_MODEX_ID);
+    pmix_mutex_unlock(&job->datalock);
     return PMIX_SUCCESS;
 }
 
@@ -869,10 +884,15 @@ drop_modex_priors(
 ) {
     pmix_gds_shmem3_modex_seg_t *seg;
 
+    /* Releasing a retired generation unmaps its segment, so a read that
+     * is walking the chain on another thread has to be finished first -
+     * see job->datalock. */
+    pmix_mutex_lock(&job->datalock);
     while (NULL != (seg = (pmix_gds_shmem3_modex_seg_t *)
                           pmix_list_remove_first(&job->modex_prior))) {
         PMIX_RELEASE(seg);
     }
+    pmix_mutex_unlock(&job->datalock);
 }
 
 static void
@@ -888,10 +908,34 @@ release_modex_segment(
         emit_shmem3_usage_stats(job, PMIX_GDS_SHMEM3_MODEX_ID);
         PMIX_RELEASE(get_tma_by_shmem3_id(job, PMIX_GDS_SHMEM3_MODEX_ID)->data_context);
     }
+    /* This one really does unmap the segment, and a read on another
+     * thread may be part way through the hash table inside it - see
+     * job->datalock. */
+    pmix_mutex_lock(&job->datalock);
     PMIX_RELEASE(job->modex_shmem3);
     job->modex_shmem3 = PMIX_NEW(pmix_shmem_t);
     job->smmodex = NULL;
     pmix_gds_shmem3_clearall_status(job, PMIX_GDS_SHMEM3_MODEX_ID);
+    pmix_mutex_unlock(&job->datalock);
+}
+
+/**
+ * Note that this job has taken on a new modex generation.
+ *
+ * Both ends do this, and for different reasons: the server needs a
+ * number that names the next backing file, and both need one that dates
+ * a tombstone. See pmix_gds_shmem3_job_t.modex_generation - a client
+ * that never advanced it made every tombstone shadow every generation.
+ *
+ * Under the lock because a read on another thread compares against it.
+ */
+static void
+advance_modex_generation(
+    pmix_gds_shmem3_job_t *job
+) {
+    pmix_mutex_lock(&job->datalock);
+    job->modex_generation++;
+    pmix_mutex_unlock(&job->datalock);
 }
 
 PMIX_CLASS_INSTANCE(
@@ -1885,7 +1929,7 @@ shmem3_segment_create_and_attach(
             );
             if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
                 PMIX_ERROR_LOG(rc);
-                goto out;
+                goto out_release;
             }
             PMIX_GDS_SHMEM3_VOUT(
                 "%s: %s found vmhole at address=0x%zx (attempt %d)",
@@ -1909,10 +1953,21 @@ shmem3_segment_create_and_attach(
         }
     }
     pmix_gds_shmem3_set_status(job, shmem3_id, PMIX_GDS_SHMEM3_ATTACHED);
-    // Fix-up backing file permission.
-    rc = shmem3_segment_fix_perms(job, shmem3);
-    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-        PMIX_ERROR_LOG(rc);
+    /* Fix up the backing file's permissions. A failure here is reported
+     * and then dropped, deliberately: the segment is created, mapped and
+     * perfectly usable by US, and what a client loses is the ability to
+     * open the backing file - which it reports as a failed attach and
+     * answers by falling back to hash. Propagating it instead failed the
+     * whole of register_job_info(), so no client got job data at all,
+     * while leaving this segment attached and NOT marked MINE - so the
+     * teardown below skipped its allocator context. Degrade, do not
+     * break. */
+    if (PMIX_UNLIKELY(PMIX_SUCCESS != shmem3_segment_fix_perms(job, shmem3))) {
+        PMIX_GDS_SHMEM3_VOUT(
+            "%s: could not set ownership/permissions on %s; a client that "
+            "cannot open it will fall back to another GDS module",
+            __func__, shmem3->backing_path
+        );
     }
 out:
     if (PMIX_SUCCESS == rc) {
@@ -1923,8 +1978,15 @@ out:
     }
     return rc;
 out_release:
-    // Mirror shmem3_attach()'s failure handling: detach and drop the job
-    // tracker entry.
+    /* Mirror shmem3_attach()'s failure handling: detach and drop the job
+     * tracker entry.
+     *
+     * Take the backing file with it. pmix_shmem_segment_create() made it
+     * and shmem_destruct() only unlinks a segment it managed to ATTACH,
+     * so a failure between the two left the file in the session tmpdir
+     * for the life of the node - and the path is built from a pid, which
+     * gets reused. */
+    (void)pmix_shmem_segment_unlink(shmem3);
     (void)pmix_shmem_segment_detach(shmem3);
     pmix_list_remove_item(&pmix_mca_gds_shmem3_component.jobs, &job->super);
     PMIX_RELEASE(job);
@@ -2567,13 +2629,25 @@ get_local_job_data_info(
                 nprocarrays += 1;
                 nkvals += kvi->value->data.darray->size;
             }
-            // See if this is the job's session ID. If so, capture it.
-            pmix_info_t *info = (pmix_info_t *)kvi->value->data.darray->array;
-            if (PMIX_CHECK_KEY(&info[0], PMIX_SESSION_ID)) {
-                rc = PMIx_Value_get_number(&info[0].value, &sid, PMIX_UINT32);
-                if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
-                    PMIX_ERROR_LOG(rc);
-                    goto out;
+            /* See if this is the job's session ID. If so, capture it.
+             *
+             * Only look inside an array whose elements really are
+             * pmix_info_t. A host is free to hand us a PMIX_DATA_ARRAY of
+             * anything - procs, strings, scalars - and reading element
+             * zero of one of those as a pmix_info_t makes PMIX_CHECK_KEY
+             * walk up to PMIX_MAX_KEYLEN bytes off the end of an
+             * allocation that may be eight bytes long. */
+            if (PMIX_INFO == kvi->value->data.darray->type) {
+                pmix_info_t *info;
+                info = (pmix_info_t *)kvi->value->data.darray->array;
+                if (PMIX_CHECK_KEY(&info[0], PMIX_SESSION_ID)) {
+                    rc = PMIx_Value_get_number(
+                        &info[0].value, &sid, PMIX_UINT32
+                    );
+                    if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+                        PMIX_ERROR_LOG(rc);
+                        goto out;
+                    }
                 }
             }
         }
@@ -2875,6 +2949,31 @@ unpack_shmem3_seg_blob_and_attach_if_necessary(
             PMIX_ERROR_LOG(rc);
             break;
         }
+        /* Everything below assumes the blob described a segment this
+         * build knows how to place, and named the job and the file. Only
+         * the sender guarantees that, and the sender may be a different
+         * release: an id outside our enum reaches the default arm of
+         * pmix_gds_shmem3_get_job_shmem3_by_id(), which abort()s, and a
+         * missing nspace reaches strcmp() with NULL.
+         *
+         * Skip such a blob rather than failing - it is the same forward
+         * compatibility the unrecognized-key arm of the unpacker keeps,
+         * one level up. A segment kind we have never heard of is one we
+         * have no use for by construction. */
+        if (PMIX_GDS_SHMEM3_JOB_ID != usb.smid &&
+            PMIX_GDS_SHMEM3_SESSION_ID != usb.smid &&
+            PMIX_GDS_SHMEM3_MODEX_ID != usb.smid) {
+            PMIX_GDS_SHMEM3_VOUT(
+                "%s: ignoring seg blob for unrecognized segment id=%u",
+                __func__, (unsigned)usb.smid
+            );
+            break;
+        }
+        if (NULL == usb.nsid || NULL == usb.seg_path) {
+            rc = PMIX_ERR_BAD_PARAM;
+            PMIX_ERROR_LOG(rc);
+            break;
+        }
         // Get the associated job tracker.
         pmix_gds_shmem3_job_t *job;
         rc = pmix_gds_shmem3_get_job_tracker(usb.nsid, true, &job);
@@ -2955,6 +3054,12 @@ unpack_shmem3_seg_blob_and_attach_if_necessary(
                     release_modex_segment(job);
                     drop_modex_priors(job);
                 }
+                /* We are about to map a generation we have not held
+                 * before, which is the same step the server counts on
+                 * its side. Both have to count it: the number is what
+                 * dates a tombstone, and one that never moves makes
+                 * every tombstone shadow every generation. */
+                advance_modex_generation(job);
             } else {
                 /* Only the modex is republished today. Anything else
                  * changing underneath us is not something this path
@@ -3216,27 +3321,34 @@ del_key(
     if (PMIX_SUCCESS != rc) {
         return PMIX_SUCCESS;
     }
+    /* A read consults this list on another thread, so hold the lock
+     * across both the search and the append - see job->datalock. */
+    pmix_mutex_lock(&job->datalock);
     /* already recorded for this rank? then nothing to do - but refresh
      * the generation, since a later removal shadows more than an
      * earlier one did */
     PMIX_LIST_FOREACH (t, &job->tombstones, pmix_gds_shmem3_tombstone_t) {
         if (t->rank == proc->rank && NULL != t->key && 0 == strcmp(t->key, key)) {
             t->generation = job->modex_generation;
+            pmix_mutex_unlock(&job->datalock);
             return PMIX_SUCCESS;
         }
     }
     t = PMIX_NEW(pmix_gds_shmem3_tombstone_t);
     if (PMIX_UNLIKELY(NULL == t)) {
+        pmix_mutex_unlock(&job->datalock);
         return PMIX_ERR_NOMEM;
     }
     t->rank = proc->rank;
     t->key = strdup(key);
     if (PMIX_UNLIKELY(NULL == t->key)) {
         PMIX_RELEASE(t);
+        pmix_mutex_unlock(&job->datalock);
         return PMIX_ERR_NOMEM;
     }
     t->generation = job->modex_generation;
     pmix_list_append(&job->tombstones, &t->super);
+    pmix_mutex_unlock(&job->datalock);
 
     /* the cached job-info reply still says the key exists, and it is
      * what the next client to attach is handed - build a fresh one */
@@ -3324,7 +3436,7 @@ server_store_modex_cb(pmix_proc_t *proc,
                 release_modex_segment(job);
                 drop_modex_priors(job);
             }
-            job->modex_generation++;
+            advance_modex_generation(job);
         }
         /* what the clients have to be told about this generation */
         job->modex_is_delta = isdelta;
@@ -3496,23 +3608,45 @@ server_add_nspace(
         return rc;
     }
 
+    /* These come from the host environment, which is not this project, so
+     * the key does not guarantee the type. Reading the union directly
+     * turned a PMIX_STRING into the low half of a pointer, and the
+     * resulting garbage id was not merely recorded - it set chown/chgrp,
+     * so shmem3_segment_fix_perms() later handed it to chown() on this
+     * job's backing files. Ask for a number and let the conversion fail. */
     for (size_t i = 0; i < ninfo; ++i) {
         if (PMIX_CHECK_KEY(&info[i], PMIX_USERID)) {
-            const uid_t nuid = (uid_t)info[i].value.data.uint32;
+            uint32_t nuid;
+            if (PMIX_SUCCESS != PMIx_Value_get_number(&info[i].value, &nuid,
+                                                      PMIX_UINT32)) {
+                PMIX_GDS_SHMEM3_VOUT(
+                    "%s: ignoring nspace=%s " PMIX_USERID " of type %s",
+                    __func__, nspace, PMIx_Data_type_string(info[i].value.type)
+                );
+                continue;
+            }
             PMIX_GDS_SHMEM3_VOUT(
                 "%s: updating nspace=%s UID from %zd to %zd",
                 __func__, nspace, (size_t)job->uid, (size_t)nuid
             );
-            job->uid = nuid;
+            job->uid = (uid_t)nuid;
             job->chown = true;
         }
         else if (PMIX_CHECK_KEY(&info[i], PMIX_GRPID)) {
-            const gid_t ngid = (gid_t)info[i].value.data.uint32;
+            uint32_t ngid;
+            if (PMIX_SUCCESS != PMIx_Value_get_number(&info[i].value, &ngid,
+                                                      PMIX_UINT32)) {
+                PMIX_GDS_SHMEM3_VOUT(
+                    "%s: ignoring nspace=%s " PMIX_GRPID " of type %s",
+                    __func__, nspace, PMIx_Data_type_string(info[i].value.type)
+                );
+                continue;
+            }
             PMIX_GDS_SHMEM3_VOUT(
                 "%s: updating nspace=%s GID from %zd to %zd",
                 __func__, nspace, (size_t)job->gid, (size_t)ngid
             );
-            job->gid = ngid;
+            job->gid = (gid_t)ngid;
             job->chgrp = true;
         }
     }

--- a/src/mca/gds/shmem3/gds_shmem3.h
+++ b/src/mca/gds/shmem3/gds_shmem3.h
@@ -22,7 +22,7 @@
 #include "src/util/pmix_shmem.h"
 #include "src/mca/gds/base/base.h"
 
-#ifdef HAVE_STDINT_h
+#ifdef HAVE_STDINT_H
 #include <stdint.h>
 #endif
 
@@ -381,7 +381,18 @@ typedef struct {
      * a client can see must never be written again. The counter names
      * the backing file, so successive generations do not collide; the
      * client tells them apart by that path, which is already in the seg
-     * blob, so nothing on the wire changes. Server-side only.
+     * blob, so nothing on the wire changes.
+     *
+     * Only the server's counter names anything - a client is told the
+     * path - but BOTH ends have to advance it, because it is also what
+     * dates a tombstone (see pmix_gds_shmem3_tombstone_t). A client that
+     * left it at zero stamped every tombstone with generation zero, and
+     * "generation <= t->generation" then held for every generation it
+     * ever mapped: a key deleted and re-published in a later fence stayed
+     * invisible to that client for the rest of the run. The two counters
+     * are never compared with each other, so they do not have to agree -
+     * each only has to advance whenever ITS process takes on a new
+     * generation.
      */
     uint32_t modex_generation;
     /** Shared-memory object that maintains backing store for smmodex data. */
@@ -396,6 +407,23 @@ typedef struct {
      * told to each client in the segment blob so it can make the same
      * keep-or-drop decision this server made. */
     bool modex_is_delta;
+    /** Guards the process-local state a read walks: the modex generation
+     *  chain below and the tombstone list.
+     *
+     * This module is is_tsafe, so pmix_gds_shmem3_fetch() runs on the
+     * APPLICATION's thread (see try_local_fetch() in
+     * src/client/pmix_client_get.c, which is on by default). Meanwhile the
+     * progress thread replaces the modex generation as each fence
+     * completes - release_modex_segment() unmaps the segment outright and
+     * retire_modex_segment() clears job->smmodex - and del_key() appends
+     * to the tombstone list. The reference the reader holds on this
+     * tracker keeps the JOB segment mapped, but it says nothing about
+     * either of those, so both need a lock.
+     *
+     * NOT needed for anything in a shared segment: those are written once,
+     * before any client can see them, and never again.
+     */
+    pmix_mutex_t datalock;
     /** Keys this job has been told to stop answering for. Process-local;
      * see pmix_gds_shmem3_tombstone_t. */
     pmix_list_t tombstones;

--- a/src/mca/gds/shmem3/gds_shmem3_fetch.c
+++ b/src/mca/gds/shmem3/gds_shmem3_fetch.c
@@ -275,9 +275,8 @@ fetch_nodeinfo(
             continue;
         }
         PMIX_GDS_SHMEM3_VOUT(
-            "%s:%s: adding key=%s",
-            PMIX_NAME_PRINT(&pmix_globals.myid),
-            __func__, kvi->key
+            "%s:%s: adding key=%s", __func__,
+            PMIX_NAME_PRINT(&pmix_globals.myid), kvi->key
         );
         // Since they only asked for one key, return just that value.
         pmix_kval_t *kv = PMIX_NEW(pmix_kval_t);

--- a/src/mca/gds/shmem3/gds_shmem3_fetch.c
+++ b/src/mca/gds/shmem3/gds_shmem3_fetch.c
@@ -823,8 +823,16 @@ shmem3_fetch_from_job(
     const bool mdrfu = pmix_gds_shmem3_has_status(
         job, PMIX_GDS_SHMEM3_MODEX_ID, PMIX_GDS_SHMEM3_READY_FOR_USE
     );
-    // Modex data are stored in PMIX_REMOTE.
-    pmix_hash_table_t *const remote_ht = mdrfu ? job->smmodex->hashtab : NULL;
+    /* Modex data are stored in PMIX_REMOTE, but there is no single table
+     * to name here: the modex is a chain of generations, and modex_fetch()
+     * walks it. Everything past "doover" therefore dispatches on the
+     * useremote flag, and "ht" is only ever read on the local side.
+     *
+     * This used to hold job->smmodex->hashtab, computed from mdrfu alone -
+     * which modex_fetch() has never trusted, because the two disagree
+     * whenever the progress thread has just set the current generation
+     * aside (see release_modex_segment()) and a read arrives before its
+     * replacement is published. That read would have dereferenced NULL. */
     // Every index in these tables was minted by the server against the
     // keyindex living in the same segment, never against this process's
     // global one, so a read has to translate through that same table.
@@ -1001,8 +1009,8 @@ shmem3_fetch_from_job(
         useremote = false;
     }
     else if (PMIX_REMOTE == scope) {
-        // Note that this ht can be NULL.
-        ht = remote_ht;
+        // The modex chain is reached through useremote, not through ht.
+        ht = NULL;
         useremote = true;
     }
     else {
@@ -1076,7 +1084,7 @@ doover:
         if (PMIX_GLOBAL == scope) {
             if (!useremote) {
                 // We need to do this again for the remote data.
-                ht = remote_ht;
+                ht = NULL;
                 useremote = true;
                 goto doover;
             }
@@ -1086,7 +1094,7 @@ doover:
         if (PMIX_GLOBAL == scope || PMIX_SCOPE_UNDEF == scope) {
             if (!useremote) {
                 // We need to also try the remote data.
-                ht = remote_ht;
+                ht = NULL;
                 /* Say which store the retry is against, exactly as the
                  * success path above does. Everything past "doover"
                  * dispatches on this flag rather than on ht, because the
@@ -1169,9 +1177,15 @@ doover:
  * means the progress thread can deregister the nspace underneath us and
  * the memory we are walking still stays put until we are done.
  *
- * Everything past this point is a read of immutable data - a segment a
- * client can see is never written again - so no further locking is
- * needed, and none is taken.
+ * What is IN the segments needs no further locking - a segment a client
+ * can see is never written again. What needs it is the process-local
+ * bookkeeping this walks alongside them: which modex generations are
+ * currently mapped, and which keys the job has been told to stop
+ * answering for. Both are rewritten by the progress thread as fences
+ * complete and keys are retracted, and releasing a generation UNMAPS it.
+ * job->datalock is what keeps a read and one of those apart; it is held
+ * across the whole read, so nothing below has to re-establish that a
+ * generation it decided to walk is still there.
  */
 pmix_status_t
 pmix_gds_shmem3_fetch(
@@ -1191,8 +1205,10 @@ pmix_gds_shmem3_fetch(
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         return rc;
     }
+    pmix_mutex_lock(&job->datalock);
     rc = shmem3_fetch_from_job(job, pr, proc, scope, copy, key,
                                qualifiers, nqual, kvs);
+    pmix_mutex_unlock(&job->datalock);
     PMIX_RELEASE(job);
     return rc;
 }

--- a/src/mca/gds/shmem3/gds_shmem3_utils.c
+++ b/src/mca/gds/shmem3/gds_shmem3_utils.c
@@ -108,6 +108,10 @@ pmix_gds_shmem3_get_job_tracker(
             }
             inspace->nspace = strdup(nspace);
             if (PMIX_UNLIKELY(!inspace->nspace)) {
+                // Nothing else has seen it: it is not on the global list
+                // and the tracker is not pointing at it yet, so this is
+                // the only chance to give it back.
+                PMIX_RELEASE(inspace);
                 rc = PMIX_ERR_NOMEM;
                 goto out;
             }

--- a/test/unit/gds_datastore.c
+++ b/test/unit/gds_datastore.c
@@ -1185,6 +1185,200 @@ static void test_realm_classifiers(void)
                && !pmix_check_session_info(NULL) && !pmix_check_special_key(NULL));
 }
 
+/* ------------------------------------------------------------------ */
+/* the shmem3 module's job segment                                      */
+/* ------------------------------------------------------------------ */
+
+/* Build a peer bound to a specific gds module, packable enough for
+ * register_job_info() to write a reply into.
+ *
+ * The wire format and role are borrowed from the local server's own
+ * peer: nothing here is a real client, but pack_shmem3_connection_info()
+ * does call PMIX_BFROPS_PACK against this peer and reads peer->info, so
+ * both have to be real. */
+static pmix_peer_t *mkgdspeer(const char *nspace, pmix_rank_t nprocs,
+                              pmix_gds_base_module_t *mod)
+{
+    pmix_peer_t *p;
+    pmix_namespace_t *ns;
+
+    p = PMIX_NEW(pmix_peer_t);
+    ns = PMIX_NEW(pmix_namespace_t);
+    ns->nspace = strdup(nspace);
+    ns->nprocs = nprocs;
+    memcpy(&ns->compat, &pmix_globals.mypeer->nptr->compat, sizeof(ns->compat));
+    ns->compat.gds = mod;
+    p->nptr = ns;
+    p->info = PMIX_NEW(pmix_rank_info_t);
+    p->info->pname.nspace = strdup(nspace);
+    p->info->pname.rank = 0;
+    p->info->peerid = 0;
+    memcpy(&p->proc_type, &pmix_globals.mypeer->proc_type, sizeof(p->proc_type));
+    return p;
+}
+
+/* Drive the shmem3 module end to end: register a job, have it build its
+ * shared segments, then read them back through its own fetch.
+ *
+ * shmem3 is not built on macOS at all and disqualifies itself where
+ * /proc/self/maps is absent, so this reports a skip rather than a
+ * failure when it is not the module that answers. That is the whole
+ * reason contrib/dockerswarm/run-gds-tests.sh exists - but the parts
+ * that a single process CAN reach are worth reaching from make check,
+ * because on Linux this is the only place they run without a DVM.
+ *
+ * The job info deliberately carries three shapes a host is entitled to
+ * send and this component used to take on trust:
+ *
+ *   - a job-level PMIX_DATA_ARRAY whose elements are NOT pmix_info_t.
+ *     The segment sizing pass read element zero of every data array as
+ *     one, so PMIX_CHECK_KEY walked up to PMIX_MAX_KEYLEN bytes past an
+ *     eight-byte allocation.
+ *   - PMIX_USERID as a string. add_nspace read the union directly, so
+ *     the low half of a pointer became the job's uid AND set chown,
+ *     which the segment's backing files were then handed to.
+ *   - a session array, so the session segment is built too.
+ */
+static void test_shmem3_job_segment(void)
+{
+    pmix_gds_base_module_t *mod;
+    pmix_info_t *info, *iptr, dir;
+    pmix_data_array_t *array;
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    pmix_peer_t *peer;
+    pmix_buffer_t reply;
+    pmix_cb_t cb;
+    pmix_proc_t proc;
+    uint32_t nprocs = 2, sid = 11, univ = 4;
+    /* Bytes, not infos - and chosen so that reading element zero as a
+     * pmix_info_t finds a key that MATCHES. PMIx_Check_key() stops at the
+     * first differing byte, so an array of arbitrary bytes is read one
+     * byte past its start and no further; it takes a leading string that
+     * really is the key to carry the read on into info[0].value, which
+     * sits 512 bytes into a 16-byte allocation. */
+    char impostor[16] = PMIX_SESSION_ID;
+    char *nodemap, *procmap;
+
+    fprintf(stdout, "\n-- shmem3 job segment --\n");
+
+    PMIX_INFO_LOAD(&dir, PMIX_GDS_MODULE, "shmem3", PMIX_STRING);
+    mod = pmix_gds_base_assign_module(&dir, 1);
+    PMIX_INFO_DESTRUCT(&dir);
+    if (NULL == mod || 0 != strcmp(mod->name, "shmem3")) {
+        fprintf(stdout, "    SKIP  shmem3 is not available in this build\n");
+        return;
+    }
+
+    nodemap = strdup(pmix_globals.hostname);
+    procmap = strdup("0-1");
+
+    PMIX_INFO_CREATE(info, 7);
+    PMIX_INFO_LOAD(&info[0], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
+    PMIX_INFO_LOAD(&info[1], PMIX_NODE_MAP, nodemap, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[2], PMIX_PROC_MAP, procmap, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[3], PMIX_UNIV_SIZE, &univ, PMIX_UINT32);
+    /* PMIX_USERID with a value that is not a uid */
+    PMIX_INFO_LOAD(&info[4], PMIX_USERID, "not-a-uid", PMIX_STRING);
+    /* a data array of bytes, not of infos */
+    PMIX_DATA_ARRAY_CREATE(array, sizeof(impostor), PMIX_BYTE);
+    memcpy(array->array, impostor, sizeof(impostor));
+    PMIX_LOAD_KEY(info[5].key, "gds.test.bytes");
+    info[5].value.type = PMIX_DATA_ARRAY;
+    info[5].value.data.darray = array;
+    /* a session array, so the session segment is built as well */
+    PMIX_INFO_CREATE(iptr, 1);
+    PMIX_INFO_LOAD(&iptr[0], PMIX_SESSION_ID, &sid, PMIX_UINT32);
+    PMIX_DATA_ARRAY_CREATE(array, 1, PMIX_INFO);
+    memcpy(array->array, iptr, sizeof(pmix_info_t));
+    free(iptr);
+    PMIX_LOAD_KEY(info[6].key, PMIX_SESSION_INFO_ARRAY);
+    info[6].value.type = PMIX_DATA_ARRAY;
+    info[6].value.data.darray = array;
+
+    PMIX_LOAD_NSPACE(ns, "gds-shmem3-job");
+    rc = PMIx_server_register_nspace(ns, nprocs, info, 7, NULL, NULL);
+    report("a job carrying a non-info data array registers", registered(rc));
+    if (!registered(rc)) {
+        fprintf(stdout, "        (register_nspace: %s)\n", PMIx_Error_string(rc));
+    }
+    PMIX_INFO_FREE(info, 7);
+    free(nodemap);
+    free(procmap);
+    if (!registered(rc)) {
+        return;
+    }
+
+    /* Building the segments happens here, on the first peer to ask. */
+    peer = mkgdspeer("gds-shmem3-job", nprocs, mod);
+    PMIX_CONSTRUCT(&reply, pmix_buffer_t);
+    PMIX_GDS_REGISTER_JOB_INFO(rc, peer, &reply);
+    report("shmem3 registers job info and describes its segments",
+           PMIX_SUCCESS == rc && 0 < reply.bytes_used);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "        (register_job_info: %s)\n",
+                PMIx_Error_string(rc));
+    }
+    PMIX_DESTRUCT(&reply);
+
+    /* Read a plain job-level key back out of the segment we just built,
+     * through shmem3's own fetch. */
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    PMIX_LOAD_PROCID(&proc, "gds-shmem3-job", PMIX_RANK_WILDCARD);
+    cb.proc = &proc;
+    /* PMIX_JOB_SIZE and not, say, PMIX_UNIV_SIZE: the datastore stores
+     * the latter under its replacement's name, so asking for it here
+     * would be testing the deprecation mapping rather than the segment. */
+    cb.key = PMIX_JOB_SIZE;
+    cb.copy = true;
+    cb.scope = PMIX_SCOPE_UNDEF;
+    PMIX_GDS_FETCH_KV(rc, peer, &cb);
+    report("a job-level key reads back out of the shared segment",
+           PMIX_SUCCESS == rc && 1 == pmix_list_get_size(&cb.kvs));
+    if (PMIX_SUCCESS != rc || 1 != pmix_list_get_size(&cb.kvs)) {
+        fprintf(stdout, "        (fetch: %s, %zu values)\n",
+                PMIx_Error_string(rc), pmix_list_get_size(&cb.kvs));
+    }
+    cb.key = NULL;
+    cb.proc = NULL;
+    PMIX_DESTRUCT(&cb);
+
+    /* The whole-job form, which walks the node, app and session lists
+     * and rebuilds a proc array per rank. */
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    PMIX_LOAD_PROCID(&proc, "gds-shmem3-job", PMIX_RANK_WILDCARD);
+    cb.proc = &proc;
+    cb.key = NULL;
+    cb.copy = true;
+    cb.scope = PMIX_SCOPE_UNDEF;
+    PMIX_GDS_FETCH_KV(rc, peer, &cb);
+    report("the whole-job fetch returns the segment's contents",
+           PMIX_SUCCESS == rc && 0 < pmix_list_get_size(&cb.kvs));
+    cb.proc = NULL;
+    PMIX_DESTRUCT(&cb);
+
+    /* A key nobody stored is a miss, not a fault. */
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    PMIX_LOAD_PROCID(&proc, "gds-shmem3-job", PMIX_RANK_WILDCARD);
+    cb.proc = &proc;
+    cb.key = "gds.test.absent";
+    cb.copy = true;
+    cb.scope = PMIX_SCOPE_UNDEF;
+    PMIX_GDS_FETCH_KV(rc, peer, &cb);
+    report("an absent key misses rather than faults", PMIX_SUCCESS != rc);
+    cb.key = NULL;
+    cb.proc = NULL;
+    PMIX_DESTRUCT(&cb);
+
+    /* Deregistering has to give the segments back - the tracker owns
+     * their mappings, and the arena reservation goes with it. */
+    PMIX_GDS_DEL_NSPACE(rc, "gds-shmem3-job");
+    report("deregistering the nspace releases the segments",
+           PMIX_SUCCESS == rc);
+
+    PMIX_RELEASE(peer);
+}
+
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
@@ -1211,6 +1405,7 @@ int main(int argc, char **argv)
     test_malformed_job_info();
     test_scope_routing();
     test_realm_classifiers();
+    test_shmem3_job_segment();
 
     fprintf(stdout, "\n=== %d passed, %d failed ===\n", npass, nfail);
 


### PR DESCRIPTION
A deep review of `src/mca/gds/shmem3`. Two findings worth the title, seven
smaller ones, and the component's first coverage in `make check`.

## A read runs on the application's thread, and the modex moves under it

`shmem3` sets `is_tsafe`, which is not decorative: `try_local_fetch()`
consults it on every keyed `PMIx_Get` and `pmix_client_globals.fast_get`
is on by default, so on a client `pmix_gds_shmem3_fetch()` runs on
whatever thread called `PMIx_Get`. The reference it takes on the job
tracker was treated as sufficient, on the grounds that a segment a client
can see is never written again. That covers what is *in* a segment, and
the job segment itself, which only `job_destruct()` lets go. It says
nothing about the bookkeeping a read walks alongside it.

Two things there are rewritten by the progress thread while a read is in
flight. As each fence completes the modex generation is replaced:
`release_modex_segment()` unmaps the current segment outright,
`drop_modex_priors()` unmaps every retired one, and
`retire_modex_segment()` clears `job->smmodex` before clearing the status
that guards it. And `del_key()` appends to the tombstone list that every
read consults. A `PMIx_Fence_nb` concurrent with a `PMIx_Get` of a remote
rank's key could therefore leave an application thread inside
`pmix_hash_fetch()` on a table that had just been `munmap`ped. The
single-threaded case was safe only by accident, because a blocking fence
parks the app thread until the modex-complete has been processed.

A per-job mutex now covers exactly those two structures, held across the
whole of `shmem3_fetch_from_job()` and taken by each of the writers. It
guards nothing in shared memory, so it lives on the process-local tracker
and **does not change the segment layout** - no rename, no layout-id bump.
`component.joblock` and it are never held simultaneously anywhere.

While in there, the `remote_ht` local is gone. It dereferenced
`job->smmodex` on the `READY_FOR_USE` flag alone - the pairing
`modex_fetch()` has never trusted, and the one the race above produces -
and nothing read it, because a modex lookup dispatches on the `useremote`
flag rather than on a table.

## The client never advanced `modex_generation`

It was introduced to name the next backing file, which is a server-side
job, and was documented and treated as server-only. But it is also what
dates a tombstone, and `del_key()` runs on the client. A client that left
it at zero stamped every tombstone with generation zero, so
`generation <= t->generation` held for every generation it ever mapped:
on that client a removal never expired.

Most of the cost is hidden by the fallbacks - a keyed get filters the key
out, misses, and is answered correctly by the server, which never had the
bug, at the price of a round trip. What is actually wrong is a NULL-key
read that reaches the modex, where `modex_fetch()` drops the re-published
key and the fetch still reports success because the list is not empty.
That needs the local table to miss for the rank, or an explicit
`PMIX_REMOTE` scope. A real inconsistency with a narrow blast radius,
then, rather than a common wrong answer.

## The smaller ones

- `add_nspace()` read `PMIX_USERID` and `PMIX_GRPID` straight out of the
  value union. The host supplies those and a key does not guarantee its
  type, so a string became the low half of a pointer - and not merely as
  a recorded id, since it also set `chown`, which the segment's backing
  files were then handed to.
- The segment sizing pass read element zero of **every** job-level data
  array as a `pmix_info_t`, whatever the array's element type, looking
  for a session id. `PMIx_Check_key()` stops at the first differing byte,
  so most arrays are read one byte past their start - but an array whose
  leading bytes spell the key carries the read on into `info[0].value`,
  512 bytes into what may be a 16-byte allocation.
- A seg blob naming a segment id outside the enum reached the `default`
  arm of `pmix_gds_shmem3_get_job_shmem3_by_id()`, which `abort()`s, and
  one with no nspace reached `strcmp()` with NULL. Such a blob is now
  skipped, the same forward compatibility the unrecognized-key arm keeps.
- A failure to `chown`/`chmod` a backing file failed the whole of
  `register_job_info()`, so no client got job data at all, while leaving
  the segment attached and not marked `MINE`. What a client actually
  loses is the ability to open the file, which it reports as a failed
  attach and answers by falling back to `hash`. Log it and carry on.
- A segment created but never attached kept its backing file:
  `shmem_destruct()` only unlinks one it managed to attach, and the path
  is built from a pid.
- `job_destruct()` returned early when one segment id could not be
  resolved, skipping the arena reservation and the session reference.
- A `pmix_namespace_t` was leaked when its own `strdup` failed.

## Coverage

`shmem3` is not built on macOS at all, so a developer there gives it no
compiler coverage, let alone runtime. `test/unit/gds_datastore` gains a
case that asks for the module by name and, when it gets it, drives the
component end to end in one process: register an nspace, build the job
and session segments through `PMIX_GDS_REGISTER_JOB_INFO` against a peer
bound to this module, read a job-level key and the whole job back out,
deregister. It sends the impostor data array that pins the sizing-pass
guard - removing that guard turns three cases red. Where the component is
not available it prints `SKIP` and passes.

`examples/delete_key.c` now also puts the key back. A deletion is not
permanent, and under `shmem3` the record of one is dated precisely so a
later generation is not shadowed by it; nothing exercised that. This
passes both before and after the counter fix - on a client the keyed get
it makes is answered by the server - so it is here because the behavior
was documented and untested, not because it discriminates.

## Testing

- `make check`: 155/155 on Linux, 154/154 on macOS (the new case `SKIP`s).
- Warning-free build on both, `--enable-debug --enable-devel-check`.
- `contrib/dockerswarm/run-gds-tests.sh`: **49/49**.

One caveat worth stating: across three full suite runs, the
`modex_attach_fail (no modex map)` 4-server case hung once, with
byte-identical library code to the runs that passed it. It did not
reproduce in 42 consecutive isolated runs of that exact case, and the two
locks in the component are never held simultaneously with nothing
blocking under either, so I have treated it as environmental - but it is
recorded here rather than dropped.

`AGENTS.md` gains a section on what `is_tsafe` actually costs, corrects
the claim that `component.sessions` holds anything (nothing ever appends
to it, so a `shmem3` session dies with its job), and records what was
looked at and refuted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014us8BBp5DpjUQmG94RGMzm