### PR TITLE
Tell the host about a connect even when everyone is local

### DIFF
--- a/src/server/pmix_server_connect.c
+++ b/src/server/pmix_server_connect.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -267,16 +267,21 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd, pmix_buffer_t *buf
             pmix_event_del(&trk->ev);
             trk->event_active = false;
         }
-        if (trk->local) {
-            /* the operation is being atomically completed and the host will
-             * not be calling us back - ensure we notify all participants.
-             * the cbfunc thread-shifts the call prior to processing,
-             * so it is okay to call it directly from here */
-            trk->host_called = false; // the host will not be calling us back
-            cbfunc(PMIX_SUCCESS, trk);
-            /* ensure that the switchyard doesn't release the caddy */
-            rc = PMIX_SUCCESS;
-        } else if (NULL == pmix_host_server.disconnect) {
+        if (NULL == pmix_host_server.disconnect) {
+            if (trk->local) {
+                /* Nobody outside this node is involved and the host offers no
+                 * way to be told, so complete the operation here.  This is the
+                 * ONLY case in which an all-local operation is finished
+                 * without the host: see the connect path below for why
+                 * locality on its own is not a reason to skip it.
+                 * The cbfunc thread-shifts the call prior to processing, so it
+                 * is okay to call it directly from here. */
+                trk->host_called = false; // the host will not be calling us back
+                cbfunc(PMIX_SUCCESS, trk);
+                /* ensure that the switchyard doesn't release the caddy */
+                rc = PMIX_SUCCESS;
+                goto cleanup;
+            }
             /* the host cannot execute this operation. Detach this caddy so
              * the switchyard can send the error to this caller, and drive the
              * op completion function to notify all other participants and tear
@@ -537,17 +542,34 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
             pmix_event_del(&trk->ev);
             trk->event_active = false;
         }
-        /* if all the participants are local, then we don't need the host */
-        if (trk->local) {
-            /* the operation is being atomically completed and the host will
-             * not be calling us back - ensure we notify all participants.
-             * the cbfunc thread-shifts the call prior to processing,
-             * so it is okay to call it directly from here */
-            trk->host_called = false; // the host will not be calling us back
-            cbfunc(PMIX_SUCCESS, trk);
-            /* ensure that the switchyard doesn't release the caddy */
-            rc = PMIX_SUCCESS;
-        } else if (NULL == pmix_host_server.connect) {
+        if (NULL == pmix_host_server.connect) {
+            if (trk->local) {
+                /* Nobody outside this node is involved and the host offers no
+                 * way to be told, so complete the operation here.
+                 *
+                 * Note what is NOT a reason to take this path: that every
+                 * participant happens to be local.  Being "connected" is not
+                 * a property of this server - it is a request that the HOST
+                 * treat the participants as one application for fault
+                 * purposes, and the host is the only thing that sees a member
+                 * terminate and can notify the rest of the assemblage.  A
+                 * host told nothing about an assemblage cannot keep that
+                 * promise for it, and neither can we: the obligation outlives
+                 * this call, and this library does not watch for a member's
+                 * death.  Skipping the host for a single-node assemblage
+                 * therefore did not save work, it silently dropped the only
+                 * thing the operation was for.  The deferred path in
+                 * pmix_server_registration.c has always called the host
+                 * regardless of locality, so the two halves of the same
+                 * operation did not even agree.
+                 * The cbfunc thread-shifts the call prior to processing, so it
+                 * is okay to call it directly from here. */
+                trk->host_called = false; // the host will not be calling us back
+                cbfunc(PMIX_SUCCESS, trk);
+                /* ensure that the switchyard doesn't release the caddy */
+                rc = PMIX_SUCCESS;
+                goto cleanup;
+            }
             /* the host cannot execute this operation. Detach this caddy so
              * the switchyard can send the error to this caller, and drive the
              * op completion function to notify all other participants and tear


### PR DESCRIPTION
The server library completed a `PMIx_Connect` or `PMIx_Disconnect` whose participants were all local by itself:

```c
/* if all the participants are local, then we don't need the host */
if (trk->local) { ... cbfunc(PMIX_SUCCESS, trk); }
```

That is true of the *collective* and false of the *operation*.

Being "connected" is not a property of this server. It is a request that the **host** treat the participants as one application for fault purposes, and the obligation it creates outlives the call — per `PMIx_Connect(3)`:

> Once processes are connected, the host environment is required to generate a `PMIX_ERR_PROC_TERM_WO_SYNC` event should any process in the assemblage terminate or call `PMIx_Finalize` without first disconnecting

> ...if the environment defaults to terminating an application upon failure of any process in that application, then it should terminate all processes in the connected assemblage upon failure of any member.

Only the host sees a member die, and it cannot keep either promise for an assemblage it was never told about. This library does not watch for a member's death and cannot keep them either. So skipping the host for a single-node assemblage did not save work — it silently dropped the only thing the operation was for.

The same reasoning applies to disconnect, and more sharply: a host told of a connect it then cannot see dissolved will go on acting on a membership the application has left. That is not hypothetical — it is what surfaced this. PRRTE connects a spawned child to its parent, as the `PMIx_Spawn` default requires; on a single node the application's `PMIx_Disconnect` never reached the host, so the assemblage could not be dissolved and a later failure in the child took down a parent that had explicitly disconnected.

Worth noting that the two halves of the same operation did not agree: the deferred path in `pmix_server_registration.c` — taken when a late `register_nspace`/`register_client` holds the collective up — has always called the host regardless of locality. So whether the host heard about an assemblage depended on the timing of an unrelated registration.

The all-local shortcut remains for the one case where it is the only thing available: a host that offers no `connect`/`disconnect` entry point at all, where completing locally is better than failing an operation that used to succeed. So the test is now "can the host do this?" first, and locality only as the fallback.

### Testing

Built warning-free and `make check`. Exercised through PRRTE (openpmix/prrte#2716), which implements the host side of the definition, with a client that spawns a child on the same node, connects, and then leaves. On one node, before this change PRRTE's `connect_fn` was never called at all; with it:

| case | result |
|---|---|
| child exits without disconnecting | parent gets `PMIX_ERR_PROC_TERM_WO_SYNC` |
| both disconnect, child exits | parent gets nothing |
| child aborts while connected | parent's job terminated with it |
| child aborts after disconnecting | parent survives |

The last two rows are only reachable because the host now hears both operations.