### PR TITLE
Stop trapping signals in the library

### DIFF
--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -111,14 +111,42 @@ Four more things about the stdin side that are easy to get wrong:
   ended up with two read events on fd 0 stealing bytes from each other,
   and `pmix_iof_flow_control` — which only knows `stdinev_global` — could
   not suspend a tool's stdin at all.
-- **The SIGCONT event belongs on `evbase`, and it has to be *added*.**
-  Its handler is `pmix_iof_stdin_cb`, which resolves `stdinev_global` and
-  arms or disarms that read event — all state `evbase` owns — so putting
-  the signal on `evauxbase` (which a host may supply as a *different*
-  thread) races the progress thread. And `pmix_event_signal_set` only
-  *assigns* an event; without a matching `pmix_event_add` the handler
-  never runs, which is how a tool started in the background can end up
-  never reading stdin at all after it is foregrounded.
+- **Do not trap a signal to notice the terminal changing hands — poll
+  for it.** PMIx is a library, and the signal dispositions of a process
+  belong to whoever wrote its `main()`. This file used to arm a `SIGCONT`
+  event to learn when a backgrounded process had been foregrounded again
+  and could resume reading its stdin, and that cost the host two things.
+  First, libevent keeps a *single process-wide* record of which event
+  base owns signals (`evsig_base` in its `signal.c`), re-claimed both by
+  adding a signal event and by entering `event_base_loop`; the OS handler
+  writes the signal number into whichever base holds it at that instant,
+  and a base with no event for that signal **drops it**. So our SIGCONT
+  event did not merely draw libevent's "Only one can have signals at a
+  time" warning — it swallowed the host's signals, and only when stdin
+  was a tty, which is what made it so hard to see. In PRRTE the casualty
+  was `SIGCHLD`: `prterun -n 1 head -1` typed at a terminal never
+  returned, because the reap notice for the application arrived at us and
+  we had no use for it (prrte issue #2709). Second, a host that does not
+  use libevent at all has its own disposition for that signal replaced
+  from under it by a library it merely linked. `stdin_resume_arm()` is
+  the replacement — an evtimer on `evbase` — and **the two rules that
+  bound its cost are the price of doing this at all, so do not relax
+  them**: it exists only when a host has asked us to forward its stdin
+  (`pmix_iof_setup_stdin_read()` is the sole thing that can arm it), and
+  only while that stdin is suspended for being in the *background*. A run
+  that forwards no stdin, or that has its terminal, sets no timer at all,
+  and an XOFF suspension is deliberately not polled either — that one ends
+  with an XON that calls `pmix_iof_stdin_cb` back. The delay then doubles
+  from `pmix_iof_stdin_resume_interval` (100 ms) to
+  `pmix_iof_stdin_resume_max_interval` (2 s), so an `fg` a moment later is
+  answered promptly while a process left in the background all day settles
+  to the ceiling instead of holding a fixed rate forever;
+  `stdin_resume_cancel()` puts it back to the floor. Polling gives up
+  nothing — the terminal buffers what is typed while we are not reading,
+  so the interval bounds latency and not data — and it is strictly more
+  reliable than the signal was, because nothing guarantees a SIGCONT
+  accompanies every change of the terminal's foreground process group
+  while `tcgetpgrp()` answers the actual question every time.
 - **`stdinev_global` and `stdinsig_ev` are process-wide, not per
   request**, so nothing in the request machinery ever gives them back.
   `pmix_iof_finalize()` does, and `pmix_rte_finalize` calls it **while
@@ -489,24 +517,50 @@ execs — and carries hazards the request files do not:
   functions before exec. Be very wary of adding `malloc`-backed calls
   (`opendir`/`readdir`, `pmix_show_help`, `pmix_output*`, `fprintf`) into
   that window — they can deadlock on a lock another thread held at fork.
-- **SIGCHLD runs on `evauxbase`; the `children` list belongs to
-  `evbase`.** The SIGCHLD handler is installed on
-  `pmix_globals.evauxbase` (a host may supply this via
-  `PMIX_EXTERNAL_AUX_EVENT_BASE`, in which case it is a *different*
-  thread than `evbase`, where spawn/kill/signal/complete run). Because of
-  that, `wait_signal_callback` must not touch the `children` list
-  directly: it `waitpid`s (process-global, thread-safe) and then
-  `PMIX_THREADSHIFT`s each reaped `(pid, status)` to `child_reaped` on
-  `evbase`, which does the list work. Preserve that split — do not move
-  list access back into the signal handler.
+- **Reaping is a poll of our own pids, not a SIGCHLD handler, and not a
+  `waitpid(-1)` sweep.** Both halves of what this used to be were wrong
+  for a library. The SIGCHLD event took the signal away from the host —
+  libevent keeps one process-wide record of which base owns signals, so a
+  second base carrying signals swallows the first's — and the handler's
+  `waitpid(-1)` took the host's *children*, reaping procs it had forked
+  and discarding their status, because a pid we do not recognize is
+  silently dropped. PRRTE's own SIGCHLD handler does exactly the same
+  sweep, so in one process the two stole from each other and whichever
+  lost never heard that its child had died (prrte issue #2709 reached
+  this way as well as through the stdin SIGCONT above).
+
+  `child_poll()` asks `waitpid(pid, WNOHANG)` about each of our own
+  children instead, and the three answers are complete: `0` alive, the
+  pid dead-with-status, `ECHILD` dead-with-status-lost to whoever reaped
+  first (a host sweeping, or one that set `SIGCHLD` to `SIG_IGN`). Per-pid
+  cannot stop a host from taking our children, but we always learn of the
+  death — which the sweep could not do, since its loser got nothing at
+  all. Say so rather than reporting a zero we did not observe.
+
+  It runs on `evbase`, which is also where the `children` list lives, so
+  there is nothing to thread-shift any more. **The two rules that bound
+  the timer's cost are the same as the stdin poll's, and matter as much:**
+  it exists only while we hold a child the host asked us to fork, and the
+  delay backs off from `pfexec_base_poll_interval` (50 ms) to
+  `pfexec_base_poll_max_interval` (1 s). The common case rarely waits for
+  it at all — `pmix_iof.c`'s read handler calls `pmix_pfexec_reap_check()`
+  when a child's last output pipe hits EOF, which for a child that
+  forwards its output is normally the moment it died.
+
+  One trap when touching `pfexec_poll_arm()`: `pmix_event_evtimer_set` is
+  `event_assign`, which libevent forbids on an event that is still
+  pending. Arming therefore takes the timer down first rather than
+  trusting `poll_active`. Getting that wrong does not fail loudly — it
+  corrupts the base's timer heap, and `make check` hangs.
 - **Do not block the progress thread.** Handlers run as events, so a
   `sleep()` inside one freezes all event processing. The kill sequence
   (SIGCONT → pause → SIGTERM → pause → SIGKILL) is therefore an
   evtimer-driven state machine (`kill_proc` → `kill_stage2` →
   `kill_stage3`), not a pair of `sleep()`s — keep it that way.
-- **`wait_signal_callback` reaps every child of the process**
-  (`waitpid(-1, ...)`), not just pfexec's — keep that in mind if you add
-  another `waitpid` consumer.
+- **`child_poll` waits only on pids we forked** — never `waitpid(-1)`,
+  which is what it used to do and which reaps whatever the host forked
+  too. Keep it that way if you add another `waitpid` consumer: in a
+  process that has more than one, `-1` is theft.
 - **A `pmix_pfexec_child_t` has more than one owner, and the
   `children` list is only one of them.** The list holds a reference; so
   does every caddy that carries the child across an event boundary —
@@ -522,7 +576,7 @@ execs — and carries hazards the request files do not:
   because that function only reports a missing item under
   `PMIX_ENABLE_DEBUG` — in a release build it splices the list using the
   item's stale pointers and decrements the length again, which silently
-  corrupts the list this file's SIGCHLD early-out reads (see below).
+  corrupts the list `child_poll()` walks.
   Getting this wrong is not a leak, it is a double free plus a kill
   sequence reading `->pid` out of freed memory to decide what to signal.
 
@@ -551,16 +605,21 @@ than just hardening it:
 
 ### Known, deliberate, not a defect
 
-`wait_signal_callback` in `pmix_pfexec.c` reads
-`pmix_list_get_size(&pmix_pfexec_globals.children)` as an early-out, and it
-runs on `evauxbase` while that list belongs to `evbase`. That is a formal
-data race. It is left alone on purpose: the child is appended to the list
-before the `fork()` that can generate its `SIGCHLD`, so the count cannot be
-stale for a child we care about, and removing the guard would make pfexec
-`waitpid(-1)` on every `SIGCHLD` in a process that currently has no
-children of its own. If you do restructure it, replace the read with a
-counter maintained rather than deleting the check — the removals are all
-funnelled through `child_delist()` now, so there is one place to do it.
+`plog/smtp` still saves, ignores and restores `SIGPIPE` around its
+`smtp_start_session()` call — the one place in the library that touches a
+process-wide signal disposition. That is libESMTP's requirement, not
+ours: it writes to a socket the remote server may drop at any moment, it
+sets neither `MSG_NOSIGNAL` nor `SO_NOSIGPIPE` on the sockets it owns,
+and it documents that the *application* must ignore `SIGPIPE`. The
+thread-safe form is `pthread_sigmask` — `SIGPIPE` from `write()` is
+raised synchronously to the writing thread, so blocking it there never
+reaches the host — but that needs a drain (`sigtimedwait` with a zero
+timeout) or a `SIGPIPE` raised while blocked stays pending on the thread
+and kills the process the moment the mask is restored, and `sigtimedwait`
+does not exist on macOS. It is left as it is because the component only
+builds with `--with-smtp`, the change is scoped to one call, and it
+restores what it changed. Do it the `pthread_sigmask` way if this ever
+moves onto a path that runs by default.
 
 ## Building and testing
 

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -507,9 +507,21 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_deregister(size_t iofhdlr, const pmix_info_t 
     return rc;
 }
 
-static pmix_event_t stdinsig_ev;
-static bool stdinsig_active = false;
+/* The read event on our own stdin, and the timer that re-arms it.
+ *
+ * When our stdin is a terminal we must not read it while we are in the
+ * background: the read would raise SIGTTIN and stop the process. So the
+ * read event is disarmed whenever pmix_iof_stdin_check() says the
+ * terminal's foreground process group is not ours, and something has to
+ * notice when we get it back. That something used to be a SIGCONT
+ * handler; it is now this timer, armed only while we are suspended for
+ * that reason. See stdin_resume_arm() for why. */
+static pmix_event_t stdin_resume_ev;
+static bool stdin_resume_active = false;
+static int stdin_resume_delay = 0;
 static pmix_iof_read_event_t *stdinev_global = NULL;
+static void stdin_resume_arm(void);
+static void stdin_resume_cancel(void);
 
 /* Give back what the stdin machinery here holds process-wide.
  *
@@ -526,10 +538,7 @@ static pmix_iof_read_event_t *stdinev_global = NULL;
  */
 void pmix_iof_finalize(void)
 {
-    if (stdinsig_active) {
-        pmix_event_del(&stdinsig_ev);
-        stdinsig_active = false;
-    }
+    stdin_resume_cancel();
     if (NULL != stdinev_global) {
         PMIX_RELEASE(stdinev_global);
         stdinev_global = NULL;
@@ -546,14 +555,15 @@ void pmix_iof_finalize(void)
     pmix_globals.iof_pending_bytes = 0;
 }
 
-/* Start reading our own stdin into stdinev_global, arming the SIGCONT
- * handler when we are looking at a terminal.
+/* Start reading our own stdin into stdinev_global, arming the
+ * foreground poll when we are looking at a terminal we do not currently
+ * own.
  *
  * Both of the roles that forward their own stdin come through here:
  * PMIx_IOF_push with PMIX_IOF_PUSH_STDIN, and a tool told PMIX_FWD_STDIN
  * at init. They used to keep a copy each and the copies drifted - the
- * tool's never added its SIGCONT event (so a backgrounded tool never
- * resumed reading), never gave its read event back, and kept it in a
+ * tool's never armed the background check at all (so a backgrounded tool
+ * never resumed reading), never gave its read event back, and kept it in a
  * file-scope struct of its own that pmix_iof_flow_control cannot see, so
  * nothing could suspend a tool's stdin. Sharing stdinev_global also
  * enforces the thing that matters in its own right: one read event per
@@ -596,26 +606,12 @@ pmix_status_t pmix_iof_setup_stdin_read(int fd, pmix_proc_t procs[], size_t npro
     }
 
     if (isatty(fd)) {
-        /* We should avoid trying to read from stdin if we
-         * have a terminal, but are backgrounded.  Catch the
-         * signals that are commonly used when we switch
-         * between being backgrounded and not.  If the
-         * filedescriptor is not a tty, don't worry about it
-         * and always stay connected.
+        /* We should avoid trying to read from stdin if we have a
+         * terminal, but are backgrounded - the read would raise SIGTTIN.
+         * If the filedescriptor is not a tty, don't worry about it and
+         * always stay connected.
          *
-         * The handler resolves and manipulates stdinev_global and its
-         * libevent registration, both of which belong to evbase - so the
-         * signal event goes there too rather than on evauxbase, which a
-         * host may have supplied as a separate thread. And it has to be
-         * *added*: setting a signal event only assigns it.
-         */
-        pmix_event_signal_set(pmix_globals.evbase, &stdinsig_ev, SIGCONT,
-                              pmix_iof_stdin_cb, NULL);
-        if (0 == pmix_event_add(&stdinsig_ev, NULL)) {
-            stdinsig_active = true;
-        }
-
-        /* setup a read event to read stdin, but don't activate it yet. The
+         * setup a read event to read stdin, but don't activate it yet. The
          * dst_name indicates who should receive the stdin. If that recipient
          * doesn't do a corresponding pull, however, then the stdin will
          * be dropped upon receipt at the local daemon
@@ -625,10 +621,12 @@ pmix_status_t pmix_iof_setup_stdin_read(int fd, pmix_proc_t procs[], size_t npro
 
         /* check to see if we want the stdin read event to be
          * active - we will always at least define the event,
-         * but may delay its activation
+         * but may delay its activation until we have the terminal
          */
         if (pmix_iof_stdin_check(fd)) {
             PMIX_IOF_READ_ACTIVATE(stdinev_global);
+        } else {
+            stdin_resume_arm();
         }
     } else {
         /* if we are not looking at a tty, just setup a read event
@@ -2560,15 +2558,101 @@ bool pmix_iof_stdin_check(int fd)
     return true;
 }
 
+/* Re-check whether our terminal has come back to us.
+ *
+ * PMIx is a library, and the signal dispositions of a process belong to
+ * whoever wrote its main() - so we do not trap signals to learn this,
+ * even though SIGCONT is what a shell sends. Two things go wrong when a
+ * library does:
+ *
+ *  - it silently takes a signal away from its host. Libevent keeps ONE
+ *    process-wide record of which event base owns signals (evsig_base in
+ *    its signal.c), re-claimed both by adding a signal event and by
+ *    entering event_base_loop, and the OS handler writes the signal
+ *    number into whichever base holds it at that instant. A base with no
+ *    event for that signal drops it. So our SIGCONT event on our own
+ *    progress-thread base did not merely draw libevent's "Only one can
+ *    have signals at a time" warning - it swallowed the host's signals
+ *    too, and did so only when stdin was a terminal, which is what made
+ *    it so hard to see. In PRRTE the casualty was SIGCHLD: "prterun -n 1
+ *    head -1" typed at a terminal never returned, because the reap
+ *    notice for the application went to us and we had no use for it
+ *    (prrte issue #2709).
+ *  - and a host that does not use libevent at all, or installs its own
+ *    handler, has its disposition for that signal replaced from under
+ *    it by a library it merely linked.
+ *
+ * Two rules keep the poll from costing a host anything it would notice,
+ * and they are the price of doing this at all: the timer exists only
+ * when a host has asked us to forward its stdin - pmix_iof_setup_stdin_read
+ * is the sole thing that can arm it - and only while that stdin is
+ * suspended for being in the background. A run that forwards no stdin, or
+ * that has its terminal, never sets a timer; and the delay backs off, so
+ * a process left in the background does not hold a fixed wakeup rate. An
+ * XOFF suspension is deliberately not polled either: that one ends with
+ * an XON that calls us back.
+ *
+ * Polling gives up nothing that matters. The terminal buffers what is
+ * typed while we are not reading, so the interval bounds latency, not
+ * data. It is also strictly more reliable than the signal was: nothing
+ * guarantees a SIGCONT accompanies every change of the terminal's
+ * foreground process group, whereas tcgetpgrp() answers the actual
+ * question every time. */
+static void stdin_resume_cb(int sd, short args, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(sd, args, cbdata);
+
+    stdin_resume_active = false;
+    pmix_iof_stdin_cb(0, 0, NULL);
+}
+
+static void stdin_resume_arm(void)
+{
+    struct timeval tv;
+
+    if (stdin_resume_active) {
+        return;
+    }
+    /* Back off the longer we go without the terminal. An "fg" a moment
+     * after backgrounding is answered in iof_stdin_resume_interval, while
+     * a process left in the background all day settles to one wakeup
+     * every iof_stdin_resume_max_interval rather than holding a fixed
+     * rate forever. stdin_resume_cancel() puts it back to the floor. */
+    if (0 == stdin_resume_delay) {
+        stdin_resume_delay = pmix_globals.iof_stdin_resume_interval;
+    } else if (stdin_resume_delay < pmix_globals.iof_stdin_resume_max_interval) {
+        stdin_resume_delay *= 2;
+        if (stdin_resume_delay > pmix_globals.iof_stdin_resume_max_interval) {
+            stdin_resume_delay = pmix_globals.iof_stdin_resume_max_interval;
+        }
+    }
+    tv.tv_sec = stdin_resume_delay / 1000;
+    tv.tv_usec = (stdin_resume_delay % 1000) * 1000;
+    pmix_event_evtimer_set(pmix_globals.evbase, &stdin_resume_ev,
+                           stdin_resume_cb, NULL);
+    if (0 == pmix_event_evtimer_add(&stdin_resume_ev, &tv)) {
+        stdin_resume_active = true;
+    }
+}
+
+static void stdin_resume_cancel(void)
+{
+    if (stdin_resume_active) {
+        pmix_event_del(&stdin_resume_ev);
+        stdin_resume_active = false;
+    }
+    stdin_resume_delay = 0;
+}
+
 void pmix_iof_stdin_cb(int sd, short args, void *cbdata)
 {
-    bool should_process;
+    bool backgrounded;
     pmix_iof_read_event_t *stdinev = (pmix_iof_read_event_t *) cbdata;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
-    /* this is also the SIGCONT handler, which is registered with no
-     * cbdata at all - it just means "reconsider the stdin we know
-     * about", so resolve it to the one read event there can be */
+    /* the foreground poll passes no cbdata at all - it just means
+     * "reconsider the stdin we know about", so resolve it to the one
+     * read event there can be */
     if (NULL == stdinev) {
         stdinev = stdinev_global;
         if (NULL == stdinev) {
@@ -2578,17 +2662,26 @@ void pmix_iof_stdin_cb(int sd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(stdinev);
 
-    /* a suspended stream stays suspended until an XON says otherwise -
-     * being told our terminal is back in the foreground does not
-     * override the fact that the far end cannot take the data */
-    should_process = !stdinev->xoff && pmix_iof_stdin_check(0);
+    backgrounded = !pmix_iof_stdin_check(0);
 
-    if (should_process) {
+    /* a suspended stream stays suspended until an XON says otherwise -
+     * having our terminal back does not override the fact that the far
+     * end cannot take the data */
+    if (!stdinev->xoff && !backgrounded) {
+        stdin_resume_cancel();
         PMIX_IOF_READ_ACTIVATE(stdinev);
-    } else {
-        pmix_event_del(&stdinev->ev);
-        stdinev->active = false;
-        PMIX_POST_OBJECT(stdinev);
+        return;
+    }
+
+    pmix_event_del(&stdinev->ev);
+    stdinev->active = false;
+    PMIX_POST_OBJECT(stdinev);
+
+    /* An XOFF ends with an XON that calls us back, but nobody sends us
+     * anything when the terminal changes hands - so that is the one
+     * suspension we have to keep looking at. */
+    if (backgrounded) {
+        stdin_resume_arm();
     }
 }
 
@@ -2967,10 +3060,19 @@ void pmix_iof_read_local_handler(int sd, short args, void *cbdata)
          * is no need to pass it upstream as WE are the ones holding the event
          * and associated file descriptor */
         if (0 == numbytes) {
-            if (NULL != child && child->completed &&
+            if (NULL != child &&
                 (NULL == child->stdoutev || !child->stdoutev->active) &&
                 (NULL == child->stderrev || !child->stderrev->active)) {
-                PMIX_PFEXEC_CHK_COMPLETE(child);
+                if (child->completed) {
+                    PMIX_PFEXEC_CHK_COMPLETE(child);
+                } else {
+                    /* the last pipe just closed, which for a child that
+                     * forwards its output is normally the moment it died.
+                     * pfexec polls for exit status rather than trapping
+                     * SIGCHLD, so ask now instead of waiting for its timer
+                     * - it will complete the child itself if it reaps one. */
+                    pmix_pfexec_reap_check();
+                }
             }
             return;
         }

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -280,15 +280,16 @@ static inline bool pmix_iof_fd_always_ready(int fd)
     } while (0);
 
 
-/* Start reading our own stdin and forwarding it, arming the SIGCONT
- * handler if the descriptor is a terminal. Every role that forwards its
+/* Start reading our own stdin and forwarding it, arming the
+ * foreground poll if the descriptor is a terminal we do not currently
+ * own. Every role that forwards its
  * own stdin uses this - PMIx_IOF_push with PMIX_IOF_PUSH_STDIN, and a
  * tool given PMIX_FWD_STDIN at init - so that there is exactly one read
  * event on the descriptor and pmix_iof_flow_control can find it. Calling
  * it again once the stream is running is a no-op. "procs"/"directives"
  * may be NULL; they name who the stdin is destined for.
  *
- * pmix_iof_finalize() releases that read event and the SIGCONT handler.
+ * pmix_iof_finalize() releases that read event and the foreground poll.
  * It must be called while the event base is still up - i.e. from
  * pmix_rte_finalize, not after it. */
 PMIX_EXPORT pmix_status_t pmix_iof_setup_stdin_read(int fd, pmix_proc_t procs[], size_t nprocs,

--- a/src/common/pmix_pfexec.c
+++ b/src/common/pmix_pfexec.c
@@ -91,12 +91,17 @@
 
 static pmix_status_t setup_prefork(pmix_pfexec_child_t *child);
 static pmix_status_t register_nspace(char *nspace, pmix_setup_caddy_t *fcd);
-static void wait_signal_callback(int fd, short event, void *arg);
+static void child_poll(int sd, short args, void *cbdata);
+static void pfexec_poll_arm(bool reset);
+static void pfexec_poll_disarm(void);
 static int fork_proc(pmix_app_t *app, pmix_pfexec_child_t *child, char **env);
 
 pmix_pfexec_globals_t pmix_pfexec_globals = {
-    .handler = NULL,
-    .active = false,
+    .poll_ev = NULL,
+    .poll_active = false,
+    .poll_delay = 0,
+    .poll_interval = PMIX_PFEXEC_POLL_INTERVAL,
+    .poll_max_interval = PMIX_PFEXEC_POLL_MAX_INTERVAL,
     .children = PMIX_LIST_STATIC_INIT,
     .timeout_before_sigkill = 0,
     .nextid = 0,
@@ -110,13 +115,14 @@ int pmix_pfexec_base_close(void)
     if (!pmix_pfexec_globals.initialized) {
         return PMIX_SUCCESS;
     }
-    if (pmix_pfexec_globals.active) {
-        pmix_event_del(pmix_pfexec_globals.handler);
-        pmix_pfexec_globals.active = false;
+    if (pmix_pfexec_globals.poll_active) {
+        pmix_event_del(pmix_pfexec_globals.poll_ev);
+        pmix_pfexec_globals.poll_active = false;
     }
     PMIX_LIST_DESTRUCT(&pmix_pfexec_globals.children);
-    free(pmix_pfexec_globals.handler);
-    pmix_pfexec_globals.handler = NULL;
+    free(pmix_pfexec_globals.poll_ev);
+    pmix_pfexec_globals.poll_ev = NULL;
+    pmix_pfexec_globals.poll_delay = 0;
     pmix_pfexec_globals.selected = false;
     pmix_pfexec_globals.initialized = false;
 
@@ -128,7 +134,7 @@ int pmix_pfexec_base_close(void)
  *
  * Both the completion path and the kill sequence remove children, and
  * either can reach a given child first: a completion posted by the IOF
- * read handler or by child_reaped sits queued on the event base, and the
+ * read handler or by child_poll sits queued on the event base, and the
  * kill sequence the tool's finalize drives can be dispatched in between.
  * Whoever gets here first does the removal and drops the list reference;
  * the second call is a no-op. Callers must hold a reference of their own
@@ -196,6 +202,24 @@ int pmix_pfexec_register(void)
                                "Time to wait for a process to die after issuing a kill signal to it",
                                PMIX_MCA_BASE_VAR_TYPE_INT,
                                &pmix_pfexec_globals.timeout_before_sigkill);
+    pmix_pfexec_globals.poll_interval = PMIX_PFEXEC_POLL_INTERVAL;
+    pmix_mca_base_var_register("pmix", "pfexec", "base", "poll_interval",
+                               "Milliseconds before the first check of a forked child's exit "
+                               "status [default: 50]",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &pmix_pfexec_globals.poll_interval);
+    if (0 >= pmix_pfexec_globals.poll_interval) {
+        pmix_pfexec_globals.poll_interval = PMIX_PFEXEC_POLL_INTERVAL;
+    }
+    pmix_pfexec_globals.poll_max_interval = PMIX_PFEXEC_POLL_MAX_INTERVAL;
+    pmix_mca_base_var_register("pmix", "pfexec", "base", "poll_max_interval",
+                               "Ceiling in milliseconds that the child exit-status check backs "
+                               "off to [default: 1000]",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &pmix_pfexec_globals.poll_max_interval);
+    if (pmix_pfexec_globals.poll_max_interval < pmix_pfexec_globals.poll_interval) {
+        pmix_pfexec_globals.poll_max_interval = pmix_pfexec_globals.poll_interval;
+    }
     return PMIX_SUCCESS;
 }
 
@@ -257,31 +281,18 @@ static pmix_status_t setup_path(pmix_app_t *app)
 
 pmix_status_t pmix_pfexec_base_spawn_job(pmix_setup_caddy_t *fcd)
 {
-    sigset_t unblock;
-
     pmix_output_verbose(5, pmix_client_globals.spawn_output,
                         "%s pfexec spawning child job",
                         PMIX_NAME_PRINT(&pmix_globals.myid));
 
-    if (NULL == pmix_pfexec_globals.handler) {
-        /* ensure that SIGCHLD is unblocked as we need to capture it */
-        if (0 != sigemptyset(&unblock)) {
-            return PMIX_ERROR;
+    /* The exit-status poll is armed once we actually have a child - see
+     * the note on poll_ev in pmix_pfexec.h for why this is a poll and
+     * not the SIGCHLD handler it used to be. */
+    if (NULL == pmix_pfexec_globals.poll_ev) {
+        pmix_pfexec_globals.poll_ev = (pmix_event_t *) malloc(sizeof(pmix_event_t));
+        if (NULL == pmix_pfexec_globals.poll_ev) {
+            return PMIX_ERR_NOMEM;
         }
-        if (0 != sigaddset(&unblock, SIGCHLD)) {
-            return PMIX_ERROR;
-        }
-        if (0 != sigprocmask(SIG_UNBLOCK, &unblock, NULL)) {
-            return PMIX_ERR_NOT_SUPPORTED;
-        }
-
-        /* set to catch SIGCHLD events */
-        pmix_pfexec_globals.handler = (pmix_event_t *) malloc(sizeof(pmix_event_t));
-        pmix_event_set(pmix_globals.evauxbase, pmix_pfexec_globals.handler, SIGCHLD,
-                       PMIX_EV_SIGNAL | PMIX_EV_PERSIST, wait_signal_callback,
-                       pmix_pfexec_globals.handler);
-        pmix_pfexec_globals.active = true;
-        pmix_event_add(pmix_pfexec_globals.handler, NULL);
     }
 
     PMIX_PFEXEC_SPAWN(fcd);
@@ -422,6 +433,9 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
             ++rank;
             pmix_list_append(&pmix_pfexec_globals.children, &child->super);
             child->onlist = true;
+            /* we now have something to watch for; start at the floor of
+             * the backoff so a short-lived child is noticed promptly */
+            pfexec_poll_arm(true);
 
             /* setup any IOF */
             child->opts.usepty = PMIX_ENABLE_PTY_SUPPORT;
@@ -1271,90 +1285,158 @@ static int fork_proc(pmix_app_t *app, pmix_pfexec_child_t *child, char **env)
     return do_parent(app, child, p[0]);
 }
 
-/* Caddy used to hand a reaped child's exit status from the SIGCHLD
- * handler over to the progress thread. The SIGCHLD handler may run on a
- * host-provided auxiliary event base (a different thread than evbase),
- * but all access to the pmix_pfexec_globals.children list must happen on
- * the progress thread, so the handler ships the (pid, status) across. */
-typedef struct {
-    pmix_object_t super;
-    pmix_event_t ev;
-    pid_t pid;
-    int status;
-} pmix_pfexec_reap_caddy_t;
-static PMIX_CLASS_INSTANCE(pmix_pfexec_reap_caddy_t, pmix_object_t, NULL, NULL);
-
-/* Runs on the progress thread: match the reaped pid to its child, record
- * the exit status, and check whether the job has now completed. */
-static void child_reaped(int sd, short args, void *cbdata)
+/* Ask about each of our own children, and only our own.
+ *
+ * Runs on evbase, which is also where the children list lives, so unlike
+ * the SIGCHLD handler this replaced there is nothing to thread-shift.
+ * waitpid(pid, WNOHANG) gives a complete three-way answer:
+ *
+ *   0       still running
+ *   pid     exited, and the status is ours
+ *   ECHILD  gone, but somebody else reaped it first - a host sweeping
+ *           with waitpid(-1), or one that set SIGCHLD to SIG_IGN and let
+ *           the kernel do it. The child is definitively dead; only its
+ *           exit status is lost, and we say so rather than reporting a
+ *           zero we did not observe.
+ *
+ * That last case is why per-pid matters even though it cannot stop a
+ * host from taking our children: we always learn of the death. The old
+ * waitpid(-1) sweep could not even do that - whichever of us and the
+ * host lost the race got no pid, no status and no notification at all.
+ */
+static void child_poll(int sd, short args, void *cbdata)
 {
-    pmix_pfexec_reap_caddy_t *rc = (pmix_pfexec_reap_caddy_t *) cbdata;
-    pmix_pfexec_child_t *child;
-    PMIX_HIDE_UNUSED_PARAMS(sd, args);
-
-    PMIX_ACQUIRE_OBJECT(rc);
-
-    PMIX_LIST_FOREACH (child, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
-        if (rc->pid == child->pid) {
-            /* record the exit status */
-            if (WIFEXITED(rc->status)) {
-                child->exitcode = WEXITSTATUS(rc->status);
-            } else if (WIFSIGNALED(rc->status)) {
-                child->exitcode = WTERMSIG(rc->status) + 128;
-            }
-            /* mark the child as complete */
-            child->completed = true;
-            if ((NULL == child->stdoutev || !child->stdoutev->active)
-                && (NULL == child->stderrev || !child->stderrev->active)) {
-                PMIX_PFEXEC_CHK_COMPLETE(child);
-            }
-            break;
-        }
-    }
-    PMIX_RELEASE(rc);
-}
-
-/* callback from the event library whenever a SIGCHLD is received */
-static void wait_signal_callback(int fd, short event, void *arg)
-{
-    (void) fd;
-    (void) event;
-    pmix_event_t *signal = (pmix_event_t *) arg;
+    pmix_pfexec_child_t *child, *next;
+    pid_t r;
     int status;
-    pid_t pid;
-    pmix_pfexec_reap_caddy_t *rc;
+    bool watching = false;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args, cbdata);
 
-    PMIX_ACQUIRE_OBJECT(signal);
+    /* the one-shot timer that brought us here (if any) has fired */
+    pmix_pfexec_globals.poll_active = false;
 
-    if (SIGCHLD != PMIX_EVENT_SIGNAL(signal)) {
-        return;
-    }
-    /* if we haven't spawned anyone, then ignore this */
-    if (0 == pmix_list_get_size(&pmix_pfexec_globals.children)) {
-        return;
-    }
-
-    /* reap all queued waitpids until we
-     * don't get anything valid back */
-    while (1) {
-        pid = waitpid(-1, &status, WNOHANG);
-        if (-1 == pid && EINTR == errno) {
-            /* try it again */
+    PMIX_LIST_FOREACH_SAFE (child, next, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
+        if (child->completed || 0 >= child->pid) {
             continue;
         }
-        /* if we got garbage, then nothing we can do */
-        if (pid <= 0) {
-            return;
+        status = 0;
+        r = waitpid(child->pid, &status, WNOHANG);
+        if (0 == r) {
+            /* still running - keep the timer going for it */
+            watching = true;
+            continue;
+        }
+        if (0 > r) {
+            if (EINTR == errno) {
+                watching = true;
+                continue;
+            }
+            if (ECHILD != errno) {
+                /* nothing we can do with this, but do not spin on it */
+                watching = true;
+                continue;
+            }
+            /* reaped by somebody else: dead, status unknown */
+            pmix_output_verbose(5, pmix_client_globals.spawn_output,
+                                "%s pfexec child %s (pid %lu) was reaped elsewhere - "
+                                "exit status unavailable",
+                                PMIX_NAME_PRINT(&pmix_globals.myid),
+                                PMIX_NAME_PRINT(&child->proc), (unsigned long) child->pid);
+            child->exitcode = 0;
+        } else if (WIFEXITED(status)) {
+            child->exitcode = WEXITSTATUS(status);
+        } else if (WIFSIGNALED(status)) {
+            child->exitcode = WTERMSIG(status) + 128;
         }
 
-        /* waitpid is process-global and safe from any thread, but the
-         * children list is not - hand the exit status to the progress
-         * thread rather than touching the list here */
-        rc = PMIX_NEW(pmix_pfexec_reap_caddy_t);
-        rc->pid = pid;
-        rc->status = status;
-        PMIX_THREADSHIFT(rc, child_reaped);
+        child->completed = true;
+        if ((NULL == child->stdoutev || !child->stdoutev->active)
+            && (NULL == child->stderrev || !child->stderrev->active)) {
+            PMIX_PFEXEC_CHK_COMPLETE(child);
+        }
     }
+
+    if (watching) {
+        pfexec_poll_arm(false);
+    } else {
+        /* nothing left to watch: no timer, and the next spawn starts
+         * the backoff over from the floor */
+        pmix_pfexec_globals.poll_delay = 0;
+    }
+}
+
+/* Arm the exit-status poll, backing the delay off unless "reset" says to
+ * start from the floor again. Noticing a child has exited carries no
+ * latency requirement -- and the IOF EOF path kicks us through
+ * pmix_pfexec_reap_check() at the moment a child that forwards its
+ * output usually dies -- so the ceiling is what governs the cost of a
+ * long-running child, and it is one wakeup per second by default. */
+static void pfexec_poll_disarm(void)
+{
+    if (pmix_pfexec_globals.poll_active) {
+        pmix_event_del(pmix_pfexec_globals.poll_ev);
+        pmix_pfexec_globals.poll_active = false;
+    }
+}
+
+static void pfexec_poll_arm(bool reset)
+{
+    struct timeval tv;
+    int delay;
+
+    if (NULL == pmix_pfexec_globals.poll_ev) {
+        return;
+    }
+    /* pmix_event_evtimer_set is event_assign, which must never be applied
+     * to an event that is still pending - so always take it down first
+     * rather than trusting poll_active to say it is not armed */
+    if (pmix_pfexec_globals.poll_active && !reset) {
+        return;
+    }
+    pfexec_poll_disarm();
+    if (reset) {
+        pmix_pfexec_globals.poll_delay = 0;
+    }
+
+    /* a zero floor would give a zero timeout and spin the event loop,
+     * which is what an unregistered parameter would otherwise produce */
+    if (0 >= pmix_pfexec_globals.poll_interval) {
+        pmix_pfexec_globals.poll_interval = PMIX_PFEXEC_POLL_INTERVAL;
+    }
+    if (pmix_pfexec_globals.poll_max_interval < pmix_pfexec_globals.poll_interval) {
+        pmix_pfexec_globals.poll_max_interval = pmix_pfexec_globals.poll_interval;
+    }
+
+    delay = pmix_pfexec_globals.poll_delay;
+    if (0 == delay) {
+        delay = pmix_pfexec_globals.poll_interval;
+    } else if (delay < pmix_pfexec_globals.poll_max_interval) {
+        delay *= 2;
+        if (delay > pmix_pfexec_globals.poll_max_interval) {
+            delay = pmix_pfexec_globals.poll_max_interval;
+        }
+    }
+    pmix_pfexec_globals.poll_delay = delay;
+
+    tv.tv_sec = delay / 1000;
+    tv.tv_usec = (delay % 1000) * 1000;
+    pmix_event_evtimer_set(pmix_globals.evbase, pmix_pfexec_globals.poll_ev,
+                           child_poll, NULL);
+    if (0 == pmix_event_evtimer_add(pmix_pfexec_globals.poll_ev, &tv)) {
+        pmix_pfexec_globals.poll_active = true;
+    }
+}
+
+void pmix_pfexec_reap_check(void)
+{
+    if (!pmix_pfexec_globals.initialized || NULL == pmix_pfexec_globals.poll_ev) {
+        return;
+    }
+    /* We are on evbase here (the IOF read handler), so just look now -
+     * but take the pending timer down first: child_poll re-arms, and
+     * arming assigns the same event. */
+    pfexec_poll_disarm();
+    child_poll(-1, 0, NULL);
 }
 
 /**** FRAMEWORK CLASS INSTANTIATIONS ****/

--- a/src/common/pmix_pfexec.h
+++ b/src/common/pmix_pfexec.h
@@ -72,9 +72,45 @@ typedef struct {
 } pmix_pfexec_child_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_child_t);
 
+/* Floor and ceiling of the child-reaping poll's backoff, in ms. Also the
+ * defaults of the two MCA parameters that override them. */
+#define PMIX_PFEXEC_POLL_INTERVAL     50
+#define PMIX_PFEXEC_POLL_MAX_INTERVAL 1000
+
 typedef struct {
-    pmix_event_t *handler;
-    bool active;
+    /* The child-reaping poll.
+     *
+     * PMIx is a library, and the signal dispositions of a process belong
+     * to whoever wrote its main(), so this used to be wrong twice over:
+     * a SIGCHLD event on an event base of ours, whose handler then swept
+     * with waitpid(-1). The event took the signal away from the host --
+     * libevent keeps ONE process-wide record of which base owns signals
+     * (evsig_base in its signal.c), so a second base carrying signals
+     * swallows the first's -- and the sweep took the host's *children*,
+     * reaping procs it had forked and discarding their exit status,
+     * because a pid we do not recognize is silently dropped. Both halves
+     * are the same bug in both directions: PRRTE's own SIGCHLD handler
+     * does exactly the same sweep, so in one process the two stole from
+     * each other and whichever lost simply never heard that its child
+     * had died (prrte issue #2709 reached this way too).
+     *
+     * So we ask instead of being told, and we ask only about our own
+     * pids: waitpid(pid, WNOHANG) is a complete answer -- 0 means alive,
+     * the pid means dead with a status, and ECHILD means dead with the
+     * status lost to whoever reaped first. We never miss a death, only
+     * possibly a status, which is strictly better than the sweep (where
+     * the loser got no notification at all).
+     *
+     * The timer exists only while we have children the host asked us to
+     * fork, and the delay backs off from poll_interval to
+     * poll_max_interval -- there is no latency requirement on noticing
+     * that a child has exited, and the IOF EOF path already gives us a
+     * prompt free kick via pmix_pfexec_reap_check(). */
+    pmix_event_t *poll_ev;
+    bool poll_active;
+    int poll_delay;
+    int poll_interval;
+    int poll_max_interval;
     /* set by pmix_pfexec_base_open, cleared by pmix_pfexec_base_close.
      * The children list below only exists between those two calls, and
      * not every role opens this framework, so anything that walks or
@@ -115,6 +151,13 @@ PMIX_EXPORT void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata);
 PMIX_EXPORT void pmix_pfexec_base_signal_proc(int sd, short args, void *cbdata);
 
 PMIX_EXPORT void pmix_pfexec_check_complete(int sd, short args, void *cbdata);
+
+/* Look at our children's exit status right now rather than waiting for
+ * the next poll, and reset the backoff. Called from the IOF read handler
+ * when a child's last output pipe hits EOF, which is the moment a child
+ * that forwards its output usually dies - so the common case costs no
+ * timer latency at all. */
+PMIX_EXPORT void pmix_pfexec_reap_check(void);
 
 #define PMIX_PFEXEC_SPAWN(fcd)                                           \
     do {                                                                 \

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -1009,6 +1009,18 @@ typedef struct {
     pmix_list_t iof_pending;
     size_t iof_pending_bytes;
     size_t iof_pending_limit;
+    /* How often, in milliseconds, to re-check whether our terminal has come
+     * back to the foreground while our own stdin is suspended for being in
+     * the background. See the note over stdin_resume_arm() in
+     * src/common/pmix_iof.c for why this is a poll and not a SIGCONT
+     * handler. The first check is _interval after we lose the terminal and
+     * the delay doubles up to _max_interval, so a quick "fg" is answered
+     * promptly and a process left in the background all day settles to the
+     * ceiling. The timer exists ONLY while a host has asked us to forward
+     * its stdin AND that stdin is suspended for being in the background:
+     * nothing else ever arms it. */
+    int iof_stdin_resume_interval;
+    int iof_stdin_resume_max_interval;
     pmix_iof_flags_t spawn_iof_flags;
     pmix_keyindex_t keyindex;
 } pmix_globals_t;

--- a/src/mca/plog/smtp/plog_smtp.c
+++ b/src/mca/plog/smtp/plog_smtp.c
@@ -250,7 +250,30 @@ static pmix_status_t send_email(char *msg, char *from, char *addrs,
 
     /* Temporarily disable SIGPIPE so that if remote servers timeout
        or hang up on us, it doesn't kill this application.  We'll
-       restore the original SIGPIPE handler when we're done. */
+       restore the original SIGPIPE handler when we're done.
+
+       This is libESMTP's requirement, not ours: it writes to a socket
+       the remote SMTP server may drop at any moment (an idle timeout, a
+       421), it does not set MSG_NOSIGNAL or SO_NOSIGPIPE on the sockets
+       it owns, and it documents that the *application* must arrange for
+       SIGPIPE to be ignored.  We are not the application - hence the
+       save/ignore/restore around just the smtp_start_session() call
+       rather than a disposition we set and keep.
+
+       It is still the one place in the library that touches a
+       process-wide signal disposition, which everything else here has
+       been moved off (see the poll notes in src/common/pmix_iof.c and
+       src/common/pmix_pfexec.h).  The thread-safe form is
+       pthread_sigmask: SIGPIPE from write() is raised synchronously to
+       the writing thread, so blocking it *in this thread* is sufficient
+       and never reaches the host.  That needs a drain -
+       sigtimedwait() with a zero timeout - or a SIGPIPE raised while
+       blocked stays pending on the thread and kills the process the
+       moment the mask is restored; and sigtimedwait does not exist on
+       macOS, so it would take a configure test plus a fallback to
+       exactly the code below.  Not worth it for a component that only
+       builds with --with-smtp and restores what it changed - but do it
+       that way if this ever moves onto a path that runs by default. */
     sig.sa_handler = SIG_IGN;
     sigemptyset(&sig.sa_mask);
     sig.sa_flags = 0;

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -126,6 +126,8 @@ PMIX_EXPORT pmix_globals_t pmix_globals = {
     .iof_pending = PMIX_LIST_STATIC_INIT,
     .iof_pending_bytes = 0,
     .iof_pending_limit = 0,
+    .iof_stdin_resume_interval = 0,
+    .iof_stdin_resume_max_interval = 0,
     .spawn_iof_flags = PMIX_IOF_FLAGS_STATIC_INIT,
     .keyindex = PMIX_KEYINDEX_STATIC_INIT
 };

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -36,6 +36,7 @@
 #include "src/client/pmix_client_ops.h"
 #include "src/hwloc/pmix_hwloc.h"
 #include "src/mca/base/pmix_mca_base_var.h"
+#include "src/common/pmix_pfexec.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
@@ -298,6 +299,14 @@ pmix_status_t pmix_register_params(void)
                                       "reply that says how to format it [default: 1MB]",
                                       PMIX_MCA_BASE_VAR_TYPE_SIZE_T,
                                       &pmix_globals.iof_pending_limit);
+
+    /* pfexec's own knobs. They are registered here, with everything else,
+     * rather than from pmix_pfexec_base_open(): only a launcher opens
+     * pfexec, so registering them there left pmix_pfexec_register() with
+     * no caller at all - which meant the parameter did not exist, and
+     * timeout_before_sigkill never got the 1-second default the kill
+     * sequence documents, running with the static initializer's 0. */
+    pmix_pfexec_register();
 
     pmix_globals.xml_output = false;
     (void) pmix_mca_base_var_register("pmix", "iof", NULL, "xml_output",

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -300,13 +300,52 @@ pmix_status_t pmix_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_SIZE_T,
                                       &pmix_globals.iof_pending_limit);
 
+    /* How often to look at whether our terminal has come back to the
+     * foreground, while our own stdin is suspended because it has not. A
+     * library must not trap signals - the process-wide dispositions belong
+     * to whoever runs main() - so this is a poll rather than the SIGCONT
+     * handler it used to be.
+     *
+     * Two rules keep it from costing a host anything it would notice, and
+     * both are enforced in pmix_iof.c rather than here: the timer exists
+     * only when a host has asked us to forward its stdin, and only while
+     * that stdin is suspended for being in the background. A run that never
+     * forwards stdin, or that has the terminal, sets no timer at all.
+     *
+     * The delay then doubles from _interval up to _max_interval, so an "fg"
+     * a moment after backgrounding is answered promptly while a process left
+     * in the background all day settles to one wakeup every couple of
+     * seconds. Nothing is lost by waiting either way: the terminal buffers
+     * what is typed while we are not reading it, so the interval bounds
+     * latency, not data. */
     /* pfexec's own knobs. They are registered here, with everything else,
      * rather than from pmix_pfexec_base_open(): only a launcher opens
      * pfexec, so registering them there left pmix_pfexec_register() with
-     * no caller at all - which meant the parameter did not exist, and
+     * no caller at all - which meant the parameters did not exist, and
      * timeout_before_sigkill never got the 1-second default the kill
      * sequence documents, running with the static initializer's 0. */
     pmix_pfexec_register();
+
+    pmix_globals.iof_stdin_resume_interval = 100;
+    (void) pmix_mca_base_var_register("pmix", "iof", NULL, "stdin_resume_interval",
+                                      "Milliseconds before the first check for our terminal "
+                                      "returning to the foreground while our stdin is suspended "
+                                      "[default: 100]",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &pmix_globals.iof_stdin_resume_interval);
+    if (0 >= pmix_globals.iof_stdin_resume_interval) {
+        pmix_globals.iof_stdin_resume_interval = 100;
+    }
+
+    pmix_globals.iof_stdin_resume_max_interval = 2000;
+    (void) pmix_mca_base_var_register("pmix", "iof", NULL, "stdin_resume_max_interval",
+                                      "Ceiling in milliseconds that the suspended-stdin check "
+                                      "backs off to [default: 2000]",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &pmix_globals.iof_stdin_resume_max_interval);
+    if (pmix_globals.iof_stdin_resume_max_interval < pmix_globals.iof_stdin_resume_interval) {
+        pmix_globals.iof_stdin_resume_max_interval = pmix_globals.iof_stdin_resume_interval;
+    }
 
     pmix_globals.xml_output = false;
     (void) pmix_mca_base_var_register("pmix", "iof", NULL, "xml_output",

--- a/src/tool/AGENTS.md
+++ b/src/tool/AGENTS.md
@@ -156,7 +156,7 @@ Three subtleties the current code documents inline and you must keep:
 - The keepalive-pipe teardown is guarded by a file-scope `keepalive_fd`
   rather than re-derived, because `PMIX_KEEPALIVE_PIPE` was a directive
   to *init* and finalize cannot see it. The stdin read event and its
-  SIGCONT handler need no such bookkeeping here — they belong to
+  foreground poll need no such bookkeeping here — they belong to
   `src/common/pmix_iof.c`, and `pmix_iof_finalize()` releases them from
   inside `pmix_rte_finalize`.
 
@@ -306,7 +306,9 @@ unpacking, exactly as the client recv callbacks do.
   This file used to build a read event of its own in a file-scope
   `pmix_iof_read_event_t`, and every way that could drift, it did: its
   SIGCONT event was assigned but never added to a base (so a backgrounded
-  tool never resumed reading once foregrounded), the read event was never
+  tool never resumed reading once foregrounded — the library now polls
+  for that instead of trapping a signal at all, see
+  [`src/common/AGENTS.md`](../common/AGENTS.md)), the read event was never
   released (so it and its libevent registration survived into the next
   `PMIx_tool_init`, naming a base that had been torn down), it was
   invisible to `pmix_iof_flow_control` — which only knows the library's
@@ -354,11 +356,13 @@ unpacking, exactly as the client recv callbacks do.
   only initializes the event; without a following `pmix_event_add` the
   handler is never installed. Both this file's SIGCONT/stdin handler and
   the library's were in that state for a long time and silently did
-  nothing.
+  nothing. Neither exists any more — a library has no business trapping
+  a signal, and the stdin resume is a poll now — but the trap is worth
+  knowing for any other signal event you are tempted to add.
 - **Anything init registers on an event base, finalize has to take
   down**, because `pmix_rte_finalize` destroys the bases underneath them.
   What is left here is the keepalive-pipe event; the stdin read event and
-  its SIGCONT handler moved to `src/common/pmix_iof.c` and are released
+  its foreground poll moved to `src/common/pmix_iof.c` and are released
   by `pmix_iof_finalize()`. Note the trap that teardown carries either
   way: `pmix_iof_read_event_t`'s destructor closes the descriptor it
   holds, and for stdin that is the application's own — which is why the
@@ -446,11 +450,13 @@ named are the ones that fail against the unfixed library.
    nothing added the event. A tool that is backgrounded and then resumed
    never reconsidered its stdin. Not unit-testable — it needs a tty — so
    there is no regression test. The identical defect in
-   `src/common/pmix_iof.c` is fixed too, and this file no longer has a
-   copy of its own to keep in step: see the stdin bullet under
-   *Invariants and gotchas*.
+   `src/common/pmix_iof.c` was fixed too, and that handler has since been
+   replaced outright by a poll, because a library must not trap signals;
+   this file no longer has a copy of its own to keep in step. See the
+   stdin bullet under *Invariants and gotchas*.
 10. **FIXED — init's file-scope events were never taken down.** The stdin
-    read event, the SIGCONT event and the keepalive-pipe event all
+    read event, the SIGCONT event (since retired for a poll) and the
+    keepalive-pipe event all
     survived finalize; the keepalive pipe's descriptor leaked one per
     init/finalize cycle. Only the keepalive pipe is still this file's to
     release. **`test/unit/tool_cycle`** runs a second pass with

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1706,9 +1706,9 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         /* if we have launched children, then we need to cleanly
          * terminate them - do this before stopping our progress
          * thread as we need it for terminating procs */
-        if (pmix_pfexec_globals.active) {
-            pmix_event_del(pmix_pfexec_globals.handler);
-            pmix_pfexec_globals.active = false;
+        if (pmix_pfexec_globals.poll_active) {
+            pmix_event_del(pmix_pfexec_globals.poll_ev);
+            pmix_pfexec_globals.poll_active = false;
         }
         /* Snapshot the identities before killing anything. Each kill parks
          * this thread on the lock for the whole SIGCONT/SIGTERM/SIGKILL


### PR DESCRIPTION
## The problem

PMIx is a library, and the signal dispositions of a process belong to whoever wrote its `main()`. We were trapping two signals anyway — `SIGCONT` (to resume a suspended stdin) and `SIGCHLD` (to reap pfexec's children).

The damage is worse than the libevent warning it produced. Libevent keeps **one process-wide record** of which event base owns signals (`evsig_base` in its `signal.c`), re-claimed both by adding a signal event and by entering `event_base_loop`. The OS handler writes the signal number into whichever base holds it at that instant, and a base with no event for that signal **drops it**. So a second base carrying signals does not merely warn — it silently swallows the host's.

PRRTE traps `SIGCHLD` on its own progress base. The result was [prrte#2709](https://github.com/openpmix/prrte/issues/2709): `prterun -n 1 head -1` typed at a terminal never returned. The application read its line, exited, and stayed an unreaped zombie, because the reap notice had been delivered to *us* and we had no use for it. Only with a terminal — that is the only case in which the offending event was armed, which is what made it so hard to see.

## The fix

**Neither trap had to be a signal at all.**

`SIGCONT` existed to notice that a backgrounded process had been foregrounded. That is a question we can simply *ask* — `getpgrp()` against `tcgetpgrp()` — and `pmix_iof_stdin_check()` already asks it on every read cycle. The read event is now disarmed while we do not hold the terminal, and an evtimer re-asks. This is strictly *more* reliable than the signal: nothing guarantees a `SIGCONT` accompanies every change of the terminal's foreground process group, while `tcgetpgrp()` answers the actual question every time.

pfexec's `SIGCHLD` was wrong twice over — the event took the signal from the host, and the handler's `waitpid(-1)` took the host's **children**, reaping procs it had forked and discarding their exit status (a pid we do not recognize is silently dropped). PRRTE's handler does the identical sweep, so in one process the two stole from each other and whichever lost never heard its child had died. `child_poll()` now asks `waitpid(pid, WNOHANG)` about our own pids, where the three answers are complete:

| | meaning |
|---|---|
| `0` | still alive |
| `pid` | dead, status ours |
| `ECHILD` | dead, status lost to whoever reaped first |

Per-pid cannot stop a host from taking our children, but we always learn of the death — which the sweep could not do, since its loser got no notification at all. The reap also no longer runs on `evauxbase`, so the thread-shift it needed to reach the children list is gone, and we no longer unblock `SIGCHLD` in the host's signal mask on the way in.

## Why the polling is defensible

Polling is only acceptable if it costs a host nothing it would notice, so **both timers obey the same two rules**: they exist only when the host asked us to do the thing (forward its stdin, fork it a child), and only while there is something to watch (a stdin suspended for being in the *background*, a child that has not exited). A run that forwards no stdin and forks nothing sets no timer at all, and an XOFF suspension is not polled either — that one ends with an XON that calls back.

Both delays back off: 100 ms → 2 s for the terminal, 50 ms → 1 s for a child, so a process left in the background all day does not hold a fixed wakeup rate. All four bounds are MCA-tunable. The child poll is rarely waited on in any case — the IOF read handler calls `pmix_pfexec_reap_check()` when a child's last output pipe hits EOF, which for a child that forwards its output is normally the moment it died.

Nothing lost either way: the terminal buffers what is typed while we are not reading it, so the interval bounds latency, not data.

## What is left

The `sigaction` calls in the forked child between `fork()` and `exec()`, resetting inherited dispositions so the application does not run with ours — correct and required. And `plog/smtp`'s save/ignore/restore of `SIGPIPE` around the one libESMTP call that requires it: libESMTP sets neither `MSG_NOSIGNAL` nor `SO_NOSIGPIPE` on the sockets it owns and documents that the *application* must ignore `SIGPIPE`. The thread-safe form is `pthread_sigmask`, but that needs a drain (`sigtimedwait` with a zero timeout) or a `SIGPIPE` raised while blocked stays pending on the thread and kills the process when the mask is restored — and `sigtimedwait` does not exist on macOS. Left as it is, since the component only builds with `--with-smtp` and it restores what it changed. Both are documented where they stand.

## Incidental fix (separate commit)

`pmix_pfexec_register()` had **no caller**, so `pfexec_base_sigkill_timeout` did not exist and `timeout_before_sigkill` ran on the static initializer's `0` rather than the documented 1 second — the kill sequence escalated `SIGCONT` → `SIGTERM` → `SIGKILL` with no pause between stages, defeating the point of having them.

## Testing

- `make check`: **156 pass / 2 skip / 0 fail**, including `tool_relay`, the one test that forks children through pfexec.
- `prterun -n 1 head -1` under a pty with stdin held open: **5/5 exit promptly**, no libevent warning. Against the unfixed build the same loop hung 3–9 times in 10.
- Backgrounded-then-`fg` still resumes and forwards. Proven to be the poll doing it: with `PMIX_MCA_iof_stdin_resume_interval=60000` the same run hangs.
- PRRTE dockerswarm multi-node suite against this branch: **684 passed, 0 failed, 3 skipped** (the skips are pre-existing no-network-device topology cases).

A regression test for the terminal case is in openpmix/prrte#2723.