### PR TITLE
Finish the pmix_client_get.c per-file review

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -295,16 +295,35 @@ both in ``src/client``:
   off by the *directory-wide* five-lens seventh sweep — recorded there as
   coming through all five lenses with nothing to fix — and has not moved
   since.
-* ``pmix_client_get.c``'s dedicated pass is **incomplete**, and the
-  ledger says so: lens 1 (memory) only, over ``process_request``,
-  ``PMIx_Get``, ``PMIx_Get_nb``, ``gcbfn`` and ``try_local_fetch``.
-  ``get_data`` (~500 lines), ``_getnb_cbfunc``, ``process_values`` and
-  ``refresh_cache``/``refcb`` were never read, and lenses 2–5 were never
-  applied.  The work that followed the same day — the realm and
-  job-level-data fixes, the NULL-key answer, the ownership contract now
-  stated in ``PMIx_Get(3)`` — chased specific findings out of that
-  partial pass; it did not finish it.  This is the next piece of
-  per-file work in either directory.
+* ``pmix_client_get.c``'s dedicated pass ran in two parts, and only the
+  second one finished it.  The first (2026-08-22) covered lens 1
+  (memory) over ``process_request``, ``PMIx_Get``, ``PMIx_Get_nb``,
+  ``gcbfn`` and ``try_local_fetch`` and stopped there; ``get_data``
+  (~500 lines), ``_getnb_cbfunc``, ``process_values`` and
+  ``refresh_cache``/``refcb`` went unread, and lenses 2–5 were never
+  applied to any of it.  The work that followed the same day — the realm
+  and job-level-data fixes, the NULL-key answer, the ownership contract
+  now stated in ``PMIx_Get(3)`` — chased specific findings out of that
+  partial pass rather than completing it.  **All five lenses have since
+  been applied to the whole file (2026-08-25)**, which is what found the
+  entry below.
+
+  What that second part found is worth stating here, because it is a
+  property of the *list* rather than of either function that walks it.
+  ``pmix_client_globals.pending_requests`` is two tables in one — the
+  coalescing table ``get_data()`` consults before it sends, and the
+  delivery table ``_getnb_cbfunc()`` walks when a reply arrives — and
+  they matched on different predicates: ``PMIX_CHECK_NAMES``, which
+  treats ``PMIX_RANK_WILDCARD`` on either side as a match, against exact
+  rank equality.  A get for a specific rank issued while a get at
+  ``WILDCARD`` for the same namespace was outstanding was therefore
+  folded onto it, never sent, and never matched by the reply — and
+  nothing else drains that list, so a blocking ``PMIx_Get`` waited
+  forever and a ``PMIx_Get_nb`` was never called back at all.  Both
+  sites now use one exact predicate; ``test/unit/get_api.c`` covers it.
+  The general shape to look for: **one list serving two questions is
+  one question, and a request the first accepts and the second rejects
+  is not refused, it is lost.**
 
 Not yet reviewed
 ^^^^^^^^^^^^^^^^

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -2978,6 +2978,25 @@ is the shape `PMIx_Connect_nb` already uses for its job-info fetch.
   `cbdes()` does not touch `proc`; the snapshot exists because the caddy
   the reply was addressed to is itself on the pending list and its `lg`
   is released partway through the delivery loop.
+- **`_getnb_cbfunc()` fetches at `PMIX_SCOPE_UNDEF`, discarding the
+  caller's `PMIX_DATA_SCOPE`**, which reads as a dropped directive. It is
+  deliberate and must stay. The fetch it is about to make is over data
+  the *server* just sent, stored under whichever scope the payload named,
+  and the caller's scope describes where *they* expected to find it — so
+  honoring it here would turn a reply that did arrive into
+  `PMIX_ERR_NOT_FOUND` whenever the two disagree. The local paths
+  (`get_data()`, `try_local_fetch()`) do honor it, because there the
+  scope selects which of this process's own tables to search.
+- **The `PMIX_RANK_WILDCARD` retry in `_getnb_cbfunc()` is the twin of
+  the one deliberately removed from `get_data()`** — the same
+  client-side compensation for a module that will not answer at
+  `PMIX_RANK_UNDEF`, in the path that runs after the server's reply is
+  stored. It is left in place, and left named here rather than quietly
+  removed: with both modules now answering `UNDEF` out of the job-level
+  store it should be dead, but the case that would prove it is a *remote*
+  get — a proc whose data is not already cached, which is a
+  `contrib/dockerswarm` case and not a `make check` one. Retire it with
+  that evidence, not by reasoning from the local path.
 - **`PMIX_GET_POINTER_VALUES` is honored only by the three shortcuts
   `process_request()` answers outright** (`PMIX_PROCID`, `PMIX_RANK`,
   and — inconsistently — not `PMIX_VERSION_NUMERIC`). Every other path
@@ -2985,6 +3004,89 @@ is the shape `PMIx_Connect_nb` already uses for its job-info fetch.
   gap against what the attribute says, but closing it is a change to the
   ownership rules `PMIx_Get(3)` documents rather than a fix; recorded in
   `docs/todo.rst`.
+
+## `pending_requests` is two tables, and both must ask it the same question
+
+`pmix_client_globals.pending_requests` does two jobs. `get_data()`
+consults it before it sends, so that several gets for one proc cost one
+round trip; `_getnb_cbfunc()` walks it when a reply arrives, to deliver
+that reply to every request waiting on it. **A request that the first
+question accepts and the second rejects is lost** — nothing else drains
+this list, so a blocking `PMIx_Get` waits on a lock nothing will wake and
+a `PMIx_Get_nb` is never called back at all (its caddy is released,
+silently, by the `PMIX_LIST_DESTRUCT` in `PMIx_Finalize`).
+
+The two used different predicates. Coalescing matched with
+`PMIX_CHECK_NAMES`, which reports a match whenever *either* rank is
+`PMIX_RANK_WILDCARD`; delivery compared ranks exactly. So a get for a
+specific rank issued while a get at `PMIX_RANK_WILDCARD` for the same
+namespace was outstanding was folded onto that request, never sent, and
+then never matched by its reply. Both directions do it, and it needs no
+threads: two `PMIx_Get_nb` calls back to back are enough, and a get of a
+job-level key the local store does not hold is exactly the kind of
+request that reaches the server at `WILDCARD`.
+
+Both call sites now go through `same_target()`, which is exact.
+**Exact is the right answer, not merely the consistent one.** A reply
+carries the data for the rank that was asked about, and job-level data —
+what a `WILDCARD` request returns — is not any particular proc's data, so
+answering a ranked request out of it would report "not found" for a
+proc the server was never asked about.
+
+Two details to preserve if you touch either site. The coalescing scan
+compares what each request **recorded about itself** (`cb->pname`), not
+the rank it is about to send: `get_data()` rewrites the outgoing rank to
+`WILDCARD` for a NULL key in another namespace and for a pre-v3.2 server,
+while `cb->pname` keeps the original — and `cb->pname` is what the reply
+is matched against. And `same_target()` uses `PMIX_CHECK_NSPACE` for the
+namespace half, which is empty-tolerant; that is safe here only because
+`process_request()` fills `lg->p.nspace` on every path, so neither side
+can carry an empty one.
+
+Regression: `check_coalescing()` in
+[`test/unit/get_api.c`](../../test/unit/get_api.c). Both of its requests
+carry `PMIX_IMMEDIATE`, which is what makes the case bounded — without it
+the server *parks* a request it cannot satisfy and neither call
+completes, fixed or not, so the test would wedge instead of failing.
+
+## A lost connection is not a missing key
+
+`_getnb_cbfunc()` seeds its status with `PMIX_ERR_NOT_FOUND` — the answer
+for a reply that arrives and carries nothing — and the empty-buffer arm
+that means "the connection died, this recv is being completed
+synthetically" used to fall into the delivery loop with that seed still
+standing. Every waiter on the proc was then told the key does not exist.
+
+Those are different facts and callers act on them differently: a missing
+key invites another key or a retry, while a dead server means nothing
+this process asks will ever be answered. `refcb()`, the other recv
+callback in this file, already reported `PMIX_ERR_LOST_CONNECTION`; the
+get path now does too. The same distinction is why `job_data()` in
+[`pmix_client.c`](pmix_client.c) reports a lost connection rather than a
+generic failure — see "Two return codes from `PMIx_Init`" above.
+
+No coverage: reaching it needs a server that dies with a request
+outstanding, which `make check` has no way to arrange from inside the one
+process that is both halves.
+
+## Building the augmented info array a realm request sends
+
+The `PMIX_NODE_INFO` / `PMIX_APP_INFO` / `PMIX_SESSION_INFO` branches of
+`get_data()` all have to add a directive or two to what the caller
+supplied, and the caller's `info[]` is never ours to edit — so each
+copies it into a fresh array and sets `cb->infocopy` so the caddy
+destructor frees the copy rather than the caller's. Six blocks did that,
+identically, and all six discarded the copy's status.
+
+`PMIX_INFO_XFER` discards it *by definition*, and the transfer sets each
+destination's type before it can fail, so a directive that would not copy
+does not leave an empty slot the server can skip: it leaves one naming a
+type with nothing behind it, and this array is what `_pack_get()` puts on
+the wire. The six blocks are now one call to `copy_directives()`, which
+uses the function form and reports. Same defect and same fix as the
+`PMIX_INFO_XFER` in the twelfth sweep's apps copy — **treat any
+`PMIX_INFO_XFER` in this directory as an unchecked call until you have
+looked**.
 
 ## The PTL never hands a recv handler a NULL buffer
 

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -2987,16 +2987,68 @@ is the shape `PMIx_Connect_nb` already uses for its job-info fetch.
   `PMIX_ERR_NOT_FOUND` whenever the two disagree. The local paths
   (`get_data()`, `try_local_fetch()`) do honor it, because there the
   scope selects which of this process's own tables to search.
-- **The `PMIX_RANK_WILDCARD` retry in `_getnb_cbfunc()` is the twin of
-  the one deliberately removed from `get_data()`** — the same
-  client-side compensation for a module that will not answer at
-  `PMIX_RANK_UNDEF`, in the path that runs after the server's reply is
-  stored. It is left in place, and left named here rather than quietly
-  removed: with both modules now answering `UNDEF` out of the job-level
-  store it should be dead, but the case that would prove it is a *remote*
-  get — a proc whose data is not already cached, which is a
-  `contrib/dockerswarm` case and not a `make check` one. Retire it with
-  that evidence, not by reasoning from the local path.
+- **The `PMIX_RANK_WILDCARD` retry in `_getnb_cbfunc()` is a
+  cross-version fallback, not compensation for our own datastore. Do not
+  remove it.** It reads like the twin of the retry deliberately removed
+  from `get_data()`, and that reading is wrong in the one way that
+  matters. `get_data()`'s retry ran against *this process's* store, where
+  answering `PMIX_RANK_UNDEF` is the module's job and a client working
+  around a module that will not is a client that cannot tell you the
+  module is broken. This one runs against what a **server** just sent us,
+  and the commit that added it (`7ba403b52`, 2024) says why: "the server
+  may have returned the data under that rank *depending upon version*".
+  Which rank the payload is filed under is the peer's decision and it
+  varies by release — the same class as the `PMIX_PEER_IS_EARLIER`
+  rewrite in `get_data()` forty lines above, which sends a NULL-key
+  request at `WILDCARD` while recording `UNDEF`, and so *creates* the
+  mismatch this retry absorbs. `try_fetch()` in
+  [`pmix_client_resolve.c`](pmix_client_resolve.c) is the third instance,
+  and its comment says the legacy resolve path resolves *because of* it.
+
+  **It has never been observed to fire, and that is not evidence against
+  it.** Instrumented on both of its sites, it was not entered once
+  across: the whole `contrib/dockerswarm` client suite; two purpose-built
+  multi-node probes (a keyed `UNDEF` get of a peer's key, and a NULL key
+  naming another namespace); and a **v3.2.5 server driving a master
+  client** through five `UNDEF`-rank get shapes. v3.2 is the
+  interoperability floor, so that last one is the oldest server that has
+  to work.
+
+  What those runs establish is *why* it is so hard to reach, which is the
+  useful part. The branch needs two things at once: the server answered
+  **successfully**, and the reply is being matched at `PMIX_RANK_UNDEF`.
+  A keyed `UNDEF` get of a peer's key satisfies the second and never the
+  first — a v3.2 server leaves it parked until `PMIX_ERR_TIMEOUT`, and
+  PRRTE answers `PMIX_ERR_NOT_FOUND`, because neither will direct-modex
+  an undefined rank; `_getnb_cbfunc()` then takes its error branch before
+  any fetch happens. The shapes that *do* come back successfully — a NULL
+  key naming another namespace, a job-level key at `UNDEF` — are answered
+  by the primary fetch. So the retry is unreachable in every
+  configuration that can be built here, and the case its author names is
+  one no available server produces.
+
+  Keep it anyway. The cost of carrying it is one extra failed lookup on a
+  path that has already missed; the cost of being wrong about it is a
+  silently stranded job on a mixed-version system, which is the failure
+  this project spends the most to avoid. If you want to retire it, the
+  thing to produce is a server that answers a `PMIX_RANK_UNDEF` request
+  with data filed under `PMIX_RANK_WILDCARD` — not another run in which
+  it stays quiet.
+
+  **Two method notes, both of which cost a full cycle here.** The swarm
+  runner prints verdicts, not client output, so the first "zero hits"
+  came from logs that could not have carried one — `strings` the
+  installed library for your marker and prove a client's stderr reaches
+  you (`prterun … /bin/sh -c 'echo x >&2'`) before believing a silent
+  instrument. And a hand-compiled probe binds to whatever
+  `DYLD_LIBRARY_PATH` the harness hands it, which under an old
+  `pmix_test` is that build's library, not yours: the in-tree clients work
+  because libtool's wrapper script *prepends* their own `.libs`. Copy
+  that, or you will measure the wrong library — and a probe whose every
+  rank publishes the same key measures nothing at all, since the caller's
+  own `PMIx_Put` answers it locally and the request never leaves the
+  process.
+
 - **`PMIX_GET_POINTER_VALUES` is honored only by the three shortcuts
   `process_request()` answers outright** (`PMIX_PROCID`, `PMIX_RANK`,
   and — inconsistently — not `PMIX_VERSION_NUMERIC`). Every other path

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -1274,7 +1274,7 @@ static void get_data(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS == rc || PMIX_OPERATION_SUCCEEDED == rc) {
                         kv = (pmix_kval_t*)pmix_list_remove_first(&cb2.kvs);
                         PMIX_DESTRUCT(&cb2);
-                        if (NULL != kv) {  // will never be NULL
+                        if (NULL != kv) { // should never be NULL
                             rc = PMIx_Value_get_number(kv->value, &lg->nodeid, PMIX_UINT32);
                             PMIX_RELEASE(kv);
                         } else {

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -94,6 +94,32 @@ static pmix_status_t refresh_cache(const pmix_proc_t *p);
         PMIX_CONSTRUCT(&(c)->kvs, pmix_list_t);     \
     } while (0)
 
+/* Do these two requests name the same data?
+ *
+ * pmix_client_globals.pending_requests is two tables in one - the
+ * coalescing table get_data() consults before it sends, and the delivery
+ * table _getnb_cbfunc() walks when a reply arrives - and the two have to
+ * ask it the same question. They did not: the coalescing scan used
+ * PMIX_CHECK_NAMES, which reports a match whenever *either* rank is
+ * PMIX_RANK_WILDCARD, while the delivery walk compares ranks exactly. So
+ * a get for a specific rank issued while a get at WILDCARD for the same
+ * namespace was outstanding was folded onto that request and never sent,
+ * and then never matched when the reply came back. Nothing else drains
+ * this list, so a blocking PMIx_Get waited forever and a PMIx_Get_nb was
+ * simply never called back (its caddy is released, silently, by the
+ * PMIX_LIST_DESTRUCT in PMIx_Finalize).
+ *
+ * Exact is the right answer for both. A reply carries the data for the
+ * rank that was asked about, and job-level data - which is what a
+ * WILDCARD request returns - is not any particular proc's data, so
+ * coalescing across the two would answer a request the server was never
+ * asked. */
+static bool same_target(const char *ns1, pmix_rank_t r1,
+                        const char *ns2, pmix_rank_t r2)
+{
+    return (r1 == r2) && PMIX_CHECK_NSPACE(ns1, ns2);
+}
+
 /* A PMIX_QUALIFIED_VALUE kval carries the value the caller actually asked for
  * as the first element of a PMIX_INFO data array, with the qualifiers behind
  * it. Three places here unwrap that, and all three used to reach straight
@@ -537,6 +563,11 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
 
     /* the request is good - let's go get the data */
     cb = PMIX_NEW(pmix_cb_t);
+    if (PMIX_UNLIKELY(NULL == cb)) {
+        PMIX_RELEASE(lg);
+        *val = NULL;
+        return PMIX_ERR_NOMEM;
+    }
     cb->lg = lg;
     cb->key = (char*)key;
     cb->info = (pmix_info_t*)info;
@@ -568,8 +599,15 @@ answered:
         if (lg->stval) {
             /* the caller provided the storage, so copy into it - and then
              * release our own copy, which nothing else owns (the caddy
-             * destructor does not touch "value") */
-            PMIx_Value_xfer(*val, cb->value);
+             * destructor does not touch "value").
+             *
+             * Report a transfer that fails rather than discarding it: the
+             * xfer sets the destination's type before it can fail, so the
+             * caller would otherwise be told the get succeeded and handed
+             * their own storage naming a type with nothing behind it.
+             * *val is not cleared on that path - it is the caller's own
+             * object, not something we allocated. */
+            rc = PMIx_Value_xfer(*val, cb->value);
             PMIX_VALUE_RELEASE(cb->value);   /* nulls cb->value */
         } else {
             *val = cb->value;
@@ -580,6 +618,15 @@ answered:
          * still ours to reclaim */
         if (NULL != cb->value) {
             PMIX_VALUE_RELEASE(cb->value);
+        }
+        if (PMIX_SUCCESS == rc) {
+            /* a success with nothing behind it is the one answer the
+             * caller cannot act on: PMIx_Get(3) entitles them to
+             * dereference *val when we say SUCCESS. Nothing produces it
+             * today - process_values() returns a value or a status - so
+             * this is what keeps that true rather than something the
+             * caller has to defend against. */
+            rc = PMIX_ERR_NOT_FOUND;
         }
         *val = NULL;
     }
@@ -646,6 +693,21 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
     if (PMIX_OPERATION_SUCCEEDED == rc) {
         /* the value has already been prepped - threadshift to return result */
         cb = PMIX_NEW(pmix_cb_t);
+        if (PMIX_UNLIKELY(NULL == cb)) {
+            /* the value process_request() prepped is ours until the
+             * callback hands it over, so it goes back here - unless it
+             * is one of the two process-lifetime globals a
+             * PMIX_GET_POINTER_VALUES request is answered with. (The
+             * third form, PMIX_GET_STATIC_VALUES, cannot arise on this
+             * entry point: it names storage the caller provides through
+             * "val", and the non-blocking form has no such argument, so
+             * process_request() refuses it.) */
+            if (NULL != val && !lg->pntrval) {
+                PMIX_VALUE_RELEASE(val);
+            }
+            PMIX_RELEASE(lg);
+            return PMIX_ERR_NOMEM;
+        }
         cb->status = PMIX_SUCCESS;
         cb->value = val;
         cb->cbfunc.valuefn = cbfunc;
@@ -683,6 +745,10 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
 
     /* the request is good - let's go get the data */
     cb = PMIX_NEW(pmix_cb_t);
+    if (PMIX_UNLIKELY(NULL == cb)) {
+        PMIX_RELEASE(lg);
+        return PMIX_ERR_NOMEM;
+    }
     cb->lg = lg;
     cb->key = (char*)key;
     cb->info = (pmix_info_t*)info;
@@ -739,6 +805,11 @@ static pmix_buffer_t *_pack_get(pmix_cb_t *cb,
 
     /* nope - see if we can get it */
     msg = PMIX_NEW(pmix_buffer_t);
+    if (PMIX_UNLIKELY(NULL == msg)) {
+        /* every failure arm below releases the message, and
+         * PMIX_RELEASE dereferences what it is given */
+        return NULL;
+    }
     /* pack the get cmd */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
@@ -817,10 +888,18 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     lg = cb->lg;
 
     /* a zero-byte buffer indicates that this recv is being
-     * completed due to a lost connection */
+     * completed due to a lost connection. Say that, rather than letting
+     * the PMIX_ERR_NOT_FOUND this status was seeded with stand: every
+     * waiter below is about to be answered with it, and "the key does not
+     * exist" is a different fact from "the server this process was asking
+     * is gone" - the first invites the caller to try another key or give
+     * up on one value, the second means nothing it asks will ever be
+     * answered. refcb() below, the other recv callback in this file,
+     * already reports it that way. */
     if (PMIX_BUFFER_IS_EMPTY(buf)) {
         pmix_output_verbose(2, pmix_client_globals.get_output,
                             "pmix: get_nb server lost connection");
+        ret = PMIX_ERR_LOST_CONNECTION;
         goto done;
     }
 
@@ -873,7 +952,8 @@ done:
      * be released, so we must not dereference lg during the loop */
     PMIX_LOAD_PROCID(&rproc, lg->p.nspace, lg->p.rank);
     PMIX_LIST_FOREACH_SAFE (cb, cb2, &pmix_client_globals.pending_requests, pmix_cb_t) {
-        if (PMIX_CHECK_NSPACE(rproc.nspace, cb->pname.nspace) && cb->pname.rank == rproc.rank) {
+        if (same_target(rproc.nspace, rproc.rank,
+                        cb->pname.nspace, cb->pname.rank)) {
             /* reset per iteration so a failed fetch for this request can
              * never deliver a value already handed to a previous one */
             val = NULL;
@@ -1005,8 +1085,17 @@ static pmix_status_t process_values(pmix_cb_t *cb)
         }
         return PMIX_SUCCESS;
     }
-    /* we will return the data as an array of pmix_info_t
-     * in the kvs pmix_value_t */
+    /* Anything else is handed back as an array of pmix_info_t in a
+     * single pmix_value_t. An empty list has to be caught before that:
+     * PMIx_Info_create() answers a zero count with the same NULL an
+     * allocation failure gives, so a fetch that reported success with
+     * nothing on the list would be reported as PMIX_ERR_NOMEM. Neither
+     * in-tree module does that today - both report success only when
+     * they appended something - which is exactly why the wrong status
+     * would be so hard to place if one ever did. */
+    if (0 == pmix_list_get_size(kvs)) {
+        return PMIX_ERR_NOT_FOUND;
+    }
     PMIX_VALUE_CREATE(val, 1);
     if (PMIX_UNLIKELY(NULL == val)) {
         return PMIX_ERR_NOMEM;
@@ -1057,6 +1146,42 @@ static pmix_status_t process_values(pmix_cb_t *cb)
     return PMIX_SUCCESS;
 }
 
+/* Copy the caller's directives into a fresh array with room for "nextra"
+ * more behind them, which the realm branches in get_data() fill in.
+ *
+ * The caller's info[] is never ours to edit, so a request that has to add
+ * a directive has to copy first - and the copy's status matters. The
+ * transfer sets each destination's type before it can fail, so a
+ * directive that would not copy does not leave an empty slot the server
+ * can skip: it leaves one naming a type with nothing behind it, and this
+ * array is what _pack_get() puts on the wire. PMIX_INFO_XFER discards
+ * that status by definition, which is why this uses the function form.
+ *
+ * Returns NULL with "*status" set, having freed the partial array; on
+ * success it sets "*nfo" to the total length. */
+static pmix_info_t *copy_directives(pmix_cb_t *cb, size_t nextra,
+                                    size_t *nfo, pmix_status_t *status)
+{
+    pmix_info_t *iptr;
+    size_t n, total;
+
+    total = cb->ninfo + nextra;
+    PMIX_INFO_CREATE(iptr, total);
+    if (PMIX_UNLIKELY(NULL == iptr)) {
+        *status = PMIX_ERR_NOMEM;
+        return NULL;
+    }
+    for (n = 0; n < cb->ninfo; n++) {
+        *status = PMIx_Info_xfer(&iptr[n], &cb->info[n]);
+        if (PMIX_UNLIKELY(PMIX_SUCCESS != *status)) {
+            PMIX_INFO_FREE(iptr, total);
+            return NULL;
+        }
+    }
+    *nfo = total;
+    return iptr;
+}
+
 static void get_data(int sd, short args, void *cbdata)
 {
     pmix_cb_t *cb, cb2;
@@ -1066,7 +1191,7 @@ static void get_data(int sd, short args, void *cbdata)
     pmix_proc_t proc;
     pmix_get_logic_t *lg;
     pmix_info_t optional, *iptr;
-    size_t nfo, n;
+    size_t nfo;
     pmix_kval_t *kv;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
@@ -1211,14 +1336,9 @@ static void get_data(int sd, short args, void *cbdata)
          * nodename or nodeid */
         if (lg->nodedirective) {
             /* just need to add the hostname/nodeid */
-            nfo = cb->ninfo + 2;
-            PMIX_INFO_CREATE(iptr, nfo);
+            iptr = copy_directives(cb, 2, &nfo, &cb->status);
             if (PMIX_UNLIKELY(NULL == iptr)) {
-                cb->status = PMIX_ERR_NOMEM;
                 goto done;
-            }
-            for (n=0; n < cb->ninfo; n++) {
-                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
             }
             if (NULL != lg->hostname) {
                 PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_HOSTNAME, lg->hostname, PMIX_STRING);
@@ -1229,14 +1349,9 @@ static void get_data(int sd, short args, void *cbdata)
             cb->infocopy = true;
         } else {
             /* need to add directive and hostname/nodeid */
-            nfo = cb->ninfo + 3;
-            PMIX_INFO_CREATE(iptr, nfo);
+            iptr = copy_directives(cb, 3, &nfo, &cb->status);
             if (PMIX_UNLIKELY(NULL == iptr)) {
-                cb->status = PMIX_ERR_NOMEM;
                 goto done;
-            }
-            for (n=0; n < cb->ninfo; n++) {
-                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
             }
             PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_NODE_INFO, NULL, PMIX_BOOL);
             if (NULL != lg->hostname) {
@@ -1317,28 +1432,18 @@ static void get_data(int sd, short args, void *cbdata)
         /* setup the request */
         if (lg->appdirective) {
             /* just need to add the appnum */
-            nfo = cb->ninfo + 2;
-            PMIX_INFO_CREATE(iptr, nfo);
+            iptr = copy_directives(cb, 2, &nfo, &cb->status);
             if (PMIX_UNLIKELY(NULL == iptr)) {
-                cb->status = PMIX_ERR_NOMEM;
                 goto done;
-            }
-            for (n=0; n < cb->ninfo; n++) {
-                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
             }
             PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_APPNUM, &lg->appnum, PMIX_UINT32);
             PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_OPTIONAL, NULL, PMIX_BOOL);
             cb->infocopy = true;
         } else {
             /* need to add directive and appnum */
-            nfo = cb->ninfo + 3;
-            PMIX_INFO_CREATE(iptr, nfo);
+            iptr = copy_directives(cb, 3, &nfo, &cb->status);
             if (PMIX_UNLIKELY(NULL == iptr)) {
-                cb->status = PMIX_ERR_NOMEM;
                 goto done;
-            }
-            for (n=0; n < cb->ninfo; n++) {
-                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
             }
             PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_APP_INFO, NULL, PMIX_BOOL);
             PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_APPNUM, &lg->appnum, PMIX_UINT32);
@@ -1421,28 +1526,18 @@ static void get_data(int sd, short args, void *cbdata)
         /* setup the request */
         if (lg->sessiondirective) {
             /* just need to add the sessionid */
-            nfo = cb->ninfo + 2;
-            PMIX_INFO_CREATE(iptr, nfo);
+            iptr = copy_directives(cb, 2, &nfo, &cb->status);
             if (PMIX_UNLIKELY(NULL == iptr)) {
-                cb->status = PMIX_ERR_NOMEM;
                 goto done;
-            }
-            for (n=0; n < cb->ninfo; n++) {
-                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
             }
             PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_SESSION_ID, &lg->sessionid, PMIX_UINT32);
             PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_OPTIONAL, NULL, PMIX_BOOL);
             cb->infocopy = true;
         } else {
             /* need to add directive and sessionid */
-            nfo = cb->ninfo + 3;
-            PMIX_INFO_CREATE(iptr, nfo);
+            iptr = copy_directives(cb, 3, &nfo, &cb->status);
             if (PMIX_UNLIKELY(NULL == iptr)) {
-                cb->status = PMIX_ERR_NOMEM;
                 goto done;
-            }
-            for (n=0; n < cb->ninfo; n++) {
-                PMIX_INFO_XFER(&iptr[n], &cb->info[n]);
             }
             PMIX_INFO_LOAD(&iptr[cb->ninfo], PMIX_SESSION_INFO, NULL, PMIX_BOOL);
             PMIX_INFO_LOAD(&iptr[cb->ninfo+1], PMIX_SESSION_ID, &lg->sessionid, PMIX_UINT32);
@@ -1592,7 +1687,12 @@ doget:
      * this nspace:rank. If we do, then no need to ask again as the
      * request will return _all_ data from that proc */
     PMIX_LIST_FOREACH (cbret, &pmix_client_globals.pending_requests, pmix_cb_t) {
-        if (PMIX_CHECK_NAMES(&cbret->pname, &proc)) {
+        /* compare what each request recorded about itself, not the rank
+         * this one is about to ask the server with - the rewrite above
+         * varies that, and cb->pname is what the reply is matched
+         * against. See same_target() for why the two must agree. */
+        if (same_target(cbret->pname.nspace, cbret->pname.rank,
+                        cb->pname.nspace, cb->pname.rank)) {
             pmix_output_verbose(2, pmix_client_globals.get_output,
                                 "%s ADDING REQUEST TO PENDING %s:%s KEY %s",
                                 PMIX_NAME_PRINT(&pmix_globals.myid), cb->proc->nspace,
@@ -1743,6 +1843,9 @@ static pmix_status_t refresh_cache(const pmix_proc_t *p)
     /* pack a quick message to the server asking it
      * to refresh our cache */
     msg = PMIX_NEW(pmix_buffer_t);
+    if (PMIX_UNLIKELY(NULL == msg)) {
+        return PMIX_ERR_NOMEM;
+    }
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, msg, &cmd, 1, PMIX_COMMAND);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
@@ -1763,6 +1866,10 @@ static pmix_status_t refresh_cache(const pmix_proc_t *p)
     }
 
     cb = PMIX_NEW(pmix_cb_t);
+    if (PMIX_UNLIKELY(NULL == cb)) {
+        PMIX_RELEASE(msg);
+        return PMIX_ERR_NOMEM;
+    }
     cb->proc = (pmix_proc_t*)p;
 
     /* send to the server */

--- a/src/mca/bfrops/bfrops_types.h
+++ b/src/mca/bfrops/bfrops_types.h
@@ -85,6 +85,15 @@ pmix_bfrop_tma_kval_new(
         if (PMIX_UNLIKELY(NULL == k->value)) {
             PMIX_RELEASE(k);
             k = NULL;
+        } else {
+            /* the allocation is raw, and kvdes() runs value_destruct()
+             * on whatever is here - reading the type and freeing the
+             * union member it names. So a kval released before its value
+             * has been filled in would hand the heap an address out of
+             * uninitialized memory, and every caller of this has at
+             * least one error path between the two. Zeroing gives the
+             * value PMIX_UNDEF, which destructs to nothing. */
+            memset(k->value, 0, sizeof(pmix_value_t));
         }
     }
     return k;

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -338,23 +338,48 @@ static pmix_status_t make_copy(pmix_regattr_input_t *p,
     pmix_data_array_t *darray;
     pmix_qual_t *quals;
     pmix_info_t *iptr;
+    pmix_status_t rc;
     size_t nq, m;
 
     if (UINT32_MAX != hv->qualindex) {
         /* this is a qualified value - need to return it as such */
         PMIX_KVAL_NEW(kv, PMIX_QUALIFIED_VALUE);
+        if (NULL == kv) {
+            return PMIX_ERR_NOMEM;
+        }
         darray = (pmix_data_array_t*)pmix_pointer_array_get_item(proc_data->quals, hv->qualindex);
         if (NULL == darray) {
             PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+            PMIX_RELEASE(kv);
             return PMIX_ERR_NOT_FOUND;
         }
         quals = (pmix_qual_t*)darray->array;
         nq = darray->size;
+        /* PMIx_Data_array_create is two allocations and reports only the
+         * first: it answers with a descriptor whose "array" is NULL when
+         * the element block could not be had */
         PMIX_DATA_ARRAY_CREATE(darray, nq+1, PMIX_INFO);
+        if (NULL == darray || NULL == darray->array) {
+            PMIX_RELEASE(kv);
+            if (NULL != darray) {
+                PMIX_DATA_ARRAY_FREE(darray);
+            }
+            return PMIX_ERR_NOMEM;
+        }
         iptr = (pmix_info_t*)darray->array;
-        /* the first location is the actual value */
+        /* the first location is the actual value. Report a transfer that
+         * fails rather than discarding it: the xfer sets the
+         * destination's type before it can fail, so a value that would
+         * not copy leaves an element naming a type with nothing behind
+         * it - and this array is what a PMIx_Get of a qualified value
+         * hands back to the application */
         PMIX_LOAD_KEY(iptr[0].key, p->string);
-        PMIx_Value_xfer(&iptr[0].value, hv->value);
+        rc = PMIx_Value_xfer(&iptr[0].value, hv->value);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(kv);
+            PMIX_DATA_ARRAY_FREE(darray);
+            return rc;
+        }
         /* now add the qualifiers */
         for (m=0; m < nq; m++) {
             p = pmix_hash_lookup_key(quals[m].index, NULL, keyindex);
@@ -365,7 +390,12 @@ static pmix_status_t make_copy(pmix_regattr_input_t *p,
                 return PMIX_ERR_BAD_PARAM;
             }
             PMIX_LOAD_KEY(iptr[m+1].key, p->string);
-            PMIx_Value_xfer(&iptr[m+1].value, quals[m].value);
+            rc = PMIx_Value_xfer(&iptr[m+1].value, quals[m].value);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_RELEASE(kv);
+                PMIX_DATA_ARRAY_FREE(darray);
+                return rc;
+            }
             PMIX_INFO_SET_QUALIFIER(&iptr[m+1]);
         }
         kv->value->type = PMIX_DATA_ARRAY;
@@ -373,7 +403,14 @@ static pmix_status_t make_copy(pmix_regattr_input_t *p,
         pmix_list_append(kvals, &kv->super);
     } else {
         PMIX_KVAL_NEW(kv, p->string);
-        PMIx_Value_xfer(kv->value, hv->value);
+        if (NULL == kv) {
+            return PMIX_ERR_NOMEM;
+        }
+        rc = PMIx_Value_xfer(kv->value, hv->value);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(kv);
+            return rc;
+        }
         pmix_list_append(kvals, &kv->super);
     }
     return PMIX_SUCCESS;

--- a/test/unit/get_api.c
+++ b/test/unit/get_api.c
@@ -203,6 +203,92 @@ static int check_client_scalar(const char *name, const char *key, uint32_t expec
     return ok ? 0 : 1;
 }
 
+/* ------------------------------------------------------------------ */
+/* two outstanding requests, one of which is coalesced onto the other  */
+/* ------------------------------------------------------------------ */
+
+/* pmix_client_globals.pending_requests is both the table get_data()
+ * consults to avoid asking the server twice for one proc's data, and the
+ * table _getnb_cbfunc() walks to deliver a reply. The two asked it
+ * different questions: the coalescing scan matched with PMIX_CHECK_NAMES,
+ * which reports a match whenever *either* rank is PMIX_RANK_WILDCARD,
+ * while delivery compares ranks exactly. So a get for a specific rank
+ * issued while a get at WILDCARD for the same namespace was outstanding
+ * was folded onto it, never sent, and then never matched by the reply -
+ * and nothing else drains that list, so the callback simply never came.
+ *
+ * Both requests carry PMIX_IMMEDIATE, which is what makes this bounded:
+ * without it the server parks a request it cannot satisfy and neither
+ * call would complete, fixed or not. With it, a miss is answered at once,
+ * so an unfixed library shows exactly one arrival and this case fails on
+ * the timeout rather than wedging the suite.
+ *
+ * Issue order matters. The WILDCARD request has to be the one already on
+ * the list when the second arrives. */
+
+#define GET_UT_ABSENT_A "get.ut.absent.a"
+#define GET_UT_ABSENT_B "get.ut.absent.b"
+
+static volatile int narrived = 0;
+static volatile bool a_done = false;
+static volatile bool b_done = false;
+
+static void arrival_cb(pmix_status_t status, pmix_value_t *kv, void *cbdata)
+{
+    volatile bool *flag = (volatile bool *) cbdata;
+
+    (void) status;
+    /* the caller owns the value on this callback - see PMIx_Get(3) */
+    if (NULL != kv) {
+        PMIX_VALUE_RELEASE(kv);
+    }
+    *flag = true;
+    ++narrived;
+}
+
+static int check_coalescing(void)
+{
+    pmix_info_t immediate;
+    pmix_proc_t p;
+    pmix_status_t rc;
+    int n, ok;
+
+    PMIX_INFO_LOAD(&immediate, PMIX_IMMEDIATE, NULL, PMIX_BOOL);
+
+    PMIX_LOAD_PROCID(&p, GET_UT_NSPACE, PMIX_RANK_WILDCARD);
+    rc = PMIx_Get_nb(&p, GET_UT_ABSENT_A, &immediate, 1, arrival_cb, (void *) &a_done);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "  FAIL: client: wildcard request refused (%s)\n",
+                PMIx_Error_string(rc));
+        PMIX_INFO_DESTRUCT(&immediate);
+        return 1;
+    }
+
+    /* rank 1 of this namespace never connects, so the server answers this
+     * out of what it holds rather than from a peer */
+    PMIX_LOAD_PROCID(&p, GET_UT_NSPACE, 1);
+    rc = PMIx_Get_nb(&p, GET_UT_ABSENT_B, &immediate, 1, arrival_cb, (void *) &b_done);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "  FAIL: client: ranked request refused (%s)\n",
+                PMIx_Error_string(rc));
+        PMIX_INFO_DESTRUCT(&immediate);
+        return 1;
+    }
+    PMIX_INFO_DESTRUCT(&immediate);
+
+    /* both are answered in a single round trip apiece; ten seconds is a
+     * timeout, not a settling time */
+    for (n = 0; n < 200 && 2 > narrived; n++) {
+        usleep(50000);
+    }
+    ok = (a_done && b_done);
+    fprintf(stdout, "  %s: client: a ranked get is not swallowed by an "
+                    "outstanding wildcard one (wildcard=%s ranked=%s)\n",
+            ok ? "PASS" : "FAIL", a_done ? "answered" : "NO ANSWER",
+            b_done ? "answered" : "NO ANSWER");
+    return ok ? 0 : 1;
+}
+
 static int run_client(void)
 {
     pmix_proc_t me;
@@ -218,6 +304,7 @@ static int run_client(void)
                                GET_UT_TOPLEVEL, GET_UT_TOPVAL);
     bad += check_client_scalar("client: job-array key with a NULL proc",
                                GET_UT_JOBARRAY, GET_UT_ARRVAL);
+    bad += check_coalescing();
     rc = PMIx_Finalize(NULL, 0);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "client PMIx_Finalize failed: %s\n", PMIx_Error_string(rc));
@@ -382,7 +469,7 @@ int main(int argc, char **argv)
                 status = 1;
             }
             /* the client prints its own PASS/FAIL lines; count the run */
-            report("client: job-level gets with a NULL proc", 0 == status);
+            report("client: job-level gets and request coalescing", 0 == status);
         }
     }
     PMIx_Argv_free(client_env);


### PR DESCRIPTION
Completes the dedicated pass over `src/client/pmix_client_get.c`. The
earlier one (2026-08-22) covered lens 1 over five functions and stopped;
`get_data`, `_getnb_cbfunc`, `process_values` and `refresh_cache`/`refcb`
had never been read. All five lenses have now been applied to the whole
file.

> Was stacked on #4194, which has since merged; this branch is rebased
> onto current master and carries only its own five commits.

## The one that matters

`pmix_client_globals.pending_requests` does two jobs: `get_data()`
consults it to coalesce ("someone is already asking about this proc"),
and `_getnb_cbfunc()` walks it to deliver a reply. **They matched on
different predicates** — `PMIX_CHECK_NAMES`, which treats
`PMIX_RANK_WILDCARD` on either side as a match, against exact rank
equality.

So a get for a specific rank issued while a get at `WILDCARD` for the
same namespace was outstanding is folded onto it, never sent, and then
never matched by the reply. Nothing else drains that list: a blocking
`PMIx_Get` waits forever, a `PMIx_Get_nb` is never called back at all
(its caddy released without a word by `PMIx_Finalize`). Two `PMIx_Get_nb`
calls back to back are enough — no threads needed — and a get of a
job-level key the local store lacks is exactly the sort that reaches the
server at `WILDCARD`. Both sites now use one exact predicate.

`check_coalescing()` in `test/unit/get_api.c` covers it, verified by
re-breaking (`wildcard=answered ranked=NO ANSWER`).

## The rest

- **A lost connection was reported as `PMIX_ERR_NOT_FOUND`.** The
  empty-buffer arm fell into the delivery loop with the seeded status
  standing, so every waiter was told the key does not exist. `refcb()`
  beside it already said `PMIX_ERR_LOST_CONNECTION`.
- **Six `PMIX_INFO_XFER` loops discarded their status** building the
  realm-redirected info array — and the xfer sets the type before it can
  fail, so a directive that would not copy left a slot naming a type with
  nothing behind it, which `_pack_get()` then put on the wire. Now one
  `copy_directives()`.
- Same discarded status in `PMIx_Get`'s `PMIX_GET_STATIC_VALUES` arm;
  five allocations dereferenced unchecked (two handing `PMIX_RELEASE` the
  NULL they just got); `process_values()` reporting `PMIX_ERR_NOMEM` for
  an empty list; `PMIx_Get` able to return `PMIX_SUCCESS` with `*val`
  NULL.
- **Drive-by, own commit:** `PMIX_KVAL_NEW` gave the kval a raw-malloc'd
  value while `kvdes()` runs `value_destruct()` on it, so a kval released
  before its value is filled frees an address made of uninitialized
  memory — `make_copy()` in `pmix_hash.c` has that path, plus an
  unchecked `PMIX_KVAL_NEW`, a leaked kval, an unchecked
  `PMIx_Data_array_create` (non-NULL descriptor, NULL block), and three
  discarded `PMIx_Value_xfer` statuses.

## Documentation

`src/client/AGENTS.md` records the pending-list rule, the deliberate
`PMIX_SCOPE_UNDEF` reset (which looks like a dropped directive and is
not), and — at length — **what the `PMIX_RANK_WILDCARD` retry in
`_getnb_cbfunc()` is actually for**. The guide had described it as
compensation for a datastore that will not answer `PMIX_RANK_UNDEF`,
which reads as an invitation to remove it; this review duly removed it
and put it back. It is a cross-version fallback — `7ba403b52`: *"the
server may have returned the data under that rank depending upon
version"* — and no modern-vs-modern run can see it fire. The entry now
says that, says it was never entered across the dockerswarm suite, two
multi-node probes, and a v3.2.5 server driving a master client, explains
why (the branch needs a **successful** reply matched at `UNDEF`, and no
available server will direct-modex an undefined rank), and states what
retiring it would actually require.

## Testing

`make check` 21/21 and unit 100/102 (2 known SKIPs), warning-free build,
`simptest`. Since the coalescing fix changes when a get reaches the
server: `contrib/dockerswarm` `run-client-tests` 12/12 (including
"dmodex with requests pending" and "10 ranks over 5 servers") and
`run-gds-tests` 49/49, plus a v3.2.5-server cross-version run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RM3UHSjpx2vfSeLU6gq7Lr
