### PR TITLE
common: add statuses and a process state for a release that kills processes

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1027,6 +1027,8 @@ Constants
 * ``PMIX_ERR_JOB_EXE_NOT_FOUND``: specified executable not found
 * ``PMIX_ERR_JOB_INSUFFICIENT_RESOURCES``: insufficient resources to
   spawn job
+* ``PMIX_ERR_JOB_KILLED_BY_RELEASE``: a resource release removed nodes
+  this job was running on, killing the processes on them
 * ``PMIX_ERR_JOB_SYS_OP_FAILED``: system library operation failed
 * ``PMIX_ERR_JOB_WDIR_NOT_FOUND``: specified working directory not
   found
@@ -1036,6 +1038,10 @@ Constants
 * ``PMIX_ERR_PROC_REQUESTED_ABORT``: process called ``PMIx_Abort``
 * ``PMIX_ERR_PROC_KILLED_BY_CMD``: process was terminated by RTE
   command
+* ``PMIX_ERR_PROC_KILLED_BY_RELEASE``: the node this process ran on was
+  released, killing it
+* ``PMIX_PROC_STATE_KILLED_BY_RELEASE``: the node this process ran on
+  was released, killing it
 * ``PMIX_ERR_PROC_FAILED_TO_START``: process failed to start
 * ``PMIX_ERR_PROC_ABORTED_BY_SIG``: process aborted by signal (e.g.,
   segmentation fault)

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1627,6 +1627,7 @@ typedef uint8_t pmix_proc_state_t;
 #define PMIX_PROC_STATE_CANNOT_RESTART          (PMIX_PROC_STATE_ERROR + 11)  /* process failed and cannot be restarted */
 #define PMIX_PROC_STATE_TERM_NON_ZERO           (PMIX_PROC_STATE_ERROR + 12)  /* process exited with a non-zero status, indicating abnormal */
 #define PMIX_PROC_STATE_FAILED_TO_LAUNCH        (PMIX_PROC_STATE_ERROR + 13)  /* unable to launch process */
+#define PMIX_PROC_STATE_KILLED_BY_RELEASE       (PMIX_PROC_STATE_ERROR + 14)  /* the node the process ran on was released */
 
 
 /****    JOB STATE DEFINITIONS    ****/
@@ -1775,6 +1776,8 @@ typedef int pmix_status_t;
 #define PMIX_ERR_JOB_WDIR_NOT_FOUND                 -233
 #define PMIX_ERR_JOB_INSUFFICIENT_RESOURCES         -234
 #define PMIX_ERR_JOB_SYS_OP_FAILED                  -235
+#define PMIX_ERR_JOB_KILLED_BY_RELEASE              -236     // a resource release removed nodes this job was
+                                                             // running on, killing the processes on them
 #define PMIX_ERR_DVM_MOD                            -196     // a requested DVM grow/shrink operation failed (e.g., daemon startup
                                                              // on grow failed) - payload includes the scheduler allocation ID
                                                              // (PMIX_ALLOC_ID) and the user-provided allocation ID
@@ -1796,6 +1799,7 @@ typedef int pmix_status_t;
 #define PMIX_ERR_PROC_REQUESTED_ABORT               -8
 #define PMIX_ERR_PROC_TERM_WO_SYNC                  -200
 #define PMIX_EVENT_PROC_TERMINATED                  -201
+#define PMIX_ERR_PROC_KILLED_BY_RELEASE             -204     // the node this process ran on was released
 #define PMIX_ERR_PROC_KILLED_BY_CMD                 -400
 #define PMIX_ERR_PROC_FAILED_TO_START               -401
 #define PMIX_ERR_PROC_ABORTED_BY_SIG                -402

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -91,6 +91,8 @@ PMIX_EXPORT const char *PMIx_Proc_state_string(pmix_proc_state_t state)
         return "PROC TERMINATED WITH NON-ZERO STATUS";
     case PMIX_PROC_STATE_FAILED_TO_LAUNCH:
         return "PROC FAILED TO LAUNCH";
+    case PMIX_PROC_STATE_KILLED_BY_RELEASE:
+        return "PROC KILLED BY RESOURCE RELEASE";
     default:
         return "UNKNOWN STATE";
     }


### PR DESCRIPTION
A resource release that removes nodes still running a job kills the processes on
them. PMIx has no status for that, so a runtime either says nothing — PRRTE
recorded such a process as normally terminated, and the job it belonged to ended
"successfully" — or borrows a status that means something else. The nearest ones
are `PMIX_ERR_JOB_CANCELED`, `PMIX_ERR_PROC_KILLED_BY_CMD` and
`PMIX_PROC_STATE_KILLED_BY_CMD`, all of which say a command ended the job and
none of which can be told apart from an operator cancelling it.

That distinction is the point for an elastic framework, which shrinks by
releasing nodes: without it, the framework cannot tell a loss it inflicted on
itself from one imposed on it, though only the latter should abort the campaign.

PMIx already names the ways a process can be lost: aborted by signal, terminated
without sync, sensor bound exceeded, killed by command. The resource-driven one
is missing, even though the operations that cause it — `PMIX_ALLOC_RELEASE`, and
the DVM size-change events `PMIX_ERR_DVM_MOD` and `PMIX_DVM_IS_READY` — are
already standard.

Adds:

- `PMIX_ERR_JOB_KILLED_BY_RELEASE` (-236), continuing the job-error block
- `PMIX_ERR_PROC_KILLED_BY_RELEASE` (-204), in the process-event block
- `PMIX_PROC_STATE_KILLED_BY_RELEASE` (`PMIX_PROC_STATE_ERROR + 14`), with its
  `PMIx_Proc_state_string()` case

All three are listed in `docs/exceptions.rst`. `pmix_event_strings.c` is
generated from `pmix_common.h.in`, so no generated file is committed; a dry run
of `contrib/construct_event_strings.py` confirms both statuses are harvested.

Consumed by the matching PRRTE change, which reports the processes a DVM node
release kills instead of recording them as normally terminated.
