### PR TITLE
Add PMIX_SPAWN_ALLOC: let a spawn carry the allocation it needs

### DIFF
--- a/contrib/construct_dictionary.py
+++ b/contrib/construct_dictionary.py
@@ -337,6 +337,8 @@ def harvest_constants(options, path, constants):
                             datatype = "PMIX_DOUBLE"
                         elif tokens[3] == "(pmix_alloc_inheritance_t)":
                             datatype = "PMIX_ALLOC_INHERIT"
+                        elif tokens[3] == "(pmix_alloc_directive_t)":
+                            datatype = "PMIX_ALLOC_DIRECTIVE"
                         else:
                             print("UNKNOWN TOKEN: {tok}".format(tok=tokens[3]))
                             return 1

--- a/contrib/dictionary_ids.txt
+++ b/contrib/dictionary_ids.txt
@@ -692,3 +692,5 @@ pmix.jctrl.ckpttime    661   PMIX_JOB_CTRL_CHECKPOINT_TIMEOUT
 pmix.fabdev.coord      662   PMIX_FABRIC_DEVICE_COORDINATES
 pmix.spwn.root         663   PMIX_SPAWN_TREE_ROOT
 pmix.spwn.actv         664   PMIX_SPAWN_TREE_ACTIVE
+pmix.spwn.alloc        665   PMIX_SPAWN_ALLOC
+pmix.alloc.dir         666   PMIX_ALLOC_REQ_DIRECTIVE

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1263,6 +1263,36 @@ Attributes
        form of a comma separated list of
        "MAJOR.MINOR" pairs
 
+   * - ``PMIX_SPAWN_ALLOC`` ``pmix.spwn.alloc``
+     - ``(pmix_data_array_t*)``
+     - An entire allocation request, to be
+       executed before the applications are
+       spawned - the host obtains the
+       allocation, waits for it, and only
+       then spawns into it. The array is of
+       pmix_info_t and begins with the
+       request's directive
+       (PMIX_ALLOC_REQ_DIRECTIVE); the
+       remaining elements are the info array
+       the request would have carried had it
+       been passed to
+       PMIx_Allocation_request. The spawn is
+       not attempted if the allocation is
+       refused (PMIX_ERR_JOB_ALLOC_FAILED is
+       returned instead), and a spawn that
+       then fails releases the allocation it
+       obtained
+
+   * - ``PMIX_ALLOC_REQ_DIRECTIVE`` ``pmix.alloc.dir``
+     - ``(pmix_alloc_directive_t)``
+     - The directive of an allocation request
+       that is being carried as data rather
+       than passed to the allocation API -
+       see PMIX_SPAWN_ALLOC. The API takes
+       its directive as a parameter, so this
+       exists to say the same thing where
+       there is no parameter to say it in
+
 .. note:: The attribute ``PMIX_DEBUG_STOP_IN_APP`` has been modified
           to only support a ``PMIX_BOOL`` value instead of an optional
           array of ranks due to questions over the use-case calling

--- a/docs/man/man3/PMIx_Spawn.3.rst
+++ b/docs/man/man3/PMIx_Spawn.3.rst
@@ -190,6 +190,22 @@ operation. Placement, mapping, and resource selection:
 * ``PMIX_SPAWN_TARGET`` (varies) |mdash| specify the allocation(s) to use when
   mapping the applications. The value is a ``char*`` ``PMIX_ALLOC_ID``, or a
   ``pmix_data_array_t`` of such allocation-ID strings.
+* ``PMIX_SPAWN_ALLOC`` (pmix_data_array_t\*) |mdash| an entire allocation
+  request, to be executed *before* the applications are spawned: the host
+  obtains the allocation, waits for it, and only then spawns into it. The array
+  is of :ref:`pmix_info_t(5) <man5-pmix_info_t>` and begins with the request's
+  directive (``PMIX_ALLOC_REQ_DIRECTIVE``, a
+  :ref:`pmix_alloc_directive_t(5) <man5-pmix_alloc_directive_t>`); the
+  remaining elements are the info array the request would have carried had it
+  been passed to
+  :ref:`PMIx_Allocation_request(3) <man3-PMIx_Allocation_request>`. This saves
+  a caller the two-step of asking a scheduler for an allocation and then
+  invoking a launcher inside it |mdash| issuing the allocation request itself,
+  waiting for it, and only then spawning |mdash| and, more importantly, makes
+  the two operations one thing that either happens or does not: the spawn is
+  not attempted if the allocation is refused, and an allocation obtained for a
+  spawn that then fails is released again. See `RETURN VALUE`_ for how the
+  caller tells the two failures apart.
 * ``PMIX_APP_ARGV`` (char\*) |mdash| the consolidated ``argv`` passed to the spawn
   command for the given application.
 * ``PMIX_INDEX_ARGV`` (bool) |mdash| mark each process's ``argv`` with the rank of
@@ -460,7 +476,9 @@ processing; the final status and assigned namespace are delivered to ``cbfunc``.
 
 * ``PMIX_SUCCESS`` |mdash| the job was successfully launched.
 * ``PMIX_ERR_JOB_ALLOC_FAILED`` |mdash| the job could not be executed due to
-  failure to obtain the specified allocation.
+  failure to obtain the specified allocation |mdash| the allocation request
+  carried by ``PMIX_SPAWN_ALLOC`` was refused, or timed out. Nothing was
+  launched, and this is what distinguishes that outcome from a launch failure.
 * ``PMIX_ERR_JOB_APP_NOT_EXECUTABLE`` |mdash| the specified executable could not be
   found or lacks execution privileges.
 * ``PMIX_ERR_JOB_NO_EXE_SPECIFIED`` |mdash| the request did not specify an

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -600,6 +600,17 @@ typedef uint32_t pmix_rank_t;
                                                                     //           (a) char* - PMIX_ALLOC_ID of the target allocation
                                                                     //           (b) a pmix_data_array_t of char* allocation IDs
                                                                     //         Note that an invalid nspace equates to the "default" allocation
+#define PMIX_SPAWN_ALLOC                    "pmix.spwn.alloc"       // (pmix_data_array_t*) An entire allocation request, to be executed
+                                                                    //         BEFORE the applications are spawned - the host obtains the
+                                                                    //         allocation, waits for it, and only then spawns into it. The array
+                                                                    //         is of pmix_info_t and begins with the request's directive
+                                                                    //         (PMIX_ALLOC_REQ_DIRECTIVE); the remaining elements are the info
+                                                                    //         array the request would have carried had it been passed to
+                                                                    //         PMIx_Allocation_request. The spawn is not attempted if the
+                                                                    //         allocation is refused: PMIX_ERR_JOB_ALLOC_FAILED is returned
+                                                                    //         instead, which is how the caller tells that outcome from a launch
+                                                                    //         failure. A spawn that then fails releases the allocation it
+                                                                    //         obtained before returning
 
 
 /* query keys - value type shown is the type of the value that will be RETURNED by that key  */
@@ -921,6 +932,11 @@ typedef uint32_t pmix_rank_t;
                                                                       //                 character, creating the envar if it doesn't already exist
 
 /* attributes relating to allocations */
+#define PMIX_ALLOC_REQ_DIRECTIVE            "pmix.alloc.dir"        // (pmix_alloc_directive_t) The directive of an allocation request that is
+                                                                    //         being carried as data rather than passed to the allocation API -
+                                                                    //         see PMIX_SPAWN_ALLOC. The API takes its directive as a parameter,
+                                                                    //         so this exists to say the same thing where there is no parameter
+                                                                    //         to say it in.
 #define PMIX_ALLOC_REQ_ID                   "pmix.alloc.reqid"      // (char*) User-provided string identifier for this allocation request
                                                                     //         which can later be used to query status of the request.
 #define PMIX_ALLOC_ID                       "pmix.alloc.id"         // (char*) A string identifier (provided by the host environment) for


### PR DESCRIPTION
### The problem

A caller that needs resources before it can launch has to issue `PMIx_Allocation_request` itself, wait for it, read the allocation id out of the answer, and then spawn with `PMIX_SPAWN_TARGET` naming it. Four steps, written the same way by everyone.

Worse than the ceremony is that the two operations are unrelated as far as the host is concerned. Nothing ties the allocation to the spawn it was obtained for, so there is a window in which resources are held for a job that does not exist yet — and if the spawn fails, for one that never will. Every caller has to write the same unwind by hand.

### The change

`PMIX_SPAWN_ALLOC` carries the whole request on the spawn instead, letting the host obtain the allocation, wait for it, and only then execute the spawn.

The value is a `pmix_data_array_t` of `pmix_info_t` beginning with the request's directive — `PMIX_ALLOC_REQ_DIRECTIVE`, a new attribute that exists because the allocation API takes its directive as a *parameter* and there is no parameter here to say it in — followed by exactly the info array that request would have carried.

Two outcomes have to be tellable apart, and are:

* an allocation that is **refused** fails the spawn with `PMIX_ERR_JOB_ALLOC_FAILED`, which `PMIx_Spawn`'s return values already describe as "could not be executed due to failure to obtain the specified allocation", and nothing is launched;
* a spawn that **fails after the grant** releases that allocation before returning its own error, so the caller is not left holding resources for a job that does not exist.

The dictionary generator learns `pmix_alloc_directive_t`, which no attribute had used as a value type before.

### Testing

`make check` clean, docs build warning-free, and the attribute driven end to end against a PRRTE DVM (both single-host and across a ten-node container swarm): granted and launched on the node it allocated; refused, with nothing launched; malformed, answered as a bad parameter; and granted-then-failed, which hands the allocation back.

The host-side implementation is openpmix/prrte#2722.