### PR TITLE
Answer a direct modex for a proc that has terminated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ examples/debugger
 examples/debuggerd
 examples/datatypes
 examples/delete_key
+examples/dmdx_departed
 examples/modex_attach_fail
 examples/dmodex
 examples/dynamic

--- a/contrib/dockerswarm/run-server-tests.sh
+++ b/contrib/dockerswarm/run-server-tests.sh
@@ -90,7 +90,7 @@ root="$(cd "$here/../.." && pwd)"
 
 # The examples this runner drives.  Each one puts the server library on a
 # path a single-node run cannot take; see the header.
-SERVER_EXAMPLES="${SERVER_EXAMPLES:-dmodex modex_twice group_dmodex dynamic multi_nspace_group resolve simple_resolve pub}"
+SERVER_EXAMPLES="${SERVER_EXAMPLES:-dmodex dmdx_departed modex_twice group_dmodex dynamic multi_nspace_group resolve simple_resolve pub}"
 
 # See run-client-tests.sh: these are COMPILED in a throwaway builder
 # container and RUN in the long-lived node containers, so they must link the
@@ -127,6 +127,9 @@ sv_geom() {
         # one actually prints on the way out, or the case passes/fails on
         # the marker rather than on the behavior.
         modex_twice)    WANT='second fence: new values visible, old values kept' ;;
+        # the point is that PMIx ANSWERS - a regression parks the get
+        # forever, and judge() reports that launch timeout as a hang
+        dmdx_departed)  WANT='DMDX-DEPARTED answered' ;;
         group_dmodex)   WANT='COMPLETE' ;;
         resolve)        WANT='Bye\.' ;;
         pub|simple_resolve) WANT='' ;;
@@ -249,6 +252,8 @@ test_linux() {
         launch "$ex"
         case "$ex" in
             dmodex)      judge "$ex" "direct modex: a key fetched from another server" ;;
+            dmdx_departed)
+                         judge "$ex" "direct modex for a terminated proc is answered, not parked" ;;
             modex_twice) judge "$ex" "repeated modex: second request joins an existing tracker" ;;
             group_dmodex) judge "$ex" "modex within a group spanning servers" ;;
             dynamic)     judge "$ex" "spawn + connect: a get across namespaces and servers" ;;

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -91,7 +91,7 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   group_invite_abort group_invite_others group_invite_suppress group_invite_nb \
                   group_invite_endpts topology \
                   spawn_reuse spawn_iof iof_watcher group_badinfo datatypes toolswitch \
-                  modex_twice delete_key modex_attach_fail
+                  modex_twice delete_key modex_attach_fail dmdx_departed
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -345,6 +345,10 @@ modex_attach_fail_SOURCES = modex_attach_fail.c examples.h
 modex_attach_fail_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 modex_attach_fail_LDADD = $(top_builddir)/src/libpmix.la
 
+dmdx_departed_SOURCES = dmdx_departed.c examples.h
+dmdx_departed_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+dmdx_departed_LDADD = $(top_builddir)/src/libpmix.la
+
 abort_SOURCES = abort.c examples.h
 abort_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 abort_LDADD = $(top_builddir)/src/libpmix.la
@@ -360,4 +364,4 @@ distclean-local:
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
         simple simple_server abort datatypes toolswitch \
-        modex_twice delete_key modex_attach_fail
+        modex_twice delete_key modex_attach_fail dmdx_departed

--- a/examples/dmdx_departed.c
+++ b/examples/dmdx_departed.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * A direct modex for a process that has already terminated.
+ *
+ * This is a deliberately FLAWED application: it reads a peer's value
+ * without any guarantee that the peer is still alive. What it is here to
+ * check is not that the read succeeds - it must not - but that PMIx says
+ * so, promptly, instead of blocking forever. A developer who writes this
+ * by accident should get an error they can act on, not a hung job that
+ * looks like a PMIx fault.
+ *
+ * The fence is deliberately NON-collecting, so no server ends up holding
+ * a copy of anybody else's data: the only route to rank 0's value is a
+ * direct modex to rank 0's own daemon, which is the ordinary path for a
+ * job that does not collect. Every rank but the last then leaves at
+ * once, and the last one asks for rank 0 well after rank 0 is gone.
+ */
+
+#include <pmix.h>
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "examples.h"
+
+#define KEY "dmdx-departed-key"
+/* how long the straggler waits, to be sure the peer is not merely slow */
+#define LINGER_SEC 5
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc, wildcard, peer;
+    pmix_value_t put, *val = NULL;
+    pmix_info_t info[2];
+    pmix_status_t rc;
+    uint32_t nprocs;
+    bool flag;
+
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "dmdx_departed: PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+    PMIX_LOAD_PROCID(&wildcard, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&wildcard, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "dmdx_departed: job size failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (2 > nprocs) {
+        fprintf(stderr, "dmdx_departed: needs at least 2 procs on 2 nodes\n");
+        PMIx_Finalize(NULL, 0);
+        exit(1);
+    }
+
+    PMIX_VALUE_CONSTRUCT(&put);
+    put.type = PMIX_UINT32;
+    put.data.uint32 = myproc.rank;
+    if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, KEY, &put))
+        || PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        fprintf(stderr, "[rank %u] put/commit failed: %s\n",
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    /* NON-collecting: everyone has committed, nobody has anyone else's
+     * data, so a peer's value can only come from a direct modex */
+    flag = false;
+    PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+    rc = PMIx_Fence(&wildcard, 1, &info[0], 1);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[rank %u] fence failed: %s\n",
+                myproc.rank, PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    if (myproc.rank != nprocs - 1) {
+        /* leave immediately - by the time the straggler asks, we are gone */
+        printf("[rank %u] DMDX-DEPARTED done\n", myproc.rank);
+        fflush(stdout);
+        PMIx_Finalize(NULL, 0);
+        return 0;
+    }
+
+    sleep(LINGER_SEC);
+    PMIX_LOAD_PROCID(&peer, myproc.nspace, 0);
+    printf("[rank %u] asking rank 0 for %s, %d s after it terminated\n",
+           myproc.rank, KEY, LINGER_SEC);
+    fflush(stdout);
+
+    {
+        struct timespec t0, t1;
+        double el;
+        clock_gettime(CLOCK_MONOTONIC, &t0);
+        /* deliberately NO PMIX_TIMEOUT: a caller-supplied one would
+         * mask the very thing under test by ending the wait itself */
+        rc = PMIx_Get(&peer, KEY, NULL, 0, &val);
+        clock_gettime(CLOCK_MONOTONIC, &t1);
+        el = (t1.tv_sec - t0.tv_sec) + (t1.tv_nsec - t0.tv_nsec) / 1e9;
+        printf("[rank %u] PMIx_Get(rank 0) returned %s after %.2f s\n",
+               myproc.rank, PMIx_Error_string(rc), el);
+    }
+    fflush(stdout);
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    /* Any prompt answer is a pass. Reading the value of a process that
+     * has terminated is not required to work, and it is not required to
+     * fail either - what is required is that the caller is TOLD, rather
+     * than parked forever on a reply nobody is left to send. */
+    printf("[rank %u] DMDX-DEPARTED answered\n", myproc.rank);
+    fflush(stdout);
+
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -160,6 +160,7 @@ static void nscon(pmix_namespace_t *p)
     PMIX_CONSTRUCT(&p->epilog.cleanup_files, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);
     PMIX_CONSTRUCT(&p->setup_data, pmix_list_t);
+    PMIX_CONSTRUCT(&p->departed, pmix_list_t);
     pmix_iof_init_flags(&p->iof_flags);
     PMIX_CONSTRUCT(&p->sinks, pmix_list_t);
 
@@ -173,6 +174,7 @@ static void nsdes(pmix_namespace_t *p)
         PMIX_RELEASE(p->jobbkt);
     }
     PMIX_LIST_DESTRUCT(&p->ranks);
+    PMIX_LIST_DESTRUCT(&p->departed);
     /* perform any epilog */
     pmix_execute_epilog(&p->epilog);
     /* cleanup the epilog */

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -386,6 +386,18 @@ typedef struct {
                                // fired for this nspace; guards against re-firing it once
                                // per rank while the nspace is torn down
     pmix_list_t ranks;     // list of pmix_rank_info_t for connection support of my clients
+    /* Ranks whose entry above the host has taken back - the proc has
+     * terminated. pmix_proclist_t, one per reaped LOCAL rank, kept until
+     * this namespace is deregistered.
+     *
+     * Without it a direct-modex request naming one of them is
+     * indistinguishable from one that arrived before the rank was
+     * registered, and _dmodex_req() treats "I do not know that rank" as
+     * "not yet" and parks the request forever. The asking process then
+     * sits in PMIx_Get until something else kills the job. Reading a
+     * peer that has exited is an application error, but it has to
+     * SURFACE as one - a hang tells the developer nothing. */
+    pmix_list_t departed;
     /* all members of an nspace are required to have the
      * same personality, but it can differ between nspaces.
      * Since servers may support clients from multiple nspaces,

--- a/src/server/pmix_server_dmodex.c
+++ b/src/server/pmix_server_dmodex.c
@@ -133,6 +133,31 @@ static void _dmodex_req(int sd, short args, void *cbdata)
         }
     }
     if (NULL == info) {
+        /* Not a rank we currently host. There are two ways to get here
+         * and they need opposite answers: it may not have been
+         * registered YET, in which case waiting is right and the data
+         * will arrive; or it may have run and been reaped, in which case
+         * nothing is ever coming and waiting means the process that
+         * asked sits in PMIx_Get until the job is killed.
+         *
+         * nptr->departed is what tells them apart - see the note on it
+         * in pmix_globals.h. Answer a departed rank the same way a
+         * request already parked when the proc finalized is answered:
+         * PMIX_ERR_NOT_FOUND, promptly. Reading a peer that has exited
+         * is an application error, and the developer needs to be told
+         * that rather than left with a hang to diagnose. */
+        pmix_proclist_t *dp;
+        PMIX_LIST_FOREACH (dp, &nptr->departed, pmix_proclist_t) {
+            if (PMIX_CHECK_PROCID(&dp->proc, &cd->proc)) {
+                pmix_output_verbose(2, pmix_server_globals.get_output,
+                                    "%s:%d DMODEX FOR TERMINATED PROC %s",
+                                    pmix_globals.myid.nspace,
+                                    pmix_globals.myid.rank,
+                                    PMIX_NAME_PRINT(&cd->proc));
+                rc = PMIX_ERR_NOT_FOUND;
+                goto cleanup;
+            }
+        }
         /* rank isn't known yet - defer
          * the request until we do */
         dcd = PMIX_NEW(pmix_dmdx_remote_t);

--- a/src/server/pmix_server_registration.c
+++ b/src/server/pmix_server_registration.c
@@ -687,6 +687,26 @@ static void remove_client(pmix_namespace_t *nptr, pmix_proc_t *p)
                 pmix_pnet.local_app_finalized(nptr);
                 pmix_pgpu.local_app_finalized(nptr);
             }
+            /* Remember that this rank existed and is gone.
+             *
+             * The entry below is about to be destroyed, and once it is,
+             * a direct-modex request naming this rank looks exactly like
+             * one that arrived before the rank was ever registered -
+             * which _dmodex_req() answers by waiting. Nothing would ever
+             * end that wait. Record the departure so it can answer "not
+             * found" instead, which is the same thing a request already
+             * parked when the proc finalized is told.
+             *
+             * Only for a named rank: p == NULL is the namespace being
+             * torn down, and this list dies with it. */
+            if (NULL != p) {
+                pmix_proclist_t *dp = PMIX_NEW(pmix_proclist_t);
+                if (NULL != dp) {
+                    PMIX_LOAD_PROCID(&dp->proc, info->pname.nspace,
+                                     info->pname.rank);
+                    pmix_list_append(&nptr->departed, &dp->super);
+                }
+            }
             pmix_list_remove_item(&nptr->ranks, &info->super);
             PMIX_RELEASE(info);
             if (NULL != p) {


### PR DESCRIPTION
Reading a peer that has already called `PMIx_Finalize` is an application
error. It has to *surface* as one. Today it does not surface at all — the
caller sits in `PMIx_Get` forever, and a developer with a hung job has
nothing to go on.

## Mechanism

`_dmodex_req()` resolves the target against `nptr->ranks` and, finding
nothing, takes the branch commented *"rank isn't known yet - defer the
request until we do"*. That is right for a request arriving **before** the
host registers the client, and wrong for one arriving **after** the host
takes it back: `remove_client()` destroys the entry, so the two cases are
indistinguishable and both wait.

Nothing ever ends the second wait. The deferral has no timeout, and the
remote request deliberately carries none — we cannot know how long a host
may legitimately take.

The already-parked ordering is fine today: the `FINALIZE_CMD` sweep calls
`pmix_server_purge_events()` → `pmix_server_fail_remote_pnd()` and answers
`PMIX_ERR_NOT_FOUND`. Only the arrives-afterwards ordering is stranded.

## Fix

Give the namespace a record of the ranks its host has reaped, kept until
the namespace is deregistered, and let `_dmodex_req()` tell the two cases
apart. A rank on that list is answered `PMIX_ERR_NOT_FOUND` at once — the
same status the sweep uses, so the caller sees the same thing whichever
side of the race it lands on.

This is a rank-level counterpart to the peer-level tombstone
`pmix_server_peer_finalized()` already keeps, and for the same stated
reason: a concurrent direct-modex get resolving ranks while a peer departs
must not be left holding nothing.

Both `_dmodex_req()` and `_deregister_client()` are `PMIX_THREADSHIFT`ed
onto the progress thread, so the two orderings are the only two.

## Evidence

Four nodes, one rank per node, `examples/dmdx_departed` (added here): a
**non-collecting** fence, so the only route to a peer's value is a direct
modex; every rank but the last then leaves, and the last asks for rank 0
five seconds later.

| | result |
|---|---|
| before | `PMIx_Get` never returns; job dies on the launch timeout |
| before, caller passes `PMIX_TIMEOUT=30` | `PMIX_ERROR` after 30.04 s — the caller's own timeout, PMIx contributes nothing |
| after | `PMIX_ERR_NOT_FOUND` after **0.00 s** |

The example is wired into `run-server-tests.sh` beside the other
server-side request-handling cases. Removing the new branch and re-running
it reports `FAIL dmdx_departed: HUNG (hit the launch timeout)`, so the case
fails for the reason it exists.

## Testing

- `make check`: 155/155 Linux, 155/155 macOS, warning-free on both.
- `contrib/dockerswarm/run-gds-tests.sh`: 49/49.
- `contrib/dockerswarm/run-server-tests.sh`: 15/15, including the valgrind
  stage and the new case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014us8BBp5DpjUQmG94RGMzm