### PR TITLE
Let PMIx_Value_get_number read the types that are integers with names

### DIFF
--- a/docs/man/man3/PMIx_Value_get_number.3.rst
+++ b/docs/man/man3/PMIx_Value_get_number.3.rst
@@ -70,6 +70,39 @@ the datatype found in the given `val`, taking one of the following actions:
       outside the range of the integer type, then the ``PMIX_ERR_LOST_PRECISION``
       error will be returned
 
+What counts as numeric
+^^^^^^^^^^^^^^^^^^^^^^
+
+Both the plain widths (``PMIX_SIZE``, ``PMIX_INT`` and the sized integer
+types, ``PMIX_FLOAT``, ``PMIX_DOUBLE``) and the PMIx datatypes that *are*
+an integer under a name of their own are numeric for the purposes of this
+function. The latter are:
+
+``PMIX_PID``, ``PMIX_STATUS``, ``PMIX_PROC_RANK``, ``PMIX_PERSIST``,
+``PMIX_SCOPE``, ``PMIX_DATA_RANGE``, ``PMIX_PROC_STATE``,
+``PMIX_ALLOC_DIRECTIVE``, ``PMIX_RESBLOCK_DIRECTIVE``,
+``PMIX_ALLOC_INHERIT``, ``PMIX_JOB_STATE``, ``PMIX_LINK_STATE``,
+``PMIX_LOCTYPE``, ``PMIX_DEVTYPE``, ``PMIX_STOR_MEDIUM``,
+``PMIX_STOR_ACCESS``, ``PMIX_STOR_PERSIST`` and ``PMIX_STOR_ACCESS_TYPE``.
+
+Any of these may appear as the datatype of `val`, as the datatype named by
+the caller, or as both. The range and sign rules above apply to them
+through the integer each one is defined as, so a ``PMIX_ALLOC_INHERIT``
+read into a ``PMIX_INT`` returns its value, and a ``PMIX_INT`` holding
+``300`` read into a ``PMIX_ALLOC_INHERIT`` -- a ``uint8_t`` -- is refused.
+
+There is one restriction. A value of one of these named types is **not**
+unloaded into a *different* named type, however alike the integers
+underneath them may be: a scope is not a process state, and an allocation
+directive is not a status. Asking for one from the other returns
+``PMIX_ERR_BAD_PARAM``. Reading any of them as a plain integer, and
+building any of them from a plain integer, is what this function is for
+and is always allowed.
+
+``PMIX_BOOL`` is not numeric here. A flag is not a count, and a caller
+that wants one should read ``val->data.flag`` or use
+:ref:`PMIx_Value_unload(3) <man3-PMIx_Value_unload>`.
+
 .. note:: The caller must provide backing memory for the value being
           returned. This function will not allocate memory. In addition, this
           function is only usable when retrieving numerical values - the :ref:`PMIx_Value_unload(3) <man3-PMIx_Value_unload>`
@@ -145,6 +178,29 @@ but:
 
 would return ``PMIX_ERR_CHANGE_SIGN`` as the sign requirements conflict.
 
+An attribute annotated with a named integer type is loaded and read with
+that type. For example, ``PMIX_ALLOC_INHERITANCE`` is annotated
+``(pmix_alloc_inheritance_t)``, so a caller sets it as:
+
+.. code-block:: c
+
+    PMIX_INFO_LOAD(&info, PMIX_ALLOC_INHERITANCE,
+                   &(pmix_alloc_inheritance_t){PMIX_ALLOC_INHERIT_CHILD},
+                   PMIX_ALLOC_INHERIT);
+
+and the host reads it back with:
+
+.. code-block:: c
+
+    pmix_alloc_inheritance_t inherit;
+    pmix_status_t rc;
+
+    rc = PMIx_Value_get_number(&info.value, (void*)&inherit,
+                               PMIX_ALLOC_INHERIT);
+
+which also accepts the same disposition sent as a plain integer of any
+width that can hold it, so a host need not care which spelling the caller
+chose.
 
 
 .. seealso::

--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -62,6 +62,7 @@
 #define PMIX_CAP_DEVICE_ENUM     15
 #define PMIX_CAP_MCA_FW_VERSION  16
 #define PMIX_CAP_DATA_DELETE     17
+#define PMIX_CAP_GET_NUMBER_ENUMS 18
 
 
 /*****    DEPRECATED    *****/

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1075,8 +1075,10 @@ static void client_teardown(void)
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
     /* A deletion that arrived while we were not marked initialized was
      * held rather than applied, and there is now nothing to apply it to.
-     * The list destructor re-constructs, so a second PMIx_Init in this
-     * process starts from an empty one. */
+     * PMIx_Init constructs this list on every cycle, which is what makes it
+     * safe to destruct it on every cycle - the list destructor does re-link
+     * the sentinel, but PMIX_DESTRUCT also zeroes the object's magic id, so
+     * a second destruct without a construct between them is an abort. */
     PMIX_LIST_DESTRUCT(&pmix_client_held_deletes);
     /* drop the delta-commit record, and leave the flag set so a second
      * PMIx_Init in this process starts cumulative rather than trusting
@@ -1280,6 +1282,17 @@ pmix_status_t PMIx_Init(pmix_proc_t *proc,
     pmix_client_globals.singleton = false;
     pmix_client_globals.local_iof = false;
     PMIX_CONSTRUCT(&pmix_client_globals.pending_requests, pmix_list_t);
+    /* Constructed here, and not left to its static initializer, for the two
+     * reasons any PMIX_LIST_STATIC_INIT list has to be. Its sentinel is
+     * NULL-linked until a construct runs, so it reads as empty but the first
+     * pmix_list_append() to it writes through a NULL - and appending is
+     * exactly what client_data_delete_handler() does when a deletion arrives
+     * before we are marked initialized, which is the case that handler exists
+     * for. And PMIX_DESTRUCT zeroes an object's magic id, so the teardown
+     * below can only run once per process unless something puts it back:
+     * without this, the second PMIx_Init in a process aborted on the
+     * assertion in a debug build. */
+    PMIX_CONSTRUCT(&pmix_client_held_deletes, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_client_globals.peers, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_client_globals.peers, 1, INT_MAX, 1);
     pmix_client_globals.myserver = PMIX_NEW(pmix_peer_t);

--- a/src/mca/bfrops/AGENTS.md
+++ b/src/mca/bfrops/AGENTS.md
@@ -292,6 +292,38 @@ compare, `PMIx_Value_get_number`) is actually implemented here in
 `bfrops/base`, because it is all fundamentally data-manipulation code.
 Do not assume `bfrops/base` is purely internal wire code.
 
+#### `PMIx_Value_get_number` and the types that are integers wearing a name
+
+Two things about that function are decisions rather than mechanics, and
+both are easy to undo by accident.
+
+**It accepts the named integer types at both ends.** A `pmix_scope_t`, a
+`pmix_proc_state_t`, a `pmix_alloc_inheritance_t` and a dozen more are
+each a fixed-width unsigned integer given its own type tag and its own
+member of the value union. The number in one of them is a number, and the
+attribute annotations in `pmix_common.h.in` tell callers to load such an
+attribute with the named type — so refusing that spelling meant refusing
+the one the standard asks for, and left every host writing the same
+special case. `plain_integer_type()` names the plain type underneath, at
+both the source and the destination end, and the ordinary `check_*`
+conversions then apply their range and precision rules to them exactly as
+to anything else. **The widths there are the ones
+`pmix_bfrops_base_value_load()` stores; adding a type to one and not the
+other is how the two drift.** Note that a `pmix_value_t`'s union members
+alias, so the source is normalized by copying the whole value and
+restamping its type — nothing has to know which member held the datum.
+
+**A named type is not unloaded into a *different* named type.** A scope is
+not a proc state and an allocation directive is not a status, however
+alike the integers underneath them are, so asking for one from the other
+is `PMIX_ERR_BAD_PARAM`. That rule predates the family — it was
+`check_rank()`'s and `check_status()`'s policy for `PMIX_PID` /
+`PMIX_STATUS` / `PMIX_PROC_RANK`, stated at the tail of each of them — and
+it now lives once at the top of `PMIx_Value_get_number` covering all of
+them. Reading any of them as a plain integer, and building any of them
+from a plain integer, stays allowed: that is what the function is for.
+`PMIX_BOOL` is deliberately outside all of this — a flag is not a count.
+
 ## The buffer (`bfrops_types.h`)
 
 The `pmix_buffer_t` is a growable byte buffer with separate `pack_ptr`

--- a/src/mca/bfrops/base/bfrop_base_get_number.c
+++ b/src/mca/bfrops/base/bfrop_base_get_number.c
@@ -89,9 +89,16 @@ static pmix_status_t check_status(const pmix_value_t *value,
 static pmix_status_t check_pid(const pmix_value_t *value,
                                void *dest, pmix_data_type_t type);
 
+static pmix_data_type_t plain_integer_type(pmix_data_type_t type);
+
+static bool structured_number(pmix_data_type_t type);
+
 pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
                                     void *dest, pmix_data_type_t type)
 {
+    pmix_value_t plain;
+    pmix_data_type_t base;
+
     /* the type tag is the first thing every branch below reads, and the
      * destination is written by every one that matches, so both have to be
      * screened here. Callers reach this with the "value" member of a
@@ -101,6 +108,36 @@ pmix_status_t PMIx_Value_get_number(const pmix_value_t *value,
      * equally exposed */
     if (NULL == value || NULL == dest) {
         return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* Stated once here rather than at the tail of every check_*: a PMIx
+     * structured value is not unloaded into a DIFFERENT structured value
+     * type, however alike the integers underneath them are.  A scope is not
+     * a proc state and an allocation directive is not a status, and a caller
+     * that asked for one of those from the other has made a mistake worth
+     * hearing about.  Reading either one as a plain integer, or building
+     * either one from a plain integer, is exactly what this function is
+     * for and stays allowed. */
+    if (value->type != type &&
+        structured_number(value->type) && structured_number(type)) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* Rewrite a named integer as the plain one underneath it, at both ends.
+     * The union members alias, so the copy carries the datum across without
+     * naming which member holds it - and `plain` is only ever read as an
+     * integer, so it owns nothing and needs no destructor. */
+    base = plain_integer_type(value->type);
+    if (PMIX_UNDEF != base) {
+        plain = *value;
+        plain.type = base;
+        value = &plain;
+    }
+    base = plain_integer_type(type);
+    if (PMIX_UNDEF != base) {
+        /* same width and representation as the type the caller named, so
+         * the store below writes exactly the destination they handed us */
+        type = base;
     }
 
     if (PMIX_SIZE == value->type) {
@@ -2502,3 +2539,67 @@ static pmix_status_t check_pid(const pmix_value_t *value,
     return PMIX_ERR_BAD_PARAM;
 }
 
+/* The integer underneath a PMIx type that is an integer wearing a name.
+ *
+ * A pmix_scope_t, a pmix_proc_state_t, a pmix_alloc_inheritance_t and a
+ * dozen more are each a fixed-width unsigned integer given its own type tag
+ * and its own member of the value union.  The number in one of them is a
+ * number, and a caller asking for it is asking a question with an answer -
+ * but the answer used to be PMIX_ERR_BAD_PARAM, because this function knew
+ * only the plain widths plus PMIX_PID, PMIX_STATUS and PMIX_PROC_RANK.
+ *
+ * That mattered most where the documentation tells a caller to use the
+ * named type: an attribute annotated "(pmix_alloc_inheritance_t)" is loaded
+ * with PMIX_ALLOC_INHERIT, and the reader PMIx offers for it then refused
+ * the spelling PMIx had asked for.  Every host was left writing the same
+ * special case.
+ *
+ * Rather than give each of these an arm in each of the fifteen check_*
+ * functions, name the plain type underneath and let the ordinary
+ * conversions do the work - so the range and precision checks apply to
+ * them exactly as they do to everything else.  Returns PMIX_UNDEF for a
+ * type that is not one of the family.
+ *
+ * The widths here are the ones pmix_bfrops_base_value_load() stores; keep
+ * the two in step.
+ */
+static pmix_data_type_t plain_integer_type(pmix_data_type_t type)
+{
+    switch (type) {
+    case PMIX_PERSIST:
+    case PMIX_SCOPE:
+    case PMIX_DATA_RANGE:
+    case PMIX_PROC_STATE:
+    case PMIX_ALLOC_DIRECTIVE:
+    case PMIX_RESBLOCK_DIRECTIVE:
+    case PMIX_ALLOC_INHERIT:
+    case PMIX_JOB_STATE:
+    case PMIX_LINK_STATE:
+        return PMIX_UINT8;
+
+    case PMIX_LOCTYPE:
+    case PMIX_STOR_ACCESS_TYPE:
+        return PMIX_UINT16;
+
+    case PMIX_DEVTYPE:
+    case PMIX_STOR_MEDIUM:
+    case PMIX_STOR_ACCESS:
+    case PMIX_STOR_PERSIST:
+        return PMIX_UINT64;
+
+    default:
+        return PMIX_UNDEF;
+    }
+}
+
+/* Is this type a number PMIx has given a meaning to, rather than a bare
+ * width?  PMIX_PID, PMIX_STATUS and PMIX_PROC_RANK are the three the
+ * check_* functions already recognized; the rest come from the family
+ * above. */
+static bool structured_number(pmix_data_type_t type)
+{
+    if (PMIX_PID == type || PMIX_STATUS == type || PMIX_PROC_RANK == type) {
+        return true;
+    }
+    return (PMIX_UNDEF != plain_integer_type(type));
+}

--- a/test/unit/bfrops_get_number.c
+++ b/test/unit/bfrops_get_number.c
@@ -67,7 +67,17 @@ static void report(const char *name, int passed)
 static pmix_data_type_t types[] = {
     PMIX_SIZE, PMIX_INT, PMIX_INT8, PMIX_INT16, PMIX_INT32, PMIX_INT64,
     PMIX_UINT, PMIX_UINT8, PMIX_UINT16, PMIX_UINT32, PMIX_UINT64,
-    PMIX_FLOAT, PMIX_DOUBLE, PMIX_PID, PMIX_PROC_RANK, PMIX_STATUS
+    PMIX_FLOAT, PMIX_DOUBLE, PMIX_PID, PMIX_PROC_RANK, PMIX_STATUS,
+    /* the types that are an integer wearing a name - each one a fixed-width
+     * unsigned integer with its own tag and its own union member.  They are
+     * listed here rather than tested apart because every property below is
+     * a property of theirs too: an inheritance disposition read into an int
+     * has to come back exactly, and a 300 read into one has to be refused. */
+    PMIX_PERSIST, PMIX_SCOPE, PMIX_DATA_RANGE, PMIX_PROC_STATE,
+    PMIX_ALLOC_DIRECTIVE, PMIX_RESBLOCK_DIRECTIVE, PMIX_ALLOC_INHERIT,
+    PMIX_JOB_STATE, PMIX_LINK_STATE,
+    PMIX_LOCTYPE, PMIX_STOR_ACCESS_TYPE,
+    PMIX_DEVTYPE, PMIX_STOR_MEDIUM, PMIX_STOR_ACCESS, PMIX_STOR_PERSIST
 };
 #define NTYPES (sizeof(types) / sizeof(types[0]))
 
@@ -87,7 +97,29 @@ static long double samples[] = {
 
 static int is_structured(pmix_data_type_t t)
 {
-    return (PMIX_PID == t || PMIX_STATUS == t || PMIX_PROC_RANK == t);
+    switch (t) {
+    case PMIX_PID:
+    case PMIX_STATUS:
+    case PMIX_PROC_RANK:
+    case PMIX_PERSIST:
+    case PMIX_SCOPE:
+    case PMIX_DATA_RANGE:
+    case PMIX_PROC_STATE:
+    case PMIX_ALLOC_DIRECTIVE:
+    case PMIX_RESBLOCK_DIRECTIVE:
+    case PMIX_ALLOC_INHERIT:
+    case PMIX_JOB_STATE:
+    case PMIX_LINK_STATE:
+    case PMIX_LOCTYPE:
+    case PMIX_STOR_ACCESS_TYPE:
+    case PMIX_DEVTYPE:
+    case PMIX_STOR_MEDIUM:
+    case PMIX_STOR_ACCESS:
+    case PMIX_STOR_PERSIST:
+        return 1;
+    default:
+        return 0;
+    }
 }
 
 /* the representable range of each integral destination type */
@@ -95,12 +127,27 @@ static int int_range(pmix_data_type_t t, long double *lo, long double *hi)
 {
     switch (t) {
     case PMIX_SIZE:
-    case PMIX_UINT64: *lo = 0; *hi = 18446744073709551615.0L; return 1;
+    case PMIX_UINT64:
+    case PMIX_DEVTYPE:
+    case PMIX_STOR_MEDIUM:
+    case PMIX_STOR_ACCESS:
+    case PMIX_STOR_PERSIST: *lo = 0; *hi = 18446744073709551615.0L; return 1;
     case PMIX_UINT32:
     case PMIX_UINT:
     case PMIX_PROC_RANK: *lo = 0; *hi = 4294967295.0L; return 1;
-    case PMIX_UINT16: *lo = 0; *hi = 65535.0L; return 1;
-    case PMIX_UINT8: *lo = 0; *hi = 255.0L; return 1;
+    case PMIX_UINT16:
+    case PMIX_LOCTYPE:
+    case PMIX_STOR_ACCESS_TYPE: *lo = 0; *hi = 65535.0L; return 1;
+    case PMIX_UINT8:
+    case PMIX_PERSIST:
+    case PMIX_SCOPE:
+    case PMIX_DATA_RANGE:
+    case PMIX_PROC_STATE:
+    case PMIX_ALLOC_DIRECTIVE:
+    case PMIX_RESBLOCK_DIRECTIVE:
+    case PMIX_ALLOC_INHERIT:
+    case PMIX_JOB_STATE:
+    case PMIX_LINK_STATE: *lo = 0; *hi = 255.0L; return 1;
     case PMIX_INT64: *lo = -9223372036854775807.0L - 1;
                      *hi = 9223372036854775807.0L; return 1;
     case PMIX_INT32:
@@ -164,6 +211,25 @@ static void setval(pmix_value_t *v, pmix_data_type_t t, long double x)
     case PMIX_PID: v->data.pid = (pid_t) x; break;
     case PMIX_PROC_RANK: v->data.rank = (pmix_rank_t) x; break;
     case PMIX_STATUS: v->data.status = (pmix_status_t) x; break;
+    case PMIX_PERSIST: v->data.persist = (pmix_persistence_t) x; break;
+    case PMIX_SCOPE: v->data.scope = (pmix_scope_t) x; break;
+    case PMIX_DATA_RANGE: v->data.range = (pmix_data_range_t) x; break;
+    case PMIX_PROC_STATE: v->data.state = (pmix_proc_state_t) x; break;
+    case PMIX_ALLOC_DIRECTIVE: v->data.adir = (pmix_alloc_directive_t) x; break;
+    case PMIX_RESBLOCK_DIRECTIVE:
+        v->data.rbdir = (pmix_resource_block_directive_t) x; break;
+    case PMIX_ALLOC_INHERIT:
+        v->data.inheritance = (pmix_alloc_inheritance_t) x; break;
+    case PMIX_JOB_STATE: v->data.jstate = (pmix_job_state_t) x; break;
+    case PMIX_LINK_STATE: v->data.linkstate = (pmix_link_state_t) x; break;
+    case PMIX_LOCTYPE: v->data.locality = (pmix_locality_t) x; break;
+    case PMIX_DEVTYPE: v->data.devtype = (pmix_device_type_t) x; break;
+    /* the storage types have no union member of their own - value_load()
+     * stores them in the plain member of matching width */
+    case PMIX_STOR_ACCESS_TYPE: v->data.uint16 = (uint16_t) x; break;
+    case PMIX_STOR_MEDIUM:
+    case PMIX_STOR_ACCESS:
+    case PMIX_STOR_PERSIST: v->data.uint64 = (uint64_t) x; break;
     default: break;
     }
 }
@@ -187,6 +253,21 @@ static long double getval(const pmix_value_t *v)
     case PMIX_PID: return (long double) v->data.pid;
     case PMIX_PROC_RANK: return (long double) v->data.rank;
     case PMIX_STATUS: return (long double) v->data.status;
+    case PMIX_PERSIST: return (long double) v->data.persist;
+    case PMIX_SCOPE: return (long double) v->data.scope;
+    case PMIX_DATA_RANGE: return (long double) v->data.range;
+    case PMIX_PROC_STATE: return (long double) v->data.state;
+    case PMIX_ALLOC_DIRECTIVE: return (long double) v->data.adir;
+    case PMIX_RESBLOCK_DIRECTIVE: return (long double) v->data.rbdir;
+    case PMIX_ALLOC_INHERIT: return (long double) v->data.inheritance;
+    case PMIX_JOB_STATE: return (long double) v->data.jstate;
+    case PMIX_LINK_STATE: return (long double) v->data.linkstate;
+    case PMIX_LOCTYPE: return (long double) v->data.locality;
+    case PMIX_DEVTYPE: return (long double) v->data.devtype;
+    case PMIX_STOR_ACCESS_TYPE: return (long double) v->data.uint16;
+    case PMIX_STOR_MEDIUM:
+    case PMIX_STOR_ACCESS:
+    case PMIX_STOR_PERSIST: return (long double) v->data.uint64;
     default: return 0;
     }
 }


### PR DESCRIPTION
### The problem

`PMIx_Value_get_number()` is the function PMIx offers for reading a number out
of a `pmix_value_t`. It recognized the plain widths plus `PMIX_PID`,
`PMIX_STATUS` and `PMIX_PROC_RANK`, and answered `PMIX_ERR_BAD_PARAM` for
everything else.

But PMIx has a whole family of datatypes that are an integer under a name of
their own — `pmix_scope_t`, `pmix_proc_state_t`, `pmix_alloc_inheritance_t`,
`pmix_device_type_t` and a dozen more — each a fixed-width unsigned integer
with its own type tag and its own member of the value union. None of them was
recognized.

That bites hardest exactly where the standard tells a caller to use the named
type. `PMIX_ALLOC_INHERITANCE` is annotated `(pmix_alloc_inheritance_t)`, and
the documentation's own example loads it as `PMIX_ALLOC_INHERIT`:

```c
PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_INHERITANCE,
               &(pmix_alloc_inheritance_t){PMIX_ALLOC_INHERIT_CHILD_DEFAULT},
               PMIX_ALLOC_INHERIT);
```

A host that then read it back with `PMIx_Value_get_number()` got
`PMIX_ERR_BAD_PARAM` — the reader refused the spelling PMIx had asked for. So
a host had two choices: reach into `value.data` itself, which is how a value
of the wrong type becomes a wrong answer instead of an error, or write the
same special case every other host was writing. PRRTE has one.

### The change

Rather than add an arm for each of these to each of the fifteen `check_*`
functions, `plain_integer_type()` names the plain integer underneath, at the
source end and the destination end alike, and the existing conversions do the
work. The range and sign rules then apply to them exactly as to anything
else — a disposition read into an `int` comes back, a `300` read into one is
refused, a `-1` is refused. Because the value union's members alias, the
source is normalized by copying the value and restamping its type, so nothing
has to know which member held the datum. The widths are the ones
`pmix_bfrops_base_value_load()` stores; the coupling is written down in both
places.

Eighteen types in total: the three already recognized plus `PERSIST`, `SCOPE`,
`DATA_RANGE`, `PROC_STATE`, `ALLOC_DIRECTIVE`, `RESBLOCK_DIRECTIVE`,
`ALLOC_INHERIT`, `JOB_STATE`, `LINK_STATE`, `LOCTYPE`, `DEVTYPE` and the four
storage types.

**The one restriction is the policy that was already there.** `check_rank()`
and `check_status()` refused to unload a structured value into another
structured type. That rule now sits once at the top of the function and covers
the whole family: a scope is not a process state, and an allocation directive
is not a status. Reading any of them as a plain integer, and building any of
them from a plain integer, stays allowed — that is what the function is for.
`PMIX_BOOL` is deliberately outside all of this; a flag is not a count.

### Verification

The existing property test needed only its tables extended — both properties
it states are properties of the new types too — so it now checks them over all
31 source and destination types. Plus a targeted check against the built
library:

```
ALLOC_INHERIT(3) -> UINT8        ok  3        INT(3)   -> ALLOC_INHERIT  ok  byte0=3 byte1=0xab
ALLOC_INHERIT(3) -> INT          ok  3        INT(300) -> ALLOC_INHERIT  REFUSED (range)
ALLOC_INHERIT -> SCOPE       REFUSED (policy) INT(-1)  -> ALLOC_INHERIT  REFUSED (sign)
PID -> PROC_RANK             REFUSED (unchanged)  BOOL -> INT            REFUSED
```

`make check`: 100 pass, 0 fail, 2 skip on macOS (debug build). Man page and
`bfrops/AGENTS.md` updated; docs build warning-free. `PMIX_CAP_GET_NUMBER_ENUMS`
lets a host tell whether it is talking to a library that does this.

### The second commit

`Construct the held-delete list PMIx_Init only ever destructed` is an
independent fix, found by running the suite for the above — it was failing
`client_cycle` and `run_simpcycle.pl` before this branch, and those are the
two failures the 100/0/2 above accounts for.

`pmix_client_held_deletes` is declared `PMIX_LIST_STATIC_INIT` and never
constructed. Two consequences. Its sentinel's `next`/`prev` stay NULL until a
construct links them to itself, so the first `pmix_list_append()` to it stores
through a NULL — and the only caller that appends is
`client_data_delete_handler()`, on precisely the path the list exists to
serve. And `PMIX_DESTRUCT` zeroes an object's magic id after asserting on it,
so `client_teardown()` could run at most once per process; the second
`PMIx_Init` in a process aborted on that assertion in a debug build. The
comment there had it backwards — the list *destructor* does re-link the
sentinel, but the destruct *macro* poisons the object.

One `PMIX_CONSTRUCT` in `PMIx_Init` beside `pending_requests`, which already
had the matching pair.

Happy to split that into its own PR if you would rather review it separately.
