### PR TITLE
Ask the module that holds the modex, not just our own

### DIFF
--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -94,6 +94,7 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank, char 
 static pmix_status_t get_job_data(char *nspace, pmix_server_caddy_t *cd,
                                   char *key, pmix_buffer_t *pbkt);
 static void get_timeout(int sd, short args, void *cbdata);
+static pmix_peer_t *local_peer_of_nspace(pmix_namespace_t *nptr);
 
 /* The release function we hand to the reply path along with a payload we
  * unloaded from a buffer: the reply copies the bytes, then calls this to
@@ -621,6 +622,39 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf, pmix_modex_cbfunc_t cbfunc, vo
         cb.ninfo = cd->ninfo;
         cb.key = key;
         PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+        if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS_OUTSIDE_SCOPE != rc) {
+            /* Not in our own store - but that does not mean it is not
+             * here, and the same reasoning applies as in
+             * _satisfy_request() below. A server assigns ITSELF "hash",
+             * while a modex is stored through the module of the nspace
+             * that contributed it: PMIX_GDS_STORE_MODEX resolves from a
+             * local peer of that nspace (pmix_server_op_replies.c). So
+             * for a job whose clients negotiated gds/shmem3 the fence
+             * data went into a shared-memory segment our module knows
+             * nothing about, and we have just searched the wrong store.
+             * For a "hash" job the two are one module and this changes
+             * nothing.
+             *
+             * Left unasked, every remote get for such a job missed here
+             * and was pushed up to the host as a direct modex - for data
+             * this server already held. Slow when it works, and it does
+             * not always work: the up-call chases the proc that owns the
+             * key, so a straggler asking for a peer that has already
+             * called PMIx_Finalize waits on an answer nobody is left to
+             * give. The remote request below deliberately carries no
+             * timeout - we cannot know how long a host may legitimately
+             * take - so that wait never ends. */
+            pmix_peer_t *nspeer = local_peer_of_nspace(nptr);
+            if (NULL != nspeer &&
+                !PMIX_GDS_CHECK_PEER_COMPONENT(nspeer, pmix_globals.mypeer)) {
+                pmix_kval_t *kvtmp;
+                /* a failed fetch may still have appended something */
+                while (NULL != (kvtmp = (pmix_kval_t *) pmix_list_remove_first(&cb.kvs))) {
+                    PMIX_RELEASE(kvtmp);
+                }
+                PMIX_GDS_FETCH_KV(rc, nspeer, &cb);
+            }
+        }
         /* if the requested key was found, but in a different scope,
          * then we report this back as there is no point in waiting */
         if (PMIX_ERR_EXISTS_OUTSIDE_SCOPE == rc) {


### PR DESCRIPTION
Found while chasing a ~1% hang in `contrib/dockerswarm/run-gds-tests.sh`
that turned out to predate #4183.

## The bug

A server assigns **itself** `"hash"` at init, but a modex is stored
through the module of the nspace that *contributed* it —
`PMIX_GDS_STORE_MODEX` resolves from a local peer of that nspace (see
`pmix_server_op_replies.c`). So for a job whose clients negotiated
`gds/shmem3`, the fence data went into a shared-memory segment, while the
lookup at the top of `pmix_server_get()` searched
`pmix_globals.mypeer` — the wrong store. For a `hash` job the two are the
same module, which is why this has never been visible.

`_satisfy_request()`, a few hundred lines below, already knew this and
asks the nspace's own module before giving up. The lookup at the top did
not, so **every** remote get for a `shmem3` job missed there and was
pushed up to the host as a direct modex — for data this server already
held.

That is slow when it works, and it does not always work. The up-call
chases the proc that owns the key, so a straggler asking for a peer that
has already called `PMIx_Finalize` waits on an answer nobody is left to
give. The remote request carries no timeout, deliberately, because we
cannot know how long a host may legitimately take — so the wait never
ends.

## The fix

Reuse the existing pattern rather than inventing a second one: if our own
module misses, and the target nspace's local clients are on a different
module, drain whatever the failed fetch appended and ask that module
before deciding we do not have it. `hash`-only jobs take no new branch.

## Evidence

`examples/modex_attach_fail`, one rank per node on four nodes, which
forces the client's modex attach to fail so every remote get has to be
served by the server:

| build | runs | hangs |
|---|---|---|
| master | 100 | 1 |
| master + this patch | 300 | **0** |

A healthy run takes about **one second** against a 20-second limit, so a
timeout there is a wedge, not a slow launch.

The counts are supporting evidence, not the argument. The mechanism was
confirmed directly: with `PMIX_MCA_gds_base_verbose=1` and every daemon
audible (`--leave-session-attached`), the lookup at the top of
`pmix_server_get()` resolves `hash` and misses, and the new one resolves
`shmem3` and hits:

```
4 pmix_server_get.c:624] GDS FETCH KV WITH hash      <- misses
4 pmix_server_get.c:655] GDS FETCH KV WITH shmem3    <- new, hits
```

The captured hang shows the shape plainly — the ranks that finished had
already exited, and the straggler never returned from its get of a
departed peer:

```
[rank 3] PMIx_Get(PMIX_LOCAL_PEERS) rc=PMIX_SUCCESS value=3
[rank 1] MODEX-ATTACH-FAIL OK      <- exited
[rank 2] MODEX-ATTACH-FAIL OK      <- exited
   ...rank 3 never returns from PMIx_Get(rank 0, "modex-attach-key")
```

## Testing

- `make check`: 155/155 Linux, 155/155 macOS. Warning-free on both,
  `--enable-debug --enable-devel-check`.
- `contrib/dockerswarm/run-gds-tests.sh`: 49/49.

No new test: the failure is a race whose only reliable detector is the
300-run measurement above, and the swarm's `modex_attach_fail` stage
already covers the path — it simply passed 99% of the time before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014us8BBp5DpjUQmG94RGMzm