### PR TITLE
Make a host environment's registered attributes reachable

### DIFF
--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -1814,6 +1814,16 @@ void pmix_attributes_print_attrs(char ***ans, char *function,
         }
         memcpy(&line[PMIX_PRINT_NAME_COLUMN_WIDTH + PMIX_PRINT_STRING_COLUMN_WIDTH + 4], tmp, len);
 
+        if (NULL == attrs[n].description) {
+            /* the string is known but the description is not - print the
+             * line we have rather than walking a NULL array.  The regattr
+             * constructor leaves this NULL, so any regattr assembled by
+             * hand arrives here that way */
+            line[PMIX_PRINT_ATTR_COLUMN_WIDTH - 1] = '\0';
+            PMIx_Argv_append_nosize(ans, line);
+            continue;
+        }
+
         for (m = 0; NULL != attrs[n].description[m]; m++) {
             len = strlen(attrs[n].description[m]);
             if ((PMIX_PRINT_ATTR_COLUMN_WIDTH - 1

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -1434,13 +1434,23 @@ static void _get_attrs(pmix_list_t *lst, pmix_info_t *info, pmix_list_t *attrs)
             regarray = (pmix_regattr_t *) darray->array;
             for (m = 0; m < nattr; m++) {
                 regarray[m].name = strdup(tptr->attrs[m]);
-                PMIX_LOAD_KEY(regarray[m].string, pmix_attributes_lookup(tptr->attrs[m]));
                 dptr = pmix_attributes_lookup_term(tptr->attrs[m]);
                 if (NULL == dptr) {
-                    PMIX_RELEASE(ip);
-                    PMIx_Argv_free(fns);
-                    return;
+                    /* A name the dictionary does not know - a typo in a
+                     * registration, or an attribute private to whoever made
+                     * it.  Report the name and nothing else: an entry whose
+                     * string field is empty is already how a name-only
+                     * attribute is rendered, and the constructor left the
+                     * type at PMIX_UNDEF and the description NULL for us.
+                     *
+                     * What must not happen is what used to: abandoning the
+                     * entry and returning discarded this function AND every
+                     * function after it in the level, so one bad name
+                     * silently truncated the answer - and gave the caller
+                     * nothing to say why the rest had gone missing. */
+                    continue;
                 }
+                PMIX_LOAD_KEY(regarray[m].string, pmix_attributes_lookup(tptr->attrs[m]));
                 regarray[m].type = dptr->type;
                 regarray[m].description = PMIx_Argv_copy(dptr->description);
             }

--- a/src/common/pmix_attributes.c
+++ b/src/common/pmix_attributes.c
@@ -1379,10 +1379,17 @@ static void _get_attrs(pmix_list_t *lst, pmix_info_t *info, pmix_list_t *attrs)
     char **fns = NULL;
     const pmix_regattr_input_t *dptr;
 
-    /* the value in the info is a comma-delimited list of
-     * functions whose attributes are being requested */
-    if (NULL != info) {
-        fns = PMIx_Argv_split(info->key, ',');
+    /* The comma-delimited list of functions whose attributes are being
+     * requested rides in the info's VALUE - the key is the level
+     * (PMIX_HOST_ATTRIBUTES and friends), which names no function and so
+     * matched nothing here.  Every remote query for a level's attributes
+     * came back empty because of it, which is the only way a caller can
+     * ever see the host's registrations: a tool answers the client,
+     * server and tool levels out of its own library and asks the server
+     * only about the host. */
+    if (NULL != info && PMIX_STRING == info->value.type &&
+        NULL != info->value.data.string) {
+        fns = PMIx_Argv_split(info->value.data.string, ',');
     }
 
     /* search the list for these functions */


### PR DESCRIPTION
Three fixes on the path by which a caller asks a PMIx server what attributes the *host* environment supports. The first makes the answer arrive at all; the second stops one bad name from silently swallowing most of it; the third is a crash the second one walks straight into.

## 1. Read the requested function list from the info's value

A query for the attributes a given level supports carries the level in the info's **key** — `PMIX_HOST_ATTRIBUTES` and its siblings — and the comma-delimited list of functions being asked about in the info's **value**. `_get_attrs()` in `src/common/pmix_attributes.c` split the key instead:

```c
    /* the value in the info is a comma-delimited list of
     * functions whose attributes are being requested */
    if (NULL != info) {
        fns = PMIx_Argv_split(info->key, ',');
    }
```

The comment directly above it already says where the list lives. Splitting the key compares the level's own string (`"pmix.host.attrs"`) against every registered function name, matches nothing, and returns an empty list.

Nothing local is affected, which is why this has gone unnoticed: a tool answers the client, server and tool levels out of its own library without ever asking anyone. The host level is the one it *must* ask the server about — and that is the one that always came back empty. So `pattrs --host <anything>` reports

```
PMIx_Query_info returned no results
```

against any server, and a host environment's registered attributes are unreachable by the only means provided for reaching them.

## 2. Report an unknown attribute rather than truncating the level

When `_get_attrs()` met an attribute name the dictionary could not resolve, it released the entry under construction and returned — discarding not only that function but every function after it in the level. One unrecognized name in one registration silently shortened the answer, with nothing to say why the rest had gone missing.

A name can fail to resolve for two ordinary reasons: a typo, or an attribute private to the layer that registered it and deliberately absent from the dictionary. Neither justifies withholding the other functions. Keep the entry and report what is known — the name. An entry with an empty string field is already how a name-only attribute renders (it is what the `NONE` case produces), and the regattr constructor has left the type at `PMIX_UNDEF` and the description NULL.

The attribute's string lookup moves below the dictionary check, because it returns the name itself for an unknown name and would fill in a field that has to stay empty here.

## 3. Survive a registered attribute that has no description

`pmix_attributes_print_attrs()` walks `attrs[n].description` without checking it, so a regattr carrying a name and a string but no description takes the process down. The constructor leaves that field NULL, so any regattr assembled by hand rather than copied out of the dictionary arrives in exactly that state — including anything produced by fix 2 above, had it filled in the string field. Print the line already built and move on.

## Verification

Found while auditing PRRTE's host attribute registrations ([openpmix/prrte#2724](https://github.com/openpmix/prrte/pull/2724)), which are invisible without fix 1.

Against a live PRRTE DVM:

- Before: `pattrs --host all` → `PMIx_Query_info returned no results`.
- After fix 1: all 46 registered host functions with their attributes resolved.

Then, with a deliberately bogus name (`PRTE_BOGUS_NOT_IN_DICTIONARY`) injected as the second attribute of the 4th function in that table:

- With fix 1 only: **3** of 46 functions returned — `PMIx_Init`, `PMIx_Finalize`, `PMIx_Abort` — and no error anywhere.
- With fixes 2 and 3: all **46** returned, the unknown attribute printed by name with empty string/type/description columns, and the resolvable attributes on either side of it within the same entry intact.

`pattrs --client`/`--server`/`--tool` are unchanged throughout, as expected — those never reach this path.