### PR TITLE
Add PMIX_ALLOC_ACTIVATE: ask for resources you already hold

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1618,3 +1618,10 @@ The ``PMIx_Allocation_request`` API includes a ``directive`` parameter to
 specify the operation being requested. These values were extended to include:
 
 * ``PMIX_ALLOC_REQ_CANCEL`` (value: 5): Cancel the indicated allocation request
+
+* ``PMIX_ALLOC_ACTIVATE`` (value: 6): Bring resources the requestor already
+  holds into service - e.g., start a daemon on an allocated node the runtime
+  is not yet spanning. The resources are named with ``PMIX_HOST`` and/or
+  ``PMIX_HOSTFILE``. Nothing is asked of the scheduler and nothing is added to
+  the allocation, so this can be honored where a request for new resources
+  cannot be.

--- a/docs/how-things-work/inheritance/overview.rst
+++ b/docs/how-things-work/inheritance/overview.rst
@@ -162,8 +162,8 @@ attribute in the ``pmix_info_t`` array of a ``PMIx_Allocation_request``
 * **Accepting APIs**: ``PMIx_Allocation_request`` and
   ``PMIx_Allocation_request_nb``, on ``PMIX_ALLOC_NEW`` and
   ``PMIX_ALLOC_EXTEND`` requests. It is ignored on
-  ``PMIX_ALLOC_RELEASE``, ``PMIX_ALLOC_REAQUIRE``, and
-  ``PMIX_ALLOC_REQ_CANCEL`` requests.
+  ``PMIX_ALLOC_RELEASE``, ``PMIX_ALLOC_REAQUIRE``,
+  ``PMIX_ALLOC_REQ_CANCEL``, and ``PMIX_ALLOC_ACTIVATE`` requests.
 * **Default**: if the attribute is absent, the host shall behave as if
   ``PMIX_ALLOC_INHERIT_DEFAULT`` had been specified - i.e., on
   termination of the owning namespace the allocation becomes unreserved

--- a/docs/how-things-work/schedulers/overview.rst
+++ b/docs/how-things-work/schedulers/overview.rst
@@ -61,6 +61,10 @@ The principal entry points used to interact with the scheduler are:
   ``PMIX_ALLOC_REAQUIRE``       Reacquire resources previously lent to the
                                 scheduler.
   ``PMIX_ALLOC_REQ_CANCEL``     Cancel a pending allocation request.
+  ``PMIX_ALLOC_ACTIVATE``       Bring resources the requestor already holds
+                                into service (named with ``PMIX_HOST`` and/or
+                                ``PMIX_HOSTFILE``). Asks the scheduler for
+                                nothing.
   ============================  ==================================================
 
 * ``PMIx_Session_control`` - request a control action against a session

--- a/docs/man/man1/palloc.1.rst
+++ b/docs/man/man1/palloc.1.rst
@@ -94,9 +94,9 @@ OPTIONS
 
 * ``-s`` | ``--share``: Allocated resources can be shared with other allocations.
 
-* ``--extend   <arg0>``:Extend the specified existing session ID per the rest of the given request.
+* ``--extend [<arg0>]``: Extend the specified existing session ID per the rest of the given request. The session ID is optional, and is passed as ``PMIX_ALLOC_ID``.
 
-* ``--shrink <arg0>``: Shrink the specified existing session ID per the rest of the given request.
+* ``--shrink [<arg0>]``: Shrink the specified existing session ID per the rest of the given request. The session ID is optional, and is passed as ``PMIX_ALLOC_ID``.
 
 * ``--no-shell``: Immediately exit after allocating resources, without running a command.
 

--- a/docs/man/man1/palloc.1.rst
+++ b/docs/man/man1/palloc.1.rst
@@ -108,6 +108,8 @@ OPTIONS
 
 * ``--do-not-wait``: Submit the allocation request to the scheduler, but do not wait for the allocation to be assigned. Intended for use when submitting a job for batch execution.
 
+* ``--activate <arg0>``: Bring resources this requestor already holds into service - e.g., start a daemon on an allocated node the runtime is not yet spanning. Takes a comma-delimited list of host names. Nothing is asked of the scheduler and nothing is added to the allocation, so this may be honored where a request for new resources cannot be.
+
 
 EXIT STATUS
 -----------

--- a/docs/man/man3/PMIx_Allocation_request.3.rst
+++ b/docs/man/man3/PMIx_Allocation_request.3.rst
@@ -135,6 +135,11 @@ identifies the requested operation:
 * ``PMIX_ALLOC_REAQUIRE`` |mdash| reacquire resources that were previously
   "lent" back to the scheduler.
 * ``PMIX_ALLOC_REQ_CANCEL`` |mdash| cancel the indicated allocation request.
+* ``PMIX_ALLOC_ACTIVATE`` |mdash| bring resources the requestor already holds
+  into service |mdash| e.g., start a daemon on an allocated node the runtime is
+  not yet spanning so that jobs can be launched there. Nothing is asked of the
+  scheduler and nothing is added to the allocation, so a host environment may
+  honor this request where it must refuse a request for new resources.
 
 Values at or above ``PMIX_ALLOC_EXTERNAL`` are reserved for
 implementer-defined directives.
@@ -269,6 +274,17 @@ Controlling ownership, sharing, and inheritance:
 * ``PMIX_ALLOC_INHERITANCE`` (pmix_alloc_inheritance_t) |mdash| inheritance
   rules to be applied to the allocated resources. If not provided, defaults to
   ``PMIX_ALLOC_INHERIT_DEFAULT``.
+
+Naming the resources to be activated (for the ``PMIX_ALLOC_ACTIVATE``
+directive):
+
+* ``PMIX_HOST`` (char*) |mdash| comma-delimited list of hosts to activate.
+* ``PMIX_HOSTFILE`` (char*) |mdash| hostfile naming the hosts to activate.
+
+At least one of the two must be given. The host environment interprets them
+exactly as it interprets the same attributes elsewhere, and it may accept
+additional forms within them; it is required to refuse any host the requestor
+does not already hold, since granting one would be an allocation.
 
 On successful completion of a request for additional resources, the returned
 data includes ``PMIX_ALLOC_ID`` (char*), a host-provided string identifier for

--- a/docs/man/man5/pmix_alloc_directive_t.5.rst
+++ b/docs/man/man5/pmix_alloc_directive_t.5.rst
@@ -24,6 +24,7 @@ C Syntax
    #define PMIX_ALLOC_RELEASE      3
    #define PMIX_ALLOC_REAQUIRE     4
    #define PMIX_ALLOC_REQ_CANCEL   5
+   #define PMIX_ALLOC_ACTIVATE     6
 
    /* define a value boundary beyond which implementers are free
     * to define their own directive values */
@@ -56,6 +57,16 @@ allocation request passed to
 
 ``PMIX_ALLOC_REQ_CANCEL`` (5)
    Cancel the indicated allocation request.
+
+``PMIX_ALLOC_ACTIVATE`` (6)
+   Bring resources the requestor already holds into service |mdash| for
+   example, start a daemon on an allocated node the runtime is not yet
+   spanning, so that jobs can be launched there. The resources are named
+   with ``PMIX_HOST`` and/or ``PMIX_HOSTFILE`` in the accompanying
+   :ref:`pmix_info_t(5) <man5-pmix_info_t>` array. Nothing is asked of the
+   scheduler and nothing is added to the allocation, so a host environment
+   may honor this request where it must refuse a request for new resources
+   |mdash| e.g., inside an allocation the scheduler owns.
 
 Values at or above ``PMIX_ALLOC_EXTERNAL`` (128) define a boundary beyond
 which implementers are free to define their own directive values.

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1998,6 +1998,11 @@ typedef uint8_t pmix_alloc_directive_t;
                                     // for some period of time.
 #define PMIX_ALLOC_REAQUIRE     4   // reacquire resources that were previously "lent" back to the scheduler
 #define PMIX_ALLOC_REQ_CANCEL   5   // Cancel the indicated allocation request
+#define PMIX_ALLOC_ACTIVATE     6   // Bring resources the requestor already holds into service - e.g., start
+                                    // a daemon on an allocated node the runtime is not yet spanning. The nodes
+                                    // are named with PMIX_HOST and/or PMIX_HOSTFILE. Nothing is asked of the
+                                    // scheduler and nothing is added to the allocation, so this may be honored
+                                    // where a request for new resources cannot be
 
 /* define a value boundary beyond which implementers are free
  * to define their own directive values */

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Jeff Squyres  All rights reserved.
  * $COPYRIGHT$
  *
@@ -213,6 +213,8 @@ PMIX_EXPORT const char *PMIx_Alloc_directive_string(pmix_alloc_directive_t direc
         return "REACQUIRE";
     case PMIX_ALLOC_REQ_CANCEL:
         return "CANCEL REQUEST";
+    case PMIX_ALLOC_ACTIVATE:
+        return "ACTIVATE";
     default:
         return "UNSPECIFIED";
     }

--- a/src/tools/palloc/help-palloc.txt
+++ b/src/tools/palloc/help-palloc.txt
@@ -87,6 +87,9 @@ PMIx Allocation Request tool
                                      completed.
    --do-not-wait                     Submit the allocation request to the scheduler, but do not wait for the allocation
                                      to be assigned. Intended for use when submitting a job for batch execution.
+   --activate <arg0>                 Bring resources this requestor already holds into service - e.g., start a
+                                     daemon on an allocated node the runtime is not yet spanning. Takes a
+                                     comma-delimited list of host names.
 
 The command returns the string session ID of the resulting allocation, or if executed with the "do-not-wait" option, the
 string session ID of the allocation request as assigned by the scheduler. Any command line arguments following the provided
@@ -322,3 +325,18 @@ will be scheduled.
 Submit the allocation request to the scheduler, but do not wait for the allocation
 to be assigned. Intended for use when submitting a job for batch execution. Users
 should provide a string request ID to enable subsequent queries of request status.
+#
+[activate]
+Bring resources this requestor already holds into service. The canonical case
+is a node that belongs to the allocation but has no daemon on it, so nothing
+can be launched there: activating it starts the daemon and brings the node into
+the runtime.
+
+The argument is a comma-delimited list of host names. Nothing is asked of the
+scheduler and nothing is added to the allocation - only resources the requestor
+already holds can be named - so this may be honored where a request for new
+resources cannot be, including inside an allocation the scheduler owns.
+
+The host list is interpreted by the host environment, which may accept forms
+beyond bare names (a hostfile, or a relative reference into the allocation).
+See that environment's documentation for what it accepts.

--- a/src/tools/palloc/help-palloc.txt
+++ b/src/tools/palloc/help-palloc.txt
@@ -78,8 +78,8 @@ PMIx Allocation Request tool
    --signal <arg0>[@arg1]            Send all processes executing within the allocated session the specified signal
                                      when it reaches the (optional) specified seconds of its end time.
 -s|--share                           Allocated resources can be shared with other allocations.
-   --extend   <arg0>                 Extend the specified existing session ID per the rest of the given request.
-   --shrink <arg0>                   Shrink the specified existing session ID per the rest of the given request.
+   --extend [<arg0>]                 Extend the specified existing session ID per the rest of the given request.
+   --shrink [<arg0>]                 Shrink the specified existing session ID per the rest of the given request.
    --no-shell                        Immediately exit after allocating resources, without running a command.
    --begin <arg0>                    Direct the scheduler to defer allocation until the specified time.
 -I|--immediate <arg0>                Exit if resources are not available within the time period specified.
@@ -275,12 +275,20 @@ Allocated resources can be shared with other allocations.
 Extend the specified existing session ID per the rest of the given request.
 For example, an existing session can have additional nodes allocated to
 it, or could have its time limit increased.
+
+The session ID is optional here, and is passed as PMIX_ALLOC_ID. Omit it
+where the rest of the request identifies the allocation - e.g. with
+"--request-id", the requestor's own identifier for it.
 #
 [shrink]
 Shrink the specified existing session ID per the rest of the given request.
 For example, an existing session could have a certain number of nodes
 removed (returning them to the scheduler for reassignment), or its
 time reduced.
+
+The session ID is optional here, and is passed as PMIX_ALLOC_ID. Omit it
+where the rest of the request identifies the allocation - e.g. with
+"--request-id", the requestor's own identifier for it.
 #
 [no-shell]
 Immediately exit after allocating resources, without running a command.

--- a/src/tools/palloc/palloc.c
+++ b/src/tools/palloc/palloc.c
@@ -84,8 +84,8 @@ static struct option pallocptions[] = {
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_TIME, PMIX_ARG_REQD, 't'),
     PMIX_OPTION_DEFINE(PMIX_CLI_SIGNAL, PMIX_ARG_REQD),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_SHARE, PMIX_ARG_NONE, 's'),
-    PMIX_OPTION_DEFINE(PMIX_CLI_EXTEND, PMIX_ARG_NONE),
-    PMIX_OPTION_DEFINE(PMIX_CLI_SHRINK, PMIX_ARG_NONE),
+    PMIX_OPTION_DEFINE(PMIX_CLI_EXTEND, PMIX_ARG_OPTIONAL),
+    PMIX_OPTION_DEFINE(PMIX_CLI_SHRINK, PMIX_ARG_OPTIONAL),
     PMIX_OPTION_DEFINE(PMIX_CLI_NO_SHELL, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PMIX_CLI_BEGIN, PMIX_ARG_REQD),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_IMMEDIATE, PMIX_ARG_OPTIONAL, 'I'),
@@ -96,6 +96,25 @@ static struct option pallocptions[] = {
     PMIX_OPTION_END
 };
 static char *pallocshorts = "h::vVq:N:i:x:w:t:I::d:";
+
+/* --extend and --shrink name the allocation they operate on, which is what
+ * PMIX_ALLOC_ID says.  The value is optional: both options are documented as
+ * taking a session id, but neither used to accept one at all, so a command
+ * line that gave none has to keep working. */
+static pmix_status_t add_alloc_id(void *options, pmix_cli_item_t *opt)
+{
+    pmix_status_t rc;
+
+    if (NULL == opt->values || NULL == opt->values[0]) {
+        return PMIX_SUCCESS;
+    }
+    PMIX_INFO_LIST_ADD(rc, options, PMIX_ALLOC_ID, opt->values[0], PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx info list add failed: %s\n", PMIx_Error_string(rc));
+        PMIX_INFO_LIST_RELEASE(options);
+    }
+    return rc;
+}
 
 static void cbfunc(pmix_status_t status,
                    pmix_info_t *info, size_t ninfo,
@@ -468,10 +487,18 @@ int main(int argc, char **argv)
 
     if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_EXTEND))) {
         directive = PMIX_ALLOC_EXTEND;
+        rc = add_alloc_id(options, opt);
+        if (PMIX_SUCCESS != rc) {
+            goto done;
+        }
     }
 
     if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_SHRINK))) {
         directive = PMIX_ALLOC_RELEASE;
+        rc = add_alloc_id(options, opt);
+        if (PMIX_SUCCESS != rc) {
+            goto done;
+        }
     }
 
     if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_ACTIVATE))) {

--- a/src/tools/palloc/palloc.c
+++ b/src/tools/palloc/palloc.c
@@ -91,6 +91,7 @@ static struct option pallocptions[] = {
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_IMMEDIATE, PMIX_ARG_OPTIONAL, 'I'),
     PMIX_OPTION_SHORT_DEFINE(PMIX_CLI_DEPENDENCY, PMIX_ARG_REQD, 'd'),
     PMIX_OPTION_DEFINE(PMIX_CLI_DO_NOT_WAIT, PMIX_ARG_NONE),
+    PMIX_OPTION_DEFINE(PMIX_CLI_ACTIVATE, PMIX_ARG_REQD),
 
     PMIX_OPTION_END
 };
@@ -471,6 +472,20 @@ int main(int argc, char **argv)
 
     if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_SHRINK))) {
         directive = PMIX_ALLOC_RELEASE;
+    }
+
+    if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_ACTIVATE))) {
+        /* Bring resources we already hold into service.  Nothing is asked of
+         * the scheduler, so this carries no allocation request attributes at
+         * all - only the hosts to activate, named the way hosts are named
+         * everywhere else. */
+        directive = PMIX_ALLOC_ACTIVATE;
+        PMIX_INFO_LIST_ADD(rc, options, PMIX_HOST, opt->values[0], PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "PMIx info list add failed: %s\n", PMIx_Error_string(rc));
+            PMIX_INFO_LIST_RELEASE(options);
+            goto done;
+        }
     }
 
     if (NULL != (opt = pmix_cmd_line_get_param(&results, PMIX_CLI_NO_SHELL))) {

--- a/src/util/convert-help.py
+++ b/src/util/convert-help.py
@@ -103,7 +103,14 @@ def parse_help_files(file_paths, data, citations, verbose=False):
         current_section = None
         with open(file_path) as file:
             for line in file:
-                stripped = line.strip()
+                # rstrip only: a content line's leading whitespace is part of
+                # the message (help text lays its option table out in columns),
+                # and stripping it also made an INDENTED line beginning with
+                # '[' - e.g. a usage line reading "[e.g., host0[1-5]]" - look
+                # like a section header, which silently truncated the section
+                # it appeared in and put the remainder under a bogus topic.
+                # Section headers start in column zero.
+                stripped = line.rstrip()
                 if stripped.startswith("#include"):
                     # if we aren't in a section, then this is an error
                     if current_section is None:

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -203,6 +203,7 @@ typedef struct {
 #define PMIX_CLI_IMMEDIATE              "immediate"                 // optional, short is 'I'
 #define PMIX_CLI_DEPENDENCY             "dependency"                // required, short is 'd'
 #define PMIX_CLI_DO_NOT_WAIT            "do-not-wait"               // none
+#define PMIX_CLI_ACTIVATE               "activate"                  // required
 
 // Job control options
 #define PMIX_CLI_PAUSE                  "pause"                     // none


### PR DESCRIPTION
### The problem

A runtime does not necessarily span every node of its allocation. A launcher told to form its virtual machine across a subset leaves the rest allocated, up, and unusable; so does a released reservation handed back without a daemon. Bringing such a node into service asks the scheduler for nothing — the requestor already holds it — but there has been no way to say so.

Every existing allocation directive is a request to *change* what is held, so a caller that only wants a daemon started where it may already launch has had to either misuse one of those or fall back on whatever private key its host environment happens to accept. PRRTE, for instance, carries the directive today as a private spawn key reachable only from a command line.

### The change

`PMIX_ALLOC_ACTIVATE` (value 6) says exactly that, naming its resources with `PMIX_HOST` and/or `PMIX_HOSTFILE` — the attributes that already mean "these hosts" and "this hostfile" everywhere else. Because it can name nothing the requestor was not already granted, a host environment may honor it where it must refuse a request for new resources — inside an allocation the scheduler owns, for example.

`palloc` grows the matching `--activate` option so the directive is reachable from a command line, `PMIx_Alloc_directive_string()` learns to name it, and the man pages, `exceptions.rst`, and the schedulers/inheritance guides document it.

### Two drive-by fixes in the same area

* **The in-memory help converter read every line with `str.strip()`.** The leading whitespace is part of the message — a usage block lays its options out in columns — and, worse, a content line that began with `[` after that strip was taken for a section header. palloc's usage text contains an indented `[e.g., host0[1-5],host128]`, so everything after it was filed under a bogus topic and `palloc --help` printed a usage message that stopped in the middle of an option. Section headers begin in column zero, so `rstrip` is the correct reading.

* **`palloc --extend` and `--shrink` could not name their allocation.** Both are documented as taking the session ID they operate on, and the option table declared them as taking no argument — so the ID a user wrote was read as the command to run inside the allocation, and there was no other way to put a `PMIX_ALLOC_ID` on a palloc request at all. They now accept it (optionally, since a command line that gave none has always been accepted) and pass it as `PMIX_ALLOC_ID`.

### Testing

`make check` clean (96 + 21 tests), docs build warning-free, and the directive driven end to end against a PRRTE DVM — granted, refused for a host the DVM does not hold, refused for a slot count, satisfied for a node already in service. The host-side implementation is openpmix/prrte#2721.