### PR TITLE
Stop probing for struct members nothing reads

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -616,13 +616,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                          #endif
                      ])
 
-    AC_CHECK_MEMBERS([struct dirent.d_type], [], [], [
-                         #include <sys/types.h>
-                         #include <dirent.h>])
-
-    AC_CHECK_MEMBERS([siginfo_t.si_fd],,,[#include <signal.h>])
-    AC_CHECK_MEMBERS([siginfo_t.si_band],,,[#include <signal.h>])
-
     #
     # Checks for struct member names in struct statfs
     #
@@ -649,23 +642,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                          #endif
                          #ifdef HAVE_SYS_STATFS_H
                          #include <sys/statfs.h>
-                         #endif
-                     ])
-
-    #
-    # Checks for struct member names in struct statvfs
-    #
-    AC_CHECK_MEMBERS([struct statvfs.f_basetype], [], [], [
-                         AC_INCLUDES_DEFAULT
-                         #ifdef HAVE_SYS_STATVFS_H
-                         #include <sys/statvfs.h>
-                         #endif
-                     ])
-
-    AC_CHECK_MEMBERS([struct statvfs.f_fstypename], [], [], [
-                         AC_INCLUDES_DEFAULT
-                         #ifdef HAVE_SYS_STATVFS_H
-                         #include <sys/statvfs.h>
                          #endif
                      ])
 


### PR DESCRIPTION
`configure` runs five `AC_CHECK_MEMBERS` tests whose results are never
consulted:

| probe | macro | readers |
|---|---|---|
| `siginfo_t.si_fd` | `HAVE_SIGINFO_T_SI_FD` | 0 |
| `siginfo_t.si_band` | `HAVE_SIGINFO_T_SI_BAND` | 0 |
| `struct dirent.d_type` | `HAVE_STRUCT_DIRENT_D_TYPE` | 0 |
| `struct statvfs.f_basetype` | `HAVE_STRUCT_STATVFS_F_BASETYPE` | 0 |
| `struct statvfs.f_fstypename` | `HAVE_STRUCT_STATVFS_F_FSTYPENAME` | 0 |

Checked both ways — no source names the member, and no source tests the
macro. The `siginfo` pair in particular was inherited alongside a stacktrace
handler PMIx does not have; PRRTE keeps that file, and its own probes for the
same two members, which is where those results are actually used.

A probe nobody reads costs a compile at every `configure` and puts a stale
entry in the installed `pmix_config.h`, where it reads as a promise that
something depends on it.

The neighbours that look similar stay: `struct sockaddr.sa_len`,
`struct statfs.f_type`, `struct statfs.f_fstypename` and the
`ucred`/`sockpeercred` group are read by `pmix_path.c`, `pmix_getid.c` and
`psec/native`. `pmix_path_df()` does call `statvfs()`, but only for `f_bsize`
and `f_bavail`, so `HAVE_STATVFS` and `HAVE_SYS_STATVFS_H` stay while the two
`statvfs` member probes go.

### Testing

`autogen.pl`, `configure` with `--enable-devel-check`, build with zero
warnings, `make check` clean at 156 tests. Confirmed the five checks are gone
from both the configure output and the generated `pmix_config.h.in`, while
`struct statfs.f_type` and `f_fstypename` still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGakf7GCGwLDoEHBoy7ieX