### PR TITLE
Deep review of src/util: 29 files, five lenses each

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,8 +458,10 @@ failures only in an ordinary build.
 
 Editing the build system means regenerating it — `make` alone can't,
 and trying will wedge the tree. If you change `configure.ac` or any
-`config/*.m4` file (including the embedded oac/Autotools macros), the
-change does not take effect until the build system is regenerated. Do
+`config/*.m4` file, the change does not take effect until the build
+system is regenerated — and so does a submodule bump that moves
+`config/oac` (see [below](#configoac-is-not-ours-to-edit)), even though
+you did not edit anything yourself. Do
 not rely on a plain `make`: PMIx builds in maintainer mode, so
 `make` auto-triggers a partial in-tree Autotools regeneration that
 frequently fails (e.g., unexpanded `OAC_*` macros, `config.status`
@@ -481,6 +483,28 @@ Note that editing `Makefile.am` files do *not* require the full
 `autogen.pl` + `./configure` process.  A simple `make` will regenerate
 the relevant `Makefile[.in]` files and then complete the build
 successfully.
+
+### `config/oac` is not ours to edit
+
+`config/oac` is a **git submodule** — the Open Autotools Components,
+shared with Open MPI (`.gitmodules` points it at `open-mpi/oac`). It is
+third-party code with its own upstream, so the no-hand-editing rule
+above applies to all of it: an edit made from this tree is either lost
+at the next submodule update or silently diverges the two projects that
+share it.
+
+That means it is also **out of scope for any sweep across
+`config/*.m4`** — a cleanup, a dead-platform removal, a style pass. If
+you find a real defect in an OAC macro, route it: file an issue against
+`open-mpi/oac` and say so in your commit message or PR, rather than
+patching it here. Check `git diff --stat -- config/oac` before you
+commit anything that touched `config/`; it should be empty.
+
+The same goes for the other code in the tree that is not ours to
+change: the autotools output (`configure`, `config/libtool.m4`,
+`Makefile.in`, …) and vendored third-party headers such as
+[`src/include/pmix_portable_platform_real.h`](src/include/pmix_portable_platform_real.h),
+whose license explicitly forbids modifying parts of it.
 
 
 **"Did I break it?" — layered:**

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -3455,7 +3455,9 @@ cdef class PMIxClient:
         return pystr.decode('ascii')
 
     # The inverse of error_string: map the name of a PMIx status back to
-    # its numeric value. Returns PMIX_ERR_NOT_FOUND for an unknown name
+    # its numeric value. Returns INT32_MIN for an unknown name - every
+    # real status is itself negative, so only that sentinel means "not
+    # recognized" - and PMIX_ERR_BAD_PARAM if handed None
     #
     # @errname [INPUT]
     #          - the symbolic name of a status, e.g. "PMIX_ERR_TIMEOUT"

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -499,7 +499,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                       sys/fcntl.h sys/statfs.h sys/statvfs.h \
                       netdb.h ucred.h sys/auxv.h \
                       sys/sysctl.h termio.h termios.h pty.h \
-                      libutil.h util.h grp.h sys/cdefs.h utmp.h stropts.h \
+                      libutil.h util.h grp.h sys/cdefs.h utmp.h \
                       sys/utsname.h stdatomic.h mntent.h])
 
     AC_CHECK_HEADERS([sys/mount.h], [], [],

--- a/config/pmix_check_attributes.m4
+++ b/config/pmix_check_attributes.m4
@@ -30,16 +30,17 @@
 #
 
 #
-# Search the generated warnings for
-# keywords regarding skipping or ignoring certain attributes
-#   Intel: ignore
-#   Sun C++: skip
+# Search the generated warnings for keywords regarding skipping or
+# ignoring certain attributes (Intel says "ignore").  The list is
+# deliberately wider than the compilers we know about: a keyword that
+# matches nothing only costs us an attribute we could have used, while
+# one we failed to look for hands us an attribute the compiler does not
+# really honor.
 #
 AC_DEFUN([_PMIX_ATTRIBUTE_FAIL_SEARCH],[
     AC_REQUIRE([AC_PROG_GREP])
     if test -s conftest.err ; then
         # icc uses 'invalid attribute' and 'attribute "__XXX__"  ignored'
-        # Sun 12.1 emits 'warning: attribute parameter "__printf__" is undefined'
         for i in invalid ignore skip undefined ; do
             $GREP -iq $i conftest.err
             if test "$?" = "0" ; then

--- a/config/pmix_check_visibility.m4
+++ b/config/pmix_check_visibility.m4
@@ -28,7 +28,7 @@ AC_DEFUN([PMIX_CHECK_VISIBILITY],[
     AC_REQUIRE([AC_PROG_GREP])
 
     # Check if the compiler has support for visibility, like some
-    # versions of gcc, icc Sun Studio cc.
+    # versions of gcc and icc.
     AC_ARG_ENABLE(visibility,
         AS_HELP_STRING([--enable-visibility],
             [enable visibility feature of certain compilers/linkers (default: enabled)]))
@@ -42,20 +42,9 @@ AC_DEFUN([PMIX_CHECK_VISIBILITY],[
     else
         CFLAGS_orig=$CFLAGS
 
-        pmix_add=
-        case "$oac_cv_c_compiler_vendor" in
-        sun)
-            # Check using Sun Studio -xldscope=hidden flag
-            pmix_add=-xldscope=hidden
-            CFLAGS="$PMIX_CFLAGS_BEFORE_PICKY $pmix_add -errwarn=%all"
-            ;;
-
-        *)
-            # Check using -fvisibility=hidden
-            pmix_add=-fvisibility=hidden
-            CFLAGS="$PMIX_CFLAGS_BEFORE_PICKY $pmix_add -Werror"
-            ;;
-        esac
+        # Check using -fvisibility=hidden
+        pmix_add=-fvisibility=hidden
+        CFLAGS="$PMIX_CFLAGS_BEFORE_PICKY $pmix_add -Werror"
 
         AC_MSG_CHECKING([if $CC supports $pmix_add])
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[

--- a/config/pmix_ensure_contains_optflags.m4
+++ b/config/pmix_ensure_contains_optflags.m4
@@ -40,7 +40,6 @@ for co_word in $co_arg; do
     case $co_word in
     -g)              co_found=1 ;;
     -g@<:@1-3@:>@)   co_found=1 ;;
-    +K@<:@0-5@:>@)   co_found=1 ;;
     -O)              co_found=1 ;;
     -O@<:@0-9@:>@)   co_found=1 ;;
     -fast)           co_found=1 ;;

--- a/config/pmix_ensure_contains_optflags.m4
+++ b/config/pmix_ensure_contains_optflags.m4
@@ -43,15 +43,7 @@ for co_word in $co_arg; do
     +K@<:@0-5@:>@)   co_found=1 ;;
     -O)              co_found=1 ;;
     -O@<:@0-9@:>@)   co_found=1 ;;
-    -xO)             co_found=1 ;;
-    -xO@<:@0-9@:>@)  co_found=1 ;;
     -fast)           co_found=1 ;;
-
-    # The below Sun Studio flags require or
-    # trigger -xO optimization
-    -xvector*)     co_found=1 ;;
-    -xdepend=yes)  co_found=1 ;;
-
     esac
 done
 

--- a/docs/man/man3/PMIx_Error_code.3.rst
+++ b/docs/man/man3/PMIx_Error_code.3.rst
@@ -36,6 +36,7 @@ INPUT PARAMETERS
 
 * ``errname``: A NULL-terminated string naming a PMIx status or event constant,
   as would be returned by :ref:`PMIx_Error_string(3) <man3-PMIx_Error_string>`.
+  A ``NULL`` pointer names no constant and is reported as unrecognized.
 
 
 DESCRIPTION
@@ -59,8 +60,9 @@ RETURN VALUE
 ------------
 
 Returns the ``pmix_status_t`` value corresponding to ``errname`` on success. If no
-known status or event constant has a matching name, the function returns
-``INT32_MIN`` to indicate that the name was not recognized.
+known status or event constant has a matching name |mdash| including when
+``errname`` is ``NULL`` |mdash| the function returns ``INT32_MIN`` to indicate that
+the name was not recognized.
 
 
 NOTES

--- a/docs/man/man3/PMIx_Error_string.3.rst
+++ b/docs/man/man3/PMIx_Error_string.3.rst
@@ -69,6 +69,10 @@ NOTES
 :ref:`PMIx_Error_code(3) <man3-PMIx_Error_code>`, which maps a status name string
 back to its numeric ``pmix_status_t`` value.
 
+A deprecation rename leaves two names sharing one value |mdash| for example
+``PMIX_ERR_EXISTS`` and the deprecated ``PMIX_EXISTS``. In that case
+``PMIx_Error_string`` returns the current name, not the deprecated alias.
+
 Because the returned string is owned by the library, callers must never pass it to
 ``free()``.
 

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1047,6 +1047,91 @@ pmix_status_t pmix_iof_expand_pattern(const char *pattern, const char *nspace,
     return process_pattern(pattern, true, nspace, rank, numdigs, suffix, result, NULL);
 }
 
+/* Where the caller's own text ends in an output pattern.
+ *
+ * process_pattern() copies everything that is not a conversion verbatim,
+ * separators included, so "%h/%n/rank-%R" has PMIx composing two whole
+ * directory levels out of the hostname and the namespace. Those are
+ * names this library produces, and they have to be created one at a time
+ * against the descriptor of their parent rather than handed to the
+ * kernel as one string - only the last component of such a string is
+ * ever checked, so a symlink at any level above it would put the output
+ * somewhere the caller never named.
+ *
+ * The dividing line is the last separator that appears before the first
+ * conversion: everything up to it is literal text the caller wrote and
+ * is taken as given, everything after it is composed here. Nothing ahead
+ * of the first conversion is transformed, so the offset is the same in
+ * the pattern and in its expansion.
+ *
+ * @retval >=0 offset of that separator within the pattern
+ * @retval  -1 there is none, so the whole name is composed relative to
+ *             the current directory
+ */
+static ssize_t pattern_literal_head(const char *pattern)
+{
+    const char *pct = strchr(pattern, '%');
+    size_t limit = (NULL == pct) ? strlen(pattern) : (size_t) (pct - pattern);
+    ssize_t head = -1;
+    size_t i;
+
+    for (i = 0; i < limit; i++) {
+        if ('/' == pattern[i]) {
+            head = (ssize_t) i;
+        }
+    }
+    return head;
+}
+
+/* Create the directories a composed output name needs, then open it.
+ * Everything below the caller's own prefix is walked a component at a
+ * time; see pattern_literal_head() for where that prefix ends. `name` is
+ * modified in place while the directory part is taken off it, and is put
+ * back before returning. */
+static int open_composed_output(const char *pattern, char *name, mode_t dmode)
+{
+    ssize_t head = pattern_literal_head(pattern);
+    char *root, *tail, *sep;
+    int rc, fd;
+
+    if (0 > head) {
+        root = strdup(".");
+        tail = name;
+    } else if (0 == head) {
+        root = strdup("/");
+        tail = name + 1;
+    } else {
+        root = (char *) malloc((size_t) head + 1);
+        if (NULL != root) {
+            memcpy(root, name, (size_t) head);
+            root[head] = '\0';
+        }
+        tail = name + head + 1;
+    }
+    if (NULL == root) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        return -1;
+    }
+
+    /* any directory levels inside the composed part have to exist first */
+    sep = strrchr(tail, '/');
+    if (NULL != sep) {
+        *sep = '\0';
+        rc = pmix_os_dirpath_create_under(root, tail, dmode);
+        *sep = '/';
+        if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
+            PMIX_ERROR_LOG(rc);
+            free(root);
+            return -1;
+        }
+    }
+
+    fd = pmix_os_dirpath_open_file_under(root, tail,
+                                         O_CREAT | O_RDWR | O_TRUNC, 0644);
+    free(root);
+    return fd;
+}
+
 static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
                                               pmix_rank_t rank,
                                               pmix_iof_channel_t stream)
@@ -1072,13 +1157,23 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
 
     /* see if we are to output to a directory */
     if (NULL != nptr->iof_flags.directory) {
-        /* construct the directory where the output files will go */
-        pmix_asprintf(&outdir, "%s/%s/rank.%0*u", nptr->iof_flags.directory,
-                      nptr->nspace, numdigs, rank);
+        /* Construct the part of the directory PMIx composes itself, kept
+         * separate from the part the caller handed us. iof_flags.directory
+         * is theirs and is taken as given; the namespace and rank
+         * components below it are ours, and are built one at a time so
+         * that a symlink at either does not send the output files
+         * somewhere the caller never named - see
+         * pmix_os_dirpath_create_under(). */
+        pmix_asprintf(&outdir, "%s/rank.%0*u", nptr->nspace, numdigs, rank);
+        if (NULL == outdir) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            return NULL;
+        }
         /* ensure the directory exists. An existing directory is fine:
          * the job may legitimately be writing into one that is already
          * there (a rerun, or another rank that got here first) */
-        rc = pmix_os_dirpath_create(outdir, S_IRWXU | S_IRGRP | S_IXGRP);
+        rc = pmix_os_dirpath_create_under(nptr->iof_flags.directory, outdir,
+                                          S_IRWXU | S_IRGRP | S_IXGRP);
         if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
             PMIX_ERROR_LOG(rc);
             free(outdir);
@@ -1088,7 +1183,13 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
             nptr->iof_flags.merge) {
             /* setup the stdout sink */
             pmix_asprintf(&outfile, "%s/stdout", outdir);
-            fdout = open(outfile, O_CREAT | O_RDWR | O_TRUNC, 0644);
+            if (NULL == outfile) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                free(outdir);
+                return NULL;
+            }
+            fdout = pmix_os_dirpath_open_file_under(nptr->iof_flags.directory, outfile,
+                                                    O_CREAT | O_RDWR | O_TRUNC, 0644);
             free(outfile);
             if (fdout < 0) {
                 /* couldn't be opened */
@@ -1111,7 +1212,13 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
         } else {
             /* setup the stderr sink */
             pmix_asprintf(&outfile, "%s/stderr", outdir);
-            fdout = open(outfile, O_CREAT | O_RDWR | O_TRUNC, 0644);
+            if (NULL == outfile) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                free(outdir);
+                return NULL;
+            }
+            fdout = pmix_os_dirpath_open_file_under(nptr->iof_flags.directory, outfile,
+                                                    O_CREAT | O_RDWR | O_TRUNC, 0644);
             free(outfile);
             if (fdout < 0) {
                 /* couldn't be opened */
@@ -1160,21 +1267,15 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
                 PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
                 return NULL;
             }
-            /* ensure the directory the file lands in exists.  This is taken
-             * from the FINAL name, not from the name we were handed: a
-             * pattern may put conversions in the directory part
-             * ("%h/rank-%R"), and creating the raw name's dirname would
-             * create a directory literally called "%h" and then fail to open
-             * the file in the one the pattern actually named. */
-            outdir = pmix_dirname(outfile);
-            rc = pmix_os_dirpath_create(outdir, S_IRWXU | S_IRGRP | S_IXGRP);
-            free(outdir);
-            if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
-                PMIX_ERROR_LOG(rc);
-                free(outfile);
-                return NULL;
-            }
-            fdout = open(outfile, O_CREAT | O_RDWR | O_TRUNC, 0644);
+            /* The directories come from the FINAL name, not from the one
+             * we were handed: a pattern may put conversions in the
+             * directory part ("%h/rank-%R"), and creating the raw name's
+             * dirname would create a directory literally called "%h" and
+             * then fail to open the file in the one the pattern actually
+             * named. Those expanded levels are composed here rather than
+             * given to us, so they are built a component at a time. */
+            fdout = open_composed_output(nptr->iof_flags.file, outfile,
+                                         S_IRWXU | S_IRGRP | S_IXGRP);
             free(outfile);
             if (fdout < 0) {
                 /* couldn't be opened */
@@ -1211,15 +1312,8 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
                 return NULL;
             }
             /* see the note on the stdout sink above */
-            outdir = pmix_dirname(outfile);
-            rc = pmix_os_dirpath_create(outdir, S_IRWXU | S_IRGRP | S_IXGRP);
-            free(outdir);
-            if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
-                PMIX_ERROR_LOG(rc);
-                free(outfile);
-                return NULL;
-            }
-            fdout = open(outfile, O_CREAT | O_RDWR | O_TRUNC, 0644);
+            fdout = open_composed_output(nptr->iof_flags.file, outfile,
+                                         S_IRWXU | S_IRGRP | S_IXGRP);
             free(outfile);
             if (fdout < 0) {
                 /* couldn't be opened */

--- a/src/hwloc/pmix_hwloc.c
+++ b/src/hwloc/pmix_hwloc.c
@@ -52,6 +52,7 @@
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_fd.h"
 #include "src/util/pmix_name_fns.h"
+#include "src/util/pmix_os_dirpath.h"
 #include "src/util/pmix_path.h"
 #include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
@@ -565,8 +566,26 @@ sharetopo:
         shmemfile = NULL;
         return PMIX_SUCCESS;
     }
-    /* enough space is available, so create the segment */
-    if (-1 == (shmemfd = open(shmemfile, O_CREAT | O_RDWR, 0600))) {
+    /* Enough space is available, so create the segment.
+     *
+     * O_EXCL, and through pmix_os_dirpath_open_file() so a symlink at
+     * the name is not followed: this process composes the whole of
+     * shmemfile, so anything already there is a file left over from an
+     * earlier run or something this code did not put there. Two passes
+     * at most - a leftover file is reclaimed once and the create
+     * retried; unlink() removes the name it is given and never follows
+     * it onward. */
+    for (int pass = 0; pass < 2; pass++) {
+        shmemfd = pmix_os_dirpath_open_file(shmemfile,
+                                            O_CREAT | O_EXCL | O_RDWR, 0600);
+        if (0 <= shmemfd || EEXIST != errno) {
+            break;
+        }
+        if (0 != unlink(shmemfile) && ENOENT != errno) {
+            break;
+        }
+    }
+    if (-1 == shmemfd) {
         int err = errno;
         if (1 < pmix_output_get_verbosity(pmix_hwloc_output)) {
             pmix_show_help("help-ploc.txt", "sys call fail", true,

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -817,6 +817,13 @@ static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd, pmix_epilog_t *e
          * allocating memory here, so we need to free it later on.
          */
         filenm = pmix_os_path(false, path, ep->d_name, NULL);
+        if (NULL == filenm) {
+            /* the assembled name is longer than PMIX_PATH_MAX, or we are
+             * out of memory - either way we cannot name this entry, and
+             * the ignore-list comparison below would hand the NULL to
+             * strcmp() */
+            continue;
+        }
 
         /* if this path is to be ignored, then do so */
         PMIX_LIST_FOREACH (cf, &epi->ignores, pmix_cleanup_file_t) {

--- a/src/mca/base/pmix_mca_base_open.c
+++ b/src/mca/base/pmix_mca_base_open.c
@@ -236,9 +236,9 @@ static void set_defaults(pmix_output_stream_t *lds)
     /* Load up defaults */
 
     PMIX_CONSTRUCT(lds, pmix_output_stream_t);
-#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
+#if defined(HAVE_SYSLOG_H)
     lds->lds_syslog_priority = LOG_INFO;
-#endif /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
+#endif /* defined(HAVE_SYSLOG_H) */
     lds->lds_syslog_ident = "pmix";
     lds->lds_want_stderr = true;
 }
@@ -268,14 +268,14 @@ static void parse_verbose(char *e, pmix_output_stream_t *lds)
         }
 
         if (0 == strcasecmp(ptr, "syslog")) {
-#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
+#if defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
             have_output = true;
 #else
             pmix_output(0, "syslog support requested but not available on this system");
-#endif /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
+#endif /* defined(HAVE_SYSLOG_H) */
         } else if (strncasecmp(ptr, "syslogpri:", 10) == 0) {
-#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
+#if defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
             have_output = true;
             if (strcasecmp(ptr + 10, "notice") == 0)
@@ -286,9 +286,9 @@ static void parse_verbose(char *e, pmix_output_stream_t *lds)
                 lds->lds_syslog_priority = LOG_DEBUG;
 #else
             pmix_output(0, "syslog support requested but not available on this system");
-#endif /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
+#endif /* defined(HAVE_SYSLOG_H) */
         } else if (strncasecmp(ptr, "syslogid:", 9) == 0) {
-#if defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H)
+#if defined(HAVE_SYSLOG_H)
             lds->lds_want_syslog = true;
             /* "ptr" points into our local copy of the value, which is
              * freed before this function returns - the caller uses the
@@ -298,7 +298,7 @@ static void parse_verbose(char *e, pmix_output_stream_t *lds)
             lds->lds_syslog_ident = syslog_ident;
 #else
             pmix_output(0, "syslog support requested but not available on this system");
-#endif /* defined(HAVE_SYSLOG) && defined(HAVE_SYSLOG_H) */
+#endif /* defined(HAVE_SYSLOG_H) */
         }
 
         else if (strcasecmp(ptr, "stdout") == 0) {

--- a/src/mca/gds/base/AGENTS.md
+++ b/src/mca/gds/base/AGENTS.md
@@ -313,23 +313,6 @@ that number came from, and the section after it for why large string
 values are no longer compressed individually before they reach the
 bucket — the same cross-rank redundancy argument, pointing the other
 way.
-||||||| parent of 442f2f2aa (Screen the modex contribution's flag byte, and name the delta marker)
-- **`pmix_gds_modex_key_fmt_t`** (`NATIVE_FMT` / `KEYMAP_FMT`) and the
-  `PMIX_GDS_COLLECT_BIT` / `PMIX_GDS_KEYMAP_BIT` blob-info flags, with the
-  `PMIX_GDS_*_IS_SET` accessors — the encoding a modex reader uses to
-  learn how keys were written and whether data was collected.
-=======
-- **`pmix_gds_modex_key_fmt_t`** (`NATIVE_FMT` / `KEYMAP_FMT`) and the
-  `PMIX_GDS_COLLECT_BIT` / `PMIX_GDS_KEYMAP_BIT` blob-info flags with their
-  `PMIX_GDS_*_IS_SET` accessors. **These describe an encoding the tree does
-  not use.** Nothing outside this header references any of them — the flag
-  byte a contribution actually carries is a plain `pmix_collect_t` value,
-  packed as a `uint8_t` by `pmix_server_collect_data` and read back as one
-  here, not a bitmask. Do not reach for the bit macros on the assumption
-  that they describe the wire; if a second thing ever does need saying
-  about a contribution, decide then whether to make the byte a bitmask (and
-  convert both ends) or to add another value, as `PMIX_MODEX_DELTA` did.
->>>>>>> 442f2f2aa (Screen the modex contribution's flag byte, and name the delta marker)
 
 ## When working here
 

--- a/src/mca/pif/AGENTS.md
+++ b/src/mca/pif/AGENTS.md
@@ -336,8 +336,18 @@ These are the non-trivial ones:
 
 The entire file is wrapped in `#if HAVE_STRUCT_SOCKADDR_IN`. On an exotic
 platform lacking `struct sockaddr_in`, a parallel set of stub
-implementations returns `PMIX_ERR_NOT_SUPPORTED` (or `false`/no-op) for
-most helpers, so callers still link and degrade cleanly.
+implementations returns `PMIX_ERR_NOT_SUPPORTED` (or `false`/no-op) so
+callers still link and degrade cleanly.
+
+That last clause is the part to be careful about, because nothing checks
+it: no configuration anyone builds selects this arm, so it gets neither
+compiler nor linker coverage. It has to define **every** entry point
+`pmix_if.h` declares — seven of the twenty-one were simply absent, which
+is a link failure rather than graceful degradation — and every parameter
+has to be named as deliberately unread (`PMIX_HIDE_UNUSED_PARAMS`), since
+the tree builds `-Wextra -Werror` and none of the stubs read theirs. If
+you add a function to `pmix_if.h`, add its stub here too, and force the
+guard false for one `make pmix_if.lo` to prove the arm still builds.
 
 ## MCA parameters
 

--- a/src/mca/pif/posix_ipv4/pif_posix.c
+++ b/src/mca/pif/posix_ipv4/pif_posix.c
@@ -119,7 +119,7 @@ static int if_posix_open(void)
      * Some notes on the behavior of ioctl(..., SIOCGIFCONF,...)
      * when not enough space is allocated for all the entries.
      *
-     * - Solaris returns -1, errno EINVAL if there is not enough
+     * - some return -1, errno EINVAL if there is not enough
      *   space
      * - OS X returns 0, sets .ifc_len to the space used by the
      *   by the entries that did fit.

--- a/src/mca/pmdl/base/pmdl_base_stubs.c
+++ b/src/mca/pmdl/base/pmdl_base_stubs.c
@@ -81,7 +81,12 @@ pmix_status_t pmix_pmdl_base_harvest_envars(char *nspace, const pmix_info_t info
     pmix_pmdl_base_active_module_t *active;
     pmix_status_t rc;
     pmix_namespace_t *nptr = NULL, *ns;
-    char *params[2] = {"PMIX_MCA_", NULL};
+    /* Trailing '*': this is a prefix, not the name of a variable. An
+     * include entry without one is an exact name (so "PATH" does not also
+     * take "PATHFINDER"), and spelled bare this matched only a variable
+     * literally called "PMIX_MCA_" - which is to say nothing at all, so
+     * none of the local MCA params reached the child. */
+    char *params[2] = {"PMIX_MCA_*", NULL};
     char **priors = NULL;
     pmix_kval_t *kv;
     pmix_mca_base_var_file_value_t *fv;

--- a/src/mca/pmdl/ompi/pmdl_ompi.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi.c
@@ -240,6 +240,14 @@ static pmix_status_t process_param_file(char *file, pmix_list_t *ilist)
     pmix_status_t rc;
     const char *prefix;
 
+    if (NULL == file) {
+        /* every caller builds the name with pmix_os_path(), which
+         * answers NULL when the assembled path exceeds PMIX_PATH_MAX or
+         * memory ran out. There is no file to read, and the name must
+         * not reach fopen() */
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
     PMIX_CONSTRUCT(&params, pmix_list_t);
     pmix_mca_base_parse_paramfile(file, &params);
     PMIX_LIST_FOREACH (fv, &params, pmix_mca_base_var_file_value_t) {

--- a/src/mca/ptl/base/ptl_base_fns.c
+++ b/src/mca/ptl/base/ptl_base_fns.c
@@ -377,6 +377,12 @@ pmix_status_t pmix_ptl_base_df_search(char *dirname, char *prefix, pmix_info_t i
             continue;
         }
         newdir = pmix_os_path(false, dirname, dir_entry->d_name, NULL);
+        if (NULL == newdir) {
+            /* nesting has taken the assembled name past PMIX_PATH_MAX,
+             * or we are out of memory - either way there is nothing to
+             * hand opendir() but a NULL */
+            continue;
+        }
         /* if it is a directory, down search */
         tst = opendir(newdir);
         if (NULL != tst) {
@@ -1277,6 +1283,10 @@ static void query_servers(char *dirname, pmix_list_t *servers)
             continue;
         }
         newdir = pmix_os_path(false, dname, dir_entry->d_name, NULL);
+        if (NULL == newdir) {
+            /* as in pmix_ptl_base_df_search() above */
+            continue;
+        }
         /* if it is a directory, down search */
         tst = opendir(newdir);
         if (NULL != tst) {

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -186,7 +186,12 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
     if (NULL != dyn_port_string) {
         pmix_util_parse_range_options(dyn_port_string, &pmix_ptl_base.ipv4_ports);
-        if (0 == strcmp(pmix_ptl_base.ipv4_ports[0], "-1")) {
+        /* the parse yields nothing at all for a value it cannot read
+         * - "-", "abc" - so the array can be NULL here, and indexing it
+         * segfaulted the process during init. Fall back to the
+         * ephemeral port, as an absent value does. */
+        if (NULL == pmix_ptl_base.ipv4_ports || NULL == pmix_ptl_base.ipv4_ports[0]
+            || 0 == strcmp(pmix_ptl_base.ipv4_ports[0], "-1")) {
             PMIx_Argv_free(pmix_ptl_base.ipv4_ports);
             pmix_ptl_base.ipv4_ports = pmix_malloc(2*sizeof(char*));
             pmix_ptl_base.ipv4_ports[0] = strdup("0");
@@ -210,7 +215,12 @@ static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
     if (NULL != dyn_port_string6) {
         pmix_util_parse_range_options(dyn_port_string6, &pmix_ptl_base.ipv6_ports);
-        if (0 == strcmp(pmix_ptl_base.ipv6_ports[0], "-1")) {
+        /* the parse yields nothing at all for a value it cannot read
+         * - "-", "abc" - so the array can be NULL here, and indexing it
+         * segfaulted the process during init. Fall back to the
+         * ephemeral port, as an absent value does. */
+        if (NULL == pmix_ptl_base.ipv6_ports || NULL == pmix_ptl_base.ipv6_ports[0]
+            || 0 == strcmp(pmix_ptl_base.ipv6_ports[0], "-1")) {
             PMIx_Argv_free(pmix_ptl_base.ipv6_ports);
             pmix_ptl_base.ipv6_ports = pmix_malloc(2*sizeof(char*));
             pmix_ptl_base.ipv6_ports[0] = strdup("0");

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -501,7 +501,14 @@ pmix_status_t pmix_ptl_base_setup_listener(pmix_info_t info[], size_t ninfo)
                     pmix_ptl_base.ipv4_ports[1] = NULL;
                 } else {
                     pmix_util_parse_range_options(info[n].value.data.string, &pmix_ptl_base.ipv4_ports);
-                    if (0 == strcmp(pmix_ptl_base.ipv4_ports[0], "-1")) {
+                    /* the parse yields nothing at all for a value it cannot
+                     * read - "-", "abc" - so the array can be NULL here,
+                     * and indexing it segfaulted the process during init.
+                     * Fall back to the ephemeral port, as an absent value
+                     * does. */
+                    if (NULL == pmix_ptl_base.ipv4_ports
+                        || NULL == pmix_ptl_base.ipv4_ports[0]
+                        || 0 == strcmp(pmix_ptl_base.ipv4_ports[0], "-1")) {
                         PMIx_Argv_free(pmix_ptl_base.ipv4_ports);
                         pmix_ptl_base.ipv4_ports = pmix_malloc(2*sizeof(char*));
                         pmix_ptl_base.ipv4_ports[0] = strdup("0");
@@ -534,7 +541,14 @@ pmix_status_t pmix_ptl_base_setup_listener(pmix_info_t info[], size_t ninfo)
                     pmix_ptl_base.ipv6_ports[1] = NULL;
                 } else {
                     pmix_util_parse_range_options(info[n].value.data.string, &pmix_ptl_base.ipv6_ports);
-                     if (0 == strcmp(pmix_ptl_base.ipv6_ports[0], "-1")) {
+                     /* the parse yields nothing at all for a value it cannot
+                     * read - "-", "abc" - so the array can be NULL here,
+                     * and indexing it segfaulted the process during init.
+                     * Fall back to the ephemeral port, as an absent value
+                     * does. */
+                    if (NULL == pmix_ptl_base.ipv6_ports
+                        || NULL == pmix_ptl_base.ipv6_ports[0]
+                        || 0 == strcmp(pmix_ptl_base.ipv6_ports[0], "-1")) {
                         PMIx_Argv_free(pmix_ptl_base.ipv6_ports);
                         pmix_ptl_base.ipv6_ports = pmix_malloc(2*sizeof(char*));
                         pmix_ptl_base.ipv6_ports[0] = strdup("0");

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -41,6 +41,7 @@
 #include "src/server/pmix_server_ops.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_hash.h"
+#include "src/util/pmix_net.h"
 #include "src/util/pmix_printf.h"
 #include "src/util/pmix_show_help.h"
 #include "src/util/pmix_timings.h"
@@ -120,6 +121,12 @@ pmix_status_t pmix_register_params(void)
         PMIX_MCA_BASE_VAR_TYPE_STRING,
         &pmix_net_private_ipv4);
     if (0 > ret) {
+        goto failed;
+    }
+    /* the value is only now known - pmix_net_init() ran back in
+     * pmix_init_util(), so the network helper has yet to see it */
+    ret = pmix_net_setup_private_ipv4();
+    if (PMIX_SUCCESS != ret) {
         goto failed;
     }
 

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -39,11 +39,11 @@
 
 BEGIN_C_DECLS
 
-#if PMIX_ENABLE_TIMING
-PMIX_EXPORT extern char *pmix_timing_sync_file;
-PMIX_EXPORT extern char *pmix_timing_output;
-PMIX_EXPORT extern bool pmix_timing_overhead;
-#endif
+/* pmix_timing_output and pmix_timing_overhead are declared by
+ * src/util/pmix_timings.h, which is where the macros that use them live
+ * and which, unlike this header, is installed. pmix_timing_sync_file was
+ * declared here and defined nowhere, so any use of it was a link error;
+ * it is gone. */
 
 PMIX_EXPORT extern char *pmix_net_private_ipv4;
 PMIX_EXPORT extern int pmix_event_caching_window;

--- a/src/tools/wrapper/pmixcc.c
+++ b/src/tools/wrapper/pmixcc.c
@@ -972,20 +972,33 @@ int main(int argc, char *argv[])
             errno = 0;
             exit_status = 1;
         } else {
-            int status;
+            int status = 0;
+            int spawn_errno;
 
             free(exec_argv[0]);
             exec_argv[0] = tmp;
             ret = pmix_few(exec_argv, &status);
-            exit_status = WIFEXITED(status) ? WEXITSTATUS(status)
-                                            : (WIFSIGNALED(status)
-                                                   ? WTERMSIG(status)
-                                                   : (WIFSTOPPED(status) ? WSTOPSIG(status) : 255));
+            /* grab this before anything below can overwrite it */
+            spawn_errno = errno;
+            /* pmix_few only writes status when it actually had a child to
+             * wait for.  Decoding it on the failure path read whatever
+             * happened to be on the stack, so a compiler that never ran
+             * could hand the build system any exit code at all - zero
+             * included. */
+            exit_status = (PMIX_SUCCESS != ret)
+                              ? 1
+                              : (WIFEXITED(status)
+                                     ? WEXITSTATUS(status)
+                                     : (WIFSIGNALED(status)
+                                            ? WTERMSIG(status)
+                                            : (WIFSTOPPED(status) ? WSTOPSIG(status) : 255)));
             if ((PMIX_SUCCESS != ret) || ((0 != exit_status) && (flags & COMP_SHOW_ERROR))) {
                 char *myexec_command = PMIx_Argv_join(exec_argv, ' ');
                 if (PMIX_SUCCESS != ret) {
+                    /* why the launch failed is in errno; status is a
+                     * wait status and in this case was never set */
                     pmix_show_help("help-pmixcc.txt", "spawn-failed", true, exec_argv[0],
-                                   strerror(status), myexec_command, NULL);
+                                   strerror(spawn_errno), myexec_command, NULL);
                 } else {
 #if 0
                     pmix_show_help("help-pmixcc.txt", "compiler-failed", true,

--- a/src/tools/wrapper/pmixcc.c
+++ b/src/tools/wrapper/pmixcc.c
@@ -691,11 +691,15 @@ int main(int argc, char *argv[])
             struct stat buf;
             filename = pmix_os_path(false, options_data[user_data_idx].path_libdir,
                                     options_data[user_data_idx].req_file, NULL);
-            if (0 != stat(filename, &buf)) {
+            /* a name we could not assemble names no file that is there,
+             * so it gets the same report a failed stat does - and the
+             * name itself was never released either way */
+            if (NULL == filename || 0 != stat(filename, &buf)) {
                 pmix_show_help("help-pmixcc.txt", "file-not-found", true, base_argv0,
                                options_data[user_data_idx].req_file,
                                options_data[user_data_idx].language, NULL);
             }
+            free(filename);
         }
     }
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -779,6 +779,58 @@ good — and note that `-UHAVE_STRUCT_SOCKADDR_IN` on the command line does
 **not** do it, because `pmix_config.h` defines the macro again from
 inside the file. Edit the `#ifdef` to `#if 0` for the one compile.
 
+### `pmix_path` — searching for an executable without scribbling on the search
+
+Resolves a filename against a search path (`pmix_path_find`,
+`pmix_path_findv`, `pmix_find_absolute_path`) and answers two questions
+about the filesystem (`pmix_path_nfs`, `pmix_path_df`). The searching
+half is reached from `pmix_pfexec` and `pmix_context_fns` when a spawn
+request has to be turned into an executable, and from `src/mca/base`
+when a parameter file has to be found.
+
+**Nothing here may write into what it was given, and two things did.**
+This is the same rule `pmix_argv` records, and it was broken in the two
+places it matters most:
+
+- `pmix_path_find()` marked the end of a `"$VAR/rest"` prefix by
+  punching a temporary NUL into `pathv[i]` and putting it back. Its
+  callers pass arrays of string literals as a matter of course, which
+  faults outright, and it races anything else reading the same array.
+  It now copies the name out. `test_path_find_does_not_write_through_pathv`
+  in [`test/unit/util/util_path.c`](../../test/unit/util/util_path.c)
+  dies on a signal, not on an assertion, if this returns.
+- `path_env_load()` walked the `$PATH` string the same way — and the
+  string it is handed is normally the one `getenv()` returned, which
+  POSIX says a program must not modify. Any other thread reading `PATH`
+  in that window, or a child forked in it, saw a truncated one. It now
+  splits a copy. Note this half is **not** observable from a
+  single-threaded test, since the value is put back before the function
+  returns; the assertion in `util_path.c` only catches a variant that
+  forgets to restore.
+
+**The two filesystem questions are each answered by an arm this platform
+does not compile**, which is the recurring trap in this directory:
+
+- `pmix_path_nfs()` reads the mount table, so it exists only where
+  `<mntent.h>` does. **On macOS and the BSDs it answers `false`
+  unconditionally**, whatever the file is really on — which the header
+  had never said. It has no in-tree caller; do not add one that needs
+  the answer to be right off Linux.
+- `pmix_path_df()`'s `HAVE_STATVFS` arm did not compile *at all*. The
+  sign test on `f_bavail` was written as a cast inside the comparison,
+  and `statvfs`'s `f_bavail` is unsigned, so it is
+  `-Werror=type-limits` on every platform that selects that arm — i.e.
+  the ones without a `struct statfs`, Solaris and NetBSD among them.
+  The test now goes through a signed variable, which is correct for the
+  BSD `statfs` case it exists for and silent for the unsigned ones.
+  That arm also multiplied `f_bavail` by the wrong number: `statfs`
+  counts it in `f_bsize` blocks, but POSIX `statvfs` counts it in
+  `f_frsize` ones, and `f_bsize` there is the *preferred I/O size* —
+  many times larger on some filesystems, so the caller was told it had
+  far more room than it does. Force both arms by hand before believing
+  an edit to this function; a stub `<mntent.h>` in the same style as
+  `pcompress`'s test-build shims is enough for the first.
+
 ### `pmix_os_path` — a NULL that callers kept forgetting to read
 
 One variadic function that concatenates its `char *` arguments with the

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -124,6 +124,23 @@ Four things about a stream's lifetime are easy to get wrong, and were.
   descriptor either, so a recycled slot could start life pointed at a
   descriptor that had been closed.
 
+**The syslog support was dead in every build ever shipped.** All of it
+was compiled behind `HAVE_SYSLOG`, and nothing in this tree defines that
+macro — `configure` probes for the *header* (`HAVE_SYSLOG_H`, via the
+`AC_CHECK_HEADERS` list in `config/pmix.m4`) and never for the function.
+So `USE_SYSLOG` was always 0, a stream that asked for syslog was given no
+destination at all, and `PMIX_OUTPUT_REDIRECT=syslog` — which also turns
+stdout, stderr and file output off — silently discarded every line the
+library produced. The guards now key off `HAVE_SYSLOG_H`, which is what
+the `#include <syslog.h>` at the top of the file is guarded on and what
+POSIX ties `openlog`/`syslog`/`closelog` to; `parse_verbose()` in
+`src/mca/base/pmix_mca_base_open.c` carried the same guard and is fixed
+with it, so `pmix mca base verbose = syslog` stops reporting that syslog
+is unavailable on a system that has it. This is the recurring shape from
+`pmix_getid`: **the macro guarding a declaration and the macro guarding
+its use must be the same one, and a guard nothing defines gets no
+compiler coverage** — that block had never been compiled by anyone.
+
 Five environment variables, read once in `pmix_output_init()`, override
 what every stream does: `PMIX_OUTPUT_REDIRECT` (`syslog` or `file`),
 `PMIX_OUTPUT_SYSLOG_PRI`, `PMIX_OUTPUT_SYSLOG_IDENT`,

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -1447,6 +1447,17 @@ an 11-byte `strcpy` into a zero-length buffer through. Both now refuse a
 buffer that cannot hold the name, with the `-5`/`EOVERFLOW` its sibling
 path already used.
 
+**An installed header has to bring its own types.** `pmix_pty.h`
+declares two functions taking a `struct winsize *` and included only
+`<termios.h>`, which is not where that type comes from: glibc keeps it
+in `<sys/ioctl.h>` and leaks it out of `<termios.h>` only under some
+feature-test settings, while macOS leaks it unconditionally. So any
+consumer that had not already included `<sys/ioctl.h>` itself built on
+macOS and failed on Linux with "declared inside parameter list" — which
+is what `test/unit/util/util_pty.c` did, so `make check` in that
+directory did not build there at all. The header includes
+`<sys/ioctl.h>` itself now, the way `pmix_tty.h` always has.
+
 **Every arm in this file is conditionally compiled and this platform
 selects one path through it.** `PMIX_ENABLE_PTY_SUPPORT` (all-stubs),
 `HAVE_PTSNAME` (the `/dev/ptmx` route vs. the BSD `/dev/ptyXY` scan),

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -475,6 +475,83 @@ this file only *consumes* it) and the `a.b.c.d[/mask]` tuple parser
 `pmix_iftupletoaddr`, which returns masks in **host** order. Mind that
 byte-order difference if you ever mix the two.
 
+Three different things in here are called a "mask" and only two of them
+are the same kind of number. `pmix_iftupletoaddr()` hands back a real
+32-bit **bit mask** in host order; `pmix_ifindextomask()` hands back the
+interface's **CIDR prefix length**, which is also what
+`pmix_net_samenetwork()` expects as its third argument. Do not feed one
+to the other.
+
+**The list is built once and read without a lock.** `pmix_pif_base_open()`
+constructs `pmix_if_list`, the discovery components append to it, and
+nothing mutates it again until `pmix_pif_base_close()` drains and
+destructs it. Every lookup in `pmix_if.c` is an unlocked walk that is safe
+only because of that; if a future component ever refreshes the list at
+run time, all of them become races at once.
+
+**An empty list answers with its sentinel, not with `NULL`.**
+`pmix_list_get_first()` returns `&list->pmix_list_sentinel` when there is
+nothing on the list, so a `NULL` test on its result never fires — the
+caller then reads its own struct fields off a `pmix_list_item_t` embedded
+in the `pmix_list_t`, which is a read past the end of that object.
+`pmix_ifbegin()` did exactly this and handed the `ptl` listener a garbage
+starting index on any node where discovery found nothing (a container in
+its own network namespace, a platform no `pif` component can read).
+Terminate on `pmix_list_get_end()`, the way every other lookup in the file
+does. `test_ifbegin_empty` in
+[`test/unit/util/util_if.c`](../../test/unit/util/util_if.c) pins it.
+
+**An entry answers only for its own address family, and the list mixes
+families in every build.** A kernel index carries one `pmix_if_list` entry
+per address, so an interface with both an IPv4 and an IPv6 address is two
+entries. Reading a `sockaddr_in` out of an AF_INET6 entry yields that
+entry's flow label, and reading a `sockaddr_in6` out of an AF_INET entry
+yields the zero padding behind the address — so an all-zero query compares
+equal to an unrelated entry of the other family. That is how
+`pmix_ifaddrtoname()` answered `"lo"` for `0.0.0.0` and for `::`, and
+`pmix_ifislocal()` is a thin wrapper over it, so the same confusion calls a
+remote node local. Screen `sa_family` before comparing, as
+`pmix_ifaddrtokindex()` and `pmix_ifmatches()` already do. Note this is
+**not** avoided by an IPv6-disabled build: `PMIX_ENABLE_IPV6` is 0 by
+default, but the `pif` IPv6 components are gated on the OS rather than on
+that flag, so they populate the list regardless — all `PMIX_ENABLE_IPV6`
+turns off is the IPv6 arm of `pmix_ifgetaliases()`.
+
+**`strtol()` answering 0 is not the same as reading a 0.** `/0` is legal
+CIDR meaning "match everything", so once `pmix_iftupletoaddr()` started
+accepting it, a suffix with no digits in it at all (`"10.0.0.0/"`,
+`"10.0.0.0/abc"`) was quietly accepted as that instead of being reported.
+In `pmix_ifmatches()` the resulting mask matches no interface, so an
+`if_include` entry with a typo silently selected nothing *and* suppressed
+the `invalid-net-mask` warning that used to fire. Check the `endptr`.
+
+Two properties that are contracts rather than defects, so that the next
+reader does not re-litigate them:
+
+- **`getaddrinfo()` blocks, and only `pmix_ifaddrtoname()` can be told
+  not to call it.** `pif_do_not_resolve` short-circuits that function
+  (and therefore `pmix_ifislocal()`); `pmix_ifaddrtokindex()` resolves
+  regardless. Both are installed API with no in-tree caller — the
+  in-tree consumers (`ptl_base_listener`, `pnet/tcp`) use only the
+  index/kernel-index lookups, at init — so nothing here runs a DNS
+  timeout on the progress thread today. Do not add such a call to a
+  progress-thread path.
+- **Nothing in this file screens its arguments.** A `NULL` name reaches
+  `strncmp`, a `NULL` tuple reaches `strchr`, and a non-positive `length`
+  reaches `memset`/`pmix_strncpy`. That is a departure from the screening
+  the rest of this directory does on installed entry points; it is left
+  alone because no caller in PMIx or PRRTE passes any of those, and the
+  header does not promise otherwise.
+
+The `#if HAVE_STRUCT_SOCKADDR_IN` `#else` arm is the usual trap: **no
+configuration anyone builds selects it, so it gets no compiler coverage
+at all.** It has to define *every* one of the 21 entry points
+`pmix_if.h` declares — seven were simply missing, which is a link
+failure rather than the graceful degradation the fallback exists for —
+and it has to name every parameter as deliberately unread, since this
+tree builds `-Wextra -Werror`. Force the guard false for one
+`make pmix_if.lo` before believing an edit there is good.
+
 ### `pmix_fd` — descriptor helpers, three of them with no caller
 
 `pmix_fd_read`/`pmix_fd_write`/`pmix_fd_set_cloexec`/`pmix_fd_is_*` are

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -179,10 +179,66 @@ and breaks the build for whoever regenerates it next — which on a fresh
 clone is CI. Regenerate whenever you add, remove, or rename a
 `pmix_show_help*()` call, not only when you edit the text.
 
-`pmix_show_help`
-also aggregates duplicate notices (fired from a libevent timer) and can
-thread-shift delivery through the log path; the global `abd_tuples` list
-is manipulated without locking and assumes progress-thread-only callers.
+`pmix_show_help` also aggregates duplicate notices (fired from a libevent
+timer) and can thread-shift delivery through the log path; the global
+`abd_tuples` list is manipulated without locking and assumes
+progress-thread-only callers.
+
+**The header describes a system that no longer exists**, or rather it
+did: it walked the reader through opening a file in `$pkgdatadir` and
+told an MCA component to install its own helpfile there. Nothing opens
+anything at run time, so following it produced a file PMIx never reads.
+It now says what actually happens, including the regenerate step and the
+`--purge` trap above, and `pmix_show_help_add_data()` — documented as
+adding a *search directory* — now says what it takes, which is a
+compiled-in table that it borrows rather than copies.
+
+**The aggregation state is process-global and outlives a finalize**, the
+same shape as `pmix_keyval_parse`'s `env_str` below. `pmix_show_help_init()`
+can run again in the same process — `pmix_rte_init()` calls it, several
+tools call it directly, and `pmix_show_help_finalize()` clears the
+initialized flag — so a `show_help_timer_set` left standing meant the
+aggregation timer was never armed again for the rest of the process.
+Finalize now deletes the timer and resets the flag and the timestamp.
+
+**Finalize is also the only place the promised termination flush can
+happen.** `pmix_help_check_dups()` documents that accumulated duplicates
+are displayed unconditionally at termination, but the summary only ever
+ran off a five-second timer, and finalize destructed the list without
+looking at it — so a job that ended sooner, which is most of them, was
+never told about the other N processes at all. It now flushes, and it
+clears `pmix_show_help_initialized` *first* so the notice takes
+`local_delivery()`'s direct-to-stderr path: `pmix_rte_finalize()` has
+already paused the progress thread by the time this runs, so anything
+thread-shifted onto the event base here would neither run nor be
+released. `test_duplicates_flushed_at_finalize` in
+[`test/unit/util/util_show_help.c`](../../test/unit/util/util_show_help.c)
+covers it, and has to fork before the test's own `PMIx_Init` — a child of
+an already-initialized process only adjusts a reference count and never
+reaches `pmix_rte_finalize()` at all.
+
+**A message can pull in another one**, with a line of the form
+`#include#FILE#TOPIC` or `#include#PROJECT#FILE#TOPIC`, parsed from the
+right. No `help-*.txt` in the tree uses it yet, which is why both copies
+of the parser — the local-array branch and the registered-array branch,
+which were the same twenty lines twice — dereferenced whatever
+`strrchr()` returned. A line with too few fields, `#include` on its own
+being the easy one to write, is a NULL dereference, and a topic that
+includes itself recursed until the stack ran out. The parse is now one
+`parse_include()` used by both, which refuses a line it cannot read, and
+the recursion carries a depth bound. Both cases are in `util_show_help.c`,
+which drives them through `pmix_show_help_add_data()` — registering a
+table of your own is the only way to reach this parser from a test, and
+the malformed cases die on a signal rather than failing an assertion when
+the guards are removed.
+
+**`pmix_show_help_string()` is not a pure lookup.** When the topic does
+not exist it displays the "couldn't find that help reference" notice
+itself and *then* returns `NULL`, so a caller that reports the miss again
+reports it twice. Anything that stores a `strdup`ed filename or topic on
+`abd_tuples` has to check it: `match()` hands both straight to `strcmp()`,
+and the list outlives the call that built it, so an entry carrying a
+`NULL` is a segfault on the next lookup rather than on this one.
 
 ### `pmix_cmd_line` — the CLI parser
 
@@ -1353,7 +1409,8 @@ regression), `if` (the tuple parser), `name_fns` (incl. special-rank
 compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,
 `string_copy`, `timings`, `getcwd`, `getid`, `keyval`, `pty` (the
-controlling-terminal and descriptor-ownership regressions).
+controlling-terminal and descriptor-ownership regressions), `show_help`
+(the `#include` parser and the termination flush).
 
 ## Fixed defects (July 2026 review)
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -1480,6 +1480,89 @@ Two things deliberately left alone:
   platform with `openpty(3)`, and the one caller it can have runs before
   a fork; do not add a second one on another thread.
 
+### `pmix_tty` — verifying a set that the driver only half made
+
+Five wrappers over `tcgetattr`/`tcsetattr` and the winsize ioctls.
+`pmix_tty.h` is installed, and nothing in PMIx or PRRTE calls any of
+them, so — like [`pmix_getid`](#pmix_getid--installed-api-with-no-caller)
+— judge them as API rather than as code with a known caller.
+
+They hold no state, allocate nothing and take no locks, which makes them
+reentrant and usable between `fork` and `exec`. What is not atomic is a
+read-modify-write of one terminal: `pmix_settermios()` reads the current
+settings so it can put them back and `pmix_setraw()` reads them so it
+can hand them to the caller, so two threads driving the same terminal
+each undo the other. That is a caller's problem to serialize, and it is
+written down in the header rather than fixed here — a leaf utility has
+no handle to lock on.
+
+**The whole difficulty in this file is that `tcsetattr(3)` reports
+success when *any* part of the request was applied.** A caller cannot
+act on that, so `pmix_settermios()` reads the settings back and requires
+them to match. Two things about that check have been wrong, in opposite
+directions, and both are easy to reintroduce:
+
+- **It used to answer `PMIX_SUCCESS` when `tcsetattr` failed outright.**
+  The failure arm restored the old settings and preserved `errno`, and
+  then fell out of the `if` into the function's trailing
+  `return PMIX_SUCCESS`. So a `pmix_setraw()` that did nothing at all
+  reported that the terminal was raw, and the caller reads echoed,
+  line-buffered input forever with nothing about the descriptor it holds
+  to say why.
+- **It compared `c_lflag` in full, and part of `c_lflag` is not a
+  setting.** `FLUSHO` and `PENDIN` are status the driver maintains for
+  itself — `PENDIN` means queued input has yet to be retyped, which is
+  exactly what re-enabling canonical mode produces — and `EXTPROC` can be
+  turned on from the master end of a pty without the slave's caller
+  asking. So `pmix_setraw()` followed by a restore of the settings it
+  handed back failed with `EINVAL` on macOS, having applied them
+  perfectly. `PMIX_TTY_LFLAG_STATUS` is the mask that keeps those bits
+  out of the comparison; do not "simplify" it away. Note that this is
+  the *second* pass at the same check — an earlier one replaced a
+  whole-struct `memcmp` with per-field compares for the same class of
+  reason, and did not go far enough.
+
+The function is now all-or-nothing: every failure arm, including a
+read-back that does not match, puts the terminal back the way it was
+found before reporting. Keep it that way — a caller told "no" while the
+terminal sits in a state neither of you chose has nothing it can do.
+
+**Making `tcsetattr` fail on demand is the hard part of testing this,
+and POSIX gives exactly one portable lever.** `tcsetattr` on a process's
+*controlling* terminal from a process group that is both in the
+background and **orphaned** fails with `EIO`, and no `SIGTTOU` is
+delivered. (Merely being in the background is not enough, and ignoring
+`SIGTTOU` makes it *succeed* rather than fail — the ignore/block case is
+explicitly permitted to perform the operation.) Building that position
+takes three processes, and
+[`test/unit/util/util_tty.c`](../../test/unit/util/util_tty.c) does:
+a session leader that acquires the pty as its controlling terminal, a
+child that moves itself into its own process group, and a grandchild
+left orphaned when that child exits. **The session leader has to stay
+alive until the verdict is in** — when the controlling process dies the
+terminal is disassociated from the session and, on BSD-derived systems,
+the slave is revoked out from under the probe, which shows up as
+`tcgetattr` failing for no visible reason.
+
+`pmix_setraw()` clears the line discipline — canonical mode, echo,
+signals, extended input, input and output post-processing — and asks for
+one character at a time with a blocking read. It deliberately does not
+touch `c_cflag`: no `CS8`, no parity clearing. That is
+[TLPI]'s `ttySetRaw()` rather than `cfmakeraw(3)`, and it is the right
+shape here, because the control modes mean nothing on a pty. A caller
+that wants a character size or parity asks for it itself.
+
+[TLPI]: https://man7.org/tlpi/
+
+**The `#else`/`HAVE_TERMIO_H` arm below `HAVE_TERMIOS_H` is inert.**
+`<termio.h>` is the SVR4 header for `struct termio` and the `TCGETA`
+family; it declares neither `struct termios` nor `tcgetattr`/`tcsetattr`,
+so on a platform that really lacked `<termios.h>` this file would not
+compile with or without it. The same three-line idiom appears in
+`pmix_pty.{c,h}` and `src/common/pmix_pfexec.c`, so it is left alone
+here — retiring it is a tree-wide change that should also drop the
+`configure` probe, not a per-file edit.
+
 ### `pmix_printf` — two implementations, only one of which you compile
 
 Four `PMIX_EXPORT` wrappers over `asprintf`/`snprintf`. On any platform
@@ -1657,7 +1740,9 @@ compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,
 `string_copy`, `timings` (which runs its real cases only in an
 `--enable-pmix-timing` build), `getcwd`, `getid`, `keyval`, `pty` (the
-controlling-terminal and descriptor-ownership regressions), `shmem` (the
+controlling-terminal and descriptor-ownership regressions), `tty` (the
+raw/restore round trip, and the orphaned-process-group probe that makes
+`tcsetattr` fail), `shmem` (the
 symlink/stale-file halves of the create, and the reference-count
 lifetime), `show_help` (the `#include` parser and the termination
 flush).
@@ -1780,7 +1865,10 @@ A second pass then cleared the remaining latent/robustness items:
 - **`pmix_tty.c`.** `pmix_settermios` verified a set via a full-struct
   `memcmp` of `struct termios` (padding / canonicalized fields → spurious
   failures) — now compares the individual POSIX fields (`c_iflag`,
-  `c_oflag`, `c_cflag`, `c_lflag`, `c_cc`).
+  `c_oflag`, `c_cflag`, `c_lflag`, `c_cc`), with the driver-maintained
+  status bits masked out of `c_lflag`; see
+  [`pmix_tty`](#pmix_tty--verifying-a-set-that-the-driver-only-half-made)
+  for why the field compare on its own was still not enough.
 
 ## Known issue left as-is (by design)
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -61,7 +61,7 @@ interface list).
 | `pmix_shmem.{c,h}` / `pmix_vmem.{c,h}` | mmap-backed shared-memory segment; `/proc/self/maps` hole finder (Linux) | `pad_to_page`/`parse_map_line` pure; rest need mmap |
 | `pmix_pty.{c,h}` / `pmix_tty.{c,h}` | pty open/forkpty; termios/winsize helpers | need real pty/tty |
 | `pmix_alfg.{c,h}` | additive lagged-Fibonacci RNG (from Open MPI's `opal_rand`) | pure/deterministic |
-| `pmix_timings.{c,h}` | optional profiling (`--enable-timing`, off by default) | needs `--enable-timing` |
+| `pmix_timings.{c,h}` | optional profiling (`--enable-pmix-timing`, off by default) | needs `--enable-pmix-timing` |
 | `pmix_context_fns.{c,h}` | process-launch cwd/exe resolution helpers | needs a fixture |
 
 ## Subsystems that deserve a closer look
@@ -1310,6 +1310,87 @@ around the chosen placement, without giving up the agreement. Tested in
 is where it has to be tested, since ASLR separates real processes well
 enough to hide whether the scatter works at all.
 
+### `pmix_timings` — a whole subsystem behind one configure switch
+
+Everything in `pmix_timings.c` below its opening `#if PMIX_ENABLE_TIMING`
+— 600 of its 645 lines — is compiled only under `--enable-pmix-timing`
+(note the spelling: `--enable-timing` is not an option and is silently
+ignored). Nothing in PMIx or PRRTE uses any of it: the `PMIX_TIMING_*`
+macros in the header are the intended entry points and have no in-tree
+caller, so **the only thing exercising this code is a developer adding
+macros by hand while chasing a latency question**.
+
+That is the whole context for reading this file. It is the recurring
+trap in this directory in its purest form — see `pmix_few`, `pmix_pty`,
+`pmix_net` above — and it had gone further than any of them: **the
+enabled arm did not compile at all.** `nodename`, the file-static that
+prefixes every line of output with the node's name, was declared `NULL`
+and assigned by nothing, anywhere, ever. gcc can see that, so all four
+`pmix_asprintf()` calls that pass it to a `%s` were
+`-Werror=format-overflow` errors, and `--enable-pmix-timing` failed to
+build. Had it built, every line would have named the node `(null)`.
+
+So: **compile this arm by hand before believing an edit to it.** Forcing
+the guard is not enough on its own — `src/runtime/pmix_rte.h` and
+`src/runtime/pmix_params.c` carry the same `#if`, and the parameters
+live there — so edit `#if PMIX_ENABLE_TIMING` to `#if 1` in all four, or
+better, flip `PMIX_ENABLE_TIMING` in the build tree's generated
+`pmix_config.h` and rebuild, which also lets
+[`test/unit/util/util_timings.c`](../../test/unit/util/util_timings.c)
+actually run. That test has a case per defect below, and its
+unmatched-stop case **dies on a signal** rather than failing an
+assertion when the screen it covers is removed.
+
+Four things about the code the compiler could not have told you:
+
+- **An interval id of -1 is an ordinary outcome, and it indexes an
+  array.** `PMIX_TIMING_MSTOP` on a handler with no measurement running
+  records `current_id`, which is -1, and both consumers index the
+  descriptor array by `ev->id`. `pmix_timing_deltas()` screened for a
+  negative id; `pmix_timing_report()` did not, and when no interval had
+  ever been described the array was not allocated at all — so an
+  unmatched stop was a read through `((struct interval_descr *)
+  NULL)[-1]`. The screen now lives in `_prepare_descriptions()`, which
+  marks such an event unusable, and in the report loop, which skips one.
+- **Nothing may be taken off `t->events`.** Every event lives inside a
+  block of `PMIX_TIMING_BUFSIZE` that `pmix_timing_event_alloc()`
+  allocated, and the only pointer to that block is its first event —
+  which is on the list, carrying `fib`, and is how
+  `pmix_timing_release()` finds the block to free. So
+  `pmix_list_remove_item()` on a malformed event leaked its entire block
+  whenever the event happened to be a block's first, one time in
+  `PMIX_TIMING_BUFSIZE`. Mark an event unusable; do not unlink it.
+- **A parameter that two files define is a parameter that does nothing.**
+  `src/runtime/pmix_params.c` registers the `timing_overhead` MCA
+  parameter against `pmix_timing_overhead`, and `pmix_timings.c` defined
+  a *file-static* of the same name, initialized `false`, which shadowed
+  it for the only two places that read it. The parameter was inert and
+  the overhead accounting it exists to switch never ran, in any build.
+  This is the same shape as `pmix_net_private_ipv4` above, with a
+  different mechanism. The declaration now lives in `pmix_timings.h`, so
+  a static definition following it is a compiler error rather than a
+  silent second variable.
+- **The installed header must declare what its macros use.**
+  `PMIX_TIMING_REPORT`/`_DELTAS` expand to a use of `pmix_timing_output`,
+  which was declared only in `src/runtime/pmix_rte.h` — not an installed
+  header — so those two macros did not compile outside this tree at all.
+  The same header spelled `__FUNCTION__`, a GNU extension, in eight
+  macros, so a consumer compiling `-pedantic` could not use any of them;
+  C11 spells it `__func__`. `pmix_timing_sync_file` was declared in
+  `pmix_rte.h` and defined nowhere, which made any use of it a link
+  error; it is gone. And `PMIX_TIMING_ID(n, r)` named `pmix_timing_id()`,
+  a function that has never existed — the real one is `pmix_init_id()`.
+
+Two smaller invariants worth keeping: `snprintf` answers what it *would*
+have written, so both output loops advance by the number of bytes that
+actually fit rather than by `strlen(line)` — otherwise a line longer than
+`PMIX_TIMING_OUTBUF_SIZE` (which only an `assert()` stands against, and
+`-DNDEBUG` removes that) walks the append cursor past the end of the
+buffer, and the remaining capacity goes negative and converts to an
+enormous `size_t`. And `hnp_offs` is a clock-offset correction that
+nothing ever sets; it is left in place because it is what a
+cross-node timing comparison would need, but read it as 0.
+
 ### `pmix_pty` — a helper that must not take a terminal for itself
 
 Four wrappers around pty setup, and one caller: `pmix_pfexec`'s
@@ -1574,7 +1655,8 @@ Current coverage includes: `argv`, `alfg`, `basename`, `cmd_line`,
 regression), `if` (the tuple parser), `name_fns` (incl. special-rank
 compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,
-`string_copy`, `timings`, `getcwd`, `getid`, `keyval`, `pty` (the
+`string_copy`, `timings` (which runs its real cases only in an
+`--enable-pmix-timing` build), `getcwd`, `getid`, `keyval`, `pty` (the
 controlling-terminal and descriptor-ownership regressions), `shmem` (the
 symlink/stale-file halves of the create, and the reference-count
 lifetime), `show_help` (the `#include` parser and the termination
@@ -1636,7 +1718,8 @@ own commit. Recorded so they are not re-introduced by a future edit.
   `snprintf(buf, PMIX_TIMING_STR_LEN, "%s%s", buf, line)` — aliasing
   `buf` as both source and destination (UB) and capping the buffer at
   1024 rather than the size it was allocated for. Now appends at the
-  current end with the real remaining capacity. (`--enable-timing` only.)
+  current end with the real remaining capacity. (`--enable-pmix-timing`
+  only.)
 - **`pmix_pty.c`.** The `PMIX_ENABLE_PTY_SUPPORT == 0` stubs had a missing
   semicolon and signatures that disagreed with the header (`pmix_ptymopen`
   dropped `maxlen`; `pmix_forkpty` had extra/concrete params), and the

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -317,6 +317,34 @@ path. Three things about them are easy to get wrong.
   [`test/unit/util/util_context_fns.c`](../../test/unit/util/util_context_fns.c)
   pins it by unsetting `$HOME`.
 
+### `pmix_getcwd` — $PWD is not authoritative
+
+The name and the ticket reference in the header suggest a function that
+prefers `$PWD` — historically it did, comparing the two by `stat()` so a
+`$PWD` that named the same directory through a symlink could be handed
+back. The `stat()` went away years ago and the comparison is now a
+`strcmp`, which means `$PWD` is used only when it is character-for-
+character what `getcwd()` already said: **the answer is always the
+`getcwd()` value.** Do not "restore" the `$PWD` preference without
+deciding deliberately that a caller should be told a directory the
+process is not in.
+
+The length test is `>=`, not `>`: `size` counts the terminating NUL, so a
+buffer exactly as long as the path is a truncation. A truncation is not
+an empty answer — the caller gets as much of the *basename* as fits and
+`PMIX_ERR_OUT_OF_RESOURCE`, so a short buffer yields a plausible-looking
+relative name rather than an obvious failure. Both boundaries, and the
+`$PWD` behavior, are pinned by
+[`test/unit/util/util_getcwd.c`](../../test/unit/util/util_getcwd.c).
+
+One contract seam worth knowing: this function accepts any `size` up to
+`INT_MAX`, but hands it to `pmix_string_copy()`, which `assert()`s at
+`PMIX_MAX_SIZE_ALLOWED_BY_PMIX_STRING_COPY` (128K). A caller with a
+buffer between those two bounds would abort rather than be served. No
+caller is close — the only one in the tree uses `PMIX_PATH_MAX` — but
+do not widen the documented range on the strength of the bozo check
+alone.
+
 ### `pmix_error` — two lookups over a table you do not write
 
 `PMIx_Error_string()` and `PMIx_Error_code()` are a linear scan each over
@@ -568,7 +596,7 @@ Current coverage includes: `argv`, `alfg`, `basename`, `cmd_line`,
 regression), `if` (the tuple parser), `name_fns` (incl. special-rank
 compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,
-`string_copy`, `timings`.
+`string_copy`, `timings`, `getcwd`.
 
 ## Fixed defects (July 2026 review)
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -114,6 +114,53 @@ quirk that bit `src/tools` is worth remembering: a bare invocation
 through the `done:` copy, which would leave the program name in the
 tail).
 
+**Any arm that claims a token getopt did not consume must first check
+that the token is there.** Several options are declared to getopt as
+taking one argument and then take a second from `argv[optind]` on the
+parser's own account — the MCA pair, `--prepend-env`/`--append-env`, the
+`-np` shortcut, `--show-version`'s trailing tokens. `argv[optind]` at the
+end of the array is the `NULL` that terminates it, and an arm that stored
+that `NULL` as a value and stepped `optind` past it left `optind ==
+argc + 1`, which the loop's end test — an equality against `argc` — did
+not catch. The next iteration then read past the end of the copied array
+and dereferenced what it found. The end test is now `>=`, and each of
+those arms reports `not-enough-arguments` instead; `is_option_token()` is
+what tells a real value from the next option. Regression cases are the
+`two-token:` group in
+[`test/unit/util/util_cmd_line.c`](../../test/unit/util/util_cmd_line.c),
+and they die on a signal rather than failing an assertion.
+
+**A lone `-` is not an option.** It conventionally names stdin, and getopt
+agrees: it stops at a bare `-` without consuming it. The loop asked only
+whether the token began with a dash, so it called getopt anyway, got the
+"no more options" answer, and the arms below then reasoned about
+`argv[optind - 1]` — the token *before* the dash — and reported an option
+that had been given its argument as though it were missing one. A bare
+`-` now ends the option list and goes to the tail, which is what
+`is_option_token()` has always said it should. Regression cases are the
+`bare dash:` group.
+
+**An optional argument arrives two ways.** getopt reports the argument of
+`-h` in `optarg` when it was written attached (`-htopic`,
+`--help=topic`) and leaves it at `argv[optind]` when it was the next
+token (`--help topic`). Only the second was ever looked at, so
+`--help=version` was refused as an unrecognized option while
+`--help version` worked. Both spellings are the same request; answer them
+in one place.
+
+**One parse at a time, on the tool's main thread.** `getopt_long` keeps
+its state in the process-global `optind`/`optarg`/`opterr`/`optopt`, which
+this parser resets on entry — so two concurrent parses corrupt each
+other, no matter which `pmix_cli_result_t` each is filling. Every caller
+today parses once, at startup, before any progress thread exists.
+
+The inline helpers in the header are used by tools outside this tree
+(the header is installed), and two of them have to remember that
+`PMIx_Argv_split()` drops empty fields: a string that is nothing but
+separators splits to **nothing at all**, not to a one-element array. So
+`pmix_convert_string_to_time(":")` and `pmix_check_cli_option("-", ...)`
+both had a `NULL` array to walk. Screen the count before indexing.
+
 **The first token that is not an option ends the option list**, and the
 short-option string is prefixed with `'+'` to make getopt agree with
 that. Without it getopt permutes non-options to the end of argv as it

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -947,17 +947,22 @@ looks more roundabout than "stat then chmod" or "readdir then unlink".
   `pmix_os_dirpath_access()` is the fossil of that decision: it is a
   no-op that always answers `PMIX_SUCCESS`, kept because it is installed
   API that PRRTE may still link against. Do not give it a body.
-- **Only the *final* component is protected against a planted symlink.**
-  `mkdir(2)` does not follow a symlink at the last component but does
-  follow one at every component before it, and the tree-building loop
-  accepts `EEXIST` on an intermediate component without asking what it
-  is - by design, since an intermediate need only be traversable. So a
-  symlink pre-planted at an intermediate component of a predictable
-  session path still redirects the leaf that gets created. Closing that
-  needs an `openat` walk from the root with `O_NOFOLLOW` at every step,
-  and `mkdirat` for each component; it is a deliberate design change, not
-  a tidy-up. **Do not "fix" it halfway** - a partial walk that still ends
-  in a path-based `mkdir` buys nothing.
+- **The plain single-path entry points protect only the *final*
+  component against a planted symlink.** `mkdir(2)` does not follow a
+  symlink at the last component but does follow one at every component
+  before it, and the tree-building loop accepts `EEXIST` on an
+  intermediate component without asking what it is - by design, since an
+  intermediate need only be traversable. So a symlink pre-planted midway
+  through a predictable session path still redirects the leaf that gets
+  created. That is why `pmix_os_dirpath_create_under()` and
+  `_open_file_under()` exist, and why they take the trusted prefix and
+  the composed tail as *separate arguments* rather than one path: only
+  the tail can be walked with `O_NOFOLLOW` at every step. Which of the
+  three entry points a caller wants is decided in
+  [Composing a path PMIx will then open](#composing-a-path-pmix-will-then-open)
+  below - and **do not "fix" the plain ones halfway**: a partial walk
+  that still ends in a path-based `mkdir` buys nothing, and one that
+  refuses a symlink at every component refuses macOS outright.
 
 Three contracts the callers depend on:
 
@@ -1088,6 +1093,79 @@ stubs recorded below: **a conditionally-compiled arm no configuration
 here selects gets no compiler coverage at all.** If you touch one,
 compile it by hand — forcing the guard false for one `make` of that
 object is enough.
+
+### Composing a path PMIx will then open
+
+Several places here build a name out of PMIx's own naming scheme and
+then create something at it — a segment backing file, an `hwloc.sm`, a
+per-rank `stdout`, a session directory. Two rules keep those from landing
+somewhere other than where the caller asked, and both are about the
+difference between naming a thing and holding it.
+
+**`O_NOFOLLOW` applies to the last component of a path and nothing
+else.** Every component before it is resolved in the ordinary way,
+symlinks included. So adding `O_NOFOLLOW` to a plain `open()` says
+nothing at all about the directories the name was reached through. That
+gives three entry points rather than one, and which you want depends on
+who composed which part of the name:
+
+| the name is | use |
+|---|---|
+| entirely from outside PMIx | `pmix_os_dirpath_create()` — the whole path is taken as given |
+| a caller's directory + a leaf PMIx composes | `pmix_os_dirpath_open_file()` |
+| a caller's directory + directories PMIx composes | `pmix_os_dirpath_create_under()` / `_open_file_under()` |
+
+- **The prefix is taken as given.** `$TMPDIR`, `PMIX_NSDIR`, a
+  user-named output directory — somebody chose those, and PMIx is in no
+  position to second-guess them. They are resolved normally, which they
+  have to be: on macOS `/tmp`, `/var` and `/etc` are *all* root-owned
+  symlinks into `/private`, so the default PMIx temporary directory
+  reaches its contents through one. A blanket "decline a symlink at any
+  component" walk therefore declines the platform; it was tried, and
+  that is what it did — while also declining the legitimate reclaim of a
+  stale segment file, which is how the mistake surfaced.
+- **What PMIx composes below the prefix gets walked.** Those names are
+  the library's own, so nothing else should have put anything at them.
+  Each is created with `mkdirat()` and opened with `O_NOFOLLOW` against
+  the descriptor of its parent, so the directory each one lands in is the
+  one just checked. The test is **how many components PMIx composes**,
+  not whether it composes any: a single one is already covered, since
+  `mkdir(2)` does not follow a link at the last component of the name it
+  is given and `dirpath_ensure_mode()` then opens that component
+  `O_NOFOLLOW`. It is the *second* composed level that nothing sees.
+  - `write_rndz_file()` does **not** need the `_under` pair. Its
+    directory is `pmix_server_globals.tmpdir`, which is
+    `PMIX_SERVER_TMPDIR` or `$TMPDIR` or `/tmp` verbatim — PMIx composes
+    only the basename beneath it.
+  - `pmix_iof`'s `PMIX_IOF_OUTPUT_TO_DIRECTORY` sink does: the caller
+    names a directory and PMIx builds `<nspace>/rank.N` under it.
+  - So does its `PMIX_IOF_OUTPUT_TO_FILE` sink, which is easy to miss.
+    `process_pattern()` copies everything that is not a conversion
+    verbatim, **separators included**, so `file:%h/%n/rank-%R` has PMIx
+    composing two directory levels out of the hostname and the
+    namespace. `pattern_literal_head()` there is what finds the dividing
+    line: the last separator before the first conversion, since nothing
+    ahead of that is transformed and the offset is therefore the same in
+    the pattern and in its expansion.
+- **Where the name is created fresh, pass `O_EXCL` with `O_CREAT`.**
+  Together they decline *anything* already at the name rather than only a
+  symlink. `write_rndz_file()` in
+  [`ptl_base_listener.c`](../mca/ptl/base/ptl_base_listener.c) is the
+  model, **including its two-pass loop** — a name that carries a pid may
+  hold a file left over from an earlier run, since pids get reused, and
+  that has to be reclaimed or the operation cannot succeed at all.
+  Reclaim it with `unlink()`, which removes the name it is given and
+  never follows it onward. A change that only declines breaks startup;
+  `test/unit/util/util_shmem.c` covers both halves for exactly that
+  reason.
+
+**Once you hold a descriptor, act on it rather than on the name.**
+`chmod()` follows a symlink at the final component and `lchown()`
+deliberately does not, so a pair of them applied to the same path act on
+two different objects — which is what `pmix_shmem_segment_chmod()` and
+its neighbour were doing. Open once and use `fchmod()`/`fstat()`, the way
+`dirpath_ensure_mode()` does in
+[`pmix_os_dirpath.c`](pmix_os_dirpath.c).
 
 ### `pmix_shmem` — a created segment reads as zero
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -147,6 +147,62 @@ qualifiers (`PMIX_INFO_IS_QUALIFIER`) can be smaller than `nquals`: index
 the destination array by the compacted counter, not the loop variable
 (this was the bug fixed in July 2026 — see below).
 
+### `pmix_basename` — two implementations, one of them invisible
+
+`pmix_dirname()` has two bodies behind a configure-time `#if`. Where
+`dirname(3)` exists — which is everywhere PMIx is actually built — it
+strdups the input, hands it to libgen, and strdups the answer back. The
+`#else` is a hand-rolled walk that no ordinary build ever compiles.
+
+Two consequences worth keeping in mind:
+
+- **The branch you can read is not the branch you are running,** and a
+  divergence between them is invisible to a build that only checks that
+  the code compiles. They *did* diverge: the fallback answered `"."` for
+  a path that is nothing but separators (`"/"`, `"//"`) where libgen
+  answers the root. `util_basename.c` now pins the whole answer table for
+  whichever branch is compiled, so a future edit to either one has to
+  keep them agreeing. If you change one body, run the corpus against the
+  other by hand before you believe it.
+- **`dirname(3)` is not reentrant on every platform.** glibc rewrites the
+  buffer you hand it, but macOS and the older BSDs return a pointer into
+  internal static storage, so two threads inside `pmix_dirname()` at once
+  can each strdup the other's answer. Nothing in the tree does that
+  today, and the reason is worth preserving rather than rediscovering:
+  the `ptl` caller (`write_rndz_file`) is reachable only from
+  `pmix_ptl_base_setup_listener`, which runs once while the process is
+  still initializing, and the remaining callers (`pmix_iof`, `pmix_path`)
+  run on the progress thread. **Do not add a `pmix_dirname()` call on a
+  thread that can run concurrently with the progress thread** without
+  first replacing the libgen branch — the `#else` body is already a
+  correct, reentrant implementation of the same function.
+
+### `pmix_argv` — copies must not write through the original
+
+Everything in this file that is named "copy" or "insert" takes its input
+by value, and two of them used to cheat:
+
+- `pmix_argv_copy_strip()` marked the end of a quoted element by punching
+  a temporary NUL into the *caller's* string and putting the quote back
+  afterwards. That faults outright on an argv whose elements are string
+  literals — an entirely ordinary thing to hand a function that promises
+  a copy — and it is not safe against a second thread reading the same
+  array. It now measures the surviving span and copies that out.
+  `test_copy_strip_readonly_source` in `util_argv.c` is the regression:
+  it dies on a signal, not with a failed assertion, if this comes back.
+- `pmix_argv_insert()` and `pmix_argv_insert_element()` grew the target
+  and shifted its suffix *before* strdup'ing the source in. A failed
+  strdup then left a NULL in the middle of the array — which terminates
+  it, so every element past the hole is at once lost to the caller and
+  leaked — and the functions reported `PMIX_SUCCESS` anyway. Both now
+  copy first and only touch the target once the copies are in hand, so
+  the failure is reported with the target untouched. Keep that order.
+
+Note also that `pmix_argv_append_unique_idx()` is documented as the
+public `PMIx_Argv_append_unique_nosize()` plus an index out-parameter,
+and callers are entitled to that: it screens `NULL` inputs the same way
+rather than handing a `NULL` arg to `strcmp`.
+
 ### `pmix_net` / `pmix_if` — network helpers
 
 `pmix_net` is pure address math (CIDR→netmask in *network* order,

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -1169,8 +1169,8 @@ its neighbour were doing. Open once and use `fchmod()`/`fstat()`, the way
 
 ### `pmix_shmem` — a created segment reads as zero
 
-`pmix_shmem_segment_create()` opens its backing file `O_CREAT | O_TRUNC`
-and `ftruncate`s it to the full size, so a freshly created segment is a
+`pmix_shmem_segment_create()` creates its backing file fresh and
+`ftruncate`s it to the full size, so a freshly created segment is a
 sparse file whose every page reads as zero. **That is a contract, not an
 incidental property**: `gds/shmem3`'s bump allocator relies on it to hand
 out zeroed storage without writing a byte (see `tma_carve()` and
@@ -1178,12 +1178,67 @@ out zeroed storage without writing a byte (see `tma_carve()` and
 what keeps building a segment from faulting in its whole — heavily
 over-estimated — extent up front.
 
-The `O_TRUNC` is the load-bearing half. Segments are unlinked when their
-last holder lets go, so a path collides only with a file left behind by a
-server that died; but the path carries a pid, and pids get reused, and
-`ftruncate()` to the same or a smaller size would leave that file's bytes
-in place. There is exactly one caller of this function and it always
-populates the segment from scratch, so the truncate costs nothing.
+"Fresh" is the load-bearing half, and it is why the open is
+`O_CREAT | O_EXCL` (through `pmix_os_dirpath_open_file()`) rather than
+`O_CREAT | O_TRUNC`. Segments are unlinked when their last holder lets
+go, so a path collides only with a file left behind by a server that
+died; but the path carries a pid, and pids get reused, and `ftruncate()`
+to the same or a smaller size would leave that file's bytes in place.
+`O_EXCL` declines whatever is there — a symlink included, which
+`O_CREAT | O_TRUNC` would have followed and truncated — and the two-pass
+loop then reclaims a leftover with `unlink()` and retries, exactly as
+`write_rndz_file()` does. A change that only declines breaks a server
+whose pid was reused; both halves are covered by
+[`test/unit/util/util_shmem.c`](../../test/unit/util/util_shmem.c).
+
+**The reference count in the segment header is what decides when the
+backing file goes away, and it is the ONLY thing that does.**
+`pmix_shmem_segment_attach()` takes a reference and
+`pmix_shmem_segment_detach()` gives it back; dropping the last one
+unlinks the file. Three consequences are easy to get wrong and two of
+them were:
+
+- **A created segment holds no reference and is not attached.** The
+  internal attach that stamps the header is undone by the same detach as
+  everybody else's, so it deliberately does not count — otherwise the
+  count would never reach zero. The creator has to attach like any other
+  holder if it means to keep the segment alive.
+- **`detach()` releases what `attach()` took.** It used to release
+  nothing: only `shmem_destruct()` decremented, and only for a handle
+  that was still attached, so a handle detached explicitly left its
+  reference standing forever and the backing file was never unlinked by
+  anyone. `gds/shmem3`'s forced-attach-failure test parameters reach
+  exactly that path.
+- **A create that fails takes its own file with it.** Nothing else can:
+  the caller is being told the create failed, and the destructor only
+  unlinks a segment it managed to attach. `gds/shmem3` unlinks by hand
+  in the window *after* a successful create (see its `out_release`),
+  which is a different case and still needed.
+
+**Two fields of the handle are inputs to `pmix_shmem_segment_attach()`**,
+and a process attaching to somebody else's segment fills them in itself:
+`backing_path`, and `size` — where `size` is the mapped *footprint*, the
+number the creator's handle carried afterwards, not the number it asked
+to store. `gds/shmem3` puts the creator's `shmem->size` on the wire for
+that reason. Passing the smaller number maps a page short of the end of
+the data region, which nothing here can detect.
+
+**The mode a segment's file carries has to allow write to every process
+meant to read it.** A peer maps `MAP_SHARED` from a descriptor it opened
+`O_RDWR`, because it writes the reference count even when it never
+writes the data — so a read-only mode does not make the segment
+read-only to a peer, it makes it unopenable, and the peer falls back to
+another GDS module. `gds/shmem3` sets `0660`. A reader that wants the
+data itself to be unwritable asks for
+`pmix_shmem_segment_protect_data()`, which leaves the header page
+writable for exactly this reason.
+
+A handle whose attach failed reads `NULL` in both address fields. That
+is worth relying on rather than re-deriving: the failure path used to
+store `MAP_FAILED` and `MAP_FAILED` plus a page — the second of which
+wraps to a small non-NULL address — so the `NULL == hdr_address` screen
+that `note_slot_in_use()` in `gds/shmem3` performs would not have caught
+either one.
 
 ### `pmix_vmem` — reserving an address before you need it
 
@@ -1490,8 +1545,10 @@ regression), `if` (the tuple parser), `name_fns` (incl. special-rank
 compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,
 `string_copy`, `timings`, `getcwd`, `getid`, `keyval`, `pty` (the
-controlling-terminal and descriptor-ownership regressions), `show_help`
-(the `#include` parser and the termination flush).
+controlling-terminal and descriptor-ownership regressions), `shmem` (the
+symlink/stale-file halves of the create, and the reference-count
+lifetime), `show_help` (the `#include` parser and the termination
+flush).
 
 ## Fixed defects (July 2026 review)
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -466,6 +466,38 @@ Both functions are pure reads of a `const` table with static storage duration:
 reentrant, safe on any thread, and safe to call from inside the library. The
 returned string belongs to the library and must never be freed.
 
+### `pmix_name_fns` — printing a name costs two buffers, not one
+
+Every `PMIX_NAME_PRINT`/`PMIX_RANK_PRINT` answer comes out of a ring of
+16 buffers held in thread-specific storage, so the result is never freed
+and stays valid only until the ring wraps. What is easy to miss is that
+`print_args()` renders the rank by calling `pmix_util_print_rank()`,
+which takes a buffer of its own — so a *name* print spends two, and the
+real budget for one statement is about eight, not sixteen. Nothing in
+the tree uses more than two per statement, and overrunning it does not
+crash; it silently makes an earlier answer read as a later one.
+
+The TSD key is created once behind an atomic latch, and
+`pmix_name_fns_finalize()` clears that latch because
+`pmix_tsd_keys_destruct()` deletes the key outright. The two must stay
+adjacent, in that order, at the point in `pmix_rte_finalize` where this
+is the only thread left — see
+[`src/runtime/AGENTS.md`](../runtime/AGENTS.md) for why they used to run
+further up and what broke.
+
+**The rank is unsigned, and 45 of its reserved values have no name.**
+`PMIX_RANK_VALID` is `UINT32_MAX-50`, so everything from there up is
+reserved, and `pmix_util_print_rank()` names only five of them
+(`UNDEF`, `WILDCARD`, `LOCAL_NODE`, `LOCAL_PEERS`, `INVALID`). The rest
+fall through to the numeric branch, which therefore has to render values
+above `INT32_MAX` — it cast to `long` and used `%ld`, which is exact on
+a 64-bit platform and implementation-defined where `long` is 32 bits, so
+the same rank printed positive on one machine and negative on another.
+`test_print_rank_above_int32` in
+[`test/unit/util/util_name_fns.c`](../../test/unit/util/util_name_fns.c)
+pins it, and note that it *cannot* fail on a 64-bit build — it is there
+for the 32-bit ones.
+
 ### `pmix_net` / `pmix_if` — network helpers
 
 `pmix_net` is pure address math (CIDR→netmask in *network* order,

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -88,7 +88,16 @@ must regenerate the pair, exactly as the top-level guide says:
 rm src/util/pmix_show_help_content.* && make
 ```
 
-A plain `make` will *not* pick up changed help text. `pmix_show_help`
+A plain `make` will *not* pick up changed help text, and the omission
+hides more than stale strings: under `--enable-devel-check` the generator
+runs with `--purge`, which makes a help topic that **no code references**
+a hard build error. So a change that removes the last caller of a topic
+compiles and tests clean for as long as the stale generated file survives,
+and breaks the build for whoever regenerates it next — which on a fresh
+clone is CI. Regenerate whenever you add, remove, or rename a
+`pmix_show_help*()` call, not only when you edit the text.
+
+`pmix_show_help`
 also aggregates duplicate notices (fired from a libevent timer) and can
 thread-shift delivery through the log path; the global `abd_tuples` list
 is manipulated without locking and assumes progress-thread-only callers.
@@ -500,8 +509,9 @@ for the 32-bit ones.
 
 ### `pmix_net` / `pmix_if` — network helpers
 
-`pmix_net` is pure address math (CIDR→netmask in *network* order,
-localhost/link-local/public classification, `isaddr`). `pmix_if` owns the
+`pmix_net` is *almost* pure address math (CIDR→netmask in *network*
+order, localhost/link-local/public classification, `isaddr`) — see the
+two pieces of state it does keep, below. `pmix_if` owns the
 discovered-interface list (populated by the `src/mca/pif/*` components —
 this file only *consumes* it) and the `a.b.c.d[/mask]` tuple parser
 `pmix_iftupletoaddr`, which returns masks in **host** order. Mind that
@@ -557,32 +567,97 @@ In `pmix_ifmatches()` the resulting mask matches no interface, so an
 `if_include` entry with a typo silently selected nothing *and* suppressed
 the `invalid-net-mask` warning that used to fire. Check the `endptr`.
 
-Two properties that are contracts rather than defects, so that the next
+**`pmix_net_init()` runs before the MCA parameters have values.** It is
+called from `pmix_init_util()`; `pmix_register_params()` — which is what
+gives `pmix_net_private_ipv4` anything but its `NULL` initializer — runs
+later, from `pmix_rte_init()` or from each tool's own startup. So the
+private-network table cannot be built in `pmix_net_init()`: parsing there
+saw `NULL`, `PMIx_Argv_split(NULL, ...)` answered `NULL`, and the table
+stayed empty, which `pmix_net_addr_isipv4public()` reads as *no network is
+private* — every RFC1918 address came back public and the MCA parameter
+was inert in every build. Worse, the malformed-entry `show_help` in that
+parse had never once fired. The parse now lives in
+`pmix_net_setup_private_ipv4()`, called from `pmix_register_params()` at
+the point the value exists. **If you add state here that comes from an MCA
+parameter, it cannot be initialized in `pmix_net_init()` either.**
+`test_isipv4public` in
+[`test/unit/util/util_net.c`](../../test/unit/util/util_net.c) supplies
+the list through the environment, so it also pins that the *user's* value
+is the one consulted.
+
+**`PMIX_ENABLE_IPV6` is not a statement about what addresses you will be
+handed.** It is 0 by default, but the `pif` IPv6 discovery components are
+gated on the OS, not on that flag, so `AF_INET6` addresses are entirely
+ordinary in a default build. `pmix_net_addr_isipv6linklocal()` had its
+`case AF_INET6:` behind that flag and so fell through to the `default:`
+arm for every IPv6 address — answering `false` *and* printing "unhandled
+sa_family" on stream 0 — while `pmix_net_islocalhost()` and
+`pmix_net_samenetwork()` next to it handle `AF_INET6` unconditionally.
+Family tests in this file are unconditional; keep them that way.
+
+**An IPv4-mapped address is an IPv4 address.** `IN6_IS_ADDR_LOOPBACK`
+matches only `::1`, so `::ffff:127.0.0.1` — the shape a dual-stack socket
+reports for an ordinary IPv4 loopback peer — read as *not* localhost.
+`pmix_net_islocalhost()` now unwraps the low 32 bits of a v4-mapped
+address and applies the same 127.0.0.0/8 test the `AF_INET` arm does.
+
+**`pmix_net_get_hostname()` is per-thread, and never `NULL`.** Its answer
+lives in a `NI_MAXHOST + 1` buffer held in thread-specific storage, so the
+two callers that reach it from different threads (the `ptl` listener
+thread's accept handler, and the connect path) do not collide; the answer
+is valid until that thread's next call and must not be freed. Anything it
+cannot render — an unsupported family, a failed conversion, no memory for
+the buffer — comes back as the file-static `"UNKNOWN"`, because a caller
+about to print the answer should not have to check it. The `#else` arm
+below has to honor that too, and used to return `NULL`. The TSD key is
+created fresh by every `pmix_net_init()` and deleted outright by
+`pmix_tsd_keys_destruct()` at finalize, so unlike `pmix_name_fns` this
+file needs no latch to clear.
+
+Four properties that are contracts rather than defects, so that the next
 reader does not re-litigate them:
 
-- **`getaddrinfo()` blocks, and only `pmix_ifaddrtoname()` can be told
-  not to call it.** `pif_do_not_resolve` short-circuits that function
+- **Neither resolver call in `pmix_net` resolves anything.**
+  `pmix_net_isaddr()` passes `AI_NUMERICHOST` to `getaddrinfo()` and
+  `pmix_net_get_hostname()` passes `NI_NUMERICHOST` to `getnameinfo()`,
+  so despite the names neither performs a DNS lookup and neither can
+  block on one. That is *not* true of `pmix_if` (see above) — do not
+  carry an assumption from one file to the other.
+- **`private_ipv4` is written only at init and finalize.**
+  `pmix_net_addr_isipv4public()` walks it with no lock, which is safe
+  because the only writers are `pmix_net_setup_private_ipv4()` (from
+  `pmix_register_params()`) and `pmix_net_finalize()`. It has no in-tree
+  caller, but `pmix_net.h` is installed, so an external one must not
+  classify addresses concurrently with a library init or finalize.
+- **`getaddrinfo()` blocks in `pmix_if`, and only `pmix_ifaddrtoname()`
+  can be told not to call it.** `pif_do_not_resolve` short-circuits it
   (and therefore `pmix_ifislocal()`); `pmix_ifaddrtokindex()` resolves
   regardless. Both are installed API with no in-tree caller — the
   in-tree consumers (`ptl_base_listener`, `pnet/tcp`) use only the
   index/kernel-index lookups, at init — so nothing here runs a DNS
   timeout on the progress thread today. Do not add such a call to a
   progress-thread path.
-- **Nothing in this file screens its arguments.** A `NULL` name reaches
+- **Neither file screens its arguments.** A `NULL` name reaches
   `strncmp`, a `NULL` tuple reaches `strchr`, and a non-positive `length`
   reaches `memset`/`pmix_strncpy`. That is a departure from the screening
   the rest of this directory does on installed entry points; it is left
   alone because no caller in PMIx or PRRTE passes any of those, and the
   header does not promise otherwise.
 
-The `#if HAVE_STRUCT_SOCKADDR_IN` `#else` arm is the usual trap: **no
-configuration anyone builds selects it, so it gets no compiler coverage
-at all.** It has to define *every* one of the 21 entry points
-`pmix_if.h` declares — seven were simply missing, which is a link
-failure rather than the graceful degradation the fallback exists for —
-and it has to name every parameter as deliberately unread, since this
-tree builds `-Wextra -Werror`. Force the guard false for one
-`make pmix_if.lo` before believing an edit there is good.
+**Both files carry a `#if HAVE_STRUCT_SOCKADDR_IN` `#else` arm, and
+neither of them compiled.** This is the usual trap: **no configuration
+anyone builds selects those arms, so they get no compiler coverage at
+all.** `pmix_if.c`'s has to define *every* one of the 21 entry points
+`pmix_if.h` declares — seven were simply missing, which is a link failure
+rather than the graceful degradation the fallback exists for.
+`pmix_net.c`'s defined all eight but named their parameters without
+reading them, which is nine `-Werror=unused-parameter` errors in a tree
+that builds `-Wextra -Werror`; `PMIX_HIDE_UNUSED_PARAMS` is how the rest
+of the tree says "deliberately unread". Force the guard false for one
+`make pmix_if.lo` / `make pmix_net.lo` before believing an edit there is
+good — and note that `-UHAVE_STRUCT_SOCKADDR_IN` on the command line does
+**not** do it, because `pmix_config.h` defines the macro again from
+inside the file. Edit the `#ifdef` to `#if 0` for the one compile.
 
 ### `pmix_fd` — descriptor helpers, three of them with no caller
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -250,6 +250,39 @@ public `PMIx_Argv_append_unique_nosize()` plus an index out-parameter,
 and callers are entitled to that: it screens `NULL` inputs the same way
 rather than handing a `NULL` arg to `strcmp`.
 
+### `pmix_context_fns` — moving the process to where an app runs
+
+Two helpers that `pmix_pfexec` calls to place a child: one `chdir()`s to
+the app's working directory, the other resolves its executable to a full
+path. Three things about them are easy to get wrong.
+
+- **Both out-parameters are owned in and owned out.** Each takes a
+  `char **`, frees what it finds there, and writes back a fresh
+  allocation. A caller must own the string it passes and must free what
+  comes back — and neither may be handed a string literal.
+- **`chdir()` moves the process, not a thread, and this runs in the
+  parent.** `pmix_pfexec`'s `setup_path()` calls these *before* the fork,
+  so honoring an app's `cwd` changes the **server's** working directory
+  for everything that follows. `pmix_util_check_context_app()` depends on
+  exactly that: a relative executable is checked with `access()`, which
+  resolves against the process's current directory and not against the
+  `cwd` argument, which is only used as the base for the `PATH` search of
+  a *naked* filename.
+- **Ask `pmix_home_directory()` by `geteuid()`, never by a sentinel.**
+  When the app's directory is unreachable and the user did not choose it,
+  these fall back to `$HOME`. That call used to pass `-1`, and both
+  spellings do take the `getenv("HOME")` shortcut — but they part company
+  the moment `$HOME` is unset, which is when the fallback matters:
+  `pmix_home_directory()` then looks up the passwd entry, and there is no
+  passwd entry for `(uid_t)-1`. The fallback therefore never fired in the
+  one case it exists for, and the caller was handed back the name of a
+  directory the process is not in and cannot reach. `getpwuid()` is also
+  not reentrant, so like `pmix_dirname()` these must not be called on a
+  thread that runs concurrently with the progress thread.
+  `test_check_cwd_home_fallback_no_HOME` in
+  [`test/unit/util/util_context_fns.c`](../../test/unit/util/util_context_fns.c)
+  pins it by unsetting `$HOME`.
+
 ### `pmix_net` / `pmix_if` — network helpers
 
 `pmix_net` is pure address math (CIDR→netmask in *network* order,

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -317,6 +317,49 @@ path. Three things about them are easy to get wrong.
   [`test/unit/util/util_context_fns.c`](../../test/unit/util/util_context_fns.c)
   pins it by unsetting `$HOME`.
 
+### `pmix_error` — two lookups over a table you do not write
+
+`PMIx_Error_string()` and `PMIx_Error_code()` are a linear scan each over
+`pmix_event_strings[]`, which is **generated** into the *build* tree
+(`$(builddir)/src/include/pmix_event_strings.{c,h}`) by
+[`contrib/construct_event_strings.py`](../../contrib/construct_event_strings.py).
+You will not find that table in the source tree, and you must not edit it.
+Four things about how it is built decide how these two functions behave.
+
+- **The table is fed by three headers, in order**: `include/pmix_common.h.in`,
+  then `include/pmix_deprecated.h`, then **`src/util/pmix_error.h`** — which
+  is why this directory's own header carries a `/**** PMIX ERROR CONSTANTS ****/`
+  banner. That banner is not decoration: the harvester skips everything before
+  it and stops at the first line mentioning `PMIX_INTERNAL_ERR_DONE`,
+  `PMIX_ERR_SYS_BASE`, or `PMIX_EXTERNAL_ERR_BASE`. **An internal status added
+  outside that window gets no name**, and `PMIX_ERROR_LOG` then prints
+  `"ERROR STRING NOT FOUND"` for it. `PMIX_INTERNAL_ERR_BASE` sits above the
+  banner and `PMIX_INTERNAL_ERR_DONE` below it precisely so the two range
+  markers stay out of the table.
+- **Scan order is what makes a renamed status print under its current name.**
+  A deprecation rename is the one case where two constants legitimately share
+  a value (see the top-level `AGENTS.md`), and there are several: `-11`, `-3`,
+  `-58`, `-145`, `-231`, `-232`. `PMIx_Error_string()` returns the *first*
+  match, and the current spelling is first only because `pmix_common.h.in` is
+  harvested before `pmix_deprecated.h`. Reorder the harvest and every error
+  message naming one of those codes silently changes.
+  `test_error_string_prefers_current_name` pins it.
+- **`PMIX_EVENT_INDEX_BOUNDARY` is the count of real entries, and the array is
+  one longer than that.** The generator appends a terminator
+  (`.index = UINT32_MAX, .name = "", .code = -1`) that both loops must stop
+  short of — a scan that ran one entry too far would answer `PMIX_ERROR` for
+  the empty name and `""` for a code of `-1`.
+  `test_error_code_empty_name` is the guard.
+- **`INT32_MIN` is the only "not recognized" answer `PMIx_Error_code()` can
+  give**, because every real status is itself negative; callers must test for
+  that sentinel rather than for negativity. A `NULL` name is answered the same
+  way rather than handed to `strcasecmp` — this is an installed public entry
+  point, so it screens its argument.
+
+Both functions are pure reads of a `const` table with static storage duration:
+reentrant, safe on any thread, and safe to call from inside the library. The
+returned string belongs to the library and must never be freed.
+
 ### `pmix_net` / `pmix_if` — network helpers
 
 `pmix_net` is pure address math (CIDR→netmask in *network* order,

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -659,6 +659,81 @@ good — and note that `-UHAVE_STRUCT_SOCKADDR_IN` on the command line does
 **not** do it, because `pmix_config.h` defines the macro again from
 inside the file. Edit the `#ifdef` to `#if 0` for the one compile.
 
+### `pmix_os_dirpath` — the session directories, and who may swap them
+
+Creates and recursively destroys directory trees. Its callers are the
+`ptl` rendezvous/session directories and the `pmix_iof` per-rank output
+directories, which means the paths that reach it have **fully predictable
+names under a world-writable root** (`/tmp` by default). That is the
+threat model the whole file is written against, and it is why the code
+looks more roundabout than "stat then chmod" or "readdir then unlink".
+
+- **Act through a descriptor, never through a re-resolved path.**
+  `dirpath_ensure_mode()` opens the final component
+  (`O_DIRECTORY | O_NOFOLLOW`) and does its `fstat`/`fchmod` on that
+  descriptor, so the object inspected is the object modified.
+  `dirpath_destroy_at()` walks with `fstatat`/`openat`/`unlinkat`
+  relative to a descriptor it already holds, so an entry cannot be
+  swapped between being classified and being removed. `O_NOFOLLOW` and
+  `AT_SYMLINK_NOFOLLOW` keep a symlink an entry to be unlinked rather
+  than a path to be followed. If you add an operation here, add it in
+  that style.
+- **Permission is not tested, deliberately.** Asking whether a directory
+  is writable and then acting on the answer is itself a check/use race
+  that no spelling of `access()`/`faccessat()` can close. Whether the
+  caller can put a file there is settled by the caller creating one.
+  `pmix_os_dirpath_access()` is the fossil of that decision: it is a
+  no-op that always answers `PMIX_SUCCESS`, kept because it is installed
+  API that PRRTE may still link against. Do not give it a body.
+- **Only the *final* component is protected against a planted symlink.**
+  `mkdir(2)` does not follow a symlink at the last component but does
+  follow one at every component before it, and the tree-building loop
+  accepts `EEXIST` on an intermediate component without asking what it
+  is - by design, since an intermediate need only be traversable. So a
+  symlink pre-planted at an intermediate component of a predictable
+  session path still redirects the leaf that gets created. Closing that
+  needs an `openat` walk from the root with `O_NOFOLLOW` at every step,
+  and `mkdirat` for each component; it is a deliberate design change, not
+  a tidy-up. **Do not "fix" it halfway** - a partial walk that still ends
+  in a path-based `mkdir` buys nothing.
+
+Three contracts the callers depend on:
+
+- **`PMIX_ERR_EXISTS` is a success.** `pmix_os_dirpath_create()` answers
+  it when the final directory was already there carrying at least the
+  requested mode. Every in-tree caller tests for it alongside
+  `PMIX_SUCCESS`; what the distinction buys them is knowing whether
+  *they* are the ones who must remove it afterwards. A caller that tests
+  only `PMIX_SUCCESS != rc` treats an ordinary rerun as a failure.
+  `PMIX_ERR_SILENT` means the user has already been shown a message and
+  must not be shown another.
+- **The `tmp` buffer in `pmix_os_dirpath_create()` is sized exactly, not
+  generously.** It is `strlen(path) + 1`, and the `strcat` chain fits
+  only because every separator it writes was a separator in the input:
+  `PMIx_Argv_split()` drops empty fields, so repeated separators
+  collapse and no component is empty. Those same two facts are what make
+  the `tmp[strlen(tmp) - 1]` read safe from the second iteration on. An
+  edit that stops splitting on `path_sep[0]`, or that starts keeping
+  empty fields, overruns the buffer and reads before it.
+- **An empty path is not a path.** `mkdir("")` answers `ENOENT`, which
+  is the same errno that means "the parents are missing, go build the
+  tree" - and an empty path splits to no components at all, so the
+  build loop never runs and the function used to report that it had
+  created a tree while doing nothing. The screen for it sits next to the
+  `NULL` screen; a `NULL` from `PMIx_Argv_split()` now therefore means
+  out of memory, and is reported as such rather than walked past.
+
+**This file reaches into two other subsystems, and that is a wart, not a
+pattern to copy.** `pmix_os_dirpath_destroy()` includes
+`src/mca/ptl/base/base.h` and `src/server/pmix_server_ops.h` so it can
+decline to remove the system tmpdir unless PMIx created it - a policy
+decision living in a leaf utility. It used to go further and `free()`
+`pmix_ptl_base.system_tmpdir` on its way out, which aliased its own
+`path` argument (the one caller that reaches that arm passes exactly that
+string) and survived only because nothing read `path` again afterwards.
+`pmix_ptl_base_close()` frees it on the line after the call. Keep the
+release with the owner.
+
 ### `pmix_fd` — descriptor helpers, three of them with no caller
 
 `pmix_fd_read`/`pmix_fd_write`/`pmix_fd_set_cloexec`/`pmix_fd_is_*` are

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -419,6 +419,40 @@ separate decision.
   since both Linux and macOS have one; the fallback has to be verified
   by hand by pointing the `opendir()` at a path that does not exist.
 
+### `pmix_few` — the only place in this tree that forks by hand
+
+One function, one caller: `src/tools/wrapper/pmixcc.c` runs the real
+compiler through it. Everything else that starts a process goes through
+`pmix_pfexec`. Three things follow from that.
+
+- **The child must leave through `_exit()`, never `exit()`.** It shares
+  the parent's stdio buffers, so `exit()` flushes whatever the parent had
+  written and not yet flushed — the output appears twice — and it runs
+  atexit handlers the parent registered, which in a threaded process can
+  deadlock on a lock some other thread held at fork time. This is the same
+  post-fork discipline `pmix_pfexec`'s `do_child()` follows, and for the
+  same reason. `test_child_does_not_flush_our_stdio` in
+  [`test/unit/util/util_few.c`](../../test/unit/util/util_few.c) is the
+  regression; it has to run inside a child of its own with stdout on a
+  pipe, since a line-buffered terminal hides the whole effect.
+- **`status` is written only on `PMIX_SUCCESS`.** On any other return
+  there was no child to wait for, so the caller's variable is whatever it
+  already held. `pmixcc` decoded it unconditionally, off an uninitialized
+  stack slot, which means a compiler that never started could hand the
+  build system any exit code at all — zero included. Initialize it, and
+  check the return code before reaching for a `WIF*` macro.
+- **`status` is a wait status, not an errno.** Why a launch *failed* is
+  in `errno`; `pmixcc` was passing the wait status to `strerror()`. If
+  the exec itself is what failed, that is a different thing again — the
+  child ran, so the call succeeded, and errno comes back as the child's
+  exit status (truncated to 8 bits, as every exit status is).
+
+A note on the guard: the body is compiled behind
+`HAVE_FORK && HAVE_EXECVE && HAVE_WAITPID` but calls `execvp`, which
+configure does not probe for separately. POSIX gives you the whole
+`exec*` family together, so the proxy holds; it is worth knowing it *is*
+a proxy before adding a fourth call here.
+
 ### `pmix_shmem` — a created segment reads as zero
 
 `pmix_shmem_segment_create()` opens its backing file `O_CREAT | O_TRUNC`
@@ -521,7 +555,7 @@ integration-style; only the arithmetic/parsing parts (`pad_to_page`,
 `parse_map_line`, `pmix_alfg` determinism) are unit-friendly.
 
 Current coverage includes: `argv`, `alfg`, `basename`, `cmd_line`,
-`context_fns`, `environ`, `error`, `fd`, `hash` (incl. a mixed-qualifier
+`context_fns`, `environ`, `error`, `fd`, `few`, `hash` (incl. a mixed-qualifier
 regression), `if` (the tuple parser), `name_fns` (incl. special-rank
 compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -58,7 +58,7 @@ interface list).
 | `pmix_fd.{c,h}` | fd read/write, cloexec, type predicates, peer name, mass-close | needs pipes/sockets |
 | `pmix_few.{c,h}` | fork/exec/waitpid a child | needs a child |
 | `pmix_getid.{c,h}` | peer uid/gid over a socket (`SO_PEERCRED`/`getpeereid`) | needs a socketpair |
-| `pmix_shmem.{c,h}` / `pmix_vmem.{c,h}` | mmap-backed shared-memory segment; `/proc/self/maps` hole finder (Linux) | `pad_to_page`/`parse_map_line` pure; rest need mmap |
+| `pmix_shmem.{c,h}` / `pmix_vmem.{c,h}` | mmap-backed shared-memory segment; `/proc/self/maps` hole finder (Linux) | `pad_to_page` pure; the hole scan runs anywhere against a synthetic map; rest need mmap |
 | `pmix_pty.{c,h}` / `pmix_tty.{c,h}` | pty open/forkpty; termios/winsize helpers | need real pty/tty |
 | `pmix_alfg.{c,h}` | additive lagged-Fibonacci RNG (from Open MPI's `opal_rand`) | pure/deterministic |
 | `pmix_timings.{c,h}` | optional profiling (`--enable-pmix-timing`, off by default) | needs `--enable-pmix-timing` |
@@ -1320,6 +1320,62 @@ around the chosen placement, without giving up the agreement. Tested in
 is where it has to be tested, since ASLR separates real processes well
 enough to hide whether the scatter works at all.
 
+**The whole answer comes out of a text scan of `/proc/self/maps`, and
+every defect this file has had lives in that scan rather than in the
+arithmetic.** Three of them, all of which reported a "hole" over a range
+that is mapped:
+
+- **A bracketed tag that is neither `[heap]` nor `[stack]` used to
+  swallow the entry after it.** `parse_map_line()` replaced the entry's
+  newline with a NUL — for a tag string nothing reads — and
+  `find_hole()` decides whether it has the whole entry by looking for
+  that newline, so it read the *next* entry as this one's tail and
+  never accounted for it. The gap after such a tag was then measured
+  past a mapping that is there. Nothing outside the stack normally
+  carries a tag, which is why this survived; a named anonymous VMA
+  (`[anon:…]`, `prctl(PR_SET_VMA_ANON_NAME)`) is enough to hit it, and
+  so is a `[vdso]` that a kernel places below the stack rather than
+  above.
+- **An entry the parser could not read used to reset `prevend` to 0.**
+  `begin` and `end` are zeroed per iteration, and the loop carried them
+  forward regardless of whether the parse succeeded, so the next entry's
+  gap was measured from address 0 — a hole spanning everything below it,
+  all of it occupied. The parse result is now carried in a `parsed` flag
+  and such an entry is skipped whole.
+- **`default: assert(0)` in the hole-kind switch.** `VMEM_HOLE_NONE` and
+  `VMEM_HOLE_CUSTOM` are in the installed enum and have no search behind
+  them, so naming either one aborted the process in a debug build and
+  fell through to a plain `PMIX_ERROR` in a release one. The kind is now
+  screened before anything is opened, and the answer is
+  `PMIX_ERR_BAD_PARAM`.
+
+Two properties of the scan that look like bugs and are not:
+`prevend` starts at 0, so **the span below the first mapping is itself a
+candidate hole** (which is what `VMEM_HOLE_BEGIN` names explicitly); and
+the scan stops at `[stack]`, so a gap above it is never a candidate
+however large — the VMAs up there are special and one of them is above
+the userspace limit.
+
+**`pmix_vmem_find_hole_in_map()` is how any of this is testable.** It
+takes the path of a map to scan instead of `/proc/self/maps`, and it
+exists because everything above is a property of the map the scan is
+handed: a live `/proc/self/maps` is neither reproducible nor steerable,
+and on a host without `/proc` the scan cannot be reached at all — which
+is how `util_vmem.c` came to skip itself entirely on the developer
+platform while the three defects above sat in it. The synthetic-map
+cases run everywhere. **Add a case there rather than reasoning about a
+map you cannot construct**, and note the geometry has to be chosen so
+the wrong answer *wins*: a first draft of the unparseable-entry case
+passed against the unfixed library because the bogus hole was beaten by
+a real one later in the map.
+
+Finally, the placement helpers take `size_t *` for the address they
+answer, not `unsigned long *`. Those are the same type on every platform
+PMIx is built on today and different types on any ILP32 one, where the
+mismatch is a `-Werror=incompatible-pointer-types` build failure rather
+than anything subtle. `find_hole()` hands them the caller's `size_t *`
+straight through; keep them agreeing.
+
 ### `pmix_timings` — a whole subsystem behind one configure switch
 
 Everything in `pmix_timings.c` below its opening `#if PMIX_ENABLE_TIMING`
@@ -1752,14 +1808,20 @@ helpers (`pmix_hash`) need `PMIx_server_init` because they copy values
 through the `bfrops` MCA framework (`util_hash.c` shows the pattern).
 Things that need real OS resources (pty, tty, shmem, `getid`, `few`) are
 integration-style; only the arithmetic/parsing parts (`pad_to_page`,
-`parse_map_line`, `pmix_alfg` determinism) are unit-friendly.
+`pmix_alfg` determinism) are unit-friendly. Where a helper's whole job is
+to read something the platform supplies, consider giving it a way to be
+handed that something instead — `pmix_vmem_find_hole_in_map()` is the
+model, and it turned a test that skipped itself on macOS into one that
+covers every arm of the scan on both platforms.
 
 Current coverage includes: `argv`, `alfg`, `basename`, `cmd_line`,
 `context_fns`, `environ`, `error`, `fd`, `few`, `hash` (incl. a mixed-qualifier
 regression), `if` (the tuple parser), `name_fns` (incl. special-rank
 compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,
-`string_copy`, `timings` (which runs its real cases only in an
+`string_copy`, `vmem` (the placement rules against maps the test writes,
+plus the reserve/restore round trip where there is a `/proc` to scan),
+`timings` (which runs its real cases only in an
 `--enable-pmix-timing` build), `getcwd`, `getid`, `keyval`, `pty` (the
 controlling-terminal and descriptor-ownership regressions), `tty` (the
 raw/restore round trip, and the orphaned-process-group probe that makes

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -345,6 +345,45 @@ caller is close — the only one in the tree uses `PMIX_PATH_MAX` — but
 do not widen the documented range on the strength of the bozo check
 alone.
 
+### `pmix_getid` — installed API with no caller
+
+`pmix_util_getid()` is called from nowhere in PMIx and nowhere in PRRTE,
+but `pmix_getid.h` is in the installed `headers` list and the symbol is
+`PMIX_EXPORT`ed, so it is API — the same situation as the three unused
+`pmix_fd` entry points above, and it takes the same treatment: judge it
+as API, do not retire it on your own authority.
+
+**Every route through it is conditionally compiled, and this platform
+selects exactly one.** There are four: `getsockopt(SO_PEERCRED)` filling
+`struct sockpeercred` (OpenBSD) or `struct ucred` with either `uid`/`gid`
+or `cr_uid`/`cr_gid` members, and `getpeereid()`. Which one you can read
+is not which one your users compile. Pick the shape in a single `#if`
+chain at the top of the file and let the body test one macro — when the
+declarations sat behind a bare `defined(SO_PEERCRED)` and the code
+reading them behind the full condition, a platform that defines
+`SO_PEERCRED` but whose `AC_CHECK_MEMBERS` probe did not fire got no
+fallback at all: it failed to build, on an incomplete `struct ucred` and
+on two variables nothing used. Compile-check every arm before believing
+it — forcing the guards by hand for one `make pmix_getid.lo` is enough,
+and a stand-in `struct ucred` in the same prologue covers the shapes this
+platform has no header for.
+
+Two things a caller must know, neither of which this function can fix:
+
+- **Only a connected AF_UNIX socket gives a meaningful answer.** A pipe
+  or a closed descriptor is `ENOTSOCK` and comes back as
+  `PMIX_ERR_INVALID_CRED`, which is what you want. A *TCP* socket is
+  worse than that: Linux answers `SO_PEERCRED` on one with success and an
+  overflow uid, so the function reports `PMIX_SUCCESS` over credentials
+  that identify nobody. Do not use this to authenticate a peer you did
+  not reach over a Unix socket.
+- **The out-parameters are written only on `PMIX_SUCCESS`.** Every error
+  return leaves them exactly as the caller had them.
+
+[`test/unit/util/util_getid.c`](../../test/unit/util/util_getid.c) covers
+it over a `socketpair()`, and skips (77) on a platform that answers
+`PMIX_ERR_NOT_SUPPORTED`.
+
 ### `pmix_error` — two lookups over a table you do not write
 
 `PMIx_Error_string()` and `PMIx_Error_code()` are a linear scan each over
@@ -596,7 +635,7 @@ Current coverage includes: `argv`, `alfg`, `basename`, `cmd_line`,
 regression), `if` (the tuple parser), `name_fns` (incl. special-rank
 compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,
-`string_copy`, `timings`, `getcwd`.
+`string_copy`, `timings`, `getcwd`, `getid`.
 
 ## Fixed defects (July 2026 review)
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -194,6 +194,45 @@ qualifiers (`PMIX_INFO_IS_QUALIFIER`) can be smaller than `nquals`: index
 the destination array by the compacted counter, not the loop variable
 (this was the bug fixed in July 2026 — see below).
 
+Four invariants in here are easy to break and hard to see broken.
+
+- **A wildcard removal with a `NULL` key must empty the table, not just
+  release what is in it.** `pmix_hash_remove_data()` releases every
+  `proc_data` it walks, and the table it walked them through still holds
+  a pointer to each one; the per-rank path removes its entry first, and
+  the wildcard path has to do the same. It cannot do it inside the loop
+  without invalidating the iteration, so it sweeps afterwards with
+  `pmix_hash_table_remove_all()`. Take that sweep away and the very next
+  `pmix_hash_fetch()` on the table dereferences a freed `proc_data` —
+  `test_remove_wildcard_empties_the_table` in
+  [`test/unit/util/util_hash.c`](../../test/unit/util/util_hash.c) dies
+  on a signal, not on an assertion. The reason nobody has hit it is that
+  the only caller of that combination is `gds/hash`'s job destructor,
+  which destructs the table on the next line.
+- **Copy the new value before releasing the old one.** An update that
+  released first and then failed to copy left the entry in the table
+  under its key with a `NULL` value, and nothing downstream expects
+  that: `make_copy()` hands the stored value straight to
+  `PMIx_Value_xfer()`, which reads `src->type` without looking. The
+  failed store returns an error the caller sees, and the process then
+  dies on the *next* fetch of that key, somewhere else entirely.
+- **`pmix_pointer_array_add()` answers a negative status, and
+  `qualindex` is unsigned.** Assigning the failure straight through
+  gives the entry an index the qualifier array can never be asked for —
+  `pmix_pointer_array_get_item()` bounds-checks and answers `NULL` — so
+  the value is stored, is never findable again, and the store reports
+  success. Check the `int` before narrowing it.
+- **Every allocation in here goes through the TMA, and the TMA can
+  fail.** Under `gds/shmem3` that allocator is a fixed-size shared
+  segment, so an exhausted one is an ordinary outcome rather than the
+  end of the process. The registration branch of `lookup_key()` is worth
+  a second look on this point: an entry whose key string did not copy is
+  worse than no entry at all, because `add_to_lookup()` declines to index
+  a `NULL` string, so the key ends up registered under an id that nothing
+  can find by name — every later reference to it mints another one — and
+  `make_copy()` loads that string as the key it reports to the
+  application.
+
 ### `pmix_basename` — two implementations, one of them invisible
 
 `pmix_dirname()` has two bodies behind a configure-time `#if`. Where

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -418,6 +418,36 @@ Four invariants in here are easy to break and hard to see broken.
   `make_copy()` loads that string as the key it reports to the
   application.
 
+### `pmix_string_copy` — and the "getline" that does not read a line
+
+`pmix_string_copy()` is the always-terminating bounded copy, and it does
+what its header says: at most `dest_len` bytes are written, the last of
+them a `\0`, with no right-padding. Its `assert()` on a `dest_len` over
+128K is a bozo check for a programmer error, not a contract a caller may
+lean on — `-DNDEBUG` removes it, and `pmix_getcwd` sits close enough to
+that bound to be worth knowing about (see its section above).
+
+`pmix_getline()` is the one to be careful with, because its name
+promises more than it does. It is one `fgets()` into a 1024-byte stack
+buffer, so **a line longer than 1023 bytes comes back in pieces, with no
+error and no marker** — the next call returns the tail, which a caller
+reading successive lines will take for the next line. The in-tree
+callers (`ptl_base_listener`'s stale-rendezvous check, `ptl_base_fns`'
+server-URI reads) are all reading files PMIx itself wrote, whose lines
+are a URI, a version, a pid and a uid:gid pair, so none of them is close
+to the limit — but the header is installed, so the limit is now written
+down there rather than left to be discovered.
+
+Two smaller things follow from the same one-`fgets` shape. A returned
+line is **not** necessarily newline-terminated in the file: the newline
+is stripped when present, and is absent both for a final line without
+one and for a 1023-byte fragment, so it says nothing about where the
+line came from. And `NULL` means end-of-file, a read error, or a failed
+`strdup`, indistinguishably; there is no other channel, and the callers
+treat it as "the writer had not finished yet". Both boundaries, and the
+long-line split, are pinned by
+[`test/unit/util/util_string_copy.c`](../../test/unit/util/util_string_copy.c).
+
 ### `pmix_basename` — two implementations, one of them invisible
 
 `pmix_dirname()` has two bodies behind a configure-time `#if`. Where

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -465,6 +465,16 @@ Two consequences worth keeping in mind:
   whichever branch is compiled, so a future edit to either one has to
   keep them agreeing. If you change one body, run the corpus against the
   other by hand before you believe it.
+- **Two of the answers are not the same on every platform, and pinning
+  them made the test fail on Linux while passing on macOS.** POSIX says
+  a pathname beginning with *exactly* two slashes may be interpreted in
+  an implementation-defined manner, so `dirname("//")` and
+  `dirname("//foo")` are `"//"` under glibc and `"/"` under the macOS
+  and BSD libgen — both conforming, and the only two inputs in the whole
+  corpus that differ. Those two rows carry an alternate accepted answer;
+  everything else is a single required one, which is the point of having
+  a table at all. Do not widen any other row to make a platform happy
+  without first checking that POSIX actually leaves it open.
 - **`dirname(3)` is not reentrant on every platform.** glibc rewrites the
   buffer you hand it, but macOS and the older BSDs return a pointer into
   internal static storage, so two threads inside `pmix_dirname()` at once

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -659,6 +659,40 @@ good — and note that `-UHAVE_STRUCT_SOCKADDR_IN` on the command line does
 **not** do it, because `pmix_config.h` defines the macro again from
 inside the file. Edit the `#ifdef` to `#if 0` for the one compile.
 
+### `pmix_os_path` — a NULL that callers kept forgetting to read
+
+One variadic function that concatenates its `char *` arguments with the
+path separator between them. It is pure: no globals, no syscalls, no
+look at the filesystem. Whether the name it builds refers to anything is
+the caller's question, asked afterwards.
+
+**It fails, and the failure is a `NULL` return.** Two ways: the assembled
+name would exceed `PMIX_PATH_MAX` (`PATH_MAX + 1`, so 1025 bytes on Linux
+and macOS), or the allocation failed. Neither is exotic - the usual
+caller is walking a directory tree, and every level of nesting lengthens
+the name - and five call sites across `src/include`, `src/mca/ptl`,
+`src/mca/pmdl` and `src/tools` used the answer without asking. One of
+them handed it to `strcmp()`. **If you call this, screen the result**;
+`__pmix_attribute_warn_unused_result__` makes the compiler insist you use
+it, which is not the same thing.
+
+**The length is tested against an estimate, not against the answer.** The
+estimate allows one separator per element, which is an upper bound
+because an element that already begins with a separator does not get
+one. It used to count that separator twice - once while measuring and
+again in the `num_elements` term - which pushed a name that fits over the
+limit and had it refused. `test_length_boundary` in
+[`test/unit/util/util_os_path.c`](../../test/unit/util/util_os_path.c)
+pins both sides of that boundary; note that the accepted case asserts the
+*length* of what came back, since asserting merely that it is non-NULL
+would pass against a library with any bound at all above 1024.
+
+Two smaller things the header now states and the code has always done:
+the empty argument list answers `"."` **plus a separator** for a relative
+path, not `"."`; and the argument list must end in `NULL`, which
+`__pmix_attribute_sentinel__` makes a compiler diagnostic rather than the
+segfault the header threatens.
+
 ### `pmix_os_dirpath` — the session directories, and who may swap them
 
 Creates and recursively destroys directory trees. Its callers are the

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -876,7 +876,7 @@ does not compile**, which is the recurring trap in this directory:
   sign test on `f_bavail` was written as a cast inside the comparison,
   and `statvfs`'s `f_bavail` is unsigned, so it is
   `-Werror=type-limits` on every platform that selects that arm — i.e.
-  the ones without a `struct statfs`, Solaris and NetBSD among them.
+  the ones without a `struct statfs`, NetBSD among them.
   The test now goes through a signed variable, which is correct for the
   BSD `statfs` case it exists for and silent for the unsigned ones.
   That arm also multiplied `f_bavail` by the wrong number: `statfs`
@@ -1216,9 +1216,12 @@ still failed to build, and the `!HAVE_PTSNAME` arm failed on an
 `errsave` it does not use. **Compile every combination by hand before
 believing an edit here**; `make src/util/pmix_pty.lo` with the guards
 edited to `#if 0`/`#if 1` is enough, and all six do build warning-free
-today. The Solaris `__SVR4 && __sun` STREAMS arm is the one exception —
-it needs a `<stropts.h>` this platform does not have, so it cannot be
-compile-checked from here.
+today — every arm in the file is now reachable that way, since the one
+that was not (the Solaris `__SVR4 && __sun` STREAMS module push, which
+needed a `<stropts.h>` no supported platform ships) has been removed
+along with the rest of this library's Solaris support. The `fdm`
+parameter of `pmix_ptysopen()` is what is left of it: nothing reads it
+any more, and it stays only because the signature is frozen.
 
 Two things deliberately left alone:
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -369,6 +369,56 @@ this file only *consumes* it) and the `a.b.c.d[/mask]` tuple parser
 `pmix_iftupletoaddr`, which returns masks in **host** order. Mind that
 byte-order difference if you ever mix the two.
 
+### `pmix_fd` — descriptor helpers, three of them with no caller
+
+`pmix_fd_read`/`pmix_fd_write`/`pmix_fd_set_cloexec`/`pmix_fd_is_*` are
+used across the tree. `pmix_fd_get_peer_name()`,
+`pmix_fd_dup2()` and `pmix_close_open_file_descriptors()` are **called
+from nowhere in PMIx and nowhere in PRRTE** — but `pmix_fd.h` is an
+installed header, so they are still API. Judge them as API, not as dead
+code; the alternative is to retire them deliberately, which is a
+separate decision.
+
+- **`pmix_fd_read()` and `pmix_fd_write()` must be given a *blocking*
+  fd.** They handle `EAGAIN` by retrying immediately, which on a
+  non-blocking descriptor is a spin loop that burns a core until the
+  peer moves. Every caller today hands them an ordinary pipe
+  (`pmix_pfexec`'s keepalive pipe, the `ptl` listener's `--report-uri`
+  pipe), none of which is `O_NONBLOCK`. Also note `pmix_fd_read()`
+  reports a short read as `PMIX_ERR_TIMEOUT` — that is EOF, not a
+  timeout, and `pmix_pfexec` depends on the distinction to tell "the
+  child reached execve" from "the child sent us a failure record".
+- **`pmix_fd_get_peer_name()` answers out of one file-static buffer.**
+  The result is valid only until the next call and two threads calling
+  at once will overwrite each other. It never returns `NULL`: a peer it
+  cannot name — `getpeername()` failed, or the family is not one it
+  renders — reads as `"Unknown"`, because a caller that is about to
+  print the answer should not have to check it. `inet_ntop()` can fail
+  too, and used to leak that `NULL` straight out.
+- **`pmix_close_open_file_descriptors()` has two routes and only one of
+  them is testable.** Where the OS lists the process's descriptors
+  (`/dev/fd`, `/proc/self/fd`) it closes exactly those; everywhere else
+  it falls back to closing every fd below a bound. Two things about that
+  bound, because getting it wrong fails *silently* — the function
+  reports nothing, and the descriptors simply travel into the exec'd
+  image:
+  - `sysconf(_SC_OPEN_MAX)` returns a `long`, and the comment in the
+    code records that some systems answer with a number in the billions.
+    Clamp it against `pmix_maxfd` **while it is still a long**. Narrowing
+    first can land on a negative `int`, and then the closing loop does
+    not execute at all.
+  - `strtol()` sets `errno` on failure and never clears it on success,
+    so the scan has to zero `errno` before each call. It did not, and a
+    stale `EINVAL`/`ERANGE` from anything earlier in the process
+    abandoned the listing on the first entry.
+
+  [`test/unit/util/util_fd.c`](../../test/unit/util/util_fd.c) runs the
+  mass close in a forked child — in-process it would take the harness's
+  own descriptors down — and checks that the protected fd and
+  stdin/stdout/stderr survive. It reaches only the directory-scan route,
+  since both Linux and macOS have one; the fallback has to be verified
+  by hand by pointing the `opendir()` at a path that does not exist.
+
 ### `pmix_shmem` — a created segment reads as zero
 
 `pmix_shmem_segment_create()` opens its backing file `O_CREAT | O_TRUNC`
@@ -471,7 +521,7 @@ integration-style; only the arithmetic/parsing parts (`pad_to_page`,
 `parse_map_line`, `pmix_alfg` determinism) are unit-friendly.
 
 Current coverage includes: `argv`, `alfg`, `basename`, `cmd_line`,
-`context_fns`, `environ`, `error`, `hash` (incl. a mixed-qualifier
+`context_fns`, `environ`, `error`, `fd`, `hash` (incl. a mixed-qualifier
 regression), `if` (the tuple parser), `name_fns` (incl. special-rank
 compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -271,6 +271,44 @@ flags and must not be eaten. Regression cases are
 `test_parse_positional_first` / `test_parse_positional_after_options` in
 [`test/unit/util/util_cmd_line.c`](../../test/unit/util/util_cmd_line.c).
 
+### `pmix_parse_options` — the port-range expander
+
+Two functions that turn `"1,3-5"` into an argv. Their only callers are
+the `ptl` and `pnet/tcp` port-range parameters, which is what makes
+them worth care: **the strings they read come straight from an MCA
+parameter or a host-supplied info key**, so every malformed input is a
+user typo rather than a library bug, and none of it may take the
+process down or be silently reinterpreted.
+
+- **`strtol()` cannot tell you it failed, and its answer here was
+  narrowed to an `int`.** It answers 0 for a string with no digits in
+  it, and saturates at `LONG_MAX` for one that is too big — and
+  `LONG_MAX` narrowed to `int` is `-1`, which this parser reads as the
+  *wildcard*. So `ptl_base_ipv4_ports=4294967295` discarded whatever the
+  caller had already collected and replaced it with "any port", and
+  `ptl_base_ipv4_ports=abc` quietly became port 0. Both are now reported
+  and skipped, by `parse_whole_int()`, which insists on digits, on
+  nothing but whitespace after them, and on a value an `int` can hold.
+  Pinned by `util_parse_options.c`.
+- **The expansion can produce nothing at all, and its callers index
+  element 0.** `"-"` splits to no tokens (`PMIx_Argv_split` drops empty
+  fields), and a malformed element is now skipped, so `*output` is
+  legitimately `NULL` on return. Four sites in `src/mca/ptl/base` read
+  `ports[0]` to see whether the user had asked for the wildcard, which
+  meant `PMIX_MCA_ptl_base_ipv4_ports=-` **segfaulted every PMIx client
+  inside `PMIx_Init`**. `pnet/tcp` got this right by asking
+  `PMIx_Argv_count()` first. If you call this function, the answer may
+  be empty — the regression is the `setenv` at the top of
+  [`test/unit/ptl_uri.c`](../../test/unit/ptl_uri.c), which dies on a
+  signal rather than failing a case.
+- Both functions return `void`, so an allocation failure is invisible
+  to the caller and a malformed element can only be *reported*, not
+  returned. `pmix_util_get_ranges()` — installed API with no in-tree
+  caller — builds two parallel arrays a pair at a time, so an
+  allocation failure between the two would leave them different
+  lengths, and there is no way to say so. Do not add a caller that
+  needs to know.
+
 ### `pmix_hash` — the TMA-aware datastore helper
 
 Backs the `gds` framework. Stores `pmix_dstor_t` values per rank in a

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -1091,6 +1091,81 @@ around the chosen placement, without giving up the agreement. Tested in
 is where it has to be tested, since ASLR separates real processes well
 enough to hide whether the scatter works at all.
 
+### `pmix_printf` — two implementations, only one of which you compile
+
+Four `PMIX_EXPORT` wrappers over `asprintf`/`snprintf`. On any platform
+built this decade they are pass-throughs, and every real defect this file
+has ever had lives in the fallbacks nobody compiles.
+
+There are **three** arms, selected independently by `configure`:
+
+| Guard | What is compiled |
+|---|---|
+| `HAVE_VASPRINTF` | `pmix_vasprintf` is one call to `vasprintf(3)` |
+| `HAVE_VSNPRINTF` | `pmix_vsnprintf` is one call to `vsnprintf(3)`; and, if `vasprintf` is missing, `guess_strlen` sizes the result with a `vsnprintf(NULL, 0, …)` probe |
+| neither | `guess_strlen` sizes the result by **walking the format itself** |
+
+Both macros really are set by `configure` (unlike some `HAVE_*` spellings
+in this tree — see `pmix_output`'s `HAVE_SYSLOG` and `pmix_getid`'s
+`SO_PEERCRED`), so the guards are honest. They just never select the
+interesting arm here.
+
+**The invariant `guess_strlen` has to hold is not "estimate the length".
+It is "bound the length *and* consume exactly the arguments the format
+names".** Those are one obligation, not two, and getting either half
+wrong is memory-unsafe:
+
+- Under-count and `vsprintf` — which has no bound argument — runs off the
+  end of the buffer the caller just allocated from that count. A field
+  width alone does this: `%200d` needs 200 bytes and mentions its size
+  nowhere in the argument list.
+- Fail to consume an argument and every conversion *after* it reads the
+  wrong `va_list` slot. The usual ending is a `%s` reading an integer as
+  a `char *`.
+
+So an unrecognized conversion cannot be skipped over: not knowing what it
+emits and not knowing what it consumes are the same ignorance. The walk
+returns **-1** for anything it cannot bound (an unrecognized conversion,
+or `%ls` with no precision) and `pmix_vasprintf` fails with `EINVAL`
+rather than allocating. Every conversion, flag, width, precision and
+length modifier C99 defines is recognized; over-estimating is deliberate
+and the bounds are worst-case (`%Lf` of `LDBL_MAX` is ~4932 digits).
+
+Two traps specific to sizing a float by arithmetic, both of which cost
+this file an infinite loop before: `while (0 != x) x /= 10.0` never
+terminates for an infinity **or** a NaN, and narrowing the `double` a
+`%f` argument actually is into a `float` first *manufactures* an infinity
+out of any ordinary value above `FLT_MAX` — `pmix_asprintf("%f", 1.0e300)`
+was enough to hang the process. Do not reintroduce a divide-down loop;
+the bounds are constants for a reason.
+
+`pmix_vsnprintf` delegates to the platform `vsnprintf` where there is
+one, rather than routing through `pmix_vasprintf`. It used to do the
+latter, which put a `malloc`/`free` pair and a full-length format on
+every line the library prints, and made `pmix_snprintf` fail outright
+under exactly the memory pressure its callers are usually reporting.
+Several in-tree callers (`pmix_output`, `pmix_name_fns`) ignore the
+return value and read the buffer regardless, so the fallback arm writes a
+terminator even when it fails — the header promises the output is always
+null-terminated, and that promise has to survive the error path.
+
+**Compiler coverage.** Nothing in a normal build compiles the fallbacks,
+and `-U HAVE_VASPRINTF` on the command line does not help — `pmix_config.h`
+defines it again from inside the file. Edit the `#if` lines to `#if 1` /
+`#if 0` for the one compile. All four combinations (live, `vsnprintf`
+probe, hand walk, and the `memcpy`-instead-of-`va_copy` arm) do compile
+warning-free; keep it that way when you touch them.
+
+**Testing them is the same trick.** `test/unit/util/util_printf.c` cross-
+checks `pmix_asprintf` against the platform's own `snprintf` for a matrix
+of conversions and asserts the return value equals `strlen` of what came
+back. That is deliberately implementation-agnostic: on a normal build it
+confirms the pass-throughs pass through, and on a platform that selects
+the hand walk `make check` exercises the walk with no changes. To
+exercise it *here*, force the guards as above, rebuild `libpmix` (not
+just the test — remove `<builddir>/src/util/pmix_printf.lo` first), and
+run `util_printf`.
+
 ### `keyval/` — the flex lexer
 
 `keyval_lex.l` is the flex source; `keyval_lex.c` is a **generated build
@@ -1300,8 +1375,10 @@ A second pass then cleared the remaining latent/robustness items:
   now returns `PMIX_ERR_NOT_FOUND` (not `PMIX_ERROR`) for a missing
   directory, per its header.
 - **`pmix_printf.c`.** The `!HAVE_VASPRINTF` fallback `guess_strlen` read
-  `double`/`long` varargs via `va_arg(ap, int)` — now uses the correct
-  `double`/`long` types. Dead on modern platforms, but no longer UB.
+  `double`/`long` varargs via `va_arg(ap, int)` — corrected to the real
+  types. That function has since been replaced outright; see
+  [`pmix_printf`](#pmix_printf--two-implementations-only-one-of-which-you-compile)
+  above for what it now guarantees.
 - **`pmix_tty.c`.** `pmix_settermios` verified a set via a full-struct
   `memcmp` of `struct termios` (padding / canonicalized fields → spurious
   failures) — now compares the individual POSIX fields (`c_iflag`,

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -710,6 +710,58 @@ product** — never hand-edit it, edit the `.l` and let the build
 regenerate. `pmix_keyval_parse` drives it over a real `FILE*` under
 `keyval_mutex` with process-global scratch buffers.
 
+### `pmix_keyval_parse` — process-global state that outlives a run
+
+Everything here is file-static: the key buffer, the lock, and `env_str`,
+which is where the `-x FOO=bar` directives of *every* file parsed so far
+pile up. They are not delivered as they are read — they are accumulated
+into one `;`-separated string and handed over as a single pair named
+`mca_base_env_list_internal` by `pmix_util_keyval_save_internal_envars()`,
+which also frees it.
+
+**That hand-off is not guaranteed to happen, and this state survives a
+finalize.** `pmix_mca_base_var_cache_files()` returns on the first file
+that fails to parse, *before* it reaches the store; and
+`pmix_finalize_util()` clears `pmix_globals.util_initialized`, so
+`pmix_init_util()` — and therefore `pmix_util_keyval_parse_init()` — runs
+again in the same process. An `env_str` left standing is therefore not
+just a leak: the next run is handed the previous run's variables.
+`pmix_util_keyval_parse_finalize()` has to release it alongside the key
+buffer. `test_finalize_drops_pending_envars` in
+[`test/unit/util/util_keyval.c`](../../test/unit/util/util_keyval.c) pins
+it.
+
+**A malformed line is a warning; running out of memory is a return
+code.** The caller acts on what `pmix_util_keyval_parse()` answers —
+`pmix_mca_base_var_cache_files()` treats anything but `PMIX_SUCCESS` or
+`PMIX_ERR_NOT_FOUND` as fatal — and the parse loop used to discard the
+per-line return codes entirely, so a file it could not read reported
+success. Only `PMIX_ERR_OUT_OF_RESOURCE` is propagated, and it stops the
+parse. Syntax errors are deliberately *not* propagated: `parse_error()`
+already reports them on stderr, the rest of the file is still read, and
+turning a typo in an optional parameter file into an init failure is a
+policy change, not a bug fix. If you want that behavior, decide it
+deliberately.
+
+Two more things the shape of this file invites:
+
+- **`PMIX_ERR_NOT_FOUND` is the answer for "could not open", not for
+  "does not exist".** The caller reads it as the latter and carries on,
+  which is right for the default parameter files, most of which are
+  absent — but it means an unreadable file discards every parameter in it
+  and looks identical to no file at all. The code is kept (failing
+  startup over an unreadable optional dotfile would be worse) and a
+  non-`ENOENT` `errno` is now reported instead.
+- **The callback runs with `keyval_mutex` held.** It is not recursive, so
+  a callback that re-enters anything in `pmix_keyval_parse.h` deadlocks
+  against itself. `save_value()` in `src/mca/base` does not; keep it that
+  way.
+
+The `NULL != pmix_util_keyval_yytext` test in `parse_line_new` is dead —
+flex never leaves `yytext` NULL after a match, and the two
+`save_param_name`-style paths `strlen()` it unguarded — but it is
+harmless and is left alone.
+
 ## Build wiring
 
 - `Makefile.am` builds `noinst` `libpmix_util.la` from the `headers` +
@@ -751,7 +803,7 @@ Current coverage includes: `argv`, `alfg`, `basename`, `cmd_line`,
 regression), `if` (the tuple parser), `name_fns` (incl. special-rank
 compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,
-`string_copy`, `timings`, `getcwd`, `getid`.
+`string_copy`, `timings`, `getcwd`, `getid`, `keyval`.
 
 ## Fixed defects (July 2026 review)
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -1091,6 +1091,92 @@ around the chosen placement, without giving up the agreement. Tested in
 is where it has to be tested, since ASLR separates real processes well
 enough to hide whether the scatter works at all.
 
+### `pmix_pty` — a helper that must not take a terminal for itself
+
+Four wrappers around pty setup, and one caller: `pmix_pfexec`'s
+`setup_prefork()` calls `pmix_openpty()` so a spawned child's stdout is a
+pty rather than a pipe (PRRTE's `iof_base_setup.c` does the same thing
+with the same call). `pmix_ptymopen()`/`pmix_ptysopen()` exist to build
+`pmix_openpty()` on a platform that has no `openpty(3)`; nothing in PMIx
+or PRRTE calls them directly, but `pmix_pty.h` is installed, so judge
+them as API.
+
+**The pty here is a pipe with a terminal on the end of it, and nothing
+more.** The child does not `setsid()` and does not want a controlling
+terminal — `pmix_pfexec` turns echo off and `dup2`s the slave onto
+stdout. What it wants is line-discipline behavior, not a session.
+
+**That makes the controlling-terminal rule the one thing to get right in
+this file.** Opening a terminal device from a session leader that has no
+controlling terminal *makes it one*, unless the open carries `O_NOCTTY`.
+A PMIx server started as a daemon is precisely a session leader with no
+controlling terminal. So a helper that opens a pty slave without
+`O_NOCTTY` — on behalf of a child, in the parent, before any fork — hands
+the **server's** controlling terminal to a pty the child is about to be
+given, and closing the last master descriptor then sends `SIGHUP` to the
+server's foreground process group. This is not theoretical: with the
+`O_NOCTTY` removed, the probe child in
+[`test/unit/util/util_pty.c`](../../test/unit/util/util_pty.c) does not
+merely report the terminal, it is killed by the hangup before it can
+report anything, which is why that test distinguishes "died on a signal"
+as an outcome of its own.
+
+`openpty(3)` gets this right, so the live path on every platform built
+here was never affected; the exposure is the fallback and the two
+exported helpers. An `ioctl(TIOCSCTTY)` on top of the open was the same
+mistake twice and is gone. **Do not add either back.** If a future caller
+genuinely wants the pty to be a controlling terminal, that belongs in the
+child after `setsid()`, which is what `forkpty()` already does — and
+`pmix_forkpty()` is there for callers who want it.
+
+**The master descriptor belongs to the caller.** `pmix_ptysopen()` takes
+it only because some platforms' STREAMS setup needs it, and it used to
+`close()` it on every failure path — while its one caller,
+`pmix_openpty()`'s fallback, closed it again on the next line. A double
+close is the descriptor equivalent of a double free: the second one lands
+on whatever the OS handed out in between. The function now leaves it
+alone, and `PMIX_HIDE_UNUSED_PARAMS` marks it deliberately unread since
+the signature is frozen.
+
+**`maxlen` means what it says.** Both `pmix_ptymopen()` arms wrote the
+device name in with `strncpy`/`strcpy` and neither honored the size: a
+short buffer came back unterminated and the `open()` on the next line
+read past the end of it, and the BSD arm's test was written
+`strlen(...) < maxlen - 1`, which wraps for a `maxlen` of zero and lets
+an 11-byte `strcpy` into a zero-length buffer through. Both now refuse a
+buffer that cannot hold the name, with the `-5`/`EOVERFLOW` its sibling
+path already used.
+
+**Every arm in this file is conditionally compiled and this platform
+selects one path through it.** `PMIX_ENABLE_PTY_SUPPORT` (all-stubs),
+`HAVE_PTSNAME` (the `/dev/ptmx` route vs. the BSD `/dev/ptyXY` scan),
+`HAVE_OPENPTY` and `HAVE_FORKPTY` are four independent switches, and the
+stub arms take `void *` where the real ones take `struct termios *`, so
+forcing `PMIX_ENABLE_PTY_SUPPORT` means forcing it in the header too. A
+July 2026 pass fixed compile errors in those stubs by adding
+`PMIX_HIDE_UNUSED_PARAMS` calls — without adding the
+`src/include/pmix_globals.h` that declares it, so all three stub arms
+still failed to build, and the `!HAVE_PTSNAME` arm failed on an
+`errsave` it does not use. **Compile every combination by hand before
+believing an edit here**; `make src/util/pmix_pty.lo` with the guards
+edited to `#if 0`/`#if 1` is enough, and all six do build warning-free
+today. The Solaris `__SVR4 && __sun` STREAMS arm is the one exception —
+it needs a `<stropts.h>` this platform does not have, so it cannot be
+compile-checked from here.
+
+Two things deliberately left alone:
+
+- The BSD arm's `lchown()`/`chmod()` pair acts on two different objects
+  if the slave name is a symlink, which is the shape of CVE-2023-41915
+  (the `chown`→`lchown` sweep that put the `// DO NOT FOLLOW LINKS`
+  comment on that line). It is left as is because the name is a `/dev`
+  device node and both calls are no-ops unless the process is already
+  root, so planting the symlink requires the privilege the attack would
+  gain.
+- `ptsname(3)` is not reentrant. `pmix_ptymopen()` has no caller on a
+  platform with `openpty(3)`, and the one caller it can have runs before
+  a fork; do not add a second one on another thread.
+
 ### `pmix_printf` — two implementations, only one of which you compile
 
 Four `PMIX_EXPORT` wrappers over `asprintf`/`snprintf`. On any platform
@@ -1266,7 +1352,8 @@ Current coverage includes: `argv`, `alfg`, `basename`, `cmd_line`,
 regression), `if` (the tuple parser), `name_fns` (incl. special-rank
 compare), `net`, `os_dirpath`, `os_path`, `output`, `parse_options`
 (incl. the bare-`-` crash regression), `path`, `printf`, `show_help`,
-`string_copy`, `timings`, `getcwd`, `getid`, `keyval`.
+`string_copy`, `timings`, `getcwd`, `getid`, `keyval`, `pty` (the
+controlling-terminal and descriptor-ownership regressions).
 
 ## Fixed defects (July 2026 review)
 
@@ -1330,7 +1417,10 @@ own commit. Recorded so they are not re-introduced by a future edit.
   dropped `maxlen`; `pmix_forkpty` had extra/concrete params), and the
   hand-rolled `pmix_openpty` fallback called `pmix_ptymopen(line)` without
   `maxlen` and used `pmix_string_copy` without including its header —
-  compile failures in those (CI-unexercised) build configs.
+  compile failures in those (CI-unexercised) build configs. Those stubs
+  did **not** build afterwards either — see
+  [`pmix_pty`](#pmix_pty--a-helper-that-must-not-take-a-terminal-for-itself)
+  above; compile-check every arm rather than trusting this entry.
 - **`pmix_keyval_parse.c`.** `isspace()` on a possibly-negative `char`
   (project portability rule) → cast to `unsigned char`; `trim_name`'s
   suffix back-scan could step before the buffer on an all-whitespace

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -447,11 +447,20 @@ compiler through it. Everything else that starts a process goes through
   child ran, so the call succeeded, and errno comes back as the child's
   exit status (truncated to 8 bits, as every exit status is).
 
-A note on the guard: the body is compiled behind
+Two notes on the guard. The body is compiled behind
 `HAVE_FORK && HAVE_EXECVE && HAVE_WAITPID` but calls `execvp`, which
 configure does not probe for separately. POSIX gives you the whole
 `exec*` family together, so the proxy holds; it is worth knowing it *is*
 a proxy before adding a fourth call here.
+
+And the `#else` arm — the one no machine anyone builds on has ever
+compiled — did not compile. It returns `PMIX_ERR_NOT_SUPPORTED` without
+reading either parameter, and this tree builds `-Wextra -Werror`, so
+both came out as errors. That is the same shape as the `pmix_pty.c`
+stubs recorded below: **a conditionally-compiled arm no configuration
+here selects gets no compiler coverage at all.** If you touch one,
+compile it by hand — forcing the guard false for one `make` of that
+object is enough.
 
 ### `pmix_shmem` — a created segment reads as zero
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -73,8 +73,73 @@ each able to fan a message out to stdout/stderr/syslog/a file. The
 `pmix_output_verbose(level, id, ...)` macro is the hot entry point;
 guard expensive verbose output behind it. `make_string` (static) is where
 a formatted line gets its prefix/suffix and trailing newline assembled —
-subtle indexing, so read it before touching. This subsystem is
-process-global and assumes single-threaded (progress-thread) use.
+subtle indexing, so read it before touching.
+
+**Writing is what a second thread may do; changing the table is not.**
+Every line is rendered on the stack and delivered with one `write()`, so
+the `ptl` listener thread and the progress thread can both write without
+a lock — which is just as well, since there is no lock anywhere in the
+file. Everything that *changes* the table (`init`, `open`, `reopen`,
+`close`, `finalize`, `set_output_file_info`) is startup/shutdown work and
+must be serialized by the caller; two concurrent `pmix_output_open()`
+calls can settle on the same free slot. The header used to promise
+serialization the code has never implemented; it now states this.
+
+Four things about a stream's lifetime are easy to get wrong, and were.
+
+- **A disabled stream is still an open stream.** `pmix_output_switch()`
+  is documented as discarding output without closing anything, but
+  `pmix_output_close()` and `free_descriptor()` both refused to act on a
+  stream whose `ldi_enabled` was false — so a stream that had been
+  switched off, or opened with `lds_is_debugging` in a build that is not
+  `--enable-debug`, could never be closed: its `strdup`'ed prefix,
+  suffix, syslog identity and file suffix were stranded, its file stayed
+  open, and its slot stayed `ldi_used` forever. Sixty-four of those
+  exhaust `pmix_output_open()`. The guards now test `ldi_used` alone;
+  `test_output_close_disabled_reclaims_slot` in
+  [`test/unit/util/util_output.c`](../../test/unit/util/util_output.c)
+  pins it.
+- **Two streams may name the same file, and each needs its own
+  descriptor.** `open_file()` deliberately does not open a file a second
+  time — the second open carries `O_TRUNC` and the two independent
+  offsets would overwrite each other — so it looks for a stream already
+  holding that file. It used to *alias* that stream's descriptor, which
+  made the first close take the file away from everyone else still
+  pointed at it: those streams then wrote into whatever descriptor the
+  OS handed out next, and closed it a second time on their own way out.
+  It now `dup()`s, so the file description (and its offset) is shared
+  while each stream owns what it closes. The scan also `break`ed on the
+  first stream whose file *differs* from ours instead of moving on to
+  the next, so a matching stream further down the table was never found.
+  `PMIX_OUTPUT_REDIRECT=file` is all it takes to have several file
+  streams at once.
+- **A file that will not open yet is not a failure.** The header
+  promises that output to a stream whose session directory does not
+  exist is counted as lost and that the open is retried on every later
+  write. The failure path used to mark the slot *unused* instead, which
+  silenced the stream permanently and handed its id to the next
+  `pmix_output_open()` while the original holder was still using it.
+- **`free_descriptor()` must reset `ldi_fd`.** The slot outlives the
+  stream and gets reissued, and one arm of `do_open()` did not set the
+  descriptor either, so a recycled slot could start life pointed at a
+  descriptor that had been closed.
+
+Five environment variables, read once in `pmix_output_init()`, override
+what every stream does: `PMIX_OUTPUT_REDIRECT` (`syslog` or `file`),
+`PMIX_OUTPUT_SYSLOG_PRI`, `PMIX_OUTPUT_SYSLOG_IDENT`,
+`PMIX_OUTPUT_SUFFIX` and `PMIX_OUTPUT_STDERR_FD`. They exist because this
+subsystem comes up before the MCA parameter system does; they are now
+documented in the header.
+
+Two smaller contracts worth knowing: `pmix_output_open()` answers either
+a handle or a *negative PMIx status*, so a caller storing the result has
+to tell them apart before using it; and `pmix_output_reopen_all()` does
+not reopen anything despite its name — it re-reads
+`PMIX_OUTPUT_STDERR_FD` and rebuilds the `[hostname:pid]` prefix of the
+default verbose stream, which is the part a restart invalidates. It used
+to rebuild only the *template* and not the descriptor's own copy, so even
+that did nothing. A stream someone else opened keeps the prefix its
+opener gave it, and only that opener can rebuild it.
 
 ### `pmix_show_help` — help text is compiled *into the library*
 

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -250,6 +250,40 @@ public `PMIx_Argv_append_unique_nosize()` plus an index out-parameter,
 and callers are entitled to that: it screens `NULL` inputs the same way
 rather than handing a `NULL` arg to `strcmp`.
 
+### `pmix_environ` — harvesting, and the array you must not realloc
+
+- **An include/exclude entry is a NAME, unless it ends in `*`.** The
+  matcher used to treat every entry as a prefix, so `"PATH"` also took
+  `PATHFINDER`; it now matches exactly unless a trailing `*` says
+  otherwise, which is what the documented `"OMPI_*,OPAL_*"` convention
+  has always meant. The cost of that correctness is that a list written
+  as a bare prefix silently stops matching *anything*, and there was one:
+  `src/mca/pmdl/base` harvests the local MCA params with `"PMIX_MCA_"`,
+  which as an exact name is the name of no variable at all, so no MCA
+  param reached a spawned child. If you add an include list, decide which
+  of the two you mean and spell it. Both directions are pinned by
+  `test_harvest_exact_vs_wildcard` in
+  [`test/unit/util/util_environ.c`](../../test/unit/util/util_environ.c).
+- **`ilist` belongs to the caller, so nothing on it can be assumed.**
+  `pmix_util_harvest_envars` walks a list it did not build: entries may
+  be of any type, and a `PMIX_ENVAR` entry need not carry a value, since
+  `PMIx_Envar_load()` leaves the value untouched when handed `NULL`.
+  Screen the type *and* the pointers before comparing.
+- **`pmix_environ_merge_inplace()` must never be given `environ`.** It
+  extends the array with `PMIx_Argv_append_nosize()`, which reallocs, and
+  `environ` may not be realloc'd — the process aborts. This was enforced
+  by a bare `assert()`, which `-DNDEBUG` removes from precisely the build
+  that needs it; it is now a real check returning `PMIX_ERR_BAD_PARAM`.
+  `test_merge_inplace_refuses_environ` aborts the test binary if the
+  check is removed, so the hazard is not theoretical.
+- **`pmix_home_directory()` consults `$HOME` only for the calling user.**
+  Any other uid goes straight to `getpwuid()`. Ask about yourself with
+  `geteuid()`, `(uid_t)-1`, or `UINT_MAX` — all three are accepted, and
+  the last is what the code historically tested, which coincides with
+  `(uid_t)-1` only while `uid_t` is exactly as wide as an `int`. See the
+  `pmix_context_fns` note below for what happened to the one caller that
+  spelled it `-1`. `getpwuid()` is not reentrant.
+
 ### `pmix_context_fns` — moving the process to where an app runs
 
 Two helpers that `pmix_pfexec` calls to place a child: one `chdir()`s to

--- a/src/util/help-cli.txt
+++ b/src/util/help-cli.txt
@@ -79,3 +79,14 @@ an argument, but no argument was given:
 
 Please use the "%s --help %s" command to learn more about
 this option.
+#
+[not-enough-arguments]
+An option was included on the %s command line that requires
+two arguments, but only one was given:
+
+  Option: %s
+  First argument: %s
+  Second argument: %s
+
+Please use the "%s --help %s" command to learn more about
+this option.

--- a/src/util/help-cli.txt
+++ b/src/util/help-cli.txt
@@ -32,13 +32,6 @@ Help was requested for an unknown option:
 Please use the "%s --help" command to obtain a list of all
 supported options.
 #
-[unrecognized-option]
-The help system for %s does not recognize the following:
-
-  Option: %s
-
-This might require help from the developers.
-#
 [version]
 Print version and exit
 #

--- a/src/util/help-pmix-util.txt
+++ b/src/util/help-pmix-util.txt
@@ -14,8 +14,8 @@
 #
 [malformed net_private_ipv4]
 PMIx has detected at least one malformed IP address or netmask in
-the value of the opal_net_private_ipv4 MCA parameter.  The
-opal_net_private_ipv4 MCA parameter accepts a semicolon-delimited list
+the value of the pmix_net_private_ipv4 MCA parameter.  The
+pmix_net_private_ipv4 MCA parameter accepts a semicolon-delimited list
 of Classless Inter-Domain Routing (CIDR) notation specifications, each
 of the form <ipaddress>/<mask>.  For example:
 

--- a/src/util/pmix_alfg.c
+++ b/src/util/pmix_alfg.c
@@ -42,11 +42,11 @@
  * @brief      Galois shift register: Used to seed the ALFG's
  *             canonical rectangle
  *
- * @param[in]  unsigned int *seed: used to seed the Galois register
- * @param[out] uint32_t lsb: least significant bit of the Galois
- *             register after shift
+ * @param[in,out] uint32_t *seed: the Galois register, advanced in place
+ * @param[out]    uint32_t lsb: least significant bit of the Galois
+ *                register before the shift
  */
-static uint32_t galois(unsigned int *seed)
+static uint32_t galois(uint32_t *seed)
 {
 
     uint32_t lsb;

--- a/src/util/pmix_argv.c
+++ b/src/util/pmix_argv.c
@@ -35,8 +35,6 @@
 #include "pmix.h"
 #include "src/util/pmix_argv.h"
 
-#define ARGSIZE 128
-
 /*
  * Append a string to the end of a new or existing argv array.
  */
@@ -103,7 +101,7 @@ char *pmix_argv_join_range(char **argv, size_t start, size_t end, int delimiter)
 
     /* Bozo case */
 
-    if (NULL == argv || NULL == argv[0] || (int) start >= PMIx_Argv_count(argv)) {
+    if (NULL == argv || NULL == argv[0] || start >= (size_t) PMIx_Argv_count(argv)) {
         return strdup("");
     }
 

--- a/src/util/pmix_argv.c
+++ b/src/util/pmix_argv.c
@@ -59,6 +59,13 @@ pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *ar
     int i;
     pmix_status_t rc;
 
+    /* screen the inputs the way the public twin
+     * (PMIx_Argv_append_unique_nosize) does - the compare loop below
+     * would otherwise hand a NULL arg straight to strcmp */
+    if (NULL == idx || NULL == argv || NULL == arg) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* if the provided array is NULL, then the arg cannot be present,
      * so just go ahead and append
      */
@@ -172,7 +179,7 @@ char **pmix_argv_copy_strip(char **argv)
     char **dupv = NULL;
     int n;
     char *start;
-    bool mod;
+    char *stripped;
     size_t len;
 
     if (NULL == argv) {
@@ -188,26 +195,34 @@ char **pmix_argv_copy_strip(char **argv)
     dupv[0] = NULL;
 
     for (n=0; NULL != argv[n]; n++) {
-        mod = false;
+        /* Narrow the element to the span that survives the strip and
+         * copy that span out. We must not punch a temporary NUL into
+         * the caller's string to mark the end: this function copies,
+         * so the source array is not ours to write to, and an element
+         * that points at read-only storage (a string literal) would
+         * fault. */
         start = argv[n];
-        if ('\"' == argv[n][0]) {
+        len = strlen(start);
+        if ('\"' == start[0]) {
             ++start;
+            --len;
         }
-        len = strlen(argv[n]);
-        if (0 < len && '\"' == argv[n][len-1]) {
-            argv[n][len-1] = '\0';
-            mod = true;
+        if (0 < len && '\"' == start[len-1]) {
+            --len;
         }
-        if (PMIX_SUCCESS != PMIx_Argv_append_nosize(&dupv, start)) {
+        stripped = (char *) malloc(len + 1);
+        if (NULL == stripped) {
             PMIx_Argv_free(dupv);
-            if (mod) {
-                argv[n][len-1] = '\"';
-            }
             return NULL;
         }
-        if (mod) {
-            argv[n][len-1] = '\"';
+        memcpy(stripped, start, len);
+        stripped[len] = '\0';
+        if (PMIX_SUCCESS != PMIx_Argv_append_nosize(&dupv, stripped)) {
+            free(stripped);
+            PMIx_Argv_free(dupv);
+            return NULL;
         }
+        free(stripped);
     }
 
     /* All done */
@@ -274,6 +289,8 @@ pmix_status_t pmix_argv_insert(char ***target, int start, char **source)
     int i, source_count, target_count;
     int suffix_count;
     char **tmp;
+    char **copies;
+    pmix_status_t rc;
 
     /* Check for the bozo cases */
 
@@ -283,13 +300,20 @@ pmix_status_t pmix_argv_insert(char ***target, int start, char **source)
         return PMIX_SUCCESS;
     }
 
-    /* Easy case: appending to the end */
-
     target_count = PMIx_Argv_count(*target);
     source_count = PMIx_Argv_count(source);
+    if (0 == source_count) {
+        return PMIX_SUCCESS;
+    }
+
+    /* Easy case: appending to the end */
+
     if (start > target_count) {
         for (i = 0; i < source_count; ++i) {
-            pmix_argv_append(&target_count, target, source[i]);
+            rc = pmix_argv_append(&target_count, target, source[i]);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
         }
     }
 
@@ -297,11 +321,29 @@ pmix_status_t pmix_argv_insert(char ***target, int start, char **source)
 
     else {
 
+        /* Copy the source strings before touching the target. A copy
+         * that failed after the target had been grown and its suffix
+         * shifted would leave a NULL in the middle of the array, which
+         * terminates it early - every element beyond the hole is both
+         * lost to the caller and leaked - and the old code reported
+         * that as success. */
+
+        copies = (char **) calloc(source_count, sizeof(char *));
+        if (NULL == copies) {
+            return PMIX_ERR_NOMEM;
+        }
+        for (i = 0; i < source_count; ++i) {
+            copies[i] = strdup(source[i]);
+            if (NULL == copies[i]) {
+                goto nomem;
+            }
+        }
+
         /* Allocate new space */
 
         tmp = (char **) realloc(*target, sizeof(char *) * (target_count + source_count + 1));
         if (NULL == tmp) {
-            return PMIX_ERR_NOMEM;
+            goto nomem;
         }
         *target = tmp;
 
@@ -313,16 +355,24 @@ pmix_status_t pmix_argv_insert(char ***target, int start, char **source)
         }
         (*target)[start + suffix_count + source_count] = NULL;
 
-        /* Strdup in the source argv */
+        /* Hand the copies over to the target */
 
-        for (i = start; i < start + source_count; ++i) {
-            (*target)[i] = strdup(source[i - start]);
+        for (i = 0; i < source_count; ++i) {
+            (*target)[start + i] = copies[i];
         }
+        free(copies);
     }
 
     /* All done */
 
     return PMIX_SUCCESS;
+
+nomem:
+    for (i = 0; i < source_count; ++i) {
+        free(copies[i]);
+    }
+    free(copies);
+    return PMIX_ERR_NOMEM;
 }
 
 pmix_status_t pmix_argv_insert_element(char ***target, int location, char *source)
@@ -330,6 +380,7 @@ pmix_status_t pmix_argv_insert_element(char ***target, int location, char *sourc
     int i, target_count;
     int suffix_count;
     char **tmp;
+    char *copy;
 
     /* Check for the bozo cases */
 
@@ -342,13 +393,20 @@ pmix_status_t pmix_argv_insert_element(char ***target, int location, char *sourc
     /* Easy case: appending to the end */
     target_count = PMIx_Argv_count(*target);
     if (location > target_count) {
-        pmix_argv_append(&target_count, target, source);
-        return PMIX_SUCCESS;
+        return pmix_argv_append(&target_count, target, source);
+    }
+
+    /* Copy the source before touching the target - see the comment in
+     * pmix_argv_insert() for why the copy cannot come last */
+    copy = strdup(source);
+    if (NULL == copy) {
+        return PMIX_ERR_NOMEM;
     }
 
     /* Allocate new space */
     tmp = (char **) realloc(*target, sizeof(char *) * (target_count + 2));
     if (NULL == tmp) {
+        free(copy);
         return PMIX_ERR_NOMEM;
     }
     *target = tmp;
@@ -360,8 +418,8 @@ pmix_status_t pmix_argv_insert_element(char ***target, int location, char *sourc
     }
     (*target)[location + suffix_count + 1] = NULL;
 
-    /* Strdup in the source */
-    (*target)[location] = strdup(source);
+    /* Hand the copy over to the target */
+    (*target)[location] = copy;
 
     /* All done */
     return PMIX_SUCCESS;

--- a/src/util/pmix_argv.h
+++ b/src/util/pmix_argv.h
@@ -55,7 +55,8 @@ BEGIN_C_DECLS
  * @param str Pointer to the string to append.
  *
  * @retval PMIX_SUCCESS On success
- * @retval PMIX_ERROR On failure
+ * @retval PMIX_ERR_BAD_PARAM If argv or arg is NULL
+ * @retval PMIX_ERR_OUT_OF_RESOURCE If the array could not be grown
  *
  * This function adds a string to an argv array of strings by value;
  * it is permissible to pass a string on the stack as the str
@@ -87,7 +88,8 @@ PMIX_EXPORT pmix_status_t pmix_argv_append(int *argc, char ***argv, const char *
  * @param str Pointer to the string to append.
  *
  * @retval PMIX_SUCCESS On success
- * @retval PMIX_ERROR On failure
+ * @retval PMIX_ERR_BAD_PARAM If idx, argv, or arg is NULL
+ * @retval PMIX_ERR_OUT_OF_RESOURCE If the array could not be grown
  *
  * This function is identical to the PMIx_Argv_append_unique_nosize() function
  * but it has an extra argument defining the index of the item in the array.
@@ -115,7 +117,8 @@ PMIX_EXPORT size_t pmix_argv_len(char **argv);
  * @param start The index of the first token to delete
  * @param num_to_delete How many tokens to delete
  *
- * @retval PMIX_SUCCESS Always
+ * @retval PMIX_SUCCESS On success, and for every no-op case
+ * @retval PMIX_ERR_BAD_PARAM If start or num_to_delete is negative
  *
  * Delete some tokens from within an existing argv.  The start
  * parameter specifies the first token to delete, and will delete
@@ -143,7 +146,9 @@ PMIX_EXPORT pmix_status_t pmix_argv_delete(int *argc, char ***argv, int start, i
  * @param source The argv to copy tokens from
  *
  * @retval PMIX_SUCCESS upon success
- * @retval PMIX_BAD_PARAM if any parameters are non-sensical
+ * @retval PMIX_ERR_BAD_PARAM if any parameters are non-sensical
+ * @retval PMIX_ERR_NOMEM if the copy could not be made, in which
+ * case the target is left exactly as it was
  *
  * This function takes one arg and inserts it in the middle of
  * another.  The first token in source will be inserted at index
@@ -166,7 +171,9 @@ PMIX_EXPORT pmix_status_t pmix_argv_insert(char ***target, int start, char **sou
  * @param source The token to be inserted
  *
  * @retval PMIX_SUCCESS upon success
- * @retval PMIX_BAD_PARAM if any parameters are non-sensical
+ * @retval PMIX_ERR_BAD_PARAM if any parameters are non-sensical
+ * @retval PMIX_ERR_NOMEM if the copy could not be made, in which
+ * case the target is left exactly as it was
  *
  * This function takes one arg and inserts it in the middle of
  * another.  The token will be inserted at the specified index
@@ -181,6 +188,19 @@ PMIX_EXPORT pmix_status_t pmix_argv_insert(char ***target, int start, char **sou
  */
 PMIX_EXPORT pmix_status_t pmix_argv_insert_element(char ***target, int location, char *source);
 
+/**
+ * Copy an argv array, stripping one leading and one trailing double
+ * quote from each element.
+ *
+ * @param argv The argv array to copy
+ *
+ * @returns A new NULL-terminated argv array, or NULL on failure
+ *
+ * The source array is left unaffected -- neither the array nor the
+ * strings it points to are written to, so it is safe to pass an argv
+ * whose elements are string literals.  The caller is responsible for
+ * freeing the result with PMIx_Argv_free().
+ */
 PMIX_EXPORT
 char **pmix_argv_copy_strip(char **argv) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
 

--- a/src/util/pmix_basename.c
+++ b/src/util/pmix_basename.c
@@ -85,6 +85,9 @@ char *pmix_basename(const char *filename)
 
     /* Remove trailing sep's (note that we already know that strlen > 0) */
     tmp = strdup(filename);
+    if (NULL == tmp) {
+        return NULL;
+    }
     if (1 < strlen(tmp)) {
         for (i = strlen(tmp) - 1; i > 0; --i) {
             if (sep == tmp[i]) {
@@ -120,6 +123,13 @@ char *pmix_dirname(const char *filename)
 
 #if defined(HAVE_DIRNAME) || PMIX_HAVE_DIRNAME
     char *safe_tmp = strdup(filename), *result;
+    /* dirname() is documented to answer "." for a NULL path, so an
+     * unchecked strdup here would turn an allocation failure into a
+     * plausible-looking directory instead of the error the header
+     * promises */
+    if (NULL == safe_tmp) {
+        return NULL;
+    }
     result = strdup(dirname(safe_tmp));
     free(safe_tmp);
     return result;
@@ -128,9 +138,17 @@ char *pmix_dirname(const char *filename)
     const char *end;
     char *ret;
 
-    /* NOTE: p will be NULL if no path separator was in the filename - i.e.,
-     * if filename is just a local file - in which case the dirname is "." */
+    /* NOTE: p will be NULL in two cases. Either no path separator was in
+     * the filename - i.e., filename is just a local file, whose dirname
+     * is "." - or the filename consists of nothing but separators
+     * ("/", "//", ...), whose dirname is the root. pmix_find_last_path_
+     * separator() cannot return NULL for anything else: were there a
+     * non-separator anywhere, its first loop would stop on it and the
+     * second would go on to find the leading separator. */
     if (NULL == p) {
+        if (PMIX_PATH_SEP[0] == filename[0]) {
+            return strdup(PMIX_PATH_SEP);
+        }
         return strdup(".");
     }
 

--- a/src/util/pmix_basename.c
+++ b/src/util/pmix_basename.c
@@ -39,7 +39,8 @@
  * was found. It does not modify the original string. Moreover, it does not
  * scan the full string, but only the part allowed by the specified number
  * of characters.
- * If the last character on the string is a path separator, it will be skipped.
+ * Any run of path separators at the end of the string is skipped, so a
+ * string that is nothing but separators yields NULL.
  */
 static inline char *pmix_find_last_path_separator(const char *filename, size_t n)
 {
@@ -54,13 +55,15 @@ static inline char *pmix_find_last_path_separator(const char *filename, size_t n
 
     /* First skip the latest separators */
     for (; p >= filename; p--) {
-        if (*p != PMIX_PATH_SEP[0])
+        if (*p != PMIX_PATH_SEP[0]) {
             break;
+        }
     }
 
     for (; p >= filename; p--) {
-        if (*p == PMIX_PATH_SEP[0])
+        if (*p == PMIX_PATH_SEP[0]) {
             return p;
+        }
     }
 
     return NULL; /* nothing found inside the filename */

--- a/src/util/pmix_basename.h
+++ b/src/util/pmix_basename.h
@@ -89,13 +89,13 @@ pmix_basename(const char *filename) __pmix_attribute_malloc__ __pmix_attribute_w
  * This function will do the Right Things on POSIX and
  * Windows-based operating systems.  For example:
  *
- * foo.txt returns "foo.txt"
+ * foo.txt returns "."
  *
  * /foo/bar/baz returns "/foo/bar"
  *
  * /yow.c returns "/"
  *
- * / returns ""
+ * / returns "/"
  *
  * C:\foo\bar\baz returns "C:\foo\bar"
  *

--- a/src/util/pmix_basename.h
+++ b/src/util/pmix_basename.h
@@ -46,8 +46,7 @@ BEGIN_C_DECLS
  * filename do not count, unless it is in the only part of the
  * filename (e.g., "/" or "C:\").
  *
- * This function will do the Right Things on POSIX and
- * Windows-based operating systems.  For example:
+ * The path separator is "/".  For example:
  *
  * foo.txt returns "foo.txt"
  *
@@ -55,17 +54,9 @@ BEGIN_C_DECLS
  *
  * /yow.c returns "yow.c"
  *
+ * /foo/bar/ returns "bar"
+ *
  * / returns "/"
- *
- * C:\foo\bar\baz returns "baz"
- *
- * D:foo.txt returns "foo.txt"
- *
- * E:\yow.c returns "yow.c"
- *
- * F: returns "F:"
- *
- * G:\ returns "G:"
  *
  * The caller is responsible for freeing the returned string.
  */
@@ -86,26 +77,17 @@ pmix_basename(const char *filename) __pmix_attribute_malloc__ __pmix_attribute_w
  * filename do not count, unless it is in the only part of the
  * filename (e.g., "/" or "C:\").
  *
- * This function will do the Right Things on POSIX and
- * Windows-based operating systems.  For example:
+ * The path separator is "/".  For example:
  *
  * foo.txt returns "."
  *
  * /foo/bar/baz returns "/foo/bar"
  *
+ * /foo/bar/ returns "/foo"
+ *
  * /yow.c returns "/"
  *
  * / returns "/"
- *
- * C:\foo\bar\baz returns "C:\foo\bar"
- *
- * D:foo.txt returns "D:"
- *
- * E:\yow.c returns "E:"
- *
- * F: returns ""
- *
- * G:\ returns ""
  *
  * The caller is responsible for freeing the returned string.
  */

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -119,6 +119,29 @@ static bool is_option_token(const char *arg, const char *shorts,
     return true;
 }
 
+/* Report an option that takes TWO tokens but was given only one.
+ *
+ * getopt is told these options take a single argument; the parser then
+ * claims a second token from argv[optind] on its own account, so noticing
+ * that the token is absent - or is the next option rather than a value -
+ * is the parser's job and nobody else's. */
+static void report_missing_second(const char *option, const char *first,
+                                  const char *second)
+{
+    char *str;
+
+    str = pmix_show_help_string("help-cli.txt", "not-enough-arguments", true,
+                                pmix_tool_basename, option, first,
+                                (NULL == second) ? "missing" : second,
+                                pmix_tool_basename, option);
+    if (NULL != str) {
+        fprintf(stderr, "%s", str);
+        fflush(stderr);
+        free(str);
+    }
+    return;
+}
+
 static void check_store(const char *name, const char *option,
                         pmix_cli_result_t *results)
 {
@@ -136,9 +159,19 @@ static void check_store(const char *name, const char *option,
         }
     }
 
-    // get here if this is new option
+    /* get here if this is new option. Nothing here can report a failure -
+     * the store function's signature has no return - so on an allocation
+     * failure drop the occurrence rather than filing an item with a NULL
+     * key, which every later lookup would hand straight to strcmp(). */
     opt = PMIX_NEW(pmix_cli_item_t);
+    if (NULL == opt) {
+        return;
+    }
     opt->key = strdup(name);
+    if (NULL == opt->key) {
+        PMIX_RELEASE(opt);
+        return;
+    }
     pmix_list_append(&results->instances, &opt->super);
     /* if the name is NULL, then this is just setting
      * a boolean value - the presence of the option in
@@ -237,6 +270,12 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
     /* the getopt_long parser reorders the input argv array, so
      * we have to protect it here */
     argv = PMIx_Argv_copy(pargv);
+    if (NULL != pargv && NULL == argv) {
+        /* the copy failed - an empty input copies to an empty array, so a
+         * NULL here means we ran out of memory. Parsing nothing and
+         * reporting success would silently discard the whole command line. */
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
     argc = PMIx_Argv_count(argv);
 
     /* Prefix the short-option string with '+' so getopt stops at the first
@@ -258,6 +297,10 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
      * longer ours - it goes to the tail. That is the intent: a launcher
      * must not eat the flags belonging to the application it launches. */
     pmix_asprintf(&shortopts, "+%s", (NULL == shorts) ? "" : shorts);
+    if (NULL == shortopts) {
+        PMIx_Argv_free(argv);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
     // assign a default store_fn if one isn't provided
     if (NULL == storefn) {
         mystore = check_store;
@@ -293,9 +336,22 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
     // run the parser
     while (1) {
         argind = optind;
-        if (optind == argc || (optind > 0 && '-' != argv[optind][0])) {
-            // This is the executable, or we are at the last argument.
-            // Don't process any further.
+        /* Stop at the end of argv, or at the first token that is not an
+         * option - that token is the executable, and everything from there
+         * on belongs to it.
+         *
+         * The end test is ">=", not "==", because the arms below that claim
+         * a second token of their own accord step optind themselves. One
+         * that stepped past the end used to slip through an equality test
+         * and send the next iteration reading past the end of the copied
+         * array, where it dereferenced whatever it found.
+         *
+         * A lone "-" is not an option either - conventionally it names
+         * stdin - and getopt agrees: it stops there without consuming it,
+         * which left the arms below reasoning about the PREVIOUS token and
+         * reporting it as missing an argument it had already been given. */
+        if (optind >= argc ||
+            (optind > 0 && ('-' != argv[optind][0] || '\0' == argv[optind][1]))) {
             break;
         }
         opt = getopt_long(argc, argv, shortopts, myoptions, &option_index);
@@ -309,16 +365,8 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                     if (NULL == argv[optind] ||
                         is_option_token(argv[optind], shorts, myoptions)) {
                         // missing the required second argument
-                        str = pmix_show_help_string("help-cli.txt", "not-enough-arguments", true,
-                                                    pmix_tool_basename, myoptions[option_index].name,
-                                                    argv[optind-1], (NULL == argv[optind]) ?
-                                                    "missing" : argv[optind],
-                                                    pmix_tool_basename, myoptions[option_index].name);
-                        if (NULL != str) {
-                            fprintf(stderr, "%s", str);
-                            fflush(stderr);
-                            free(str);
-                        }
+                        report_missing_second(myoptions[option_index].name,
+                                              argv[optind-1], argv[optind]);
                         PMIx_Argv_free(argv);
                         free(shortopts);
                         return PMIX_ERR_SILENT;
@@ -334,6 +382,19 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                 // that describe what to do
                 if (0 == strcmp(myoptions[option_index].name, PMIX_CLI_PREPEND_ENVAR) ||
                     0 == strcmp(myoptions[option_index].name, PMIX_CLI_APPEND_ENVAR)) {
+                    /* Like the MCA options above, these take TWO tokens and
+                     * getopt only knows about one, so check that the second
+                     * is really there. Storing it unchecked took the NULL
+                     * that terminates argv for a value and stepped optind
+                     * past the end of the array. */
+                    if (NULL == argv[optind] ||
+                        is_option_token(argv[optind], shorts, myoptions)) {
+                        report_missing_second(myoptions[option_index].name,
+                                              argv[optind-1], argv[optind]);
+                        PMIx_Argv_free(argv);
+                        free(shortopts);
+                        return PMIX_ERR_SILENT;
+                    }
                     store_occurrence(mystore, myoptions[option_index].name,
                                      argv[optind-1], results);
                     store_occurrence(mystore, myoptions[option_index].name,
@@ -378,13 +439,20 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                                  optarg, results);
                 break;
             case 'h':
-                /* the "help" option can optionally take an argument. Since
-                 * the argument _is_ optional, getopt will _NOT_ increment
-                 * optind, so argv[optind] is the potential argument */
-                if (NULL == optarg &&
-                    NULL != argv[optind]) {
+                /* The "help" option can optionally take an argument, and an
+                 * optional argument reaches us two ways. Attached to the
+                 * option ("-htopic", "--help=topic") getopt hands it back in
+                 * optarg; given as the next token ("--help topic") it does
+                 * NOT step optind, so the token is still at argv[optind].
+                 *
+                 * Both spell the same request, and both have to be answered
+                 * the same way. The attached form used to fall through to an
+                 * "unrecognized option" complaint naming the topic, so
+                 * "--help=version" was refused while "--help version"
+                 * worked. */
+                ptr = (NULL != optarg) ? optarg : argv[optind];
+                if (NULL != ptr) {
                     /* strip any leading dashes */
-                    ptr = argv[optind];
                     while ('-' == *ptr) {
                         ++ptr;
                     }
@@ -446,33 +514,21 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                     PMIx_Argv_free(argv);
                     free(shortopts);
                     return PMIX_OPERATION_SUCCEEDED;
-                } else if (NULL == optarg) {
-                    // high-level help request
-                    str = pmix_show_help_string(helpfile, "usage", false,
-                                                pmix_tool_basename, pmix_tool_org,
-                                                pmix_tool_version,
-                                                pmix_tool_basename,
-                                                pmix_tool_msg);
-                    if (NULL != str) {
-                        printf("%s\n", str);
-                        fflush(stdout);
-                        free(str);
-                    }
-                    PMIx_Argv_free(argv);
-                    free(shortopts);
-                    return PMIX_OPERATION_SUCCEEDED;
-                } else {  // unrecognized option
-                    str = pmix_show_help_string("help-cli.txt", "unrecognized-option", true,
-                                                pmix_tool_basename, optarg);
-                    if (NULL != str) {
-                        fprintf(stderr, "%s", str);
-                        fflush(stderr);
-                        free(str);
-                    }
+                }
+                // high-level help request
+                str = pmix_show_help_string(helpfile, "usage", false,
+                                            pmix_tool_basename, pmix_tool_org,
+                                            pmix_tool_version,
+                                            pmix_tool_basename,
+                                            pmix_tool_msg);
+                if (NULL != str) {
+                    printf("%s\n", str);
+                    fflush(stdout);
+                    free(str);
                 }
                 PMIx_Argv_free(argv);
                 free(shortopts);
-                return PMIX_ERR_SILENT;
+                return PMIX_OPERATION_SUCCEEDED;
             case 'V':
                 str = pmix_show_help_string(helpfile, "version", false,
                                             pmix_tool_basename, pmix_tool_org,
@@ -531,7 +587,10 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                 break;
             default:
                 found = false;
-                for (n=0; '\0' != shorts[n]; n++) {
+                /* A tool with no short options at all passes shorts == NULL,
+                 * which the '+'-prefixing above and is_option_token() both
+                 * allow for - so this scan has to as well. */
+                for (n=0; NULL != shorts && '\0' != shorts[n]; n++) {
                     int ascii = shorts[n];
                     if (opt == ascii) {
                         /* found it - now search for matching option. The
@@ -585,7 +644,21 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                                     ptr = NULL;
                                 } else if (0 == strcmp(myoptions[m].name, "np") &&
                                            (NULL != optarg && 0 == strcmp(optarg, "p"))) {
-                                    /* we special-case the very common "-np" option */
+                                    /* We special-case the very common "-np"
+                                     * option: getopt read the "p" as the
+                                     * argument of "-n", so the count is the
+                                     * token after it. It has to be there -
+                                     * claiming the NULL that terminates argv
+                                     * stepped optind past the end of the
+                                     * array, and the next iteration then
+                                     * read past it. */
+                                    if (NULL == argv[optind]) {
+                                        report_missing_second(myoptions[m].name,
+                                                              "-np", NULL);
+                                        PMIx_Argv_free(argv);
+                                        free(shortopts);
+                                        return PMIX_ERR_SILENT;
+                                    }
                                     ptr = argv[optind];
                                     ++optind;
                                 }
@@ -631,7 +704,14 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                  * getopt_long function declares these as "unrecognized", but
                  * we would like to provide a more user-friendly error message */
                 for (n=0; NULL != myoptions[n].name; n++) {
-                    /* skip the "--" prefix */
+                    /* Skip the "--" prefix. Only a token that actually has
+                     * one can be indexed past it: getopt hands back the
+                     * offending option here, but the arms that reach this
+                     * point on a -1 return are looking at whatever token
+                     * preceded it, which need not be that long. */
+                    if ('-' != argv[optind-1][0] || '-' != argv[optind-1][1]) {
+                        break;
+                    }
                     if (0 == strcmp(&argv[optind-1][2], myoptions[n].name)) {
                         /* the option is recognized - probably misssing
                          * an argument */

--- a/src/util/pmix_cmd_line.c
+++ b/src/util/pmix_cmd_line.c
@@ -378,8 +378,8 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                     ++optind;
                     break;
                 }
-                // if this is a "-env" option, then there can be three entries
-                // that describe what to do
+                // these "-env" options are given as two entries: the
+                // envar and the value to prepend or append to it
                 if (0 == strcmp(myoptions[option_index].name, PMIX_CLI_PREPEND_ENVAR) ||
                     0 == strcmp(myoptions[option_index].name, PMIX_CLI_APPEND_ENVAR)) {
                     /* Like the MCA options above, these take TWO tokens and
@@ -713,7 +713,7 @@ int pmix_cmd_line_parse(char **pargv, char *shorts,
                         break;
                     }
                     if (0 == strcmp(&argv[optind-1][2], myoptions[n].name)) {
-                        /* the option is recognized - probably misssing
+                        /* the option is recognized - probably missing
                          * an argument */
                         str = pmix_show_help_string("help-cli.txt", "missing-argument", true,
                                                     pmix_tool_basename, argv[optind-1],

--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -217,8 +217,8 @@ typedef struct {
 #define PMIX_CLI_PSET_NAME              "pset"                      // required
 #define PMIX_CLI_FWD_ENVAR              "x"                         // required
 #define PMIX_CLI_SET_ENVAR              "set-env"                   // required
-#define PMIX_CLI_PREPEND_ENVAR          "prepend-env"               // required
-#define PMIX_CLI_APPEND_ENVAR           "append-env"                // required
+#define PMIX_CLI_PREPEND_ENVAR          "prepend-env"               // requires TWO
+#define PMIX_CLI_APPEND_ENVAR           "append-env"                // requires TWO
 #define PMIX_CLI_UNSET_ENVAR            "unset-env"                 // required
 
 // Info options
@@ -230,7 +230,7 @@ typedef struct {
 #define PMIX_CLI_INFO_PARAM             "param"                     // required
 #define PMIX_CLI_INFO_PARAMS            "params"                    // required
 #define PMIX_CLI_INFO_PATH              "path"                      // required
-#define PMIX_CLI_INFO_VERSION           "show-version"              // required
+#define PMIX_CLI_INFO_VERSION           "show-version"              // optional, up to TWO
 #define PMIX_CLI_INFO_TYPES             "type"                      // required
 #define PMIX_CLI_INFO_COLOR             "color"                     // required
 #define PMIX_CLI_INFO_SHOW_FAILED       "show-failed"               //none
@@ -240,6 +240,26 @@ typedef struct {
 typedef void (*pmix_cmd_line_store_fn_t)(const char *name, const char *option,
                                          pmix_cli_result_t *results);
 
+/* Parse a command line into "results", which the caller has already
+ * constructed (and which may already hold values the caller put there -
+ * those keep a position of -1, see pmix_cli_item_t above).
+ *
+ * "argv" is left untouched; the parser works on a copy, because getopt
+ * reorders the array it is given. "shorts" is the getopt short-option
+ * string, or NULL for a tool that registers none. "storefn" is NULL to
+ * file each occurrence in "results" the ordinary way.
+ *
+ * Returns:
+ *   PMIX_SUCCESS              the command line was parsed; carry on.
+ *   PMIX_OPERATION_SUCCEEDED  the parse is over and the tool has already
+ *                             said its piece (--help, --version): print
+ *                             nothing more and exit successfully.
+ *   PMIX_ERR_SILENT           the command line was refused and the reason
+ *                             has already been printed to stderr: exit
+ *                             without adding a message of your own.
+ *   anything else             a failure with nothing yet reported - say
+ *                             so, e.g. via PMIx_Error_string().
+ */
 PMIX_EXPORT int pmix_cmd_line_parse(char **argv, char *shorts,
                                     struct option myoptions[],
                                     pmix_cmd_line_store_fn_t storefn,
@@ -310,7 +330,8 @@ static inline char* pmix_cmd_line_get_nth_instance(pmix_cli_result_t *results,
         return NULL;
     }
     ninst = PMIx_Argv_count(opt->values);
-    if (ninst < idx) {
+    if (0 > idx || idx >= ninst) {
+        // bound it at both ends, as pmix_cmd_line_get_nth_seq does
         return NULL;
     }
     return opt->values[idx];
@@ -365,9 +386,17 @@ static inline bool pmix_check_cli_option(char *ain, char *bin)
     char **asplit, **bsplit;
     int match, acnt, bcnt;
 
+    if (NULL == ain || NULL == bin) {
+        return false;
+    }
     // protect the input
     a = strdup(ain);
     b = strdup(bin);
+    if (NULL == a || NULL == b) {
+        free(a);
+        free(b);
+        return false;
+    }
 
     /* if there is an '=' in the option, then we only
      * check up to that position in the option as
@@ -396,6 +425,16 @@ static inline bool pmix_check_cli_option(char *ain, char *bin)
         bsplit = PMIx_Argv_split(b, '-');
         acnt = PMIx_Argv_count(asplit);
         bcnt = PMIx_Argv_count(bsplit);
+        /* A string that is nothing but separators - "-", "--" - splits to
+         * nothing at all, and the walk below would read that NULL array.
+         * There are no segments, so nothing can match. */
+        if (NULL == asplit || NULL == bsplit) {
+            PMIx_Argv_free(asplit);
+            PMIx_Argv_free(bsplit);
+            free(a);
+            free(b);
+            return false;
+        }
         if (acnt > bcnt) {
             PMIx_Argv_free(asplit);
             PMIx_Argv_free(bsplit);
@@ -481,11 +520,20 @@ static inline char *pmix_cli_qualifier_value(char *qual)
 #define PMIX_CLI_QUALIFIER_VALUE(q) \
     pmix_cli_qualifier_value(q)
 
+/* Convert a "[[[days:]hours:]minutes:]seconds" string to a count of
+ * seconds. A string carrying no fields at all - empty, or nothing but
+ * colons - is no time, and answers zero; reading tmp[sz-1] on it
+ * dereferenced the NULL array that a field-less split returns. */
 static inline unsigned int pmix_convert_string_to_time(const char *t)
 {
     char **tmp = PMIx_Argv_split(t, ':');
     int sz = PMIx_Argv_count(tmp);
     unsigned int tm;
+
+    if (0 == sz) {
+        PMIx_Argv_free(tmp);
+        return 0;
+    }
 
     /* work upwards from the bottom, where the
      * bottom represents seconds, then minutes,

--- a/src/util/pmix_context_fns.c
+++ b/src/util/pmix_context_fns.c
@@ -58,7 +58,7 @@ pmix_status_t pmix_util_check_context_cwd(char **incwd,
 {
     bool good = true;
     const char *tmp;
-    char *cwd = NULL;
+    char *cwd = NULL, *newcwd;
 
     if (NULL == incwd) {
         return PMIX_ERR_BAD_PARAM;
@@ -88,8 +88,15 @@ pmix_status_t pmix_util_check_context_cwd(char **incwd,
         /* If the user didn't specifically ask for it, then it
          was a system-supplied default directory, so it's ok
          to not go there.  Try to go to the $HOME directory
-         instead. */
-        tmp = pmix_home_directory(-1);
+         instead.
+         *
+         * Ask by our own effective uid rather than by a sentinel. Both
+         * spellings take the $HOME shortcut, but they part company when
+         * $HOME is unset: pmix_home_directory() then falls back to the
+         * passwd entry, and there is no passwd entry for (uid_t)-1 - so
+         * the fallback this whole arm exists for never happened in the
+         * one case that needs it. */
+        tmp = pmix_home_directory(geteuid());
         if (NULL != tmp) {
             /* Try $HOME.  Same test as above. */
             if (want_chdir && 0 != chdir(tmp)) {
@@ -97,12 +104,16 @@ pmix_status_t pmix_util_check_context_cwd(char **incwd,
                 return PMIX_ERR_JOB_WDIR_NOT_ACCESSIBLE;
             }
 
-            /* Reset the pwd in this local copy of the
-             context */
-            if (NULL != cwd) {
-                free(cwd);
+            /* Reset the pwd in this local copy of the context. Only
+             * once we have the replacement in hand - handing back a
+             * freed pointer, or a NULL one, is worse than reporting
+             * that we could not get there. */
+            newcwd = strdup(tmp);
+            if (NULL == newcwd) {
+                return PMIX_ERR_OUT_OF_RESOURCE;
             }
-            *incwd = strdup(tmp);
+            free(cwd);
+            *incwd = newcwd;
         }
 
         /* If we couldn't find $HOME, then just take whatever
@@ -118,7 +129,15 @@ pmix_status_t pmix_util_check_context_app(char **incmd,
                                           char **env)
 {
     char *tmp;
-    char *cmd = *incmd;
+    char *cmd;
+
+    /* Screen the input the way our sibling above does - this is handed
+     * an app's cmd, and a spawn request that carries none would reach
+     * strlen() with a NULL. */
+    if (NULL == incmd || NULL == *incmd) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    cmd = *incmd;
 
     /* Here's the possibilities:
 
@@ -134,6 +153,9 @@ pmix_status_t pmix_util_check_context_app(char **incmd,
     */
 
     tmp = pmix_basename(cmd);
+    if (NULL == tmp) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
     if (strlen(tmp) == strlen(cmd)) {
         /* If this is a naked executable -- no relative or absolute
         pathname -- then search the PATH for it */

--- a/src/util/pmix_context_fns.c
+++ b/src/util/pmix_context_fns.c
@@ -38,9 +38,6 @@
 #ifdef HAVE_SYS_PARAM_H
 #    include <sys/param.h>
 #endif
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
 #ifdef HAVE_NETDB_H
 #    include <netdb.h>
 #endif

--- a/src/util/pmix_context_fns.h
+++ b/src/util/pmix_context_fns.h
@@ -31,10 +31,44 @@
 
 BEGIN_C_DECLS
 
+/* Move the calling process to the working directory an app asked for,
+ * and report where it ended up.
+ *
+ * "want_chdir" false makes this a no-op that reports success: the only
+ * check performed IS the chdir, so there is nothing to test without it.
+ *
+ * On failure to reach *incwd, what happens next depends on who chose the
+ * directory. If "user_cwd" is set the user named it explicitly, so the
+ * request cannot be honored and PMIX_ERR_JOB_WDIR_NOT_ACCESSIBLE is
+ * returned. Otherwise it was a system-supplied default and going
+ * elsewhere is acceptable: the process moves to $HOME and *incwd is
+ * freed and replaced with a copy of it, so the caller must own the
+ * string it passes in and takes ownership of whatever comes back.
+ *
+ * NOTE that chdir() moves the whole process, not one thread, and this
+ * routine calls getpwuid(), which is not reentrant. Both make it a
+ * caller-serialization problem - see the pmix_context_fns notes in
+ * src/util/AGENTS.md.
+ */
 PMIX_EXPORT pmix_status_t pmix_util_check_context_cwd(char **incwd,
                                                       bool want_chdir,
                                                       bool user_cwd);
 
+/* Resolve an app's executable to something that can actually be run,
+ * and report it back through *incmd.
+ *
+ * A naked filename is searched for along "env"'s PATH, with "cwd" as the
+ * directory relative paths in that PATH resolve against; on success
+ * *incmd is freed and replaced with the full path found, so the caller
+ * must own the string it passes in and takes ownership of the result. A
+ * name that already carries a path is only checked for executability,
+ * and a RELATIVE one is checked against the process's current directory
+ * rather than "cwd" - callers reach here having already moved there with
+ * pmix_util_check_context_cwd().
+ *
+ * Returns PMIX_ERR_JOB_EXE_NOT_FOUND if the search came up empty, or
+ * PMIX_ERR_EXE_NOT_ACCESSIBLE if the named file cannot be executed.
+ */
 PMIX_EXPORT pmix_status_t pmix_util_check_context_app(char **incmd,
                                                       char *cwd,
                                                       char **env);

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -104,7 +104,19 @@ pmix_status_t pmix_environ_merge_inplace(char ***orig, char **adders)
 {
     pmix_status_t ret;
 
-    assert(*orig != environ);
+    /* The header states this as a hard requirement, and for a real
+     * reason: we extend the array with PMIx_Argv_append_nosize(), which
+     * reallocs, and environ may not be realloc'd. This used to be an
+     * assert() - which the shipped build compiles out with -DNDEBUG, so
+     * the one configuration that has to be protected was the one with no
+     * protection at all. Refuse the call instead. */
+    if (environ == *orig) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (NULL == adders) {
+        // nothing to merge in, as pmix_environ_merge() also allows
+        return PMIX_SUCCESS;
+    }
 
     for (size_t adders_idx = 0 ; adders[adders_idx] != NULL ; adders_idx++) {
         const char *adder_string = adders[adders_idx];
@@ -237,7 +249,14 @@ const char *pmix_home_directory(uid_t uid)
 {
     const char *home = NULL;
 
-    if (UINT_MAX == uid || uid == geteuid()) {
+    /* Accept either spelling of "whoever I am": (uid_t)-1 is how a caller
+     * would naturally write it, UINT_MAX is what this has always tested,
+     * and the two coincide only while uid_t is exactly as wide as an int.
+     * Note that anything else falls through to getpwuid(), which has no
+     * entry for a sentinel - so a caller that means its own uid and wants
+     * the $HOME-less fallback to work must say so with one of these or
+     * with its real uid. */
+    if ((uid_t) -1 == uid || UINT_MAX == uid || uid == geteuid()) {
         home = getenv("HOME");
     }
     if (NULL == home) {
@@ -261,7 +280,15 @@ pmix_status_t pmix_util_harvest_envars(char **incvars, char **excvars, pmix_list
     char *cs_env, *string_key;
     bool duplicate;
 
-    /* harvest envars to pass along */
+    /* harvest envars to pass along. A NULL include list means there is
+     * nothing to harvest - the exclusion list below is screened the same
+     * way, and callers (the pgpu components) rely on it. */
+    if (NULL == ilist) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (NULL == incvars) {
+        return PMIX_SUCCESS;
+    }
     for (j = 0; NULL != incvars[j]; j++) {
         bool inc_wild = false;
         len = strlen(incvars[j]);
@@ -289,15 +316,27 @@ pmix_status_t pmix_util_harvest_envars(char **incvars, char **excvars, pmix_list
                 /* see if we already have this envar on the list */
                 duplicate = false;
                 PMIX_LIST_FOREACH (kv, ilist, pmix_kval_t) {
-                    if (PMIX_ENVAR != kv->value->type) {
+                    /* the list is caller-supplied: it may hold kvals of
+                     * other types, and an envar carries no value at all
+                     * unless one was loaded into it */
+                    if (NULL == kv->value || PMIX_ENVAR != kv->value->type ||
+                        NULL == kv->value->data.envar.envar) {
                         continue;
                     }
                     if (0 == strcmp(kv->value->data.envar.envar, cs_env)) {
                         /* if the value is the same, then ignore it */
-                        if (0 != strcmp(kv->value->data.envar.value, string_key)) {
-                            /* otherwise, overwrite the value */
+                        if (NULL == kv->value->data.envar.value ||
+                            0 != strcmp(kv->value->data.envar.value, string_key)) {
+                            /* otherwise, overwrite the value - taking the
+                             * copy first, so a failure leaves the entry
+                             * with the value it had rather than none */
+                            char *newval = strdup(string_key);
+                            if (NULL == newval) {
+                                free(cs_env);
+                                return PMIX_ERR_NOMEM;
+                            }
                             free(kv->value->data.envar.value);
-                            kv->value->data.envar.value = strdup(string_key);
+                            kv->value->data.envar.value = newval;
                         }
                         duplicate = true;
                         break;
@@ -337,8 +376,10 @@ pmix_status_t pmix_util_harvest_envars(char **incvars, char **excvars, pmix_list
                 exc_wild = true;
             }
             PMIX_LIST_FOREACH_SAFE (kv, next, ilist, pmix_kval_t) {
-                /* the list is caller-supplied; only consider envar kvals */
-                if (PMIX_ENVAR != kv->value->type) {
+                /* the list is caller-supplied; only consider envar kvals
+                 * that actually carry a name */
+                if (NULL == kv->value || PMIX_ENVAR != kv->value->type ||
+                    NULL == kv->value->data.envar.envar) {
                     continue;
                 }
                 /* .envar is the bare name, so an exact match ends at the

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -30,6 +30,7 @@
 
 #include "pmix_common.h"
 
+#include <limits.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -216,14 +217,16 @@ pmix_status_t pmix_unsetenv(const char *name, char ***env)
        the array. */
 
     found = false;
-    for (i = 0; (*env)[i] != NULL; ++i) {
-        if (0 != strncmp((*env)[i], compare, len))
+    for (i = 0; NULL != (*env)[i]; ++i) {
+        if (0 != strncmp((*env)[i], compare, len)) {
             continue;
+        }
         if (environ != *env) {
             free((*env)[i]);
         }
-        for (; (*env)[i] != NULL; ++i)
+        for (; NULL != (*env)[i]; ++i) {
             (*env)[i] = (*env)[i + 1];
+        }
         found = true;
         break;
     }
@@ -238,10 +241,16 @@ const char *pmix_tmp_directory(void)
 {
     const char *str;
 
-    if (NULL == (str = getenv("TMPDIR")))
-        if (NULL == (str = getenv("TEMP")))
-            if (NULL == (str = getenv("TMP")))
-                str = PMIX_DEFAULT_TMPDIR;
+    str = getenv("TMPDIR");
+    if (NULL == str) {
+        str = getenv("TEMP");
+    }
+    if (NULL == str) {
+        str = getenv("TMP");
+    }
+    if (NULL == str) {
+        str = PMIX_DEFAULT_TMPDIR;
+    }
     return str;
 }
 

--- a/src/util/pmix_environ.h
+++ b/src/util/pmix_environ.h
@@ -133,12 +133,37 @@ PMIX_EXPORT pmix_status_t pmix_unsetenv(const char *name, char ***env)
     __pmix_attribute_nonnull__(1);
 
 /* A consistent way to retrieve the home and tmp directory on all supported
- * platforms.
+ * platforms. Both return storage owned by the environment or the passwd
+ * database - do not free it, and do not hold it across another call.
+ *
+ * pmix_home_directory() answers $HOME when asked about the calling user,
+ * and otherwise consults the passwd database. "The calling user" may be
+ * written as geteuid(), as (uid_t)-1, or as UINT_MAX. Note that $HOME is
+ * consulted ONLY for the calling user: any other uid goes straight to
+ * getpwuid(), which returns NULL when the uid has no passwd entry (a
+ * container whose /etc/passwd lacks it, or a sentinel handed to it by
+ * mistake), and so does this. getpwuid() is not reentrant.
  */
 PMIX_EXPORT const char *pmix_home_directory(uid_t uid);
 PMIX_EXPORT const char *pmix_tmp_directory(void);
 
-/* Provide a utility for harvesting envars */
+/* Copy environment variables matching "incvars" out of the process
+ * environment and onto "ilist" as PMIX_ENVAR kvals, then drop from that
+ * list any whose name matches "excvars".
+ *
+ * Each entry of either list is the NAME of a variable, matched exactly,
+ * unless it ends in '*' - which makes everything before the '*' a prefix
+ * to match on. That distinction matters: "PATH" takes only PATH, while
+ * "PATH*" also takes PATHFINDER. A list meant as a family of variables
+ * needs the '*'.
+ *
+ * Either list may be NULL: no include list means nothing is harvested,
+ * and no exclude list means nothing is dropped. "ilist" must be a
+ * constructed list, and may already hold entries - an incoming variable
+ * that names one of them overwrites its value rather than adding a
+ * second entry, and entries that are not PMIX_ENVAR kvals are left
+ * alone. The kvals added are owned by the list.
+ */
 PMIX_EXPORT pmix_status_t pmix_util_harvest_envars(char **incvars, char **excvars,
                                                    pmix_list_t *ilist);
 

--- a/src/util/pmix_error.c
+++ b/src/util/pmix_error.c
@@ -22,6 +22,10 @@
 
 #include "src/include/pmix_config.h"
 
+#ifdef HAVE_STRINGS_H
+#    include <strings.h>
+#endif
+
 #include "src/include/pmix_globals.h"
 #include "src/include/pmix_event_strings.h"
 #include "src/util/pmix_error.h"
@@ -30,7 +34,7 @@ PMIX_EXPORT const char *PMIx_Error_string(pmix_status_t errnum)
 {
     size_t n;
 
-    for (n=0; n < PMIX_EVENT_INDEX_BOUNDARY; n++) {
+    for (n = 0; n < PMIX_EVENT_INDEX_BOUNDARY; n++) {
         if (errnum == pmix_event_strings[n].code) {
             return pmix_event_strings[n].name;
         }
@@ -50,7 +54,7 @@ PMIX_EXPORT pmix_status_t PMIx_Error_code(const char *errname)
         return INT32_MIN;
     }
 
-    for (n=0; n < PMIX_EVENT_INDEX_BOUNDARY; n++) {
+    for (n = 0; n < PMIX_EVENT_INDEX_BOUNDARY; n++) {
         if (0 == strcasecmp(pmix_event_strings[n].name, errname)) {
             return pmix_event_strings[n].code;
         }

--- a/src/util/pmix_error.c
+++ b/src/util/pmix_error.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,6 +42,13 @@ PMIX_EXPORT const char *PMIx_Error_string(pmix_status_t errnum)
 PMIX_EXPORT pmix_status_t PMIx_Error_code(const char *errname)
 {
     size_t n;
+
+    /* the table holds no nameless entry, so a NULL name can only be
+     * a name we do not know - say so instead of handing it to
+     * strcasecmp, which would dereference it */
+    if (NULL == errname) {
+        return INT32_MIN;
+    }
 
     for (n=0; n < PMIX_EVENT_INDEX_BOUNDARY; n++) {
         if (0 == strcasecmp(pmix_event_strings[n].name, errname)) {

--- a/src/util/pmix_fd.c
+++ b/src/util/pmix_fd.c
@@ -75,11 +75,11 @@ pmix_status_t pmix_fd_read(int fd, int len, void *buffer)
     }
 
     l2 = len;
-    while (l2 > 0) {
+    while (0 < l2) {
         rc = read(fd, b, l2);
-        if (rc < 0 && (EAGAIN == errno || EINTR == errno)) {
+        if (0 > rc && (EAGAIN == errno || EINTR == errno)) {
             continue;
-        } else if (rc > 0) {
+        } else if (0 < rc) {
             l2 -= rc;
             b += rc;
         } else if (0 == rc) {
@@ -107,11 +107,11 @@ pmix_status_t pmix_fd_write(int fd, int len, const void *buffer)
     }
 
     l2 = len;
-    while (l2 > 0) {
+    while (0 < l2) {
         rc = write(fd, b, l2);
-        if (rc < 0 && (EAGAIN == errno || EINTR == errno)) {
+        if (0 > rc && (EAGAIN == errno || EINTR == errno)) {
             continue;
-        } else if (rc > 0) {
+        } else if (0 < rc) {
             l2 -= rc;
             b += rc;
         } else {
@@ -134,7 +134,7 @@ pmix_status_t pmix_fd_set_cloexec(int fd)
         return PMIX_ERR_IN_ERRNO;
     }
 
-    if (fcntl(fd, F_SETFD, FD_CLOEXEC | flags) == -1) {
+    if (-1 == fcntl(fd, F_SETFD, FD_CLOEXEC | flags)) {
         return PMIX_ERR_IN_ERRNO;
     }
 #endif
@@ -198,13 +198,13 @@ const char *pmix_fd_get_peer_name(int fd)
         return ret;
     }
 
-    if (sa.ss_family == AF_INET) {
+    if (AF_INET == sa.ss_family) {
         struct sockaddr_in *si;
         si = (struct sockaddr_in *) &sa;
         ret = inet_ntop(AF_INET, &(si->sin_addr), str, INET_ADDRSTRLEN);
     }
 #if PMIX_ENABLE_IPV6
-    else if (sa.ss_family == AF_INET6) {
+    else if (AF_INET6 == sa.ss_family) {
         struct sockaddr_in6 *si6;
         si6 = (struct sockaddr_in6 *) &sa;
         ret = inet_ntop(AF_INET6, &(si6->sin6_addr), str, INET6_ADDRSTRLEN);
@@ -245,7 +245,7 @@ void pmix_close_open_file_descriptors(int protected_fd)
     /* grab the fd of the opendir above so we don't close in the
      * middle of the scan. */
     dir_scan_fd = dirfd(dir);
-    if (dir_scan_fd < 0) {
+    if (0 > dir_scan_fd) {
         closedir(dir);
         goto slow;
     }
@@ -260,11 +260,11 @@ void pmix_close_open_file_descriptors(int protected_fd)
          * perfectly good scan for the slow path */
         errno = 0;
         int fd = strtol(files->d_name, NULL, 10);
-        if (errno == EINVAL || errno == ERANGE) {
+        if (EINVAL == errno || ERANGE == errno) {
             closedir(dir);
             goto slow;
         }
-        if (fd >= 3 && (-1 == protected_fd || fd != protected_fd) && fd != dir_scan_fd) {
+        if (3 <= fd && fd != protected_fd && fd != dir_scan_fd) {
             close(fd);
         }
     }

--- a/src/util/pmix_fd.c
+++ b/src/util/pmix_fd.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -39,6 +39,8 @@
 #endif
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #ifdef HAVE_PWD_H
@@ -191,7 +193,7 @@ const char *pmix_fd_get_peer_name(int fd)
 
     rc = getpeername(fd, (struct sockaddr *) &sa, &slt);
     if (0 != rc) {
-        pmix_string_copy(str, "Unknown", sizeof(str) - 1);
+        pmix_string_copy(str, "Unknown", sizeof(str));
         ret = str;
         return ret;
     }
@@ -208,10 +210,14 @@ const char *pmix_fd_get_peer_name(int fd)
         ret = inet_ntop(AF_INET6, &(si6->sin6_addr), str, INET6_ADDRSTRLEN);
     }
 #endif
-    else {
-        // This string is guaranteed to be <= INET_ADDRSTRLEN
+
+    if (NULL == ret) {
+        /* either the family was one we do not render, or inet_ntop
+         * itself failed - and the caller is promised a printable name,
+         * not a pointer it has to check.  This string is guaranteed to
+         * be <= INET_ADDRSTRLEN */
         memset(str, 0, sizeof(str));
-        pmix_string_copy(str, "Unknown", sizeof(str) - 1);
+        pmix_string_copy(str, "Unknown", sizeof(str));
         ret = str;
     }
 
@@ -240,13 +246,19 @@ void pmix_close_open_file_descriptors(int protected_fd)
      * middle of the scan. */
     dir_scan_fd = dirfd(dir);
     if (dir_scan_fd < 0) {
+        closedir(dir);
         goto slow;
     }
 
     while (NULL != (files = readdir(dir))) {
-        if (!isdigit(files->d_name[0])) {
+        if (!isdigit((unsigned char) files->d_name[0])) {
             continue;
         }
+        /* strtol reports failure by setting errno and leaves it alone
+         * otherwise, so it has to start from a known value - reading a
+         * stale EINVAL/ERANGE left by some earlier call would abandon a
+         * perfectly good scan for the slow path */
+        errno = 0;
         int fd = strtol(files->d_name, NULL, 10);
         if (errno == EINVAL || errno == ERANGE) {
             closedir(dir);
@@ -262,7 +274,18 @@ void pmix_close_open_file_descriptors(int protected_fd)
 slow:
     // close *all* file descriptors -- slow
     if (0 > fdmax) {
-        fdmax = sysconf(_SC_OPEN_MAX);
+        long sysmax = sysconf(_SC_OPEN_MAX);
+        /* sysconf answers -1 when the limit is indeterminate, and the
+         * note below records that it can also answer a number no int
+         * can hold.  Clamp while the value is still a long: truncating
+         * such a number into an int can land on a negative, and then
+         * the loop at the bottom closes nothing at all - silently
+         * handing every open descriptor to the exec'd image, which is
+         * the one thing this function exists to prevent */
+        if (0 > sysmax || (long) INT_MAX < sysmax) {
+            sysmax = INT_MAX;
+        }
+        fdmax = (int) sysmax;
     }
     // On some OS's (e.g., macOS), the value returned by
     // sysconf(_SC_OPEN_MAX) can be set by the user via "ulimit -n X",
@@ -277,7 +300,7 @@ slow:
     // there's uncertainty on how the macOS default value works, so we
     // provide the pmix_maxfd MCA var to allow the user to set the max
     // FD value if needed.
-    if (-1 == fdmax || pmix_maxfd < fdmax) {
+    if (pmix_maxfd < fdmax) {
         fdmax = pmix_maxfd;
     }
     for (int fd = 3; fd < fdmax; fd++) {

--- a/src/util/pmix_fd.h
+++ b/src/util/pmix_fd.h
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,11 +31,16 @@ BEGIN_C_DECLS
  * @param buffer Pre-allocated buffer (large enough to hold len bytes)
  *
  * @returns PMIX_SUCCESS upon success.
+ * @returns PMIX_ERR_BAD_PARAM if len is negative.
  * @returns PMIX_ERR_TIMEOUT if the fd closes before reading the full amount.
  * @returns PMIX_ERR_IN_ERRNO otherwise.
  *
  * Loop over reading from the fd until len bytes are read or an error
  * occurs.  EAGAIN and EINTR are transparently handled.
+ *
+ * EAGAIN is handled by retrying immediately, so this must only be
+ * given a *blocking* fd: on a non-blocking one it becomes a spin loop
+ * that burns a core until the peer supplies the data.
  */
 PMIX_EXPORT pmix_status_t pmix_fd_read(int fd, int len, void *buffer);
 
@@ -47,10 +52,12 @@ PMIX_EXPORT pmix_status_t pmix_fd_read(int fd, int len, void *buffer);
  * @param buffer Buffer to write from
  *
  * @returns PMIX_SUCCESS upon success.
+ * @returns PMIX_ERR_BAD_PARAM if len is negative.
  * @returns PMIX_ERR_IN_ERRNO otherwise.
  *
  * Loop over writing to the fd until len bytes are written or an error
- * occurs.  EAGAIN and EINTR are transparently handled.
+ * occurs.  EAGAIN and EINTR are transparently handled - so, as with
+ * pmix_fd_read(), the fd must be a blocking one.
  */
 PMIX_EXPORT pmix_status_t pmix_fd_write(int fd, int len, const void *buffer);
 
@@ -74,7 +81,7 @@ PMIX_EXPORT pmix_status_t pmix_fd_set_cloexec(int fd);
  * @param fd File descriptor
  *
  * @returns true if "fd" points to a regular file.
- * @returns false otherwise.
+ * @returns false otherwise (including when "fd" cannot be fstat'd).
  */
 PMIX_EXPORT bool pmix_fd_is_regular(int fd);
 
@@ -83,8 +90,8 @@ PMIX_EXPORT bool pmix_fd_is_regular(int fd);
  *
  * @param fd File descriptor
  *
- * @returns true if "fd" points to a regular file.
- * @returns false otherwise.
+ * @returns true if "fd" points to a character device.
+ * @returns false otherwise (including when "fd" cannot be fstat'd).
  */
 PMIX_EXPORT bool pmix_fd_is_chardev(int fd);
 
@@ -93,19 +100,51 @@ PMIX_EXPORT bool pmix_fd_is_chardev(int fd);
  *
  * @param fd File descriptor
  *
- * @returns true if "fd" points to a regular file.
- * @returns false otherwise.
+ * @returns true if "fd" points to a block device.
+ * @returns false otherwise (including when "fd" cannot be fstat'd).
  */
 PMIX_EXPORT bool pmix_fd_is_blkdev(int fd);
 
 /**
- * Close all open sockets other than stdin/out/err prior to
- * exec'ing a new binary
+ * Close all open file descriptors other than stdin/out/err prior to
+ * exec'ing a new binary.
+ *
+ * @param protected_fd An additional fd to leave open, or -1 for none.
+ *
+ * Where the OS lists the process's open descriptors (/dev/fd,
+ * /proc/self/fd) only those are closed.  Everywhere else this falls
+ * back to closing every fd below a bound, which is the smaller of
+ * sysconf(_SC_OPEN_MAX) and the pmix_maxfd MCA parameter - see the
+ * comment on that fallback for why the cap is needed.
  */
 PMIX_EXPORT void pmix_close_open_file_descriptors(int protected_fd);
 
+/**
+ * Return a printable form of the address at the far end of a socket.
+ *
+ * @param fd A connected socket.
+ *
+ * @returns A NUL-terminated string, never NULL.  A peer that cannot be
+ * named - getpeername failed, or the address family is not one this
+ * renders - comes back as "Unknown" rather than as an error.
+ *
+ * The string lives in a single file-static buffer, so the result is
+ * only valid until the next call and this is not safe to call from two
+ * threads at once.  Copy it if you need to keep it.
+ */
 PMIX_EXPORT const char *pmix_fd_get_peer_name(int fd);
 
+/**
+ * dup2(2) with the standard streams named by number.
+ *
+ * @param src The fd to duplicate.
+ * @param target 0, 1 or 2 to mean stdin/stdout/stderr as this process's
+ * stdio actually has them, or any other fd number to pass straight to
+ * dup2().
+ *
+ * @returns whatever dup2() returned: the new descriptor, or -1 with
+ * errno set.  Note this is NOT a pmix_status_t.
+ */
 PMIX_EXPORT int pmix_fd_dup2(int src, int target);
 
 END_C_DECLS

--- a/src/util/pmix_few.c
+++ b/src/util/pmix_few.c
@@ -31,6 +31,7 @@
 #endif
 
 #include "pmix_common.h"
+#include "src/include/pmix_globals.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_basename.h"
 #include "src/util/pmix_few.h"
@@ -85,6 +86,11 @@ PMIX_EXPORT pmix_status_t pmix_few(char *argv[], int *status)
 
     return PMIX_SUCCESS;
 #else
+    /* nothing here to fork with.  Both parameters go unread, and this
+     * tree builds with -Wextra -Werror, so say so explicitly - a
+     * platform that takes this branch would otherwise not compile the
+     * file at all */
+    PMIX_HIDE_UNUSED_PARAMS(argv, status);
     return PMIX_ERR_NOT_SUPPORTED;
 #endif
 }

--- a/src/util/pmix_few.c
+++ b/src/util/pmix_few.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,7 +18,7 @@
  * $HEADER$
  */
 
-#include "pmix_config.h"
+#include "src/include/pmix_config.h"
 
 #include <errno.h>
 #include <stdio.h>
@@ -35,7 +35,7 @@
 #include "src/util/pmix_basename.h"
 #include "src/util/pmix_few.h"
 
-int pmix_few(char *argv[], int *status)
+PMIX_EXPORT pmix_status_t pmix_few(char *argv[], int *status)
 {
 #if defined(HAVE_FORK) && defined(HAVE_EXECVE) && defined(HAVE_WAITPID)
     pid_t pid, ret;
@@ -48,7 +48,13 @@ int pmix_few(char *argv[], int *status)
 
     else if (0 == pid) {
         execvp(argv[0], argv);
-        exit(errno);
+        /* _exit, not exit: the child shares the parent's stdio buffers,
+         * and exit() flushes them - so anything the parent had written
+         * but not yet flushed goes out a second time, from here.  It
+         * also runs atexit handlers registered by the parent, which in
+         * a threaded process can deadlock on a lock some other thread
+         * held at fork time. */
+        _exit(errno);
     }
 
     /* Parent loops waiting for the child to die. */

--- a/src/util/pmix_few.c
+++ b/src/util/pmix_few.c
@@ -21,7 +21,6 @@
 #include "src/include/pmix_config.h"
 
 #include <errno.h>
-#include <stdio.h>
 #ifdef HAVE_SYS_WAIT_H
 #    include <sys/wait.h>
 #endif
@@ -32,8 +31,6 @@
 
 #include "pmix_common.h"
 #include "src/include/pmix_globals.h"
-#include "src/util/pmix_argv.h"
-#include "src/util/pmix_basename.h"
 #include "src/util/pmix_few.h"
 
 PMIX_EXPORT pmix_status_t pmix_few(char *argv[], int *status)
@@ -41,7 +38,7 @@ PMIX_EXPORT pmix_status_t pmix_few(char *argv[], int *status)
 #if defined(HAVE_FORK) && defined(HAVE_EXECVE) && defined(HAVE_WAITPID)
     pid_t pid, ret;
 
-    if ((pid = fork()) < 0) {
+    if (0 > (pid = fork())) {
         return PMIX_ERROR;
     }
 
@@ -70,7 +67,7 @@ PMIX_EXPORT pmix_status_t pmix_few(char *argv[], int *status)
 
             /* If waitpid was interrupted, loop around again */
 
-            else if (ret < 0) {
+            else if (0 > ret) {
                 if (EINTR == errno) {
                     continue;
                 }

--- a/src/util/pmix_few.h
+++ b/src/util/pmix_few.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,8 +38,9 @@ BEGIN_C_DECLS
  * (see waitpid(2)).
  *
  * @retval PMIX_SUCCESS If the child launched and exited.
- * @retval PMIX_ERROR If a failure occurred, errno should be
- * examined for the specific error.
+ * @retval PMIX_ERROR If the child could not be launched or could not be
+ * waited for; errno should be examined for the specific error.
+ * @retval PMIX_ERR_NOT_SUPPORTED If this platform has no fork/exec.
  *
  * This function forks, execs, and waits for an executable to
  * complete.  The input argv must be a NULL-terminated array (perhaps
@@ -50,12 +51,25 @@ BEGIN_C_DECLS
  * Note that a return of PMIX_SUCCESS does \em not imply that the child
  * process exited successfully -- it simply indicates that the child
  * process exited.  The WIF* macros (see waitpid(2)) should be used to
- * examine the status to see hold the child exited.
+ * examine the status to see how the child exited.
  *
- * \warning This function should not be called if \c orte_init()
- *          or \c MPI_Init() have been called.  This function is not
- *          safe in a multi-threaded environment in which a handler
- *          for \c SIGCHLD has been registered.
+ * \warning \c status is written only when PMIX_SUCCESS is returned.
+ *          On any other return there was no child to wait for and the
+ *          caller's variable is left exactly as it was, so it must not
+ *          be handed to the WIF* macros -- initialize it, and decode it
+ *          only after checking the return code.  Note also that
+ *          \c status is a wait status and not an errno: the reason a
+ *          launch failed is in errno, not in here.
+ *
+ * If the exec itself fails, the child exits carrying errno as its exit
+ * status, so WEXITSTATUS() reports it -- truncated to the low 8 bits,
+ * as every exit status is.
+ *
+ * \warning This function is not safe in a multi-threaded environment,
+ *          nor in one in which a handler for \c SIGCHLD has been
+ *          registered: it waits on its own child by pid, and a SIGCHLD
+ *          handler that reaps indiscriminately will take that child
+ *          before waitpid() can see it.
  */
 PMIX_EXPORT pmix_status_t pmix_few(char *argv[], int *status);
 

--- a/src/util/pmix_getcwd.c
+++ b/src/util/pmix_getcwd.c
@@ -13,7 +13,6 @@
 #include "pmix_common.h"
 
 #include <limits.h>
-#include <stdio.h>
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #    include <unistd.h>

--- a/src/util/pmix_getcwd.h
+++ b/src/util/pmix_getcwd.h
@@ -29,12 +29,15 @@ BEGIN_C_DECLS
  * combination of $PWD and getcwd() to find the current working
  * directory.
  *
- * Use $PWD instead of getcwd() a) if $PWD exists and b) is a valid
- * synonym for the results from getcwd(). If both of these conditions
- * are not met, just fall back and use the results of getcwd().
+ * The result of getcwd() is authoritative. $PWD is consulted, but is
+ * used only when it is textually identical to getcwd(); any difference
+ * (a stale $PWD, or one that preserves the symlink components getcwd()
+ * resolves) falls back to the getcwd() value.
  *
  * @param buf Caller-allocated buffer to put the result
- * @param size Length of the buf array
+ * @param size Length of the buf array, including room for the
+ * terminating NUL. A buffer exactly as long as the path is therefore
+ * too short, and is reported as a truncation.
  *
  * @retval PMIX_ERR_OUT_OF_RESOURCE If an internal malloc() fails, or if
  * the supplied buf buffer was not long enough to hold the full result

--- a/src/util/pmix_getid.c
+++ b/src/util/pmix_getid.c
@@ -20,19 +20,26 @@
  */
 
 /*
- * Buffer safe printf functions for portability to archaic platforms.
+ * Recover the credentials of the process on the far end of a socket.
  */
 
 #include "src/include/pmix_config.h"
 #include "pmix_common.h"
 #include "src/include/pmix_socket_errno.h"
 
+#include <string.h>
 #ifdef HAVE_UNISTD_H
 #    include <unistd.h>
 #endif
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
+/* SO_PEERCRED is what the route below is selected on, so the header
+ * that spells it has to be in scope here and not merely reachable
+ * through some other include's includes: were it to go missing, this
+ * file would quietly compile the getpeereid() route on a platform that
+ * wanted the other one, rather than say anything about it */
+#include <sys/socket.h>
 
 #include "src/include/pmix_globals.h"
 #include "src/util/pmix_error.h"
@@ -40,41 +47,74 @@
 
 #include "src/util/pmix_getid.h"
 
-pmix_status_t pmix_util_getid(int sd, uid_t *uid, gid_t *gid)
-{
-#if defined(SO_PEERCRED)
-#    ifdef HAVE_STRUCT_SOCKPEERCRED_UID
-#        define HAVE_STRUCT_UCRED_UID
-    struct sockpeercred ucred;
-#    else
-    struct ucred ucred;
-#    endif
-    socklen_t crlen = sizeof(ucred);
+/* Which shape of peer credential this platform offers is decided once,
+ * here, because SO_PEERCRED on its own does not answer it: the struct
+ * getsockopt fills is `struct sockpeercred` on OpenBSD and `struct
+ * ucred` elsewhere, and the latter spells its members either uid/gid or
+ * cr_uid/cr_gid. Only a build in which configure recognized one of those
+ * three shapes can take the getsockopt route.
+ *
+ * Deciding it in one place is the point. The declarations used to sit
+ * behind a bare SO_PEERCRED test while the code reading them sat behind
+ * the full condition, so a platform that defines SO_PEERCRED but whose
+ * member probe did not fire - a cross-compile, a sysroot, any configure
+ * test that failed for reasons of its own - did not fall back to
+ * getpeereid() at all. It failed to build: on an incomplete struct
+ * ucred, and on two variables nothing went on to use. */
+#if defined(SO_PEERCRED) && defined(HAVE_STRUCT_SOCKPEERCRED_UID)
+#    define PMIX_HAVE_PEERCRED 1
+#    define PMIX_PEERCRED_T    struct sockpeercred
+#    define PMIX_PEERCRED_UID  uid
+#    define PMIX_PEERCRED_GID  gid
+#elif defined(SO_PEERCRED) && defined(HAVE_STRUCT_UCRED_UID)
+#    define PMIX_HAVE_PEERCRED 1
+#    define PMIX_PEERCRED_T    struct ucred
+#    define PMIX_PEERCRED_UID  uid
+#    define PMIX_PEERCRED_GID  gid
+#elif defined(SO_PEERCRED) && defined(HAVE_STRUCT_UCRED_CR_UID)
+#    define PMIX_HAVE_PEERCRED 1
+#    define PMIX_PEERCRED_T    struct ucred
+#    define PMIX_PEERCRED_UID  cr_uid
+#    define PMIX_PEERCRED_GID  cr_gid
+#else
+#    define PMIX_HAVE_PEERCRED 0
 #endif
 
-#if defined(SO_PEERCRED) && (defined(HAVE_STRUCT_UCRED_UID) || defined(HAVE_STRUCT_UCRED_CR_UID))
-    /* Ignore received 'cred' and validate ucred for socket instead. */
+pmix_status_t pmix_util_getid(int sd, uid_t *uid, gid_t *gid)
+{
+#if PMIX_HAVE_PEERCRED
+    PMIX_PEERCRED_T cred;
+    socklen_t crlen = sizeof(cred);
+
+    /* Ignore any credential the peer sent us and ask the kernel about
+     * the socket instead. */
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "getid: checking getsockopt for peer credentials");
-    if (getsockopt(sd, SOL_SOCKET, SO_PEERCRED, &ucred, &crlen) < 0) {
+    if (getsockopt(sd, SOL_SOCKET, SO_PEERCRED, &cred, &crlen) < 0) {
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "getid: getsockopt SO_PEERCRED failed: %s",
                             strerror(pmix_socket_errno));
         return PMIX_ERR_INVALID_CRED;
     }
-#    if defined(HAVE_STRUCT_UCRED_UID)
-    *uid = ucred.uid;
-    *gid = ucred.gid;
-#    else
-    *uid = ucred.cr_uid;
-    *gid = ucred.cr_gid;
-#    endif
+    /* getsockopt reports back how much it actually wrote. Anything short
+     * of the whole struct leaves the rest of it holding whatever was on
+     * the stack, and these two fields are what a caller decides an
+     * identity on - so refuse the answer rather than hand back a uid
+     * that was never written. */
+    if (crlen < sizeof(cred)) {
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "getid: getsockopt SO_PEERCRED returned %u bytes, expected %u",
+                            (unsigned) crlen, (unsigned) sizeof(cred));
+        return PMIX_ERR_INVALID_CRED;
+    }
+    *uid = cred.PMIX_PEERCRED_UID;
+    *gid = cred.PMIX_PEERCRED_GID;
 
 #elif defined(HAVE_GETPEEREID)
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "getid: checking getpeereid for peer credentials");
     if (0 != getpeereid(sd, uid, gid)) {
-        pmix_output_verbose(2, pmix_globals.debug_output, "getid: getsockopt getpeereid failed: %s",
+        pmix_output_verbose(2, pmix_globals.debug_output, "getid: getpeereid failed: %s",
                             strerror(pmix_socket_errno));
         return PMIX_ERR_INVALID_CRED;
     }

--- a/src/util/pmix_getid.h
+++ b/src/util/pmix_getid.h
@@ -35,4 +35,4 @@ PMIX_EXPORT pmix_status_t pmix_util_getid(int sd, uid_t *uid, gid_t *gid);
 
 END_C_DECLS
 
-#endif /* PMIX_PRINTF_H */
+#endif /* PMIX_GETID_H */

--- a/src/util/pmix_getid.h
+++ b/src/util/pmix_getid.h
@@ -23,7 +23,14 @@
 
 BEGIN_C_DECLS
 
-/* lookup the effective uid and gid of a socket */
+/* Ask the kernel for the credentials of the process on the far end of
+ * the connected socket `sd`, and write them to *uid and *gid.
+ *
+ * Returns PMIX_SUCCESS, in which case both out-parameters have been
+ * written; PMIX_ERR_INVALID_CRED if the descriptor has no credentials
+ * to report, in which case neither has; or PMIX_ERR_NOT_SUPPORTED on a
+ * platform that offers no way to ask. Only a connected AF_UNIX socket
+ * gives a meaningful answer - see src/util/AGENTS.md. */
 PMIX_EXPORT pmix_status_t pmix_util_getid(int sd, uid_t *uid, gid_t *gid);
 
 END_C_DECLS

--- a/src/util/pmix_hash.c
+++ b/src/util/pmix_hash.c
@@ -180,7 +180,9 @@ pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
     pmix_status_t rc;
     pmix_data_array_t *darray;
     pmix_qual_t *qarray;
+    pmix_value_t *newval;
     size_t n, m = 0;
+    int idx;
     pmix_tma_t *const tma = pmix_obj_get_tma(&table->super);
     pmix_keyindex_t *const keyindex = get_keyindex_ptr(kidx);
 
@@ -244,14 +246,26 @@ pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
                             PMIX_NAME_PRINT(&pmix_globals.myid), kin->key, tmp);
                 free(tmp);
             }
-            pmix_bfrops_base_tma_value_release(&hv->value, tma);
         }
-        /* TODO(skg) eventually, we want to eliminate this copy */
-        rc = pmix_bfrops_base_tma_copy_value(&hv->value, kin->value, PMIX_VALUE, tma);
+        /* Make the new copy before letting go of the old one. Releasing
+         * first and then failing to copy leaves this entry in the table
+         * under its key with no value behind it, and nothing downstream
+         * is prepared for that: make_copy() hands the stored value
+         * straight to PMIx_Value_xfer(), which reads src->type without
+         * looking, so the next fetch of this key takes the process down.
+         * Copying first costs one value's worth of storage for the
+         * duration and leaves a failed update with the entry exactly as
+         * it was.
+         * TODO(skg) eventually, we want to eliminate this copy */
+        rc = pmix_bfrops_base_tma_copy_value(&newval, kin->value, PMIX_VALUE, tma);
         if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
+        if (NULL != hv->value) {
+            pmix_bfrops_base_tma_value_release(&hv->value, tma);
+        }
+        hv->value = newval;
         return PMIX_SUCCESS;
     }
 
@@ -269,11 +283,38 @@ pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
         }
         if (0 < m) {
             darray = (pmix_data_array_t*)pmix_tma_malloc(tma, sizeof(pmix_data_array_t));
+            if (PMIX_UNLIKELY(NULL == darray)) {
+                pmix_dstor_release_tma(hv, tma);
+                return PMIX_ERR_NOMEM;
+            }
             /* zero-initialize so a partially-filled array can be safely
              * released by erase_qualifiers() on an error path below */
             darray->array = (pmix_qual_t*)pmix_tma_calloc(tma, m, sizeof(pmix_qual_t));
+            if (PMIX_UNLIKELY(NULL == darray->array)) {
+                pmix_tma_free(tma, darray);
+                pmix_dstor_release_tma(hv, tma);
+                return PMIX_ERR_NOMEM;
+            }
+            /* A pmix_qual_t is not one of the PMIx data types, so there
+             * is no honest value to put here - but the field must not be
+             * left holding whatever the allocator handed back either,
+             * because under the gds/shmem3 TMA that allocator is a
+             * segment other processes map and read. */
+            darray->type = PMIX_UNDEF;
             darray->size = m;
-            hv->qualindex = pmix_pointer_array_add(proc_data->quals, darray);
+            idx = pmix_pointer_array_add(proc_data->quals, darray);
+            if (PMIX_UNLIKELY(0 > idx)) {
+                /* pmix_pointer_array_add answers a negative status when
+                 * it cannot grow, and qualindex is unsigned: storing
+                 * that would give this value an index the array can
+                 * never be asked for, so it would be kept and never
+                 * found again while the store reported success */
+                pmix_tma_free(tma, darray->array);
+                pmix_tma_free(tma, darray);
+                pmix_dstor_release_tma(hv, tma);
+                return PMIX_ERR_OUT_OF_RESOURCE;
+            }
+            hv->qualindex = (uint32_t)idx;
             qarray = (pmix_qual_t*)darray->array;
             for (n=0, m=0; n < nquals; n++) {
                 if (PMIX_INFO_IS_QUALIFIER(&qualifiers[n])) {
@@ -683,6 +724,16 @@ pmix_status_t pmix_hash_remove_data(pmix_hash_table_t *table,
             rc = pmix_hash_table_get_next_key_uint32(table, &id, (void **) &proc_data, node,
                                                      (void **) &node);
         }
+        if (NULL == key) {
+            /* Every proc_data above has been released, but the table is
+             * still holding a pointer to each of them. The per-rank path
+             * below removes its entry before releasing it, and this one
+             * has to do the same or it leaves the table full of freed
+             * objects - a lookup then hands one back and the caller uses
+             * it. It cannot be done inside the loop without invalidating
+             * the iteration, so it is done in one sweep here. */
+            pmix_hash_table_remove_all(table);
+        }
         return PMIX_SUCCESS;
     }
 
@@ -1038,9 +1089,17 @@ static pmix_regattr_input_t* lookup_key(uint32_t inid,
         ptr->string = pmix_tma_strdup(tma, key);
         ptr->type = PMIX_UNDEF; // we don't know what type the user will set
         ptr->description = (char**)pmix_tma_malloc(tma, 2 * sizeof(char*));
-        if (PMIX_UNLIKELY(NULL == ptr->description)) {
-            /* the entry was never handed to the keyindex, so nothing
-             * else will ever free it - release what we took here */
+        if (PMIX_UNLIKELY(NULL == ptr->name || NULL == ptr->string ||
+                          NULL == ptr->description)) {
+            /* An entry whose string did not copy is worse than no entry:
+             * add_to_lookup() declines to index a NULL string, so the
+             * key would be registered under an id nothing can look up by
+             * name - every later reference to it would mint another one -
+             * and make_copy() loads that string as the key it reports to
+             * the application. The entry was never handed to the
+             * keyindex, so nothing else will ever free it: release what
+             * we took here. */
+            pmix_tma_free(tma, ptr->description);
             pmix_tma_free(tma, ptr->name);
             pmix_tma_free(tma, ptr->string);
             pmix_tma_free(tma, ptr);

--- a/src/util/pmix_if.c
+++ b/src/util/pmix_if.c
@@ -33,6 +33,7 @@
 #    include <unistd.h>
 #endif
 #include <errno.h>
+#include <stdlib.h>
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif
@@ -63,6 +64,7 @@
 #include <ctype.h>
 
 #include "src/class/pmix_list.h"
+#include "src/include/pmix_globals.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_net.h"
@@ -176,19 +178,35 @@ int pmix_ifaddrtoname(const char *if_addr, char *if_name, int length)
              intf != (pmix_pif_t *) pmix_list_get_end(&pmix_if_list);
              intf = (pmix_pif_t *) pmix_list_get_next(intf)) {
 
+            /* An entry answers only for its own address family.  A kernel
+             * index carries one pmix_if_list entry per address, so the list
+             * routinely mixes AF_INET and AF_INET6 entries; reading an IPv4
+             * address out of a sockaddr_in6 yields that entry's flow label,
+             * and reading an IPv6 address out of a sockaddr_in yields the
+             * zero padding behind it.  Either way an unrelated entry can
+             * compare equal - "0.0.0.0" matched the first IPv6 entry and
+             * "::" matched the first IPv4 one - so the wrong interface name
+             * was returned and pmix_ifislocal() called a remote node local.
+             * The sibling pmix_ifaddrtokindex() has always screened this.
+             */
+            if (r->ai_family != ((struct sockaddr *) &intf->if_addr)->sa_family) {
+                continue;
+            }
+
             if (AF_INET == r->ai_family) {
                 struct sockaddr_in ipv4;
                 struct sockaddr_in *inaddr;
 
                 inaddr = (struct sockaddr_in *) &intf->if_addr;
-                memcpy(&ipv4, r->ai_addr, r->ai_addrlen);
+                memset(&ipv4, 0, sizeof(ipv4));
+                memcpy(&ipv4, r->ai_addr, MIN((size_t) r->ai_addrlen, sizeof(ipv4)));
 
                 if (inaddr->sin_addr.s_addr == ipv4.sin_addr.s_addr) {
                     pmix_strncpy(if_name, intf->if_name, length - 1);
                     freeaddrinfo(res);
                     return PMIX_SUCCESS;
                 }
-            } else {
+            } else if (AF_INET6 == r->ai_family) {
                 if (IN6_ARE_ADDR_EQUAL(&((struct sockaddr_in6 *) &intf->if_addr)->sin6_addr,
                                        &((struct sockaddr_in6 *) r->ai_addr)->sin6_addr)) {
                     pmix_strncpy(if_name, intf->if_name, length - 1);
@@ -287,8 +305,15 @@ int pmix_ifbegin(void)
     pmix_pif_t *intf;
 
     intf = (pmix_pif_t *) pmix_list_get_first(&pmix_if_list);
-    if (NULL != intf)
+    /* An empty list answers with its sentinel, never with NULL, so the
+     * NULL test this used to make could not fire: if_index was then read
+     * from a pmix_pif_t laid over pmix_if_list's own sentinel, which is
+     * a read well past the end of the pmix_list_t, and the caller began
+     * its walk from whatever that happened to hold.  Every other lookup
+     * in this file already terminates on pmix_list_get_end(). */
+    if (intf != (pmix_pif_t *) pmix_list_get_end(&pmix_if_list)) {
         return intf->if_index;
+    }
     return (-1);
 }
 
@@ -535,9 +560,11 @@ static int parse_ipv4_dots(const char *addr, uint32_t *net, int *dots)
         }
         n[i] = (uint32_t) val;
         /* skip all the . */
-        for (start = end; '\0' != *start; start++)
-            if ('.' != *start)
+        for (start = end; '\0' != *start; start++) {
+            if ('.' != *start) {
                 break;
+            }
+        }
     }
     *dots = i;
     *net = PMIX_PIF_ASSEMBLE_FABRIC(n[0], n[1], n[2], n[3]);
@@ -570,18 +597,27 @@ int pmix_iftupletoaddr(const char *inaddr, uint32_t *net, uint32_t *mask)
                 /* no - must be an int telling us how much of the addr to use: e.g., /16
                  * For more information please read http://en.wikipedia.org/wiki/Subnetwork.
                  */
-                pval = strtol(ptr, NULL, 10);
-                /* a prefix length of 0..32 is valid CIDR: /0 matches
-                 * everything, /32 is an exact host match */
-                if ((pval > 32) || (pval < 0)) {
+                char *endptr;
+                long plen;
+
+                plen = strtol(ptr, &endptr, 10);
+                /* The whole suffix has to be digits, and a prefix length of
+                 * 0..32 is valid CIDR: /0 matches everything, /32 is an
+                 * exact host match.  The endptr test is what keeps a typo
+                 * from being accepted: strtol() answers 0 for a suffix with
+                 * no digits at all ("10.0.0.0/", "10.0.0.0/abc"), and since
+                 * /0 became legal that 0 would be taken as "match
+                 * everything" instead of being reported to the user.
+                 */
+                if (endptr == ptr || '\0' != *endptr || plen > 32 || plen < 0) {
                     pmix_output(0, "pmix_iftupletoaddr: unknown mask");
                     return PMIX_ERR_FABRIC_NOT_PARSEABLE;
                 }
                 /* guard against a 32-bit shift-by-32 (undefined behavior) */
-                if (0 == pval) {
+                if (0 == plen) {
                     *mask = 0;
                 } else {
-                    *mask = 0xFFFFFFFF << (32 - pval);
+                    *mask = 0xFFFFFFFF << (32 - plen);
                 }
             }
         } else {
@@ -763,21 +799,46 @@ void pmix_ifgetaliases(char ***aliases)
 
 #else /* HAVE_STRUCT_SOCKADDR_IN */
 
-/* if we don't have struct sockaddr_in, we don't have traditional
-   ethernet devices.  Just make everything a no-op error call */
+/* If we don't have struct sockaddr_in, we don't have traditional
+ * ethernet devices.  Just make everything a no-op error call.
+ *
+ * Every entry point pmix_if.h declares must appear here, or a platform
+ * that takes this branch fails to link rather than degrading; and every
+ * parameter has to be named as deliberately unread, since this tree
+ * builds -Wextra -Werror.  Neither held before: seven functions were
+ * missing outright and none of the stubs compiled.  No configuration
+ * anyone builds selects this arm, so it gets no compiler coverage --
+ * force the guard false for one object build before believing an edit
+ * here is good.
+ */
 
 int pmix_ifaddrtoname(const char *if_addr, char *if_name, int size)
 {
+    PMIX_HIDE_UNUSED_PARAMS(if_addr, if_name, size);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 int pmix_ifnametoindex(const char *if_name)
 {
+    PMIX_HIDE_UNUSED_PARAMS(if_name);
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+int pmix_ifnametokindex(const char *if_name)
+{
+    PMIX_HIDE_UNUSED_PARAMS(if_name);
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+int pmix_ifaddrtokindex(const char *if_addr)
+{
+    PMIX_HIDE_UNUSED_PARAMS(if_addr);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 int pmix_ifindextokindex(int if_index)
 {
+    PMIX_HIDE_UNUSED_PARAMS(if_index);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
@@ -793,46 +854,88 @@ int pmix_ifbegin(void)
 
 int pmix_ifnext(int if_index)
 {
+    PMIX_HIDE_UNUSED_PARAMS(if_index);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 int pmix_ifindextoname(int if_index, char *if_name, int length)
 {
+    PMIX_HIDE_UNUSED_PARAMS(if_index, if_name, length);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 int pmix_ifkindextoname(int kif_index, char *if_name, int length)
 {
+    PMIX_HIDE_UNUSED_PARAMS(kif_index, if_name, length);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 int pmix_ifindextoaddr(int if_index, struct sockaddr *if_addr, unsigned int length)
 {
+    PMIX_HIDE_UNUSED_PARAMS(if_index, if_addr, length);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-int pmix_ifindextomask(int if_index, uint32_t *if_addr, int length)
+int pmix_ifkindextoaddr(int if_kindex, struct sockaddr *if_addr, unsigned int length)
 {
+    PMIX_HIDE_UNUSED_PARAMS(if_kindex, if_addr, length);
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+int pmix_ifindextomask(int if_index, uint32_t *if_mask, int length)
+{
+    PMIX_HIDE_UNUSED_PARAMS(if_index, if_mask, length);
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+int pmix_ifindextomac(int if_index, uint8_t mac[6])
+{
+    PMIX_HIDE_UNUSED_PARAMS(if_index, mac);
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+int pmix_ifindextomtu(int if_index, int *mtu)
+{
+    PMIX_HIDE_UNUSED_PARAMS(if_index, mtu);
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+int pmix_ifindextoflags(int if_index, uint32_t *if_flags)
+{
+    PMIX_HIDE_UNUSED_PARAMS(if_index, if_flags);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 bool pmix_ifislocal(const char *hostname)
 {
+    PMIX_HIDE_UNUSED_PARAMS(hostname);
     return false;
 }
 
+/* This one must not answer PMIX_SUCCESS: it leaves *net and *mask
+ * untouched, and a caller that trusts the return code then reads
+ * whatever it had in them. */
 int pmix_iftupletoaddr(const char *inaddr, uint32_t *net, uint32_t *mask)
 {
-    return 0;
+    PMIX_HIDE_UNUSED_PARAMS(inaddr, net, mask);
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+bool pmix_ifisloopback(int if_index)
+{
+    PMIX_HIDE_UNUSED_PARAMS(if_index);
+    return false;
 }
 
 int pmix_ifmatches(int idx, char **nets)
 {
+    PMIX_HIDE_UNUSED_PARAMS(idx, nets);
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
 void pmix_ifgetaliases(char ***aliases)
 {
+    PMIX_HIDE_UNUSED_PARAMS(aliases);
     return;
 }
 

--- a/src/util/pmix_if.h
+++ b/src/util/pmix_if.h
@@ -124,7 +124,8 @@ PMIX_EXPORT int pmix_ifindextokindex(int if_index);
 PMIX_EXPORT int pmix_ifcount(void);
 
 /**
- *  Returns the index of the first available interface.
+ *  Returns the index of the first available interface, or -1 when no
+ *  interface has been discovered.
  */
 PMIX_EXPORT int pmix_ifbegin(void);
 
@@ -227,11 +228,21 @@ PMIX_EXPORT bool pmix_ifislocal(const char *hostname);
 /**
  * Convert a dot-delimited network tuple to an IP address
  *
+ * The tuple may be partial ("192.168"), in which case the mask is
+ * inferred from the number of dots, or it may carry an explicit
+ * "/N" prefix length or "/a.b.c.d" dotted netmask.
+ *
+ * Note that the mask handed back here is a real bit mask in *host*
+ * byte order -- unlike pmix_ifindextomask(), which yields a CIDR
+ * prefix length.
+ *
  * @param addr (IN) character string tuple
- * @param net (IN) Pointer to returned network address
- * @param mask (IN) Pointer to returned netmask
+ * @param net (OUT) Pointer to returned network address; may be NULL
+ * @param mask (OUT) Pointer to returned netmask; may be NULL
  * @return PMIX_SUCCESS if no problems encountered
- * @return PMIX_ERROR if data could not be released
+ * @return PMIX_ERR_FABRIC_NOT_PARSEABLE if the tuple, the prefix
+ *         length, or the dotted netmask is malformed.  Neither
+ *         out-parameter can be relied on in that case.
  */
 PMIX_EXPORT int pmix_iftupletoaddr(const char *addr, uint32_t *net, uint32_t *mask);
 

--- a/src/util/pmix_keyval_parse.c
+++ b/src/util/pmix_keyval_parse.c
@@ -24,6 +24,7 @@
 #include "src/include/pmix_config.h"
 
 #include <ctype.h>
+#include <errno.h>
 #include <string.h>
 
 #include "pmix_common.h"
@@ -46,13 +47,27 @@ static int parse_line_new(const char *filename, int first_val,
 static void parse_error(int num, const char *filename);
 
 static char *env_str = NULL;
-static int envsize = 1024;
+#define PMIX_KEYVAL_ENV_STR_INIT 1024
+static int envsize = PMIX_KEYVAL_ENV_STR_INIT;
 
 void pmix_util_keyval_parse_finalize(void)
 {
     free(key_buffer);
     key_buffer = NULL;
     key_buffer_len = 0;
+
+    /* env_str accumulates the -x directives of every file parsed, and is
+     * normally handed off - and freed - by
+     * pmix_util_keyval_save_internal_envars().  That hand-off does not
+     * always happen: pmix_mca_base_var_cache_files() returns on the first
+     * file that fails to parse, before it reaches the store.  Leaving the
+     * string standing is worse than a leak, because everything in this
+     * file is process-global and pmix_init_util() runs again after
+     * pmix_finalize_util() - a surviving env_str hands the next run the
+     * previous run's variables. */
+    free(env_str);
+    env_str = NULL;
+    envsize = PMIX_KEYVAL_ENV_STR_INIT;
 
     PMIX_DESTRUCT(&keyval_mutex);
 }
@@ -68,6 +83,7 @@ int pmix_util_keyval_parse(const char *filename, pmix_keyval_parse_fn_t callback
                            void *cbdata)
 {
     int val;
+    int rc;
     int ret = PMIX_SUCCESS;
 
     pmix_mutex_lock(&keyval_mutex);
@@ -75,6 +91,18 @@ int pmix_util_keyval_parse(const char *filename, pmix_keyval_parse_fn_t callback
     /* Open the pmix */
     pmix_util_keyval_yyin = fopen(filename, "r");
     if (NULL == pmix_util_keyval_yyin) {
+        /* Our caller treats PMIX_ERR_NOT_FOUND as "there is no such file,
+         * carry on", which is right for the default parameter files since
+         * most systems have none of them.  It is not right for a file that
+         * is there and could not be read - a permission problem or an
+         * exhausted descriptor table discards every parameter in it and
+         * looks exactly like the file never existing.  Keep the return
+         * code, since failing startup over an unreadable optional dotfile
+         * would be worse, but do not let it pass without a word. */
+        if (ENOENT != errno) {
+            pmix_output(0, "keyval parser: cannot read file %s: %s", filename,
+                        strerror(errno));
+        }
         ret = PMIX_ERR_NOT_FOUND;
         goto cleanup;
     }
@@ -83,6 +111,7 @@ int pmix_util_keyval_parse(const char *filename, pmix_keyval_parse_fn_t callback
     pmix_util_keyval_yynewlines = 1;
     pmix_util_keyval_init_buffer(pmix_util_keyval_yyin);
     while (!pmix_util_keyval_parse_done) {
+        rc = PMIX_SUCCESS;
         val = pmix_util_keyval_yylex();
         switch (val) {
             case PMIX_UTIL_KEYVAL_PARSE_DONE:
@@ -95,19 +124,31 @@ int pmix_util_keyval_parse(const char *filename, pmix_keyval_parse_fn_t callback
                 break;
 
             case PMIX_UTIL_KEYVAL_PARSE_SINGLE_WORD:
-                parse_line(filename, callback, cbdata);
+                rc = parse_line(filename, callback, cbdata);
                 break;
 
             case PMIX_UTIL_KEYVAL_PARSE_MCAVAR:
             case PMIX_UTIL_KEYVAL_PARSE_ENVVAR:
             case PMIX_UTIL_KEYVAL_PARSE_ENVEQL:
-                parse_line_new(filename, val, callback, cbdata);
+                rc = parse_line_new(filename, val, callback, cbdata);
                 break;
 
             default:
                 /* anything else is an error */
                 parse_error(1, filename);
+                rc = PMIX_ERROR;
                 break;
+        }
+        /* A malformed line is reported to the user by parse_error() and the
+         * rest of the file is still read - that is long-standing behavior
+         * and callers depend on a typo not aborting startup.  Running out
+         * of memory is different: the line was dropped without a word to
+         * anyone, nothing after it can succeed, and our caller
+         * (pmix_mca_base_var_cache_files) acts on this return code but was
+         * being told the file parsed cleanly. */
+        if (PMIX_ERR_OUT_OF_RESOURCE == rc) {
+            ret = rc;
+            break;
         }
     }
     fclose(pmix_util_keyval_yyin);
@@ -340,6 +381,9 @@ static int parse_line_new(const char *filename, int first_val,
             if (PMIX_UTIL_KEYVAL_PARSE_VALUE == val) {
                 if (NULL != pmix_util_keyval_yytext) {
                     tmp = strdup(pmix_util_keyval_yytext);
+                    if (NULL == tmp) {
+                        return PMIX_ERR_OUT_OF_RESOURCE;
+                    }
                     if ('\'' == tmp[0] || '\"' == tmp[0]) {
                         trim_name(tmp, "\'", "\'");
                         trim_name(tmp, "\"", "\"");
@@ -357,7 +401,10 @@ static int parse_line_new(const char *filename, int first_val,
 
             val = pmix_util_keyval_yylex();
             if (PMIX_UTIL_KEYVAL_PARSE_VALUE == val) {
-                add_to_env_str(key_buffer, pmix_util_keyval_yytext);
+                rc = add_to_env_str(key_buffer, pmix_util_keyval_yytext);
+                if (PMIX_SUCCESS != rc) {
+                    return rc;
+                }
             } else {
                 parse_error(5, filename);
                 return PMIX_ERROR;
@@ -365,7 +412,10 @@ static int parse_line_new(const char *filename, int first_val,
         } else if (PMIX_UTIL_KEYVAL_PARSE_ENVVAR == val) {
             trim_name(key_buffer, "-x", "=");
             trim_name(key_buffer, "--x", NULL);
-            add_to_env_str(key_buffer, NULL);
+            rc = add_to_env_str(key_buffer, NULL);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
         } else {
             /* we got something unexpected.  Bonk! */
             parse_error(6, filename);

--- a/src/util/pmix_keyval_parse.h
+++ b/src/util/pmix_keyval_parse.h
@@ -54,14 +54,47 @@ typedef void (*pmix_keyval_parse_fn_t)(const char *file, int lineno,
  * called exactly once, with \c cbdata passed through untouched.  In a
  * multithreaded context, calls to pmix_util_keyval_parse() will
  * serialize multiple calls.
+ *
+ * The callback runs with that serializing lock held, so it must not
+ * call back into any function declared here - the lock is not
+ * recursive and doing so deadlocks the caller against itself.
+ *
+ * @return PMIX_SUCCESS if the file was read to the end.  A malformed
+ *         line does not change this: it is reported on stderr, is
+ *         skipped, and parsing continues, because a typo in an
+ *         optional parameter file has never been allowed to abort
+ *         startup.
+ * @return PMIX_ERR_NOT_FOUND if the file could not be opened.  This is
+ *         the ordinary answer for the default parameter files, most of
+ *         which do not exist; a file that is present but unreadable is
+ *         reported on stderr before answering the same way.
+ * @return PMIX_ERR_OUT_OF_RESOURCE if the parse ran out of memory, in
+ *         which case the remainder of the file was not read.
  */
 PMIX_EXPORT int pmix_util_keyval_parse(const char *filename, pmix_keyval_parse_fn_t callback,
                                        void *cbdata);
 
+/**
+ * Ready this file's process-global state (the serializing lock).
+ * Must be called before the first pmix_util_keyval_parse(); paired
+ * with pmix_util_keyval_parse_finalize(), which releases the lock and
+ * every buffer accumulated since, and may be called again afterwards.
+ */
 PMIX_EXPORT int pmix_util_keyval_parse_init(void);
 
 PMIX_EXPORT void pmix_util_keyval_parse_finalize(void);
 
+/**
+ * Hand off the environment variables named by the "-x" directives of
+ * every file parsed so far.
+ *
+ * The parser accumulates them into one ';'-separated string rather
+ * than reporting each as it is seen.  This delivers that string to
+ * \c callback as a single pair under the name
+ * "mca_base_env_list_internal", then releases it - so a second call
+ * with no intervening parse delivers nothing.  It is a no-op, and
+ * still PMIX_SUCCESS, when no "-x" directive has been seen.
+ */
 PMIX_EXPORT int pmix_util_keyval_save_internal_envars(pmix_keyval_parse_fn_t callback,
                                                       void *cbdata);
 

--- a/src/util/pmix_name_fns.c
+++ b/src/util/pmix_name_fns.c
@@ -214,7 +214,15 @@ char *pmix_util_print_rank(const pmix_rank_t vpid)
     } else if (PMIX_RANK_INVALID == vpid) {
         pmix_snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "INVALID");
     } else {
-        pmix_snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "%ld", (long) vpid);
+        /* pmix_rank_t is uint32_t and the reserved band runs from
+         * PMIX_RANK_VALID (UINT32_MAX-50) up, only five of which are
+         * named above - so a value this branch has to render can exceed
+         * LONG_MAX where long is 32 bits, and casting it there is
+         * implementation-defined: the same rank printed as a large
+         * positive number on one platform and a negative one on another.
+         * Render it as what it is. */
+        pmix_snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "%u",
+                      (unsigned int) vpid);
     }
     ptr->cntr++;
     if (PMIX_PRINT_NAME_ARG_NUM_BUFS == ptr->cntr) {

--- a/src/util/pmix_name_fns.c
+++ b/src/util/pmix_name_fns.c
@@ -52,7 +52,12 @@ static pmix_atomic_bool_t fns_init = false;
 static pthread_mutex_t print_args_init_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static pmix_tsd_key_t print_args_tsd_key;
-char *pmix_print_args_null = "NULL";
+/* Handed back when a thread cannot get its buffers.  A writable array
+ * rather than a pointer to a literal: these functions return char *, so
+ * a caller is nominally entitled to write through the answer, and doing
+ * that to a string literal is undefined.  Nothing outside this file
+ * names it. */
+static char pmix_print_args_null[] = "NULL";
 typedef struct {
     char *buffers[PMIX_PRINT_NAME_ARG_NUM_BUFS];
     int cntr;
@@ -103,8 +108,9 @@ static pmix_print_args_buffers_t *get_print_name_buffer(void)
     }
 
     ret = pmix_tsd_getspecific(print_args_tsd_key, (void **) &ptr);
-    if (PMIX_SUCCESS != ret)
+    if (PMIX_SUCCESS != ret) {
         return NULL;
+    }
 
     if (NULL == ptr) {
         ptr = (pmix_print_args_buffers_t *) malloc(sizeof(pmix_print_args_buffers_t));

--- a/src/util/pmix_name_fns.h
+++ b/src/util/pmix_name_fns.h
@@ -26,7 +26,7 @@
 
 #include "src/include/pmix_config.h"
 
-#ifdef HAVE_STDINT_h
+#ifdef HAVE_STDINT_H
 #    include <stdint.h>
 #endif
 
@@ -44,18 +44,43 @@ typedef struct {
 #define PMIX_CHECK_NAMES(a, b) \
     (PMIX_CHECK_NSPACE((a)->nspace, (b)->nspace) && ((a)->rank == (b)->rank || (PMIX_RANK_WILDCARD == (a)->rank || PMIX_RANK_WILDCARD == (b)->rank)))
 
-/* useful define to print name args in output messages */
+/* Useful defines to print name args in output messages.
+ *
+ * All three answer out of a small ring of buffers private to the
+ * calling thread, so the result must never be freed and stays valid
+ * only until the ring wraps around to it again.  The ring holds 16
+ * buffers, but a name print spends *two* of them - one for the rank,
+ * one for the assembled "[nspace,rank]" - so about eight name prints
+ * may be live at once in a single statement.  Nothing in the tree
+ * comes close (two per statement is the most any call site uses), and
+ * exceeding it does not crash: the earliest result quietly becomes a
+ * later one.
+ *
+ * A thread that cannot get its buffers gets a shared, static "NULL"
+ * back instead, so the answer is never a null pointer and is always
+ * safe to hand to a "%s" - but it is not safe to write through.
+ */
 PMIX_EXPORT char *pmix_util_print_name_args(const pmix_proc_t *name);
 #define PMIX_NAME_PRINT(n) pmix_util_print_name_args(n)
 
 PMIX_EXPORT char *pmix_util_print_pname_args(const pmix_name_t *name);
 #define PMIX_PNAME_PRINT(n) pmix_util_print_pname_args(n)
 
+/* Renders the five named reserved ranks by name; anything else, valid
+ * rank or unnamed member of the reserved band, as an unsigned decimal.
+ */
 PMIX_EXPORT char *pmix_util_print_rank(const pmix_rank_t vpid);
 #define PMIX_RANK_PRINT(n) pmix_util_print_rank(n)
 
 #define PMIX_PEER_PRINT(p) pmix_util_print_pname_args(&(p)->info->pname)
 
+/* qsort/bsearch comparator over pmix_proc_t: namespace first, then
+ * rank.  The rank half is an explicit three-way compare rather than a
+ * subtraction, because pmix_rank_t is unsigned and the reserved ranks
+ * sit at the top of its range - a difference reduced mod 2^32 has the
+ * wrong sign whenever two ranks are more than INT_MAX apart, which is
+ * exactly what a sort mixing ordinary and reserved ranks does.
+ */
 PMIX_EXPORT int pmix_util_compare_proc(const void *a, const void *b);
 
 /* reset the one-time initialization of the print-buffer TSD key so that

--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -60,6 +60,7 @@
 #    include <ifaddrs.h>
 #endif
 
+#include "src/include/pmix_globals.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/threads/pmix_tsd.h"
 #include "src/util/pmix_argv.h"
@@ -67,7 +68,12 @@
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_show_help.h"
 
-char *pmix_hostname_unknown = "UNKNOWN";
+/* What every routine here answers when it cannot name an address.  It is
+ * an array rather than a pointer at a string literal because callers are
+ * handed it as a plain char*, and one that writes through it - stripping
+ * a suffix, say, the way this file does to a real answer - would
+ * otherwise be modifying a string literal. */
+static char pmix_hostname_unknown[] = "UNKNOWN";
 
 /* this function doesn't depend on sockaddr_h */
 bool pmix_net_isaddr(const char *name)
@@ -115,58 +121,79 @@ static char *get_hostname_buffer(void)
     int ret;
 
     ret = pmix_tsd_getspecific(hostname_tsd_key, &buffer);
-    if (PMIX_SUCCESS != ret)
+    if (PMIX_SUCCESS != ret) {
         return NULL;
+    }
 
     if (NULL == buffer) {
-        buffer = (void *) calloc((NI_MAXHOST + 1), sizeof(char));
+        buffer = calloc((NI_MAXHOST + 1), sizeof(char));
+        if (NULL == buffer) {
+            return NULL;
+        }
+        /* the buffer is reachable only through the key - if we cannot
+         * bind it there, nothing will ever free it, and every later call
+         * would allocate another one. Hand back the failure instead */
         ret = pmix_tsd_setspecific(hostname_tsd_key, buffer);
+        if (PMIX_SUCCESS != ret) {
+            free(buffer);
+            return NULL;
+        }
     }
 
     return (char *) buffer;
 }
 
-int pmix_net_init(void)
+pmix_status_t pmix_net_setup_private_ipv4(void)
 {
     char **args, *arg;
     uint32_t a, b, c, d, bits, addr;
     int i, j, count, found_bad = 0;
 
+    /* the value arrives from the MCA parameter system, so this cannot be
+     * folded back into pmix_net_init() - that runs from pmix_init_util(),
+     * well before pmix_register_params() gives the variable its value */
+    free(private_ipv4);
+    private_ipv4 = NULL;
+
     args = PMIx_Argv_split(pmix_net_private_ipv4, ';');
-    if (NULL != args) {
-        count = PMIx_Argv_count(args);
-        private_ipv4 = (private_ipv4_t *) calloc((count + 1), sizeof(private_ipv4_t));
-        if (NULL == private_ipv4) {
-            pmix_output(0, "Unable to allocate memory for the private addresses array");
-            PMIx_Argv_free(args);
-            goto do_local_init;
-        }
-        /* j tracks the next slot to fill so that malformed entries are
-         * skipped rather than left as zeroed holes - a zero addr is the
-         * array terminator, so a hole would truncate the list. */
-        for (i = 0, j = 0; i < count; i++) {
-            arg = args[i];
-
-            if (5 != sscanf(arg, "%u.%u.%u.%u/%u", &a, &b, &c, &d, &bits)
-                || (a > 255) || (b > 255) || (c > 255) || (d > 255) || (bits > 32)) {
-                if (0 == found_bad) {
-                    pmix_show_help("help-pmix-util.txt", "malformed net_private_ipv4", true,
-                                   args[i]);
-                    found_bad = 1;
-                }
-                continue;
-            }
-            addr = (a << 24) | (b << 16) | (c << 8) | d;
-            private_ipv4[j].addr = htonl(addr);
-            private_ipv4[j].netmask_bits = bits;
-            j++;
-        }
-        private_ipv4[j].addr = 0;
-        private_ipv4[j].netmask_bits = 0;
-        PMIx_Argv_free(args);
+    if (NULL == args) {
+        return PMIX_SUCCESS;
     }
+    count = PMIx_Argv_count(args);
+    private_ipv4 = (private_ipv4_t *) calloc((count + 1), sizeof(private_ipv4_t));
+    if (NULL == private_ipv4) {
+        PMIx_Argv_free(args);
+        return PMIX_ERR_NOMEM;
+    }
+    /* j tracks the next slot to fill so that malformed entries are
+     * skipped rather than left as zeroed holes - a zero addr is the
+     * array terminator, so a hole would truncate the list. */
+    for (i = 0, j = 0; i < count; i++) {
+        arg = args[i];
 
-do_local_init:
+        if (5 != sscanf(arg, "%u.%u.%u.%u/%u", &a, &b, &c, &d, &bits)
+            || (a > 255) || (b > 255) || (c > 255) || (d > 255) || (bits > 32)) {
+            if (0 == found_bad) {
+                pmix_show_help("help-pmix-util.txt", "malformed net_private_ipv4", true,
+                               args[i]);
+                found_bad = 1;
+            }
+            continue;
+        }
+        addr = (a << 24) | (b << 16) | (c << 8) | d;
+        private_ipv4[j].addr = htonl(addr);
+        private_ipv4[j].netmask_bits = bits;
+        j++;
+    }
+    private_ipv4[j].addr = 0;
+    private_ipv4[j].netmask_bits = 0;
+    PMIx_Argv_free(args);
+
+    return PMIX_SUCCESS;
+}
+
+int pmix_net_init(void)
+{
     return pmix_tsd_key_create(&hostname_tsd_key, hostname_cleanup);
 }
 
@@ -212,7 +239,18 @@ bool pmix_net_islocalhost(const struct sockaddr *addr)
     case AF_INET6: {
         const struct sockaddr_in6 *inaddr = (struct sockaddr_in6 *) addr;
         if (IN6_IS_ADDR_LOOPBACK(&inaddr->sin6_addr)) {
-            return true; /* Bug, FIXME: check for 127.0.0.1/8 */
+            return true;
+        }
+        /* an IPv4-mapped address carries an ordinary IPv4 address in its
+         * low 32 bits, so ::ffff:127.0.0.1 names this host just as surely
+         * as 127.0.0.1 does - answer for the whole 127.0.0.0/8 range the
+         * AF_INET arm above covers */
+        if (IN6_IS_ADDR_V4MAPPED(&inaddr->sin6_addr)) {
+            uint32_t v4;
+            memcpy(&v4, ((const uint8_t *) &inaddr->sin6_addr) + 12, sizeof(v4));
+            if (0x7F000000 == (0xFF000000 & ntohl(v4))) {
+                return true;
+            }
         }
         return false;
     }
@@ -317,19 +355,25 @@ bool pmix_net_samenetwork(const struct sockaddr_storage *addr1,
 
 bool pmix_net_addr_isipv6linklocal(const struct sockaddr *addr)
 {
-#    if PMIX_ENABLE_IPV6
-    struct sockaddr_in6 if_addr;
-#    endif
-
+    /* PMIX_ENABLE_IPV6 does not gate this. It is off by default, but the
+     * pif IPv6 discovery components are gated on the OS rather than on
+     * that flag, so an AF_INET6 address is entirely ordinary in a default
+     * build - and every one of them used to fall through to the default
+     * arm below, which answers "unhandled sa_family" on stream 0 rather
+     * than answering the question. Every other family test in this file
+     * (islocalhost, samenetwork) is likewise unconditional. */
     switch (addr->sa_family) {
-#    if PMIX_ENABLE_IPV6
-    case AF_INET6:
+    case AF_INET6: {
+        struct sockaddr_in6 if_addr;
+
+        memset(&if_addr, 0, sizeof(if_addr));
         if_addr.sin6_family = AF_INET6;
         if (1 != inet_pton(AF_INET6, "fe80::0000", &if_addr.sin6_addr)) {
             return false;
         }
-        return pmix_net_samenetwork((const struct sockaddr_storage *) addr, (const struct sockaddr_storage *) &if_addr, 64);
-#    endif
+        return pmix_net_samenetwork((const struct sockaddr_storage *) addr,
+                                    (const struct sockaddr_storage *) &if_addr, 64);
+    }
     case AF_INET:
         return false;
     default:
@@ -437,6 +481,16 @@ int pmix_net_get_port(const struct sockaddr *addr)
 
 #else /* HAVE_STRUCT_SOCKADDR_IN */
 
+/* No configuration anyone builds selects this arm, so it gets no compiler
+ * coverage: every stub has to name its parameters as deliberately unread,
+ * since the tree builds -Wextra -Werror. Force the guard false for one
+ * "make pmix_net.lo" before believing an edit here is good. */
+
+pmix_status_t pmix_net_setup_private_ipv4(void)
+{
+    return PMIX_SUCCESS;
+}
+
 int pmix_net_init(void)
 {
     return PMIX_SUCCESS;
@@ -449,11 +503,13 @@ int pmix_net_finalize(void)
 
 uint32_t pmix_net_prefix2netmask(uint32_t prefixlen)
 {
+    PMIX_HIDE_UNUSED_PARAMS(prefixlen);
     return 0;
 }
 
 bool pmix_net_islocalhost(const struct sockaddr *addr)
 {
+    PMIX_HIDE_UNUSED_PARAMS(addr);
     return false;
 }
 
@@ -461,26 +517,33 @@ bool pmix_net_samenetwork(const struct sockaddr_storage *addr1,
                           const struct sockaddr_storage *addr2,
                           uint32_t prefixlen)
 {
+    PMIX_HIDE_UNUSED_PARAMS(addr1, addr2, prefixlen);
     return false;
 }
 
 bool pmix_net_addr_isipv6linklocal(const struct sockaddr *addr)
 {
+    PMIX_HIDE_UNUSED_PARAMS(addr);
     return false;
 }
 
 bool pmix_net_addr_isipv4public(const struct sockaddr *addr)
 {
+    PMIX_HIDE_UNUSED_PARAMS(addr);
     return false;
 }
 
 char *pmix_net_get_hostname(const struct sockaddr *addr)
 {
-    return NULL;
+    /* the contract is that a caller may print the answer without checking
+     * it, so this cannot be NULL just because the platform is thin */
+    PMIX_HIDE_UNUSED_PARAMS(addr);
+    return pmix_hostname_unknown;
 }
 
 int pmix_net_get_port(const struct sockaddr *addr)
 {
+    PMIX_HIDE_UNUSED_PARAMS(addr);
     return -1;
 }
 

--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -288,8 +288,10 @@ bool pmix_net_samenetwork(const struct sockaddr_storage *addr1,
             prefixlen = plen;
         }
         struct sockaddr_in inaddr1, inaddr2;
-        /* Use temporary variables and memcpy's so that we don't
-           run into bus errors on Solaris/SPARC */
+        /* Copy into properly aligned locals rather than casting the
+           caller's sockaddr: a struct sockaddr* need not be aligned for
+           the larger family-specific struct, and a misaligned load is a
+           bus error on any strict-alignment architecture */
         memcpy(&inaddr1, addr1, sizeof(inaddr1));
         memcpy(&inaddr2, addr2, sizeof(inaddr2));
         uint32_t netmask = pmix_net_prefix2netmask(prefixlen);
@@ -305,8 +307,10 @@ bool pmix_net_samenetwork(const struct sockaddr_storage *addr1,
         const uint8_t *a6_1, *a6_2;
         uint32_t nbytes, nbits;
 
-        /* Use temporary variables and memcpy's so that we don't
-           run into bus errors on Solaris/SPARC */
+        /* Copy into properly aligned locals rather than casting the
+           caller's sockaddr: a struct sockaddr* need not be aligned for
+           the larger family-specific struct, and a misaligned load is a
+           bus error on any strict-alignment architecture */
         memcpy(&inaddr1, addr1, sizeof(inaddr1));
         memcpy(&inaddr2, addr2, sizeof(inaddr2));
         a6_1 = (const uint8_t *) &inaddr1.sin6_addr;

--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -75,7 +75,7 @@
  * otherwise be modifying a string literal. */
 static char pmix_hostname_unknown[] = "UNKNOWN";
 
-/* this function doesn't depend on sockaddr_h */
+/* this function does not depend on struct sockaddr_in */
 bool pmix_net_isaddr(const char *name)
 {
     struct addrinfo hint, *res = NULL;
@@ -111,8 +111,9 @@ static pmix_tsd_key_t hostname_tsd_key;
 
 static void hostname_cleanup(void *value)
 {
-    if (NULL != value)
+    if (NULL != value) {
         free(value);
+    }
 }
 
 static char *get_hostname_buffer(void)
@@ -146,7 +147,11 @@ static char *get_hostname_buffer(void)
 pmix_status_t pmix_net_setup_private_ipv4(void)
 {
     char **args, *arg;
-    uint32_t a, b, c, d, bits, addr;
+    /* the four octets and the prefix length are read with "%u", which
+     * writes an unsigned int - say so, rather than relying on uint32_t
+     * being spelled that way on the platform being built */
+    unsigned int a, b, c, d, bits;
+    uint32_t addr;
     int i, j, count, found_bad = 0;
 
     /* the value arrives from the MCA parameter system, so this cannot be
@@ -347,7 +352,7 @@ bool pmix_net_samenetwork(const struct sockaddr_storage *addr1,
     }
 
     default:
-        pmix_output(0, "unhandled sa_family %d passed to pmix_samenetwork", a1.sa_family);
+        pmix_output(0, "unhandled sa_family %d passed to pmix_net_samenetwork", a1.sa_family);
     }
 
     return false;
@@ -377,7 +382,7 @@ bool pmix_net_addr_isipv6linklocal(const struct sockaddr *addr)
     case AF_INET:
         return false;
     default:
-        pmix_output(0, "unhandled sa_family %d passed to pmix_net_addr_isipv6linklocal\n",
+        pmix_output(0, "unhandled sa_family %d passed to pmix_net_addr_isipv6linklocal",
                     addr->sa_family);
     }
 
@@ -410,7 +415,7 @@ bool pmix_net_addr_isipv4public(const struct sockaddr *addr)
     }
         return true;
     default:
-        pmix_output(0, "unhandled sa_family %d passed to pmix_net_addr_isipv4public\n",
+        pmix_output(0, "unhandled sa_family %d passed to pmix_net_addr_isipv4public",
                     addr->sa_family);
     }
 
@@ -425,7 +430,7 @@ char *pmix_net_get_hostname(const struct sockaddr *addr)
     char *p;
 
     if (NULL == name) {
-        pmix_output(0, "pmix_net_get_hostname: malloc() failed\n");
+        pmix_output(0, "pmix_net_get_hostname: malloc() failed");
         return pmix_hostname_unknown;
     }
     memset(name, 0, NI_MAXHOST + 1);
@@ -439,7 +444,7 @@ char *pmix_net_get_hostname(const struct sockaddr *addr)
         /* hotfix for netbsd: on my netbsd machine, getnameinfo
            returns an unknown error code. */
         if (NULL == inet_ntop(AF_INET6, &((struct sockaddr_in6 *) addr)->sin6_addr, name, NI_MAXHOST)) {
-            pmix_output(0, "pmix_sockaddr2str failed with error code %d", errno);
+            pmix_output(0, "pmix_net_get_hostname failed with error code %d", errno);
             return pmix_hostname_unknown;
         }
         return name;
@@ -456,7 +461,8 @@ char *pmix_net_get_hostname(const struct sockaddr *addr)
     if (error) {
         /* getnameinfo() returns an EAI_* code directly; decode that,
          * not errno (which it does not generally set) */
-        pmix_output(0, "pmix_sockaddr2str failed:%s (return code %i)\n", gai_strerror(error), error);
+        pmix_output(0, "pmix_net_get_hostname failed: %s (return code %d)",
+                    gai_strerror(error), error);
         return pmix_hostname_unknown;
     }
     /* strip any trailing % data as it isn't pertinent */

--- a/src/util/pmix_net.h
+++ b/src/util/pmix_net.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2007      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2017      Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -164,7 +164,7 @@ PMIX_EXPORT char *pmix_net_get_hostname(const struct sockaddr *addr);
 /**
  * Get port number from struct sockaddr
  *
- * Return the port number (as an integr) from either a struct
+ * Return the port number (as an integer) from either a struct
  * sockaddr_in or a struct sockaddr_in6.
  *
  * @param addr             struct sockaddr containing address

--- a/src/util/pmix_net.h
+++ b/src/util/pmix_net.h
@@ -49,8 +49,9 @@ BEGIN_C_DECLS
  * helper subsystem.
  *
  * @retval PMIX_SUCCESS   Success
- * @retval PMIX_ERR_TEMP_OUT_OF_RESOURCE Not enough memory for static
- *                        buffer creation
+ * @retval PMIX_ERR_OUT_OF_RESOURCE  No thread-specific-data key was
+ *                        available
+ * @retval PMIX_ERR_NOMEM Out of memory
  */
 PMIX_EXPORT int pmix_net_init(void);
 
@@ -66,6 +67,25 @@ PMIX_EXPORT int pmix_net_init(void);
 PMIX_EXPORT int pmix_net_finalize(void);
 
 /**
+ * Parse the pmix_net_private_ipv4 MCA parameter
+ *
+ * Build the table of "private" IPv4 networks that
+ * pmix_net_addr_isipv4public() consults, from the current value of the
+ * pmix_net_private_ipv4 MCA parameter.  This is deliberately *not* part
+ * of pmix_net_init(): that runs from pmix_init_util(), which completes
+ * before pmix_register_params() has given the variable its value, so a
+ * parse there would only ever see the NULL initializer and leave every
+ * address looking public.  Call this once the parameters are registered;
+ * calling it again simply replaces the table.
+ *
+ * @retval PMIX_SUCCESS   Success - including the case where the
+ *                        parameter is empty, which leaves no network
+ *                        classified as private
+ * @retval PMIX_ERR_NOMEM Out of memory
+ */
+PMIX_EXPORT pmix_status_t pmix_net_setup_private_ipv4(void);
+
+/**
  * Calculate netmask in network byte order from CIDR notation
  *
  * @param prefixlen (IN)  CIDR prefixlen
@@ -76,11 +96,12 @@ PMIX_EXPORT uint32_t pmix_net_prefix2netmask(uint32_t prefixlen);
 /**
  * Determine if given IP address is in the localhost range
  *
- * Determine if the given IP address is in the localhost range
- * (127.0.0.0/8), meaning that it can't be used to connect to machines
- * outside the current host.
+ * Determine if the given IP address is in the localhost range, meaning
+ * that it can't be used to connect to machines outside the current host.
+ * That is 127.0.0.0/8 for IPv4, and ::1 or an IPv4-mapped address whose
+ * embedded IPv4 address is itself in 127.0.0.0/8 for IPv6.
  *
- * @param addr             struct sockaddr_in of IP address
+ * @param addr             struct sockaddr of IP address
  * @return                 true if \c addr is a localhost address,
  *                         false otherwise.
  */
@@ -128,7 +149,12 @@ PMIX_EXPORT bool pmix_net_addr_isipv4public(const struct sockaddr *addr);
  *
  * Return the un-resolved address in a string format.  The string will
  * be returned in a per-thread static buffer and should not be freed
- * by the user.
+ * by the user; it is valid until this thread's next call.
+ *
+ * This never returns NULL - an address it cannot render (an unsupported
+ * family, a failed conversion, no memory for the buffer) reads as
+ * "UNKNOWN", so a caller that is about to print the answer does not have
+ * to check it.
  *
  * @param addr              struct sockaddr of address
  * @return                  literal representation of \c addr
@@ -142,7 +168,8 @@ PMIX_EXPORT char *pmix_net_get_hostname(const struct sockaddr *addr);
  * sockaddr_in or a struct sockaddr_in6.
  *
  * @param addr             struct sockaddr containing address
- * @return                 port number from \addr
+ * @return                 port number from \c addr in host byte order,
+ *                         or -1 if it carries neither
  */
 PMIX_EXPORT int pmix_net_get_port(const struct sockaddr *addr);
 

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -52,6 +52,309 @@
 
 static const char path_sep[] = PMIX_PATH_SEP;
 
+/* The flag that opens a directory for *traversal* rather than for
+ * reading it.
+ *
+ * The whole point of the walk below is to hold a descriptor on every
+ * component, and a plain O_RDONLY would demand the read bit on each of
+ * them - which would refuse a traverse-only (0711) intermediate
+ * directory that the old path-based code handled without complaint.
+ * POSIX.1-2008 spells the "execute permission is enough" open O_SEARCH;
+ * Linux spells the same idea O_PATH. Both yield a descriptor that
+ * openat()/mkdirat()/fstatat()/unlinkat() accept as their dirfd, which
+ * is all we ask of an intermediate. Where neither exists we fall back
+ * to O_RDONLY and accept the stricter requirement. */
+#if defined(O_SEARCH)
+#    define PMIX_O_TRAVERSE O_SEARCH
+#elif defined(O_PATH)
+#    define PMIX_O_TRAVERSE O_PATH
+#else
+#    define PMIX_O_TRAVERSE O_RDONLY
+#endif
+
+static int openat_and_close(int dirfd, const char *name, int flags, mode_t mode)
+{
+    int fd, save;
+
+    fd = openat(dirfd, name, flags | O_NOFOLLOW, mode);
+    save = errno;
+    close(dirfd);
+    errno = save;
+    return fd;
+}
+
+/**
+ * Open the trusted root a walk starts from.
+ *
+ * The prefix PMIx is handed - $TMPDIR, PMIX_NSDIR, a user-named output
+ * directory - is taken as given: somebody chose it, and this library is
+ * in no position to second-guess it. So it is resolved the ordinary way,
+ * symlinks and all. That is not a concession: on macOS /tmp, /var and
+ * /etc are root-owned symlinks into /private, so the default PMIx
+ * temporary directory reaches its contents through one, and a walk that
+ * declined a link at every component would decline the platform.
+ *
+ * PMIX_O_TRAVERSE asks only for the execute bit, so a traverse-only
+ * (e.g. 0711) root still works where a plain O_RDONLY would be declined.
+ */
+static int open_trusted_root(const char *root)
+{
+    if (NULL == root || '\0' == root[0]) {
+        errno = EINVAL;
+        return -1;
+    }
+    return open(root, PMIX_O_TRAVERSE | O_DIRECTORY);
+}
+
+/**
+ * Walk `tail` beneath the descriptor `fd`, one component at a time,
+ * refusing a symlink at each. Takes ownership of fd.
+ *
+ * `create` decides whether a missing component is an error or is made.
+ * The last component is opened with `last_flags`; the ones above it need
+ * only be traversable.
+ *
+ * This is the half that O_NOFOLLOW cannot do on its own. O_NOFOLLOW
+ * covers the last component of a name and nothing else - every component
+ * before it is resolved in the ordinary way - so a symlink at any of the
+ * directories PMIx is building through sends everything underneath it
+ * somewhere the caller did not name, and the check on the final
+ * component cannot notice, since it is applied on the far side of that.
+ * Each step here is an openat()/mkdirat() against a descriptor already
+ * held, so a link anywhere along the way is declined rather than walked,
+ * and the descriptor returned is bound to a directory that was reached
+ * without traversing one.
+ */
+static int walk_tail(int fd, const char *tail, bool create, mode_t mode,
+                     int last_flags, bool *last_existed)
+{
+    char **parts;
+    int next, i, len, save;
+
+    if (NULL != last_existed) {
+        *last_existed = false;
+    }
+    parts = PMIx_Argv_split(tail, path_sep[0]);
+    if (NULL == parts) {
+        /* nothing but separators: the caller means the root itself */
+        close(fd);
+        errno = EINVAL;
+        return -1;
+    }
+    len = PMIx_Argv_count(parts);
+
+    for (i = 0; i < len; ++i) {
+        if (create) {
+            if (0 != mkdirat(fd, parts[i], mode)) {
+                if (EEXIST != errno) {
+                    save = errno;
+                    close(fd);
+                    PMIx_Argv_free(parts);
+                    errno = save;
+                    return -1;
+                }
+                if (NULL != last_existed && (len - 1) == i) {
+                    *last_existed = true;
+                }
+            }
+        }
+        next = openat(fd, parts[i],
+                      (((len - 1) == i) ? last_flags : PMIX_O_TRAVERSE)
+                          | O_DIRECTORY | O_NOFOLLOW);
+        save = errno;
+        close(fd);
+        if (0 > next) {
+            PMIx_Argv_free(parts);
+            errno = save;
+            return -1;
+        }
+        fd = next;
+    }
+    PMIx_Argv_free(parts);
+    return fd;
+}
+
+int pmix_os_dirpath_create_under(const char *root, const char *tail,
+                                 const mode_t mode)
+{
+    int fd, rc;
+    bool last_existed = false;
+    struct stat buf;
+
+    if (NULL == root || NULL == tail || '\0' == tail[0]) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    fd = open_trusted_root(root);
+    if (0 > fd) {
+        pmix_show_help("help-pmix-util.txt", "mkdir-failed", true,
+                       root, strerror(errno));
+        return PMIX_ERR_SILENT;
+    }
+    /* the final component is opened O_RDONLY because its mode may have
+     * to be adjusted through this descriptor; fchmod() is not available
+     * on the traverse-only kind */
+    fd = walk_tail(fd, tail, true, mode, O_RDONLY, &last_existed);
+    if (0 > fd) {
+        pmix_show_help("help-pmix-util.txt", "mkdir-failed", true,
+                       tail, strerror(errno));
+        return PMIX_ERR_SILENT;
+    }
+
+    /* The caller is going to use the final directory, so it has to carry
+     * at least the mode asked for. Everything above it needs only to be
+     * traversable, and a traverse-only intermediate is legitimate.
+     *
+     * A failed chmod is tolerated: whether the caller can put files here
+     * is settled by the caller creating one, and the kernel re-runs that
+     * check at open() time regardless. Asking first and acting on the
+     * answer afterwards is the very race this is written to avoid. */
+    if (0 == fstat(fd, &buf) && mode != (mode & buf.st_mode)) {
+        if (0 != fchmod(fd, buf.st_mode | mode)) {
+            pmix_output_verbose(2, pmix_globals.debug_output,
+                                "PATH %s/%s ALREADY EXISTS AND CHMOD FAILED: %s",
+                                root, tail, strerror(errno));
+        }
+    }
+    rc = last_existed ? PMIX_ERR_EXISTS : PMIX_SUCCESS;
+    close(fd);
+    return rc;
+}
+
+int pmix_os_dirpath_open_file_under(const char *root, const char *tail,
+                                    int flags, mode_t mode)
+{
+    char *dir;
+    const char *base;
+    int fd, save;
+
+    if (NULL == root || NULL == tail || '\0' == tail[0]) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    fd = open_trusted_root(root);
+    if (0 > fd) {
+        return -1;
+    }
+
+    base = strrchr(tail, path_sep[0]);
+    if (NULL == base) {
+        /* the file sits directly in the root */
+        base = tail;
+    } else {
+        dir = (char *) malloc((size_t) (base - tail) + 1);
+        if (NULL == dir) {
+            close(fd);
+            errno = ENOMEM;
+            return -1;
+        }
+        memcpy(dir, tail, (size_t) (base - tail));
+        dir[base - tail] = '\0';
+        ++base;
+        if ('\0' == base[0]) {
+            free(dir);
+            close(fd);
+            errno = EISDIR;
+            return -1;
+        }
+        fd = walk_tail(fd, dir, false, 0, PMIX_O_TRAVERSE, NULL);
+        save = errno;
+        free(dir);
+        if (0 > fd) {
+            errno = save;
+            return -1;
+        }
+    }
+
+    fd = openat_and_close(fd, base, flags, mode);
+    return fd;
+}
+
+/**
+ * Open a file, declining a symlink at the file itself.
+ *
+ * O_NOFOLLOW protects the LAST component of a path and nothing else -
+ * every component before it is resolved in the ordinary way, symlinks
+ * included. That split is deliberate here rather than a shortcoming:
+ *
+ *   - The *leaf* is a name PMIx composes out of its own naming scheme.
+ *     A symlink at that name is not something this library put there,
+ *     and following it would land the operation on some unrelated file,
+ *     so O_NOFOLLOW declines it. Pass O_EXCL alongside O_CREAT where the
+ *     name is created fresh, which declines anything already there
+ *     rather than only a link.
+ *
+ *   - The *directory* is handed to PMIx by the system or the admin -
+ *     $TMPDIR, PMIX_NSDIR, a user-named output directory - and symlinks
+ *     along it are ordinary and legitimate. On macOS /tmp, /var and /etc
+ *     are all root-owned symlinks into /private, so the default PMIx
+ *     temporary directory reaches its leaf through one. Refusing those
+ *     would refuse the platform.
+ *
+ * The directory half is handled by pmix_os_dirpath_open_file_under(),
+ * where the caller names the prefix it was given and only the part PMIx
+ * composes beneath it is walked. Use that one wherever PMIx composes a
+ * directory name of its own; this one where it composes only the leaf.
+ *
+ * @param path  The file to open.
+ * @param flags open(2) flags. O_NOFOLLOW is added.
+ * @param mode  open(2) mode, used only when creating.
+ * @retval >=0  A descriptor on the file. The caller closes it.
+ * @retval -1   errno says why.
+ */
+int pmix_os_dirpath_open_file(const char *path, int flags, mode_t mode)
+{
+    char *dir;
+    const char *base;
+    int dirfd, save;
+
+    if (NULL == path || '\0' == path[0]) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    base = strrchr(path, path_sep[0]);
+    if (NULL == base) {
+        /* a bare filename in the current directory */
+        return open(path, flags | O_NOFOLLOW, mode);
+    }
+    if (base == path) {
+        dir = strdup(path_sep);
+    } else {
+        dir = (char *) malloc((size_t) (base - path) + 1);
+        if (NULL != dir) {
+            memcpy(dir, path, (size_t) (base - path));
+            dir[base - path] = '\0';
+        }
+    }
+    if (NULL == dir) {
+        errno = ENOMEM;
+        return -1;
+    }
+    ++base;
+    if ('\0' == base[0]) {
+        /* the name ended in a separator, so it names no file */
+        free(dir);
+        errno = EISDIR;
+        return -1;
+    }
+
+    /* The directory is trusted, so it is resolved the ordinary way.
+     * PMIX_O_TRAVERSE asks only for the execute bit, so a traverse-only
+     * (e.g. 0711) directory still works - which a plain O_RDONLY would
+     * refuse. */
+    dirfd = open(dir, PMIX_O_TRAVERSE | O_DIRECTORY);
+    save = errno;
+    free(dir);
+    if (0 > dirfd) {
+        errno = save;
+        return -1;
+    }
+
+    return openat_and_close(dirfd, base, flags, mode);
+}
+
 /**
  * The named path already exists: make sure it really is a directory,
  * and give it (at least) the requested mode bits.

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -204,7 +204,7 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
 
     len = PMIx_Argv_count(parts);
     for (i = 0; i < len; ++i) {
-        if (i == 0) {
+        if (0 == i) {
             /* If in POSIX-land, ensure that we never end a directory
                name with path_sep */
 
@@ -243,7 +243,7 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
          * final component is the one the caller is going to use, so
          * it has to really be a directory and carry the mode we were
          * asked for */
-        if (i == (len - 1)) {
+        if ((len - 1) == i) {
             ret = dirpath_ensure_mode(tmp, mode);
             if (PMIX_SUCCESS != ret) {
                 if (PMIX_ERR_NOT_FOUND == ret) {
@@ -466,7 +466,7 @@ bool pmix_os_dirpath_is_empty(const char *path)
         /* fdopendir() takes ownership of fd; closedir() will close it */
         dp = fdopendir(fd);
         if (NULL != dp) {
-            while ((ep = readdir(dp))) {
+            while (NULL != (ep = readdir(dp))) {
                 if ((0 != strcmp(ep->d_name, ".")) && (0 != strcmp(ep->d_name, ".."))) {
                     closedir(dp);
                     return false;

--- a/src/util/pmix_os_dirpath.c
+++ b/src/util/pmix_os_dirpath.c
@@ -131,6 +131,14 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
     if (NULL == path) { /* protect ourselves from errors */
         return (PMIX_ERR_BAD_PARAM);
     }
+    /* an empty path names nothing, and mkdir("") answers ENOENT - which
+     * is the "build the tree" signal below, where an empty path splits
+     * to no components at all and the whole loop is skipped. Left to
+     * itself this function therefore reported that it had created a
+     * directory tree while doing nothing whatsoever */
+    if ('\0' == path[0]) {
+        return (PMIX_ERR_BAD_PARAM);
+    }
 
     /* try to make directory */
     if (0 == mkdir(path, mode)) {
@@ -164,9 +172,24 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
     /* Split the requested path up into its individual parts */
 
     parts = PMIx_Argv_split(path, path_sep[0]);
+    if (NULL == parts) {
+        /* the path is neither empty nor made only of separators - the
+         * first is screened above and the second would have answered
+         * EEXIST at the mkdir - so the split is what ran out of memory.
+         * Saying so matters: a zero-component walk skips the loop
+         * entirely and would otherwise report success */
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
 
     /* Ensure to allocate enough space for tmp: the strlen of the
-       incoming path + 1 (for \0) */
+       incoming path + 1 (for \0).
+       That bound is exact rather than generous: the assembled name has
+       one separator between consecutive components, and every one of
+       those was a separator in the input, so it can only ever be
+       shorter than the input - repeated separators collapse, since
+       PMIx_Argv_split() drops the empty fields between them. That also
+       means no component is empty, which is what lets the tmp[strlen-1]
+       read below be safe from the second iteration on. */
 
     tmp = (char *) calloc((strlen(path) + 1), sizeof(char));
     if (NULL == tmp) {
@@ -185,7 +208,7 @@ int pmix_os_dirpath_create(const char *path, const mode_t mode)
             /* If in POSIX-land, ensure that we never end a directory
                name with path_sep */
 
-            if ('/' == path[0]) {
+            if (path_sep[0] == path[0]) {
                 strcat(tmp, path_sep);
             }
             strcat(tmp, parts[i]);
@@ -407,18 +430,20 @@ int pmix_os_dirpath_destroy(const char *path, bool recursive,
     exit_status = dirpath_destroy_at(fd, path, recursive, cbfunc);
 
     /*
-     * If the directory is empty, then remove it - but
-     * leave the system tmpdir alone unless we created it!
+     * If the directory is empty, then remove it - but leave the system
+     * tmpdir alone unless we created it!
+     *
+     * Releasing pmix_ptl_base.system_tmpdir here is not this function's
+     * to do, and it aliased its own argument: the only caller that
+     * reaches the second arm passes that very string, so the free left
+     * "path" dangling for the rest of the function and survived only
+     * because nothing read it again. pmix_ptl_base_close() frees it on
+     * the line after the call regardless.
      */
     if (NULL == pmix_server_globals.system_tmpdir ||
-        0 != strcmp(path, pmix_server_globals.system_tmpdir)) {
+        0 != strcmp(path, pmix_server_globals.system_tmpdir) ||
+        pmix_ptl_base.created_system_tmpdir) {
         rmdir(path);
-    } else if (NULL != pmix_server_globals.system_tmpdir &&
-               0 == strcmp(path, pmix_server_globals.system_tmpdir) &&
-               pmix_ptl_base.created_system_tmpdir) {
-        rmdir(path);
-        free(pmix_ptl_base.system_tmpdir);
-        pmix_ptl_base.system_tmpdir = NULL;
     }
     return exit_status;
 }
@@ -458,7 +483,8 @@ bool pmix_os_dirpath_is_empty(const char *path)
 }
 
 /**
- * Stale function left for PRRTE backward compatility
+ * Stale function left for PRRTE backward compatibility - see the header
+ * for why it must stay a no-op.
  */
 int pmix_os_dirpath_access(const char *path, const mode_t mode)
 {

--- a/src/util/pmix_os_dirpath.h
+++ b/src/util/pmix_os_dirpath.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,8 +55,16 @@ BEGIN_C_DECLS
  * directories being constructed.
  * @retval PMIX_SUCCESS If the directory tree has been successfully created with
  * the specified access permissions.
- * @retval PMIX_ERROR If the directory tree could not be created with the
- * specified access permissions.
+ * @retval PMIX_ERR_EXISTS If the final directory was already there. It carries
+ * at least the requested permissions, so this is a usable directory and most
+ * callers treat it exactly as they treat PMIX_SUCCESS - but they have to test
+ * for it, since it is not PMIX_SUCCESS. The distinction is what tells a caller
+ * whether it is the one that must clean the directory up afterwards.
+ * @retval PMIX_ERR_BAD_PARAM If path is NULL or empty.
+ * @retval PMIX_ERR_OUT_OF_RESOURCE If memory ran out while building the tree.
+ * @retval PMIX_ERR_SILENT If the tree could not be created - because something
+ * that is not a directory occupies the name, or the OS refused. A message has
+ * already been displayed to the user; the caller must not display another.
  */
 
 PMIX_EXPORT int pmix_os_dirpath_create(const char *path, const mode_t mode);
@@ -64,15 +72,25 @@ PMIX_EXPORT int pmix_os_dirpath_create(const char *path, const mode_t mode);
 /**
  * Check to see if a directory is empty
  *
+ * A directory that cannot be opened as a directory - it does not exist, it is
+ * a plain file, it is a symlink, or it is unreadable - answers false, on the
+ * grounds that the answer is normally used to decide whether to remove the
+ * thing, and none of those may be removed on the strength of this call. A NULL
+ * path answers true, there being nothing in it.
+ *
  * @param path A pointer to a string that contains the path name to be checked.
  *
- * @retval true If the directory is empty
- * @retval false If the directory is not empty
+ * @retval true If the directory is empty, or path is NULL
+ * @retval false If the directory is not empty, or could not be read
  */
 PMIX_EXPORT bool pmix_os_dirpath_is_empty(const char *path);
 
 /**
- * Stale function left for PRRTE backward compatility
+ * Stale function left for PRRTE backward compatibility. It is a no-op that
+ * always answers PMIX_SUCCESS, and it must stay one: asking whether a
+ * directory is writable and then acting on the answer is a time-of-check /
+ * time-of-use race that no spelling of access()/faccessat() can close.
+ * Whether files can be placed in a directory is settled by placing one.
  */
 PMIX_EXPORT int pmix_os_dirpath_access(const char *path, const mode_t mode);
 

--- a/src/util/pmix_os_dirpath.h
+++ b/src/util/pmix_os_dirpath.h
@@ -70,6 +70,79 @@ BEGIN_C_DECLS
 PMIX_EXPORT int pmix_os_dirpath_create(const char *path, const mode_t mode);
 
 /**
+ * Build a directory tree beneath a trusted root, refusing a symlink at
+ * every component of the part PMIx is inventing.
+ *
+ * The split is the whole point. `root` is what somebody handed PMIx -
+ * $TMPDIR, PMIX_NSDIR, a user-named output directory - and is trusted by
+ * construction: if the caller supplies an untrustworthy starting point,
+ * that is theirs to answer for. It is resolved the ordinary way, which
+ * it has to be, since /tmp and /var are themselves symlinks on macOS.
+ * `tail` is what PMIx composes underneath it out of its own naming
+ * scheme, and every component of it is created with mkdirat() and opened
+ * with O_NOFOLLOW against the descriptor of its parent, so the directory
+ * each one lands in is the one just checked.
+ *
+ * That covers what a single O_NOFOLLOW cannot: O_NOFOLLOW applies to the
+ * last component of a name and nothing else, so a symlink at one of the
+ * directories PMIx is building through would otherwise send everything
+ * created below it somewhere the caller did not name.
+ *
+ * @param root A directory that already exists. Trusted; not walked.
+ * @param tail The relative path to build inside it. Walked.
+ * @param mode Access permissions for the directories created.
+ * @retval PMIX_SUCCESS     The tree was created.
+ * @retval PMIX_ERR_EXISTS  The final directory was already there, and
+ *                          carries at least the requested mode. Callers
+ *                          normally treat this exactly as SUCCESS.
+ * @retval PMIX_ERR_BAD_PARAM  A NULL root or an empty tail.
+ * @retval PMIX_ERR_SILENT  It could not be built - the user has already
+ *                          been shown why, and must not be shown again.
+ */
+PMIX_EXPORT int pmix_os_dirpath_create_under(const char *root, const char *tail,
+                                             const mode_t mode);
+
+/**
+ * Open (or create) a file beneath a trusted root, declining a symlink at
+ * every component of the part PMIx composes - the file included.
+ *
+ * The companion to pmix_os_dirpath_create_under(); see it for what the
+ * root/tail split means and why it exists.
+ *
+ * @param root  A directory that already exists. Trusted; not walked.
+ * @param tail  The relative path of the file inside it. Walked.
+ * @param flags open(2) flags. O_NOFOLLOW is added.
+ * @param mode  open(2) mode, used only when creating.
+ * @retval >=0  A descriptor on the file. The caller closes it.
+ * @retval -1   errno says why.
+ */
+PMIX_EXPORT int pmix_os_dirpath_open_file_under(const char *root, const char *tail,
+                                                int flags, mode_t mode);
+
+/**
+ * Open (or create) a file, declining a symlink at the file itself.
+ *
+ * Adding O_NOFOLLOW to a plain open() is only half of what is wanted, and
+ * this supplies exactly that half. The leaf is a name PMIx composes, so a
+ * symlink there is not something this library put in place and following
+ * it would land the operation on an unrelated file. The directory above
+ * it comes from the system or the admin - and on macOS /tmp, /var and
+ * /etc are all root-owned symlinks into /private - so it is resolved the
+ * ordinary way. Where PMIx composes directory components of its own, use
+ * pmix_os_dirpath_open_file_under() instead.
+ *
+ * @param path  The file to open.
+ * @param flags open(2) flags. O_NOFOLLOW is added. Pass O_EXCL alongside
+ *              O_CREAT where the name is one this process creates fresh:
+ *              together they refuse anything already at the name rather
+ *              than only a symlink.
+ * @param mode  open(2) mode, used only when creating.
+ * @retval >=0  A descriptor on the file. The caller closes it.
+ * @retval -1   errno says why.
+ */
+PMIX_EXPORT int pmix_os_dirpath_open_file(const char *path, int flags, mode_t mode);
+
+/**
  * Check to see if a directory is empty
  *
  * A directory that cannot be opened as a directory - it does not exist, it is

--- a/src/util/pmix_os_path.c
+++ b/src/util/pmix_os_path.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,8 +50,6 @@ char *pmix_os_path(int relative, ...)
     while (NULL != (element = va_arg(ap, char *))) {
         num_elements++;
         total_length = total_length + strlen(element);
-        if (path_sep[0] != element[0])
-            total_length++;
     }
     va_end(ap);
 
@@ -67,11 +65,18 @@ char *pmix_os_path(int relative, ...)
         } else {
             strcpy(path, path_sep);
         }
-        return (path);
+        return pmix_make_filename_os_friendly(path);
     }
 
-    /* setup path with enough room for the string terminator, the elements, and
-       the separator between each of the elements */
+    /* setup path with enough room for the string terminator, the elements,
+       and the separator between each of the elements.
+
+       At most one separator is written per element - none at all for an
+       element that already begins with one - so this is an upper bound
+       and not an exact size. It used to also count that same separator a
+       second time in the measuring loop above, which made the bound
+       wrong by one byte per element in the same direction as the
+       PMIX_PATH_MAX test below: a name that fits was rejected. */
     total_length = total_length + num_elements * strlen(path_sep) + 1;
     if (relative) {
         total_length++;

--- a/src/util/pmix_os_path.c
+++ b/src/util/pmix_os_path.c
@@ -90,19 +90,13 @@ char *pmix_os_path(int relative, ...)
     if (NULL == path) {
         return (NULL);
     }
-    path[0] = 0;
+    path[0] = '\0';
 
     if (relative) {
         strcpy(path, ".");
     }
 
     va_start(ap, relative);
-    if (NULL != (element = va_arg(ap, char *))) {
-        if (path_sep[0] != element[0]) {
-            strcat(path, path_sep);
-        }
-        strcat(path, element);
-    }
     while (NULL != (element = va_arg(ap, char *))) {
         if (path_sep[0] != element[0]) {
             strcat(path, path_sep);

--- a/src/util/pmix_os_path.h
+++ b/src/util/pmix_os_path.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,15 +29,22 @@
  *
  * CRITICAL NOTE: The input variable list MUST be terminated by a NULL value. Failure
  * to do this will cause the program to suffer a catastrophic failure - usually a
- * segmentation violation or bus error.
+ * segmentation violation or bus error. The declaration below carries
+ * __pmix_attribute_sentinel__ so that a compiler which supports it will say so
+ * at the call site.
  *
- * The function calls orte_sys_info() to ensure that the path separator character
- * has been identified. If that value cannot be identified for some reason,
- * the function will return a NULL value. Likewise, specifying a path name that
- * exceeds the maximum allowable path name length on the local system will result
- * in the return of a NULL value.
+ * The function returns NULL if the assembled path would exceed PMIX_PATH_MAX
+ * (PATH_MAX + 1, so 1025 bytes on most systems), or if memory could not be
+ * allocated for it. Both are ordinary outcomes rather than can't-happen ones -
+ * walking a deep directory tree lengthens the name at every level - so the
+ * answer must be screened before it is used. It is never returned for an empty
+ * argument list; that case has its own answer, described below.
  *
- *
+ * The function is a pure string operation. It touches no global state, consults
+ * nothing about the running system, and never looks at the filesystem: whether
+ * the path it composes names anything is the caller's question to ask
+ * afterwards. It is therefore safe to call on any thread and from inside the
+ * library.
  */
 
 #ifndef PMIX_OS_PATH_H
@@ -55,8 +62,8 @@ BEGIN_C_DECLS
  * @param relative A boolean that specifies if the path name is to be constructed
  * relative to the current directory or as an absolute path. If no path
  * elements are included in the function call, then the function returns
- * "." for a relative path name and "<path separator char>" -
- * the top of the directory tree - for an absolute path name.
+ * ".<path separator char>" for a relative path name and "<path separator char>"
+ * - the top of the directory tree - for an absolute path name.
  * @param elem1,elem2,... A variable number of (char *)path_elements
  * can be provided to the function, terminated by a NULL value. These
  * elements will be concatenated, each separated by the path separator

--- a/src/util/pmix_output.c
+++ b/src/util/pmix_output.c
@@ -71,7 +71,13 @@ static int make_string(char **out, char **no_newline_string, pmix_output_desc_t 
                        va_list arglist);
 static int output(int output_id, const char *format, va_list arglist);
 
-#if defined(HAVE_SYSLOG)
+/* HAVE_SYSLOG is not a macro anything in this tree defines - configure
+ * probes for the *header*, and never for the function - so keying the
+ * syslog support off it left every syslog path in the library dead in
+ * every build ever shipped. syslog.h is what the include above is
+ * guarded on, and POSIX ships openlog/syslog/closelog with it, so that
+ * is the honest test. */
+#if defined(HAVE_SYSLOG_H)
 #    define USE_SYSLOG 1
 #else
 #    define USE_SYSLOG 0
@@ -87,7 +93,7 @@ pmix_output_desc_t pmix_output_info[PMIX_OUTPUT_MAX_STREAMS];
 static bool initialized = false;
 static int default_stderr_fd = -1;
 
-#if defined(HAVE_SYSLOG)
+#if USE_SYSLOG
 static bool syslog_opened = false;
 #endif
 static char *redirect_syslog_ident = NULL;
@@ -305,7 +311,7 @@ void pmix_output_close(int output_id)
             }
         }
 
-#if defined(HAVE_SYSLOG)
+#if USE_SYSLOG
         if (i >= PMIX_OUTPUT_MAX_STREAMS && syslog_opened) {
             closelog();
         }
@@ -548,7 +554,7 @@ static int do_open(int output_id, pmix_output_stream_t *lds)
     pmix_output_info[i].ldi_verbose_level = lds->lds_verbose_level;
 
 #if USE_SYSLOG
-#    if defined(HAVE_SYSLOG)
+#    if USE_SYSLOG
     if (pmix_output_redirected_to_syslog) {
         pmix_output_info[i].ldi_syslog = true;
         pmix_output_info[i].ldi_syslog_priority = pmix_output_redirected_syslog_pri;
@@ -565,7 +571,7 @@ static int do_open(int output_id, pmix_output_stream_t *lds)
         pmix_output_info[i].ldi_syslog = lds->lds_want_syslog;
         if (lds->lds_want_syslog) {
 
-#    if defined(HAVE_SYSLOG)
+#    if USE_SYSLOG
             if (NULL != lds->lds_syslog_ident) {
                 pmix_output_info[i].ldi_syslog_ident = strdup(lds->lds_syslog_ident);
                 openlog(lds->lds_syslog_ident, LOG_PID, LOG_USER);
@@ -578,7 +584,7 @@ static int do_open(int output_id, pmix_output_stream_t *lds)
             pmix_output_info[i].ldi_syslog_priority = lds->lds_syslog_priority;
         }
 
-#    if defined(HAVE_SYSLOG)
+#    if USE_SYSLOG
     }
 #    endif
 
@@ -930,7 +936,7 @@ static int output(int output_id, const char *format, va_list arglist)
         outlen = strlen(out);
 
         /* Syslog output -- does not use the newline-appended string */
-#if defined(HAVE_SYSLOG)
+#if USE_SYSLOG
         if (ldi->ldi_syslog) {
             syslog(ldi->ldi_syslog_priority, "%s", str);
         }

--- a/src/util/pmix_output.c
+++ b/src/util/pmix_output.c
@@ -26,6 +26,7 @@
 #include "pmix_common.h"
 
 #include <ctype.h>
+#include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -142,7 +143,7 @@ bool pmix_output_init(void)
     if (pmix_output_redirected_to_syslog) {
         verbose.lds_want_syslog = true;
         verbose.lds_syslog_priority = pmix_output_redirected_syslog_pri;
-        if (NULL != str) {
+        if (NULL != redirect_syslog_ident) {
             verbose.lds_syslog_ident = strdup(redirect_syslog_ident);
         }
         verbose.lds_want_stderr = false;
@@ -153,7 +154,7 @@ bool pmix_output_init(void)
     gethostname(hostname, sizeof(hostname) - 1);
     hostname[sizeof(hostname) - 1] = '\0';
     if (0 > pmix_asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid())) {
-        return false;
+        goto failed;
     }
 
     for (i = 0; i < PMIX_OUTPUT_MAX_STREAMS; ++i) {
@@ -168,18 +169,33 @@ bool pmix_output_init(void)
         pmix_output_info[i].ldi_file_num_lines_lost = 0;
     }
 
-    initialized = true;
-
     /* Set some defaults */
 
     if (0 > pmix_asprintf(&output_prefix, "pmix-output-pid%d-", getpid())) {
-        return false;
+        goto failed;
     }
     output_dir = strdup(pmix_tmp_directory());
+
+    initialized = true;
 
     /* Open the default verbose stream */
     verbose_stream = pmix_output_open(&verbose);
     return true;
+
+failed:
+    /* leave nothing behind: every entry point in here re-enters this
+     * function while "initialized" is false, so state kept across a
+     * failed attempt is leaked once per call, not once */
+    free(verbose.lds_prefix);
+    verbose.lds_prefix = NULL;
+    free(verbose.lds_syslog_ident);
+    verbose.lds_syslog_ident = NULL;
+    PMIX_DESTRUCT(&verbose);
+    free(redirect_syslog_ident);
+    redirect_syslog_ident = NULL;
+    free(output_prefix);
+    output_prefix = NULL;
+    return false;
 }
 
 /*
@@ -207,8 +223,8 @@ bool pmix_output_switch(int output_id, bool enable)
 
     /* Setup */
 
-    if (!initialized) {
-        pmix_output_init();
+    if (!initialized && !pmix_output_init()) {
+        return false;
     }
 
     if (output_id >= 0 && output_id < PMIX_OUTPUT_MAX_STREAMS) {
@@ -241,8 +257,21 @@ void pmix_output_reopen_all(void)
         verbose.lds_prefix = NULL;
     }
     if (0 > pmix_asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid())) {
-        verbose.lds_prefix = NULL;
         return;
+    }
+
+    /* the descriptor holds its own copy of the prefix, made when the
+     * stream was opened, so rebuilding the template alone left the
+     * default verbose stream still announcing the pid of the process we
+     * were before the restart */
+    if (0 <= verbose_stream && verbose_stream < PMIX_OUTPUT_MAX_STREAMS
+        && pmix_output_info[verbose_stream].ldi_used) {
+        str = strdup(verbose.lds_prefix);
+        if (NULL != str) {
+            free(pmix_output_info[verbose_stream].ldi_prefix);
+            pmix_output_info[verbose_stream].ldi_prefix = str;
+            pmix_output_info[verbose_stream].ldi_prefix_len = (int) strlen(str);
+        }
     }
 }
 
@@ -259,11 +288,13 @@ void pmix_output_close(int output_id)
         return;
     }
 
-    /* If it's valid, used, enabled, and has an open file descriptor,
-     * free the resources associated with the descriptor */
+    /* If it's valid and used, free the resources associated with the
+     * descriptor. Note that a stream that has been disabled with
+     * pmix_output_switch() is still open - switching only discards the
+     * output - so being disabled must not keep it from being closed. */
 
-    if (output_id >= 0 && output_id < PMIX_OUTPUT_MAX_STREAMS && pmix_output_info[output_id].ldi_used
-        && pmix_output_info[output_id].ldi_enabled) {
+    if (output_id >= 0 && output_id < PMIX_OUTPUT_MAX_STREAMS
+        && pmix_output_info[output_id].ldi_used) {
         free_descriptor(output_id);
 
         /* If no one has the syslog open, we should close it */
@@ -312,11 +343,15 @@ void pmix_output_set_verbosity(int output_id, int level)
 void pmix_output_set_output_file_info(const char *dir, const char *prefix, char **olddir,
                                       char **oldprefix)
 {
+    /* the defaults are established by pmix_output_init(), and this is
+     * documented as being callable before any stream exists - so both
+     * globals can still be NULL here, and strdup() must not be handed
+     * one */
     if (NULL != olddir) {
-        *olddir = strdup(output_dir);
+        *olddir = (NULL == output_dir) ? NULL : strdup(output_dir);
     }
     if (NULL != oldprefix) {
-        *oldprefix = strdup(output_prefix);
+        *oldprefix = (NULL == output_prefix) ? NULL : strdup(output_prefix);
     }
 
     if (NULL != dir) {
@@ -403,10 +438,22 @@ void pmix_output_finalize(void)
             pmix_output_close(verbose_stream);
         }
         free(verbose.lds_prefix);
+        verbose.lds_prefix = NULL;
+        /* the class destructor releases only lds_file_suffix - it cannot
+         * touch lds_syslog_ident, since a caller is entitled to point
+         * that at a string literal (src/mca/base does) - so the one we
+         * allocated for our own stream is ours to release */
+        free(verbose.lds_syslog_ident);
+        verbose.lds_syslog_ident = NULL;
         verbose_stream = -1;
 
+        free(redirect_syslog_ident);
+        redirect_syslog_ident = NULL;
+
         free(output_prefix);
+        output_prefix = NULL;
         free(output_dir);
+        output_dir = NULL;
         PMIX_DESTRUCT(&verbose);
         initialized = false;
     }
@@ -455,8 +502,8 @@ static int do_open(int output_id, pmix_output_stream_t *lds)
 
     /* Setup */
 
-    if (!initialized) {
-        pmix_output_init();
+    if (!initialized && !pmix_output_init()) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
     str = getenv("PMIX_OUTPUT_REDIRECT");
@@ -570,6 +617,7 @@ static int do_open(int output_id, pmix_output_stream_t *lds)
         if (NULL != str && redirect_to_file) {
             pmix_output_info[i].ldi_stdout = false;
             pmix_output_info[i].ldi_stderr = false;
+            pmix_output_info[i].ldi_fd = -1;
             pmix_output_info[i].ldi_file = true;
         } else {
             pmix_output_info[i].ldi_stdout = lds->lds_want_stdout;
@@ -602,7 +650,12 @@ static int open_file(int i)
 
     /* first check to see if this file is already open
      * on someone else's stream - if so, we don't want
-     * to open it twice
+     * to open it twice: a second open would truncate what the other
+     * stream has already written, and the two independent file offsets
+     * would then overwrite each other. A stream whose name differs from
+     * ours is simply not the file we are looking for, so keep looking -
+     * giving up on the first mismatch would leave us opening a file a
+     * later stream already holds.
      */
     for (n = 0; n < PMIX_OUTPUT_MAX_STREAMS; n++) {
         if (i == n) {
@@ -616,19 +669,37 @@ static int open_file(int i)
         }
         if (NULL != pmix_output_info[i].ldi_file_suffix && NULL != pmix_output_info[n].ldi_file_suffix) {
             if (0 != strcmp(pmix_output_info[i].ldi_file_suffix, pmix_output_info[n].ldi_file_suffix)) {
-                break;
+                continue;
             }
         }
         if (NULL == pmix_output_info[i].ldi_file_suffix && NULL != pmix_output_info[n].ldi_file_suffix) {
-            break;
+            continue;
         }
         if (NULL != pmix_output_info[i].ldi_file_suffix && NULL == pmix_output_info[n].ldi_file_suffix) {
-            break;
+            continue;
         }
         if (pmix_output_info[n].ldi_fd < 0) {
-            break;
+            continue;
         }
-        pmix_output_info[i].ldi_fd = pmix_output_info[n].ldi_fd;
+        /* same file, and it is already open - take a descriptor of our
+         * own onto it rather than aliasing theirs. Both descriptors
+         * share one file description, so the offset stays shared and
+         * the writes still interleave correctly, but each stream now
+         * owns what free_descriptor() closes: aliasing meant whichever
+         * stream closed first closed the file out from under the other,
+         * which then wrote into whatever descriptor the OS handed out
+         * next, and closed it a second time on its own way out.
+         */
+        pmix_output_info[i].ldi_fd = dup(pmix_output_info[n].ldi_fd);
+        if (0 > pmix_output_info[i].ldi_fd) {
+            return PMIX_ERR_IN_ERRNO;
+        }
+        /* dup() does not carry the close-on-exec flag across */
+        if (-1 == fcntl(pmix_output_info[i].ldi_fd, F_SETFD, FD_CLOEXEC)) {
+            close(pmix_output_info[i].ldi_fd);
+            pmix_output_info[i].ldi_fd = -1;
+            return PMIX_ERR_IN_ERRNO;
+        }
         return PMIX_SUCCESS;
     }
 
@@ -644,10 +715,9 @@ static int open_file(int i)
          * PMIX_PATH_MAX buffer for a pathological output_dir/prefix */
         const char *file_prefix = (NULL != output_prefix) ? output_prefix : "";
         const char *file_suffix;
-        if (pmix_output_info[i].ldi_file_suffix != NULL) {
+        if (NULL != pmix_output_info[i].ldi_file_suffix) {
             file_suffix = pmix_output_info[i].ldi_file_suffix;
         } else {
-            pmix_output_info[i].ldi_file_suffix = NULL;
             file_suffix = "output.txt";
         }
         snprintf(filename, PMIX_PATH_MAX, "%s/%s%s", output_dir, file_prefix,
@@ -661,13 +731,23 @@ static int open_file(int i)
         pmix_output_info[i].ldi_fd = open(filename, flags, 0644);
         free(filename); /* release the filename in all cases */
         if (-1 == pmix_output_info[i].ldi_fd) {
-            pmix_output_info[i].ldi_used = false;
+            /* leave the stream in use: the session directory may simply
+             * not exist yet, and pmix_output() is documented to keep
+             * counting the lost lines and to retry the open on every
+             * subsequent write. Releasing the slot here instead both
+             * stranded the descriptor's strings and handed its id to
+             * the next pmix_output_open() while the original holder was
+             * still using it. */
             return PMIX_ERR_IN_ERRNO;
         }
 
         /* Make the file be close-on-exec to prevent child inheritance
          * problems */
-        if (-1 == fcntl(pmix_output_info[i].ldi_fd, F_SETFD, 1)) {
+        if (-1 == fcntl(pmix_output_info[i].ldi_fd, F_SETFD, FD_CLOEXEC)) {
+            /* we could not make it safe to hold, so do not hold it -
+             * the retry path above will try again */
+            close(pmix_output_info[i].ldi_fd);
+            pmix_output_info[i].ldi_fd = -1;
             return PMIX_ERR_IN_ERRNO;
         }
     }
@@ -685,13 +765,16 @@ static void free_descriptor(int output_id)
 {
     pmix_output_desc_t *ldi;
 
-    if (output_id >= 0 && output_id < PMIX_OUTPUT_MAX_STREAMS && pmix_output_info[output_id].ldi_used
-        && pmix_output_info[output_id].ldi_enabled) {
+    if (output_id >= 0 && output_id < PMIX_OUTPUT_MAX_STREAMS
+        && pmix_output_info[output_id].ldi_used) {
         ldi = &pmix_output_info[output_id];
 
         if (-1 != ldi->ldi_fd) {
             close(ldi->ldi_fd);
         }
+        /* the slot outlives us and may be handed to another stream, so
+         * it must not be left naming a descriptor we just closed */
+        ldi->ldi_fd = -1;
         ldi->ldi_used = false;
 
         /* If we strduped a prefix, suffix, or syslog ident, free it */
@@ -789,6 +872,34 @@ static int make_string(char **out, char **no_newline_string, pmix_output_desc_t 
 }
 
 /*
+ * Deliver one rendered line to one descriptor.
+ *
+ * write(2) is allowed to accept fewer bytes than it was offered, and a
+ * signal that arrives before any byte is written makes it fail with
+ * EINTR - neither of which means the line could not be delivered. A
+ * single unchecked write() therefore truncated or dropped output for a
+ * reason the caller could do nothing about. EAGAIN is deliberately not
+ * retried: a non-blocking descriptor would turn that into a spin.
+ */
+static int write_line(int fd, const char *buf, size_t len)
+{
+    ssize_t n;
+
+    while (0 < len) {
+        n = write(fd, buf, len);
+        if (0 > n) {
+            if (EINTR == errno) {
+                continue;
+            }
+            return PMIX_ERROR;
+        }
+        buf += n;
+        len -= (size_t) n;
+    }
+    return PMIX_SUCCESS;
+}
+
+/*
  * Do the actual output.  Take a va_list so that we can be called from
  * multiple different places, even functions that took "..." as input
  * arguments.
@@ -797,12 +908,13 @@ static int output(int output_id, const char *format, va_list arglist)
 {
     int rc = PMIX_SUCCESS;
     char *str = NULL, *out = NULL;
+    size_t outlen = 0;
     pmix_output_desc_t *ldi;
 
     /* Setup */
 
-    if (!initialized) {
-        pmix_output_init();
+    if (!initialized && !pmix_output_init()) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
     /* If it's valid, used, and enabled, output */
@@ -815,6 +927,7 @@ static int output(int output_id, const char *format, va_list arglist)
         if (PMIX_SUCCESS != (rc = make_string(&out, &str, ldi, format, arglist))) {
             goto cleanup;
         }
+        outlen = strlen(out);
 
         /* Syslog output -- does not use the newline-appended string */
 #if defined(HAVE_SYSLOG)
@@ -823,21 +936,23 @@ static int output(int output_id, const char *format, va_list arglist)
         }
 #endif
 
-        /* stdout output */
+        /* stdout output. Note that a sink we cannot write to is
+         * remembered but does not stop us trying the others: a stream
+         * fanned out to several destinations must not fall silent on
+         * all of them because one of them was closed. */
         if (ldi->ldi_stdout) {
-            if (0 > write(fileno(stdout), out, (int) strlen(out))) {
+            if (PMIX_SUCCESS != write_line(fileno(stdout), out, outlen)) {
                 rc = PMIX_ERROR;
-                goto cleanup;
             }
             fflush(stdout);
         }
 
         /* stderr output */
         if (ldi->ldi_stderr) {
-            if (0 > write((-1 == default_stderr_fd) ? fileno(stderr) : default_stderr_fd, out,
-                          (int) strlen(out))) {
+            if (PMIX_SUCCESS
+                != write_line((-1 == default_stderr_fd) ? fileno(stderr) : default_stderr_fd, out,
+                              outlen)) {
                 rc = PMIX_ERROR;
-                goto cleanup;
             }
             fflush(stderr);
         }
@@ -858,22 +973,18 @@ static int output(int output_id, const char *format, va_list arglist)
                              "[WARNING: %d lines lost because the PMIx process session directory "
                              "did\n not exist when pmix_output() was invoked]\n",
                              ldi->ldi_file_num_lines_lost);
-                    if (0 > write(ldi->ldi_fd, buffer, (int) strlen(buffer))) {
+                    if (PMIX_SUCCESS != write_line(ldi->ldi_fd, buffer, strlen(buffer))) {
                         rc = PMIX_ERROR;
-                        goto cleanup;
                     }
                     ldi->ldi_file_num_lines_lost = 0;
                 }
             }
             if (ldi->ldi_fd != -1) {
-                if (0 > write(ldi->ldi_fd, out, (int) strlen(out))) {
+                if (PMIX_SUCCESS != write_line(ldi->ldi_fd, out, outlen)) {
                     rc = PMIX_ERROR;
-                    goto cleanup;
                 }
             }
         }
-        free(str);
-        str = NULL;
     }
 
 cleanup:

--- a/src/util/pmix_output.c
+++ b/src/util/pmix_output.c
@@ -379,6 +379,7 @@ void pmix_output_hexdump(int verbose_level, int output_id, void *ptr, int buflen
     int i, j;
 
     if (output_id >= 0 && output_id < PMIX_OUTPUT_MAX_STREAMS
+        && pmix_output_info[output_id].ldi_used
         && pmix_output_info[output_id].ldi_verbose_level >= verbose_level) {
         pmix_output_verbose(verbose_level, output_id, "dump data at %p %d bytes\n", ptr, buflen);
         for (i = 0; i < buflen; i += 16) {
@@ -389,7 +390,7 @@ void pmix_output_hexdump(int verbose_level, int output_id, void *ptr, int buflen
             }
             out_pos += ret;
             for (j = 0; j < 16; j++) {
-                if (1023 < (out_pos+2)) {
+                if ((int) sizeof(out_buf) - 1 < out_pos + 2) {
                     return;
                 }
                 if (i + j < buflen) {
@@ -402,7 +403,7 @@ void pmix_output_hexdump(int verbose_level, int output_id, void *ptr, int buflen
                 }
                 out_pos += ret;
             }
-            if (1023 < (out_pos+1)) {
+            if ((int) sizeof(out_buf) - 1 < out_pos + 1) {
                 return;
             }
             ret = snprintf(out_buf + out_pos, sizeof(out_buf) - out_pos, " ");
@@ -411,7 +412,7 @@ void pmix_output_hexdump(int verbose_level, int output_id, void *ptr, int buflen
             }
             out_pos += ret;
             for (j = 0; j < 16; j++) {
-                if (1023 < (out_pos+1)) {
+                if ((int) sizeof(out_buf) - 1 < out_pos + 1) {
                     return;
                 }
                 if (i + j < buflen) {
@@ -422,7 +423,7 @@ void pmix_output_hexdump(int verbose_level, int output_id, void *ptr, int buflen
                     out_pos += ret;
                 }
             }
-            if (1023 < (out_pos+1)) {
+            if ((int) sizeof(out_buf) - 1 < out_pos + 1) {
                 return;
             }
             ret = snprintf(out_buf + out_pos, sizeof(out_buf) - out_pos, "\n");
@@ -554,7 +555,6 @@ static int do_open(int output_id, pmix_output_stream_t *lds)
     pmix_output_info[i].ldi_verbose_level = lds->lds_verbose_level;
 
 #if USE_SYSLOG
-#    if USE_SYSLOG
     if (pmix_output_redirected_to_syslog) {
         pmix_output_info[i].ldi_syslog = true;
         pmix_output_info[i].ldi_syslog_priority = pmix_output_redirected_syslog_pri;
@@ -567,11 +567,8 @@ static int do_open(int output_id, pmix_output_stream_t *lds)
         }
         syslog_opened = true;
     } else {
-#    endif
         pmix_output_info[i].ldi_syslog = lds->lds_want_syslog;
         if (lds->lds_want_syslog) {
-
-#    if USE_SYSLOG
             if (NULL != lds->lds_syslog_ident) {
                 pmix_output_info[i].ldi_syslog_ident = strdup(lds->lds_syslog_ident);
                 openlog(lds->lds_syslog_ident, LOG_PID, LOG_USER);
@@ -579,15 +576,10 @@ static int do_open(int output_id, pmix_output_stream_t *lds)
                 pmix_output_info[i].ldi_syslog_ident = NULL;
                 openlog("pmix", LOG_PID, LOG_USER);
             }
-#    endif
             syslog_opened = true;
             pmix_output_info[i].ldi_syslog_priority = lds->lds_syslog_priority;
         }
-
-#    if USE_SYSLOG
     }
-#    endif
-
 #else
     pmix_output_info[i].ldi_syslog = false;
 #endif
@@ -620,7 +612,7 @@ static int do_open(int output_id, pmix_output_stream_t *lds)
         /* since we aren't redirecting to syslog, use what was
          * given to us
          */
-        if (NULL != str && redirect_to_file) {
+        if (redirect_to_file) {
             pmix_output_info[i].ldi_stdout = false;
             pmix_output_info[i].ldi_stderr = false;
             pmix_output_info[i].ldi_fd = -1;
@@ -966,13 +958,13 @@ static int output(int output_id, const char *format, va_list arglist)
         /* File output -- first check to see if the file opening was
          * delayed.  If so, try to open it.  If we failed to open it,
          * then just discard (there are big warnings in the
-         * pmix_pmix_output.h docs about this!). */
+         * pmix_output.h docs about this!). */
 
         if (ldi->ldi_file) {
-            if (ldi->ldi_fd == -1) {
+            if (-1 == ldi->ldi_fd) {
                 if (PMIX_SUCCESS != open_file(output_id)) {
                     ++ldi->ldi_file_num_lines_lost;
-                } else if (ldi->ldi_file_num_lines_lost > 0 && 0 <= ldi->ldi_fd) {
+                } else if (0 < ldi->ldi_file_num_lines_lost && 0 <= ldi->ldi_fd) {
                     char buffer[BUFSIZ];
                     memset(buffer, 0, BUFSIZ);
                     pmix_snprintf(buffer, BUFSIZ - 1,
@@ -985,7 +977,7 @@ static int output(int output_id, const char *format, va_list arglist)
                     ldi->ldi_file_num_lines_lost = 0;
                 }
             }
-            if (ldi->ldi_fd != -1) {
+            if (-1 != ldi->ldi_fd) {
                 if (PMIX_SUCCESS != write_line(ldi->ldi_fd, out, outlen)) {
                     rc = PMIX_ERROR;
                 }

--- a/src/util/pmix_output.h
+++ b/src/util/pmix_output.h
@@ -59,9 +59,37 @@
  * pmix_output_finalize()).  This stream outputs to stderr only, and
  * has a stream handle ID of 0.
  *
- * It is erroneous to have one thread close a stream and have another
- * try to write to it.  Multiple threads writing to a single stream
- * will be serialized in an unspecified order.
+ * ENVIRONMENT: five variables, read once by pmix_output_init(),
+ * override what every stream in the process does.  They are the only
+ * way to reach these settings before the MCA parameter system exists,
+ * which is why they are environment variables rather than parameters:
+ *
+ * - PMIX_OUTPUT_REDIRECT - "syslog" sends every stream to the syslog
+ *   and to nothing else; "file" sends every stream to a file and to
+ *   nothing else.  Any other value is ignored.
+ * - PMIX_OUTPUT_SYSLOG_PRI - "info", "warn" or "error" (the default)
+ *   for the priority of syslog output.
+ * - PMIX_OUTPUT_SYSLOG_IDENT - the identity string to open the syslog
+ *   under; "pmix" if unset.
+ * - PMIX_OUTPUT_SUFFIX - overrides the file suffix of every stream that
+ *   writes to a file, so they all share one file.
+ * - PMIX_OUTPUT_STDERR_FD - a descriptor number to write "stderr"
+ *   output to instead of fileno(stderr).
+ *
+ * THREADING: this subsystem keeps process-global state - the stream
+ * table, the output directory and prefix - and takes no lock over any
+ * of it.  Writing is what a second thread may safely do: each call
+ * renders its own line on the stack and delivers it with a single
+ * write(), so two threads writing to the same stream do not corrupt
+ * each other's state, although nothing orders their lines and a line
+ * longer than the pipe buffer may still be split by the OS.
+ * Everything that *changes* the table - pmix_output_init(),
+ * pmix_output_open(), pmix_output_reopen(), pmix_output_close(),
+ * pmix_output_finalize(), pmix_output_set_output_file_info() - must be
+ * called by one thread at a time, and not while another thread is
+ * writing to the stream being changed.  In PMIx that means they run
+ * during startup and shutdown, on the progress thread.  Two concurrent
+ * pmix_output_open() calls can settle on the same free slot.
  */
 
 #ifndef PMIX_OUTPUT_H_
@@ -318,12 +346,18 @@ PMIX_EXPORT void pmix_output_finalize(void);
  * using it in successive calls to PMIX_OUTPUT(), pmix_output(),
  * pmix_output_switch(), and pmix_output_close().
  *
+ * On failure it returns a negative PMIx status - not a handle - so a
+ * caller that stores the answer must tell the two apart before using
+ * it.  There are only PMIX_OUTPUT_MAX_STREAMS handles, and a stream is
+ * held until it is closed, so PMIX_ERR_OUT_OF_RESOURCE is the answer
+ * once they are all spoken for.
+ *
  * If lds is NULL, the default descriptions will be used, meaning
  * that output will only be sent to stderr.
  *
- * It is safe to have multiple threads invoke this function
- * simultaneously; their execution will be serialized in an
- * unspecified manner.
+ * This function is not thread safe: the search for a free slot is
+ * unlocked, so two threads calling it at once can be handed the same
+ * stream.  See the THREADING note at the top of this file.
  *
  * Be sure to see pmix_output() for a description of what happens
  * when open_open() / pmix_output() is directed to send output to a
@@ -367,11 +401,19 @@ PMIX_EXPORT bool pmix_output_switch(int output_id, bool enable);
 /**
  * \internal
  *
- * Reopens all existing output streams.
+ * Re-derives the process-dependent parts of the output configuration.
  *
  * This function should never be called by user applications; it is
  * typically only invoked after a restart (i.e., in a new process)
  * where output streams need to be re-initialized.
+ *
+ * Despite the name it does not reopen streams: it re-reads the stderr
+ * descriptor override from the environment and rebuilds the
+ * "[hostname:pid]" prefix of the default verbose stream, which is the
+ * part a new process invalidates.  A stream opened by anyone else keeps
+ * the prefix, suffix, syslog identity and file its opener gave it, and
+ * only that opener knows how to rebuild them - it must call
+ * pmix_output_reopen() itself.
  */
 PMIX_EXPORT void pmix_output_reopen_all(void);
 
@@ -384,6 +426,11 @@ PMIX_EXPORT void pmix_output_reopen_all(void);
  * after it is closed.  Be aware that pmix_output_handles tend to be
  * re-used; it is possible that after a stream is closed, if another
  * stream is opened, it will get the same handle value.
+ *
+ * A stream that has been disabled with pmix_output_switch() is still
+ * an open stream and must still be closed; closing it is what returns
+ * its handle and releases the copies pmix_output_open() made of the
+ * prefix, suffix, syslog identity and file suffix.
  */
 PMIX_EXPORT void pmix_output_close(int output_id);
 
@@ -468,7 +515,9 @@ PMIX_EXPORT void pmix_output_set_verbosity(int output_id, int level);
  * Get the verbosity level for a stream
  *
  * @param output_id Stream id returned from pmix_output_open()
- * @returns Verbosity of stream
+ * @returns Verbosity of stream, or -1 if output_id does not name an
+ * open stream.  Note that -1 is also a legal verbosity to have set, so
+ * this does not distinguish the two.
  */
 PMIX_EXPORT int pmix_output_get_verbosity(int output_id);
 
@@ -499,7 +548,9 @@ PMIX_EXPORT int pmix_output_get_verbosity(int output_id);
  *
  * If olddir or oldprefix are not NULL, copies of the old
  * directory and prefix (respectively) are returned in these
- * parameters.  The caller is responsible for calling (free) on
+ * parameters - or NULL, if the output subsystem has not been
+ * initialized yet and therefore has no value to hand back.  The
+ * caller is responsible for calling (free) on
  * these values.  This allows one to get the old values, output an
  * output file in a specific directory and/or with a specific
  * prefix, and then restore the old values.

--- a/src/util/pmix_parse_options.c
+++ b/src/util/pmix_parse_options.c
@@ -23,6 +23,9 @@
  */
 #include "pmix_config.h"
 
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -41,6 +44,43 @@
 
 #include "src/util/pmix_parse_options.h"
 
+/*
+ * Read one whole token as an int.
+ *
+ * strtol() answers 0 for a string with no digits in it and saturates at
+ * LONG_MAX/LONG_MIN for one that is too big, and neither of those is
+ * distinguishable from a real value once it has been narrowed to an
+ * int - "4294967295" and "99999999999999999999" both narrow to -1,
+ * which this file reads as the wildcard meaning "every value", so a
+ * mistyped port range silently discarded the caller's whole list and
+ * replaced it with "any". Insist on digits, on nothing after them, and
+ * on a value an int can actually hold.
+ */
+static bool parse_whole_int(const char *str, int *val)
+{
+    char *endptr;
+    long tmp;
+
+    if (NULL == str || '\0' == *str) {
+        return false;
+    }
+    errno = 0;
+    tmp = strtol(str, &endptr, 10);
+    if (endptr == str || 0 != errno || tmp < INT_MIN || tmp > INT_MAX) {
+        return false;
+    }
+    /* strtol skips leading whitespace on its own; allow trailing
+     * whitespace too, so a list written as "1, 3" keeps working */
+    while (isspace((unsigned char) *endptr)) {
+        ++endptr;
+    }
+    if ('\0' != *endptr) {
+        return false;
+    }
+    *val = (int) tmp;
+    return true;
+}
+
 void pmix_util_parse_range_options(char *inp, char ***output)
 {
     char **r1 = NULL, **r2 = NULL;
@@ -57,6 +97,9 @@ void pmix_util_parse_range_options(char *inp, char ***output)
 
     /* protect the provided input */
     input = strdup(inp);
+    if (NULL == input) {
+        return;
+    }
 
     /* check for the special '!' operator */
     if (NULL != (bang = strchr(input, '!'))) {
@@ -71,14 +114,16 @@ void pmix_util_parse_range_options(char *inp, char ***output)
         r2 = PMIx_Argv_split(r1[i], '-');
         if (1 < PMIx_Argv_count(r2)) {
             /* given range - get start and end */
-            start = strtol(r2[0], NULL, 10);
-            end = strtol(r2[1], NULL, 10);
+            if (!parse_whole_int(r2[0], &start) || !parse_whole_int(r2[1], &end)) {
+                pmix_output(0, "Unknown parse error on string: %s(%s)", inp, r1[i]);
+                PMIx_Argv_free(r2);
+                continue;
+            }
         } else {
             /* check for wildcard - have to do this here because
              * the -1 would have been caught in the split
              */
-            vint = strtol(r1[i], NULL, 10);
-            if (-1 == vint) {
+            if (parse_whole_int(r1[i], &vint) && -1 == vint) {
                 PMIx_Argv_free(*output);
                 *output = NULL;
                 PMIx_Argv_append_nosize(output, "-1");
@@ -92,7 +137,11 @@ void pmix_util_parse_range_options(char *inp, char ***output)
                 PMIx_Argv_free(r2);
                 continue;
             }
-            start = strtol(r2[0], NULL, 10);
+            if (!parse_whole_int(r2[0], &start)) {
+                pmix_output(0, "Unknown parse error on string: %s(%s)", inp, r1[i]);
+                PMIx_Argv_free(r2);
+                continue;
+            }
             end = start;
         }
         for (n = start; n <= end; n++) {
@@ -123,6 +172,9 @@ void pmix_util_get_ranges(char *inp, char ***startpts, char ***endpts)
 
     /* protect the provided input */
     input = strdup(inp);
+    if (NULL == input) {
+        return;
+    }
 
     /* split on commas */
     r1 = PMIx_Argv_split(input, ',');

--- a/src/util/pmix_parse_options.h
+++ b/src/util/pmix_parse_options.h
@@ -30,8 +30,48 @@
 
 BEGIN_C_DECLS
 
+/**
+ * Expand a comma-delimited list of numbers and ranges into an argv.
+ *
+ * "1,3-5,9" appends "1", "3", "4", "5", "9" to *output.  The input is
+ * not modified.  Elements are *appended*, so an *output that already
+ * holds values keeps them - the caller owns the array and frees it with
+ * PMIx_Argv_free().
+ *
+ * Three pieces of syntax are not obvious:
+ *
+ * - "-1" anywhere in the list is a wildcard meaning "everything".  It
+ *   *discards* whatever *output already held and replaces it with the
+ *   single element "-1", and the rest of the input is not read.
+ * - a trailing "!" is a flag rather than a value: it is stripped from
+ *   the input, and the element "BANG" is appended after everything
+ *   else.  It is the caller's to interpret.
+ * - a range whose end is below its start ("5-3") expands to nothing,
+ *   silently.
+ *
+ * An element that is not a whole number an int can hold - "abc", "3x",
+ * "4294967295" - is reported on the default output stream and skipped;
+ * the rest of the list is still expanded.  Note that this reporting is
+ * all the caller gets: the function returns void, so it also cannot
+ * tell the caller that an allocation failed.  A NULL input is a no-op.
+ */
 PMIX_EXPORT void pmix_util_parse_range_options(char *input, char ***output);
 
+/**
+ * Split a comma-delimited list of ranges into parallel start/end arrays.
+ *
+ * "3-5,7" appends "3" and "7" to *startpts and "5" and "7" to *endpts -
+ * a bare value is its own start and end.  Unlike
+ * pmix_util_parse_range_options() the values are not expanded and not
+ * parsed as numbers; they are handed back as the strings they were.
+ *
+ * The two arrays are parallel and the caller is entitled to that: entry
+ * n of one describes the same range as entry n of the other.  Both are
+ * appended to, both belong to the caller, and both are freed with
+ * PMIx_Argv_free().  An element that is neither a value nor a pair is
+ * reported on the default output stream and contributes to neither
+ * array.  A NULL input is a no-op.
+ */
 PMIX_EXPORT void pmix_util_get_ranges(char *inp, char ***startpts, char ***endpts);
 
 END_C_DECLS

--- a/src/util/pmix_path.c
+++ b/src/util/pmix_path.c
@@ -89,9 +89,9 @@
 #endif
 
 /*
- * Note that some OS's (e.g., NetBSD and Solaris) have statfs(), but
- * no struct statfs (!).  So check to make sure we have struct statfs
- * before allowing the use of statfs().
+ * Note that some OS's (e.g., NetBSD) have statfs(), but no struct
+ * statfs (!).  So check to make sure we have struct statfs before
+ * allowing the use of statfs().
  */
 #if defined(HAVE_STATFS) \
     && (defined(HAVE_STRUCT_STATFS_F_FSTYPENAME) || defined(HAVE_STRUCT_STATFS_F_TYPE))

--- a/src/util/pmix_path.c
+++ b/src/util/pmix_path.c
@@ -96,6 +96,8 @@
 #if defined(HAVE_STATFS) \
     && (defined(HAVE_STRUCT_STATFS_F_FSTYPENAME) || defined(HAVE_STRUCT_STATFS_F_TYPE))
 #    define USE_STATFS 1
+#else
+#    define USE_STATFS 0
 #endif
 
 static void path_env_load(char *path, int *pargc, char ***pargv);
@@ -103,6 +105,9 @@ static char *list_env_get(char *var, char **list);
 
 bool pmix_path_is_absolute(const char *path)
 {
+    if (NULL == path) {
+        return false;
+    }
     if (PMIX_PATH_SEP[0] == *path) {
         return true;
     }
@@ -118,7 +123,13 @@ char *pmix_path_find(char *fname, char **pathv, int mode, char **envv)
     char *delimit;
     char *env;
     char *pfix;
+    char *varname;
+    size_t namelen;
     int i;
+
+    if (NULL == fname || NULL == pathv) {
+        return NULL;
+    }
 
     /* If absolute path is given, return it without searching. */
     if (pmix_path_is_absolute(fname)) {
@@ -138,13 +149,21 @@ char *pmix_path_find(char *fname, char **pathv, int mode, char **envv)
         /* Replace environment variable at the head of the string. */
         if ('$' == *pathv[i]) {
             delimit = strchr(pathv[i], PMIX_PATH_SEP[0]);
-            if (delimit) {
-                *delimit = '\0';
+            /* copy the variable name out rather than punching a
+             * temporary NUL into the caller's string and putting it
+             * back: pathv belongs to the caller, its elements may be
+             * string literals, and another thread may be reading the
+             * same array */
+            namelen = (NULL == delimit) ? strlen(pathv[i] + 1)
+                                        : (size_t)(delimit - (pathv[i] + 1));
+            varname = (char *) malloc(namelen + 1);
+            if (NULL == varname) {
+                return NULL;
             }
-            env = list_env_get(pathv[i] + 1, envv);
-            if (delimit) {
-                *delimit = PMIX_PATH_SEP[0];
-            }
+            memcpy(varname, pathv[i] + 1, namelen);
+            varname[namelen] = '\0';
+            env = list_env_get(varname, envv);
+            free(varname);
             if (NULL != env) {
                 if (!delimit) {
                     fullpath = pmix_path_access(fname, env, mode);
@@ -238,6 +257,10 @@ char *pmix_path_access(char *fname, char *path, int mode)
 {
     char *fullpath = NULL;
 
+    if (NULL == fname) {
+        return NULL;
+    }
+
     /* Allocate space for the full pathname. */
     if (NULL == path) {
         fullpath = pmix_os_path(false, fname, NULL);
@@ -267,41 +290,27 @@ char *pmix_path_access(char *fname, char *path, int mode)
  */
 static void path_env_load(char *path, int *pargc, char ***pargv)
 {
-    char *p;
-    char saved;
+    char **elements;
+    int i;
 
     if (NULL == path) {
         *pargc = 0;
         return;
     }
 
-    /* Loop through the paths (delimited by PATHENVSEP), adding each
-       one to argv. */
-
-    while ('\0' != *path) {
-
-        /* Locate the delimiter. */
-
-        for (p = path; *p && (*p != PMIX_ENV_SEP); ++p) {
-            continue;
-        }
-
-        /* Add the path. */
-
-        if (p != path) {
-            saved = *p;
-            *p = '\0';
-            pmix_argv_append(pargc, pargv, path);
-            *p = saved;
-            path = p;
-        }
-
-        /* Skip past the delimiter, if present. */
-
-        if (*path) {
-            ++path;
-        }
+    /* Split the paths (delimited by PATHENVSEP) and add each one to
+     * argv. This used to walk the string in place, punching a temporary
+     * NUL in at each delimiter and putting it back - but the string it
+     * is handed is usually the value getenv() returned, which POSIX
+     * says must not be modified, and any other thread reading the same
+     * variable in that window sees a truncated PATH. Split a copy.
+     * PMIx_Argv_split() drops empty fields, which is what the walk did
+     * with a repeated or leading delimiter. */
+    elements = PMIx_Argv_split(path, PMIX_ENV_SEP);
+    for (i = 0; NULL != elements && NULL != elements[i]; ++i) {
+        pmix_argv_append(pargc, pargv, elements[i]);
     }
+    PMIx_Argv_free(elements);
 }
 
 /**
@@ -347,6 +356,10 @@ char *pmix_find_absolute_path(char *app_name)
     char *abs_app_name;
     char cwd[PMIX_PATH_MAX], *pcwd;
 
+    if (NULL == app_name) {
+        return NULL;
+    }
+
     if (pmix_path_is_absolute(app_name)) { /* already absolute path */
         abs_app_name = app_name;
     } else if ('.' == app_name[0] || NULL != strchr(app_name, PMIX_PATH_SEP[0])) {
@@ -364,6 +377,14 @@ char *pmix_find_absolute_path(char *app_name)
 
     if (NULL != abs_app_name) {
         char *resolved_path = (char *) malloc(PMIX_PATH_MAX);
+        if (NULL == resolved_path) {
+            /* realpath() would allocate a buffer of its own for a NULL
+             * argument, and we would then return this NULL and leak it */
+            if (abs_app_name != app_name) {
+                free(abs_app_name);
+            }
+            return NULL;
+        }
         if (NULL == realpath(abs_app_name, resolved_path)) {
             free(resolved_path);
             /* only free abs_app_name if we allocated it - in the
@@ -467,6 +488,12 @@ bool pmix_path_nfs(char *fname, char **fstype)
                     // the false paths where it would leak.
                     if (NULL != fstype) {
                         *fstype = strdup(mnt.mnt_type);
+                        if (NULL == *fstype) {
+                            /* the contract is that *fstype is valid on a
+                             * true return, so we cannot answer true
+                             * without it */
+                            return false;
+                        }
                     }
                     return true;
                 }
@@ -494,7 +521,8 @@ int pmix_path_df(const char *path, uint64_t *out_avail)
     int rc = -1;
     int trials = 5;
     int err = 0;
-#if defined(USE_STATFS)
+    int64_t avail;
+#if USE_STATFS
     struct statfs buf;
 #elif defined(HAVE_STATVFS)
     struct statvfs buf;
@@ -506,7 +534,7 @@ int pmix_path_df(const char *path, uint64_t *out_avail)
     *out_avail = 0;
 
     do {
-#if defined(USE_STATFS)
+#if USE_STATFS
         rc = statfs(path, &buf);
 #elif defined(HAVE_STATVFS)
         rc = statvfs(path, &buf);
@@ -515,21 +543,38 @@ int pmix_path_df(const char *path, uint64_t *out_avail)
     } while (-1 == rc && ESTALE == err && (--trials > 0));
 
     if (-1 == rc) {
-        pmix_output_verbose(10, 2,
+        pmix_output_verbose(10, 0,
                              "pmix_path_df: stat(v)fs on "
                              "path: %s failed with errno: %d (%s)\n",
                              path, err, strerror(err));
         return PMIX_ERROR;
     }
 
-    /* now set the amount of free space available on path */
-    /* f_bavail is signed on some platforms and can be negative; check the
-     * sign in a full-width signed type rather than truncating to int,
-     * which on a large filesystem would misread a valid 64-bit count as
-     * negative and report zero free space */
-    *out_avail = buf.f_bsize * (((int64_t) buf.f_bavail < 0) ? 0 : buf.f_bavail);
+    /* now set the amount of free space available on path.
+     *
+     * The two interfaces do not count in the same units. statfs()
+     * reports f_bavail in f_bsize blocks, but POSIX statvfs() reports it
+     * in f_frsize ones - and f_bsize there is the *preferred I/O size*,
+     * which on several filesystems is many times f_frsize. Multiplying
+     * by the wrong one told the caller it had far more room than it has.
+     *
+     * f_bavail is signed on the BSDs, where it can be negative, and
+     * unsigned elsewhere - so the sign test has to be made through a
+     * variable of a signed type. Written as a cast in the comparison
+     * itself it is -Werror=type-limits on every platform where the
+     * field is unsigned, which is why the statvfs arm of this function
+     * has never compiled. */
+    avail = (int64_t) buf.f_bavail;
+    if (0 > avail) {
+        avail = 0;
+    }
+#if USE_STATFS
+    *out_avail = (uint64_t) buf.f_bsize * (uint64_t) avail;
+#else
+    *out_avail = (uint64_t) buf.f_frsize * (uint64_t) avail;
+#endif
 
-    pmix_output_verbose(10, 2,
+    pmix_output_verbose(10, 0,
                          "pmix_path_df: stat(v)fs states "
                          "path: %s has %" PRIu64 " B of free space.",
                          path, *out_avail);

--- a/src/util/pmix_path.c
+++ b/src/util/pmix_path.c
@@ -144,7 +144,7 @@ char *pmix_path_find(char *fname, char **pathv, int mode, char **envv)
     /* Consider each directory until the file is found.  Thus, the
        order of directories is important. */
 
-    while (pathv[i] && NULL == fullpath) {
+    while (NULL != pathv[i] && NULL == fullpath) {
 
         /* Replace environment variable at the head of the string. */
         if ('$' == *pathv[i]) {
@@ -165,7 +165,7 @@ char *pmix_path_find(char *fname, char **pathv, int mode, char **envv)
             env = list_env_get(varname, envv);
             free(varname);
             if (NULL != env) {
-                if (!delimit) {
+                if (NULL == delimit) {
                     fullpath = pmix_path_access(fname, env, mode);
                 } else {
                     pfix = (char *) calloc((strlen(env) + strlen(delimit) + 1), sizeof(char));
@@ -424,7 +424,7 @@ bool pmix_path_nfs(char *fname, char **fstype)
     dev_t dev;
     char buf[1024];
     int fd, n;
-    char* fs_types[] = {
+    const char *fs_types[] = {
         "lustre",
         "nfs",
         "autofs",
@@ -446,32 +446,33 @@ bool pmix_path_nfs(char *fname, char **fstype)
             return false;
         }
     }
-    if (fstat(fd, &s) != 0) {
+    if (0 != fstat(fd, &s)) {
         close(fd);
         return false;
     }
     close(fd);
 
-    // retain the inode of the file
+    // retain the device the file lives on - st_dev, not the inode:
+    // what identifies a mount point is the device, and two files on
+    // the same filesystem share it
     dev = s.st_dev;
 
     // try a couple of possible locations for the
     // mount table
-    if ((fp = setmntent("/proc/mounts", "r")) == NULL) {
-        if ((fp = setmntent("/etc/mtab", "r")) == NULL) {
+    if (NULL == (fp = setmntent("/proc/mounts", "r"))) {
+        if (NULL == (fp = setmntent("/etc/mtab", "r"))) {
             return false;
         }
     }
 
-    // search the mount table for an entry with
-    // matching inode
+    // search the mount table for an entry on the same device
     while (getmntent_r(fp, &mnt, buf, sizeof(buf))) {
         fd = open(mnt.mnt_dir, O_RDONLY);
         if (0 > fd) {
             // probably lack permissions
             continue;
         }
-        if (fstat(fd, &s) != 0) {
+        if (0 != fstat(fd, &s)) {
             close(fd);
             continue;
         }

--- a/src/util/pmix_path.h
+++ b/src/util/pmix_path.h
@@ -53,6 +53,9 @@ BEGIN_C_DECLS
  *  Environment variables must be followed by a path delimiter or
  *  end-of-string.
  *
+ *  pathv and its elements are read, never written - they may be string
+ *  literals, and another thread may be reading the same array.
+ *
  * The caller is responsible for freeing the returned string.
  */
 PMIX_EXPORT char *pmix_path_find(char *fname, char **pathv, int mode, char **envv)
@@ -71,8 +74,12 @@ PMIX_EXPORT char *pmix_path_find(char *fname, char **pathv, int mode, char **env
  *  @retval NULL Failure
  *
  *  Locates a file with certain permissions from the list of paths
- *  given by the $PATH environment variable.  Replaces "." in the
- *  path with the working dir.
+ *  given by the $PATH environment variable - taken from envv if that
+ *  list carries one, and from the process environment otherwise.
+ *
+ *  A wrkdir replaces every "." in that path; if there was no ".", it
+ *  is appended to the end instead, so a wrkdir is always searched.
+ *  Neither envv nor the environment is modified.
  *
  * The caller is responsible for freeing the returned string.
  */
@@ -116,11 +123,16 @@ PMIX_EXPORT char *pmix_find_absolute_path(char *app_name) __pmix_attribute_warn_
  * permissions
  *
  * @param fname File name
- * @param path Path prefix, if NULL then fname is an absolute path
+ * @param path Path prefix; if NULL, fname is used as given
  * @param mode Target permissions which must be satisfied (see access(2))
  *
- * @retval NULL Failure
+ * @retval NULL Failure - the file does not exist, does not grant the
+ * requested permissions, or the assembled name was too long
  * @retval Full pathname of the located file on Success
+ *
+ * Note that this answers a question about the filesystem at the moment
+ * it is asked: the file may be gone, or its permissions changed, by the
+ * time the caller acts on the answer.
  *
  * The caller is responsible for freeing the returned string.
  */
@@ -139,10 +151,17 @@ PMIX_EXPORT char *pmix_path_access(char *fname, char *path, int mode)
  * This allows checking for NFS prior to opening the file.
  *
  * @fname[in]     File name to check
- * @fstype[out]   File system type if retval is true
+ * @fstype[out]   File system type if retval is true.  Allocated here
+ * and owned by the caller; written only on a true return.
  *
  * @retval true                If fname is on NFS, Lustre or Panasas
  * @retval false               otherwise
+ *
+ * This is answered from the mount table, so it is implemented only
+ * where <mntent.h> exists - Linux, in practice.  **Everywhere else,
+ * including macOS and the BSDs, it answers false unconditionally**,
+ * whatever the file is really on.  Do not use it to decide something
+ * that must be right on those platforms.
  */
 PMIX_EXPORT bool pmix_path_nfs(char *fname, char **fstype) __pmix_attribute_warn_unused_result__;
 
@@ -150,7 +169,10 @@ PMIX_EXPORT bool pmix_path_nfs(char *fname, char **fstype) __pmix_attribute_warn
  * @brief Returns the disk usage of path.
  *
  * @param[in] path       Path to check
- * @out_avail[out]       Amount of free space available on path (if successful)
+ * @out_avail[out]       Amount of free space available on path, in
+ * bytes, and available to *this* user - the reserved blocks a
+ * privileged process could still use are not counted.  Set to zero
+ * before anything else, so it is defined even on an error return.
  *
  * @retval PMIX_SUCCESS  If the operation was successful
  * @retval PMIX_ERROR    otherwise

--- a/src/util/pmix_printf.c
+++ b/src/util/pmix_printf.c
@@ -352,7 +352,7 @@ int pmix_vasprintf(char **ptr, const char *fmt, va_list ap)
     int length;
 
     length = vasprintf(ptr, fmt, ap);
-    if (length < 0) {
+    if (0 > length) {
         *ptr = NULL;
     }
 
@@ -479,41 +479,3 @@ int pmix_vsnprintf(char *str, size_t size, const char *fmt, va_list ap)
     return length;
 #endif
 }
-
-#ifdef TEST
-
-int main(int argc, char *argv[])
-{
-    char a[10];
-    char b[173];
-    char *s;
-    int length;
-
-    puts("test for NULL buffer in snprintf:");
-    length = pmix_snprintf(NULL, 0, "this is a string %d", 1004);
-    printf("length = %d\n", length);
-
-    puts("test of snprintf to an undersize buffer:");
-    length = pmix_snprintf(a, sizeof(a), "this is a string %d", 1004);
-    printf("string = %s\n", a);
-    printf("length = %d\n", length);
-    printf("strlen = %d\n", (int) strlen(a));
-
-    puts("test of snprintf to an oversize buffer:");
-    length = pmix_snprintf(b, sizeof(b), "this is a string %d", 1004);
-    printf("string = %s\n", b);
-    printf("length = %d\n", length);
-    printf("strlen = %d\n", (int) strlen(b));
-
-    puts("test of asprintf:");
-    length = pmix_asprintf(&s, "this is a string %d", 1004);
-    printf("string = %s\n", s);
-    printf("length = %d\n", length);
-    printf("strlen = %d\n", (int) strlen(s));
-
-    free(s);
-
-    return 0;
-}
-
-#endif

--- a/src/util/pmix_printf.c
+++ b/src/util/pmix_printf.c
@@ -29,174 +29,308 @@
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_printf.h"
 
+#include <ctype.h>
 #include <errno.h>
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #ifndef HAVE_VASPRINTF
+
+#if !HAVE_VSNPRINTF
+/*
+ * Upper bounds on what a single conversion can emit.  Over-estimating
+ * costs a few unused bytes; under-estimating overruns the buffer that
+ * vsprintf() is about to fill without a bound, so each of these is the
+ * worst case rounded up.
+ */
+/* a 64-bit value in octal is 22 digits; leave room for a sign and a
+ * "0x" or "0" prefix */
+#define PMIX_GUESS_INT_CHARS 32
+/* %f of DBL_MAX is 309 integral digits, plus a sign, the radix
+ * character and the default precision of six */
+#define PMIX_GUESS_DBL_CHARS 512
+/* %Lf of LDBL_MAX reaches 4932 integral digits on x87 */
+#define PMIX_GUESS_LDBL_CHARS 5120
+/* a single character can expand to several bytes in a multibyte
+ * locale */
+#define PMIX_GUESS_CHAR_CHARS 16
+/* "0x" and 16 hex digits, with slack for stranger renderings */
+#define PMIX_GUESS_PTR_CHARS 32
+#endif /* !HAVE_VSNPRINTF */
+
 /*
  * Make a good guess about how long a printf-style varargs formatted
- * string will be once all the % escapes are filled in.  We don't
- * handle every % escape here, but we handle enough, and then add a
- * fudge factor in at the end.
+ * string will be once all the % escapes are filled in, and consume the
+ * arguments it names from ap.
+ *
+ * Returns the number of bytes to allocate, or -1 if the format contains
+ * something whose output cannot be bounded - an unrecognized conversion,
+ * or a wide string with no precision.  The caller must fail on -1: a
+ * conversion we cannot size is also a conversion whose argument we
+ * cannot consume, so everything after it in the va_list would be read
+ * as the wrong type.
  */
 static int guess_strlen(const char *fmt, va_list ap)
 {
 #if HAVE_VSNPRINTF
     char dummy[1];
+    int len;
 
     /* vsnprintf() returns the number of bytes that would have been
      copied if the provided buffer were infinite. */
-    return 1 + vsnprintf(dummy, sizeof(dummy), fmt, ap);
+    len = vsnprintf(dummy, sizeof(dummy), fmt, ap);
+    if (0 > len || INT_MAX == len) {
+        return -1;
+    }
+    return 1 + len;
 #else
-    char *sarg, carg;
-    double darg;
-    float farg;
+    enum {
+        GUESS_LEN_INT,
+        GUESS_LEN_LONG,
+        GUESS_LEN_LLONG,
+        GUESS_LEN_INTMAX,
+        GUESS_LEN_SIZE,
+        GUESS_LEN_PTRDIFF,
+        GUESS_LEN_LDBL
+    } lenmod;
+    const char *sarg;
+    size_t fmtlen;
+    size_t total;
+    size_t width;
+    size_t prec;
+    size_t chars;
+    bool have_prec;
     size_t i;
     int iarg;
-    int len;
-    long larg;
 
-    /* Start off with a fudge factor of 128 to handle the % escapes that
-     we aren't calculating here */
+    fmtlen = strlen(fmt);
 
-    len = (int) strlen(fmt) + 128;
-    for (i = 0; i < strlen(fmt); ++i) {
-        if ('%' == fmt[i] && i + 1 < strlen(fmt) && '%' != fmt[i + 1]) {
+    /* Start off with a fudge factor of 128 to cover whatever the walk
+     below gets wrong */
+    total = fmtlen + 128;
+
+    for (i = 0; i < fmtlen; ++i) {
+        if ('%' != fmt[i]) {
+            continue;
+        }
+        ++i;
+        if (i >= fmtlen || '%' == fmt[i]) {
+            /* a trailing '%', or the "%%" escape: neither takes an
+             argument */
+            continue;
+        }
+
+        /* flags */
+        while (i < fmtlen && NULL != strchr("-+ #0'", fmt[i])) {
             ++i;
+        }
+
+        /* field width */
+        width = 0;
+        if (i < fmtlen && '*' == fmt[i]) {
+            iarg = va_arg(ap, int);
+            width = (0 > iarg) ? (size_t)(-(long long) iarg) : (size_t) iarg;
+            ++i;
+        } else {
+            while (i < fmtlen && isdigit((unsigned char) fmt[i])) {
+                if ((size_t) INT_MAX >= width) {
+                    width = (width * 10) + (size_t)(fmt[i] - '0');
+                }
+                ++i;
+            }
+        }
+
+        /* precision */
+        prec = 0;
+        have_prec = false;
+        if (i < fmtlen && '.' == fmt[i]) {
+            ++i;
+            have_prec = true;
+            if (i < fmtlen && '*' == fmt[i]) {
+                iarg = va_arg(ap, int);
+                /* a negative precision is taken as if it were omitted */
+                if (0 > iarg) {
+                    have_prec = false;
+                } else {
+                    prec = (size_t) iarg;
+                }
+                ++i;
+            } else {
+                while (i < fmtlen && isdigit((unsigned char) fmt[i])) {
+                    if ((size_t) INT_MAX >= prec) {
+                        prec = (prec * 10) + (size_t)(fmt[i] - '0');
+                    }
+                    ++i;
+                }
+            }
+        }
+
+        /* length modifier */
+        lenmod = GUESS_LEN_INT;
+        if (i < fmtlen) {
             switch (fmt[i]) {
-                case 'c':
-                    carg = va_arg(ap, int);
-                    len += 1; /* let's suppose it's a printable char */
-                    (void)
-                    carg; /* prevent compiler from complaining about set but not used variables */
-                    break;
-                case 's':
-                    sarg = va_arg(ap, char *);
-
-                    /* If there's an arg, get the strlen, otherwise we'll
-                     * use (null) */
-
-                    if (NULL != sarg) {
-                        len += (int) strlen(sarg);
-                    } else {
-#if PMIX_ENABLE_DEBUG
-                        pmix_output(0, "PMIX DEBUG WARNING: Got a NULL argument to pmix_vasprintf!\n");
-#endif
-                        len += 5;
-                    }
-                    break;
-
-                case 'd':
-                case 'i':
-                    iarg = va_arg(ap, int);
-                    /* Alloc for minus sign */
-                    if (iarg < 0)
-                        ++len;
-                    /* Now get the log10 */
-                    do {
-                        ++len;
-                        iarg /= 10;
-                    } while (0 != iarg);
-                    break;
-
-                case 'x':
-                case 'X':
-                    iarg = va_arg(ap, int);
-                    /* Now get the log16 */
-                    do {
-                        ++len;
-                        iarg /= 16;
-                    } while (0 != iarg);
-                    break;
-
-                case 'f':
-                    /* a float argument is promoted to double through
-                     * varargs; read it as a double, not an int */
-                    farg = (float) va_arg(ap, double);
-                    /* Alloc for minus sign */
-                    if (farg < 0) {
-                        ++len;
-                        farg = -farg;
-                    }
-                    /* Alloc for 3 decimal places + '.' */
-                    len += 4;
-                    /* Now get the log10 */
-                    do {
-                        ++len;
-                        farg /= 10.0;
-                    } while (0 != farg);
-                    break;
-
-                case 'g':
-                    darg = va_arg(ap, double);
-                    /* Alloc for minus sign */
-                    if (darg < 0) {
-                        ++len;
-                        darg = -darg;
-                    }
-                    /* Alloc for 3 decimal places + '.' */
-                    len += 4;
-                    /* Now get the log10 */
-                    do {
-                        ++len;
-                        darg /= 10.0;
-                    } while (0 != darg);
-                    break;
-
-                case 'l':
-                    /* Get %ld %lx %lX %lf */
-                    if (i + 1 < strlen(fmt)) {
+                case 'h':
+                    /* both %hd and %hhd are promoted to int */
+                    ++i;
+                    if (i < fmtlen && 'h' == fmt[i]) {
                         ++i;
-                        switch (fmt[i]) {
-                            case 'x':
-                            case 'X':
-                                larg = va_arg(ap, long);
-                                /* Now get the log16 */
-                                do {
-                                    ++len;
-                                    larg /= 16;
-                                } while (0 != larg);
-                                break;
-
-                            case 'f':
-                                darg = va_arg(ap, double);
-                                /* Alloc for minus sign */
-                                if (darg < 0) {
-                                    ++len;
-                                    darg = -darg;
-                                }
-                                /* Alloc for 3 decimal places + '.' */
-                                len += 4;
-                                /* Now get the log10 */
-                                do {
-                                    ++len;
-                                    darg /= 10.0;
-                                } while (0 != darg);
-                                break;
-
-                            case 'd':
-                            default:
-                                larg = va_arg(ap, long);
-                                /* Now get the log10 */
-                                do {
-                                    ++len;
-                                    larg /= 10;
-                                } while (0 != larg);
-                                break;
-                        }
                     }
-
+                    break;
+                case 'l':
+                    ++i;
+                    if (i < fmtlen && 'l' == fmt[i]) {
+                        ++i;
+                        lenmod = GUESS_LEN_LLONG;
+                    } else {
+                        lenmod = GUESS_LEN_LONG;
+                    }
+                    break;
+                case 'q':
+                    ++i;
+                    lenmod = GUESS_LEN_LLONG;
+                    break;
+                case 'j':
+                    ++i;
+                    lenmod = GUESS_LEN_INTMAX;
+                    break;
+                case 'z':
+                    ++i;
+                    lenmod = GUESS_LEN_SIZE;
+                    break;
+                case 't':
+                    ++i;
+                    lenmod = GUESS_LEN_PTRDIFF;
+                    break;
+                case 'L':
+                    ++i;
+                    lenmod = GUESS_LEN_LDBL;
+                    break;
                 default:
                     break;
             }
         }
+        if (i >= fmtlen) {
+            /* the format ended in the middle of a conversion */
+            break;
+        }
+
+        /* the conversion itself.  Signed and unsigned types of the same
+         width are interchangeable in va_arg, so one arm covers both. */
+        chars = 0;
+        switch (fmt[i]) {
+            case 'd':
+            case 'i':
+            case 'o':
+            case 'u':
+            case 'x':
+            case 'X':
+                switch (lenmod) {
+                    case GUESS_LEN_LONG:
+                        (void) va_arg(ap, long);
+                        break;
+                    case GUESS_LEN_LLONG:
+                        (void) va_arg(ap, long long);
+                        break;
+                    case GUESS_LEN_INTMAX:
+                        (void) va_arg(ap, intmax_t);
+                        break;
+                    case GUESS_LEN_SIZE:
+                        (void) va_arg(ap, size_t);
+                        break;
+                    case GUESS_LEN_PTRDIFF:
+                        (void) va_arg(ap, ptrdiff_t);
+                        break;
+                    default:
+                        (void) va_arg(ap, int);
+                        break;
+                }
+                /* a precision on an integer conversion is a minimum
+                 number of digits */
+                chars = PMIX_GUESS_INT_CHARS + prec;
+                break;
+
+            case 'f':
+            case 'F':
+            case 'e':
+            case 'E':
+            case 'g':
+            case 'G':
+            case 'a':
+            case 'A':
+                if (GUESS_LEN_LDBL == lenmod) {
+                    (void) va_arg(ap, long double);
+                    chars = PMIX_GUESS_LDBL_CHARS + prec;
+                } else {
+                    (void) va_arg(ap, double);
+                    chars = PMIX_GUESS_DBL_CHARS + prec;
+                }
+                break;
+
+            case 'c':
+                /* %lc names a wint_t, which is an integer-promoted type
+                 the same width as int everywhere we build; take it as an
+                 int rather than requiring <wchar.h> here */
+                (void) va_arg(ap, int);
+                chars = PMIX_GUESS_CHAR_CHARS;
+                break;
+
+            case 's':
+                sarg = va_arg(ap, const char *);
+                if (GUESS_LEN_LONG == lenmod) {
+                    /* a wchar_t string cannot be measured from here, so
+                     an explicit precision is the only bound we have */
+                    if (!have_prec) {
+                        return -1;
+                    }
+                    chars = prec * PMIX_GUESS_CHAR_CHARS;
+                } else if (NULL == sarg) {
+#if PMIX_ENABLE_DEBUG
+                    pmix_output(0,
+                                "PMIX DEBUG WARNING: Got a NULL argument to pmix_vasprintf!\n");
+#endif
+                    /* implementations render this as "(null)" */
+                    chars = 8;
+                } else {
+                    chars = strlen(sarg);
+                    if (have_prec && prec < chars) {
+                        chars = prec;
+                    }
+                }
+                break;
+
+            case 'p':
+                (void) va_arg(ap, void *);
+                chars = PMIX_GUESS_PTR_CHARS;
+                break;
+
+            case 'n':
+                /* consumes a pointer and emits nothing */
+                (void) va_arg(ap, void *);
+                break;
+
+            default:
+                /* we do not know what this consumes, so we cannot keep
+                 reading the va_list either */
+                return -1;
+        }
+
+        if (chars < width) {
+            chars = width;
+        }
+        if ((size_t) INT_MAX < chars || (size_t) INT_MAX - chars < total) {
+            return -1;
+        }
+        total += chars;
     }
 
-    return len;
+    return (int) total;
 #endif
 }
+
 #endif /* #ifndef HAVE_VASPRINTF */
 
 int pmix_asprintf(char **ptr, const char *fmt, ...)
@@ -224,6 +358,8 @@ int pmix_vasprintf(char **ptr, const char *fmt, va_list ap)
 
     return length;
 #else
+    char *buf;
+    char *tmp;
     int length;
     va_list ap2;
 
@@ -240,28 +376,48 @@ int pmix_vasprintf(char **ptr, const char *fmt, va_list ap)
 
     /* guess the size */
     length = guess_strlen(fmt, ap);
+    if (0 > length) {
+        /* the format holds something we cannot bound; refuse it rather
+         than hand vsprintf() a buffer it would run off the end of */
+#if PMIX_HAVE_VA_COPY || PMIX_HAVE_UNDERSCORE_VA_COPY
+        va_end(ap2);
+#endif /* PMIX_HAVE_VA_COPY || PMIX_HAVE_UNDERSCORE_VA_COPY */
+        *ptr = NULL;
+        errno = EINVAL;
+        return -1;
+    }
 
     /* allocate a buffer */
-    *ptr = (char *) calloc(((size_t) length + 1), sizeof(char));
-    if (NULL == *ptr) {
-        errno = ENOMEM;
+    buf = (char *) calloc(((size_t) length + 1), sizeof(char));
+    if (NULL == buf) {
+#if PMIX_HAVE_VA_COPY || PMIX_HAVE_UNDERSCORE_VA_COPY
         va_end(ap2);
+#endif /* PMIX_HAVE_VA_COPY || PMIX_HAVE_UNDERSCORE_VA_COPY */
+        *ptr = NULL;
+        errno = ENOMEM;
         return -1;
     }
 
     /* fill the buffer */
-    length = vsprintf(*ptr, fmt, ap2);
+    length = vsprintf(buf, fmt, ap2);
 #if PMIX_HAVE_VA_COPY || PMIX_HAVE_UNDERSCORE_VA_COPY
     va_end(ap2);
 #endif /* PMIX_HAVE_VA_COPY || PMIX_HAVE_UNDERSCORE_VA_COPY */
-
-    /* realloc */
-    *ptr = (char *) realloc(*ptr, (size_t) length + 1);
-    if (NULL == *ptr) {
-        errno = ENOMEM;
+    if (0 > length) {
+        free(buf);
+        *ptr = NULL;
         return -1;
     }
 
+    /* hand back the slack the guess left over.  Failing to shrink an
+     allocation is not a reason to throw away a string we already
+     formatted successfully - just keep the larger buffer. */
+    tmp = (char *) realloc(buf, (size_t) length + 1);
+    if (NULL != tmp) {
+        buf = tmp;
+    }
+
+    *ptr = buf;
     return length;
 #endif
 }
@@ -280,16 +436,35 @@ int pmix_snprintf(char *str, size_t size, const char *fmt, ...)
 
 int pmix_vsnprintf(char *str, size_t size, const char *fmt, va_list ap)
 {
+#if HAVE_VSNPRINTF
+    /* C99 vsnprintf() already has exactly these semantics, and reaches
+     them without allocating.  Going the long way round through
+     pmix_vasprintf() would put a malloc/free pair on every line the
+     library prints, and would fail outright under the memory pressure
+     that the diagnostics are usually there to report. */
+    if (NULL == str || 0 == size) {
+        /* the C99 "how long would it be" form; a NULL buffer with a
+         non-zero size is undefined, so normalize it here */
+        return vsnprintf(NULL, 0, fmt, ap);
+    }
+    return vsnprintf(str, size, fmt, ap);
+#else
     int length;
     char *buf;
 
     length = pmix_vasprintf(&buf, fmt, ap);
-    if (length < 0) {
+    if (0 > length) {
+        /* the header promises the output is always null-terminated,
+         and a caller that ignores the return value will read this
+         buffer regardless */
+        if (NULL != str && 0 < size) {
+            str[0] = '\0';
+        }
         return length;
     }
 
     /* return the length when given a null buffer (C99) */
-    if (str && size > 0) {
+    if (NULL != str && 0 < size) {
         if ((size_t) length < size) {
             strcpy(str, buf);
         } else {
@@ -302,6 +477,7 @@ int pmix_vsnprintf(char *str, size_t size, const char *fmt, va_list ap)
     free(buf);
 
     return length;
+#endif
 }
 
 #ifdef TEST

--- a/src/util/pmix_printf.h
+++ b/src/util/pmix_printf.h
@@ -47,10 +47,13 @@ BEGIN_C_DECLS
  * size'th character then gets the terminating `\0'); if the return
  * value is greater than or equal to the size argument, the string was
  * too short and some of the printed characters were discarded.  The
- * output is always null-terminated.
+ * output is always null-terminated, including on failure.
  *
  * Returns the number of characters that would have been printed if
- * the size were unlimited (again, not including the final `\0').
+ * the size were unlimited (again, not including the final `\0'), or a
+ * negative value if the string could not be formatted at all.  A NULL
+ * str, or a size of zero, asks for that length without writing
+ * anything.
  *
  * THIS IS A PORTABILITY FEATURE: USE snprintf() in CODE.
  */
@@ -72,10 +75,13 @@ __pmix_attribute_format__(__printf__, 3, 4);
  * size'th character then gets the terminating `\0'); if the return
  * value is greater than or equal to the size argument, the string was
  * too short and some of the printed characters were discarded.  The
- * output is always null-terminated.
+ * output is always null-terminated, including on failure.
  *
  * Returns the number of characters that would have been printed if
- * the size were unlimited (again, not including the final `\0').
+ * the size were unlimited (again, not including the final `\0'), or a
+ * negative value if the string could not be formatted at all.  A NULL
+ * str, or a size of zero, asks for that length without writing
+ * anything.
  *
  * THIS IS A PORTABILITY FEATURE: USE vsnprintf() in CODE.
  */
@@ -105,6 +111,13 @@ __pmix_attribute_format__(__printf__, 3, 0);
  * on error and some implementations (modern Linux) do not guarantee
  * such behavior.
  *
+ * On a platform with no asprintf(3) of its own the format is sized by
+ * hand before the buffer is allocated, so a format holding a
+ * conversion that cannot be bounded - one this library does not
+ * recognize, or a wide string with no precision - is refused with -1
+ * and errno set to EINVAL rather than formatted into a buffer that
+ * would be too small.  Every conversion C99 defines is recognized.
+ *
  */
 PMIX_EXPORT int pmix_asprintf(char **ptr, const char *fmt, ...)
 __pmix_attribute_format__(__printf__, 2, 3);
@@ -133,6 +146,9 @@ __pmix_attribute_format__(__printf__, 2, 3);
  * asprintf fails.  The standard does not require *ptr be set to NULL
  * on error and some implementations (modern Linux) do not guarantee
  * such behavior.
+ *
+ * See pmix_asprintf() for the EINVAL case that only arises on a
+ * platform with no asprintf(3) of its own.
  *
  */
 PMIX_EXPORT int pmix_vasprintf(char **ptr, const char *fmt, va_list ap)

--- a/src/util/pmix_pty.c
+++ b/src/util/pmix_pty.c
@@ -87,9 +87,6 @@
 
 #ifdef HAVE_PTSNAME
 #    include <stdlib.h>
-#    ifdef HAVE_STROPTS_H
-#        include <stropts.h>
-#    endif
 #endif
 
 #ifdef HAVE_UTIL_H
@@ -211,7 +208,9 @@ int pmix_ptysopen(int fdm, char *pts_name)
     int fds;
 
     /* the master descriptor belongs to our caller: we neither use nor
-     close it, but it stays in the signature, which is frozen */
+     close it.  It stays in the signature because the signature is
+     frozen - the last route that needed it was the STREAMS module push
+     on Solaris, which this library no longer supports. */
     PMIX_HIDE_UNUSED_PARAMS(fdm);
 
 #    ifdef HAVE_PTSNAME
@@ -225,23 +224,6 @@ int pmix_ptysopen(int fdm, char *pts_name)
                             pts_name, strerror(errno));
         return -5;
     }
-#        if defined(__SVR4) && defined(__sun)
-    int errsave;
-
-    if (0 > ioctl(fds, I_PUSH, "ptem")) {
-        errsave = errno;
-        close(fds);  // might change errno
-        errno = errsave;
-        return -6;
-    }
-    if (0 > ioctl(fds, I_PUSH, "ldterm")) {
-        errsave = errno;
-        close(fds);  // might change errno
-        errno = errsave;
-        return -7;
-    }
-#        endif
-
     /* Deliberately NO TIOCSCTTY here.  This runs in the process that is
      opening the pty, not in the child that will use it, and TIOCSCTTY
      succeeds for any session leader that has no controlling terminal -

--- a/src/util/pmix_pty.c
+++ b/src/util/pmix_pty.c
@@ -96,6 +96,7 @@
 #    include <util.h>
 #endif
 
+#include "src/include/pmix_globals.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_pty.h"
 #include "src/util/pmix_string_copy.h"
@@ -120,17 +121,25 @@ PMIX_EXPORT int pmix_ptysopen(int fdm, char *pts_name)
 int pmix_ptymopen(char *pts_name, size_t maxlen)
 {
     int fdm;
-    int errsave;
 
 #    ifdef HAVE_PTSNAME
+    int errsave;
     char *ptr;
 
 #        ifdef _AIX
-    strncpy(pts_name, "/dev/ptc", maxlen);
+    static const char master[] = "/dev/ptc";
 #        else
-    strncpy(pts_name, "/dev/ptmx", maxlen);
+    static const char master[] = "/dev/ptmx";
 #        endif
-    fdm = open(pts_name, O_RDWR);
+
+    /* strncpy() would leave pts_name unterminated for a short maxlen,
+     and the open() below would then read off the end of it */
+    if (maxlen < sizeof(master)) {
+        errno = EOVERFLOW;
+        return -5;
+    }
+    pmix_string_copy(pts_name, master, maxlen);
+    fdm = open(pts_name, O_RDWR | O_NOCTTY);
     if (fdm < 0) {
         return -1;
     }
@@ -154,7 +163,7 @@ int pmix_ptymopen(char *pts_name, size_t maxlen)
         return -4;
     }
     if (strlen(ptr) < maxlen) {
-        strncpy(pts_name, ptr, maxlen); /* return name of slave */
+        pmix_string_copy(pts_name, ptr, maxlen); /* return name of slave */
         return fdm;            /* return fd of master */
     } else {
         close(fdm);
@@ -164,20 +173,23 @@ int pmix_ptymopen(char *pts_name, size_t maxlen)
 
 #    else  // HAVE_PTSNAME
 
-    char *ptr1, *ptr2;
+    static const char ptyname[] = "/dev/ptyXY";
+    const char *ptr1, *ptr2;
 
-    if (strlen("/dev/ptyXY") < maxlen-1) {
-        strcpy(pts_name, "/dev/ptyXY");
-    } else {
-        return PMIX_ERR_BAD_PARAM;
+    /* maxlen is unsigned: "maxlen - 1" wraps for a maxlen of zero, and
+     the strcpy below would then run off the end of the buffer */
+    if (maxlen < sizeof(ptyname)) {
+        errno = EOVERFLOW;
+        return -5;
     }
-    /* array index: 012345689 (for references in following code) */
+    pmix_string_copy(pts_name, ptyname, maxlen);
+    /* array index: 0123456789 (for references in following code) */
     for (ptr1 = "pqrstuvwxyzPQRST"; *ptr1 != 0; ptr1++) {
         pts_name[8] = *ptr1;
         for (ptr2 = "0123456789abcdef"; *ptr2 != 0; ptr2++) {
             pts_name[9] = *ptr2;
             /* try to open master */
-            fdm = open(pts_name, O_RDWR);
+            fdm = open(pts_name, O_RDWR | O_NOCTTY);
             if (fdm < 0) {
                 if (errno == ENOENT) { /* different from EIO */
                     return -1;         /* out of pty devices */
@@ -197,39 +209,47 @@ int pmix_ptymopen(char *pts_name, size_t maxlen)
 int pmix_ptysopen(int fdm, char *pts_name)
 {
     int fds;
-    int errsave;
+
+    /* the master descriptor belongs to our caller: we neither use nor
+     close it, but it stays in the signature, which is frozen */
+    PMIX_HIDE_UNUSED_PARAMS(fdm);
 
 #    ifdef HAVE_PTSNAME
-    /* following should allocate controlling terminal */
-    fds = open(pts_name, O_RDWR);
+    /* O_NOCTTY: opening a terminal device from a session leader that has
+     no controlling terminal makes it one, and this runs in the process
+     opening the pty rather than in the child that will use it */
+    fds = open(pts_name, O_RDWR | O_NOCTTY);
     if (fds < 0) {
-        pmix_output(0, "FAILED WITH %s", strerror(errno));
-        errsave = errno;
-        close(fdm);  // might change errno
-        errno = errsave;
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "pmix_ptysopen: could not open %s: %s",
+                            pts_name, strerror(errno));
         return -5;
     }
 #        if defined(__SVR4) && defined(__sun)
+    int errsave;
+
     if (ioctl(fds, I_PUSH, "ptem") < 0) {
         errsave = errno;
-        close(fdm);  // might change errno
         close(fds);  // might change errno
         errno = errsave;
         return -6;
     }
     if (ioctl(fds, I_PUSH, "ldterm") < 0) {
         errsave = errno;
-        close(fdm);  // might change errno
         close(fds);  // might change errno
         errno = errsave;
         return -7;
     }
 #        endif
 
-#ifdef TIOCSCTTY                        /* Acquire controlling tty on BSD */
-        // just make the attempt - don't worry if it fails
-        ioctl(fds, TIOCSCTTY, 0);
-#endif
+    /* Deliberately NO TIOCSCTTY here.  This runs in the process that is
+     opening the pty, not in the child that will use it, and TIOCSCTTY
+     succeeds for any session leader that has no controlling terminal -
+     which is exactly the shape of a daemonized PMIx server.  It would
+     then be the *server* whose controlling terminal is the child's pty,
+     so a hangup on that pty reaches the server.  A caller who wants the
+     pty to be a controlling terminal has to say so after setsid() in
+     the child, the way forkpty()/login_tty() do. */
 
     return fds;
 
@@ -247,11 +267,8 @@ int pmix_ptysopen(int fdm, char *pts_name)
     /* following two functions don't work unless we're root */
     lchown(pts_name, getuid(), gid);  // DO NOT FOLLOW LINKS
     chmod(pts_name, S_IRUSR | S_IWUSR | S_IWGRP);
-    fds = open(pts_name, O_RDWR);
+    fds = open(pts_name, O_RDWR | O_NOCTTY);
     if (fds < 0) {
-        errsave = errno;
-        close(fdm);  // might change errno
-        errno = errsave;
         return -1;
     }
     return fds;

--- a/src/util/pmix_pty.c
+++ b/src/util/pmix_pty.c
@@ -140,23 +140,23 @@ int pmix_ptymopen(char *pts_name, size_t maxlen)
     }
     pmix_string_copy(pts_name, master, maxlen);
     fdm = open(pts_name, O_RDWR | O_NOCTTY);
-    if (fdm < 0) {
+    if (0 > fdm) {
         return -1;
     }
-    if (grantpt(fdm) < 0) { /* grant access to slave */
+    if (0 > grantpt(fdm)) { /* grant access to slave */
         errsave = errno;
         close(fdm);  // might change errno
         errno = errsave;
         return -2;
     }
-    if (unlockpt(fdm) < 0) { /* clear slave's lock flag */
+    if (0 > unlockpt(fdm)) { /* clear slave's lock flag */
         errsave = errno;
         close(fdm);  // might change errno
         errno = errsave;
         return -3;
     }
     ptr = ptsname(fdm);
-    if (ptr == NULL) { /* get slave's name */
+    if (NULL == ptr) { /* get slave's name */
         errsave = errno;
         close(fdm);  // might change errno
         errno = errsave;
@@ -184,14 +184,14 @@ int pmix_ptymopen(char *pts_name, size_t maxlen)
     }
     pmix_string_copy(pts_name, ptyname, maxlen);
     /* array index: 0123456789 (for references in following code) */
-    for (ptr1 = "pqrstuvwxyzPQRST"; *ptr1 != 0; ptr1++) {
+    for (ptr1 = "pqrstuvwxyzPQRST"; 0 != *ptr1; ptr1++) {
         pts_name[8] = *ptr1;
-        for (ptr2 = "0123456789abcdef"; *ptr2 != 0; ptr2++) {
+        for (ptr2 = "0123456789abcdef"; 0 != *ptr2; ptr2++) {
             pts_name[9] = *ptr2;
             /* try to open master */
             fdm = open(pts_name, O_RDWR | O_NOCTTY);
-            if (fdm < 0) {
-                if (errno == ENOENT) { /* different from EIO */
+            if (0 > fdm) {
+                if (ENOENT == errno) { /* different from EIO */
                     return -1;         /* out of pty devices */
                 } else {
                     continue; /* try next pty device */
@@ -219,7 +219,7 @@ int pmix_ptysopen(int fdm, char *pts_name)
      no controlling terminal makes it one, and this runs in the process
      opening the pty rather than in the child that will use it */
     fds = open(pts_name, O_RDWR | O_NOCTTY);
-    if (fds < 0) {
+    if (0 > fds) {
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "pmix_ptysopen: could not open %s: %s",
                             pts_name, strerror(errno));
@@ -228,13 +228,13 @@ int pmix_ptysopen(int fdm, char *pts_name)
 #        if defined(__SVR4) && defined(__sun)
     int errsave;
 
-    if (ioctl(fds, I_PUSH, "ptem") < 0) {
+    if (0 > ioctl(fds, I_PUSH, "ptem")) {
         errsave = errno;
         close(fds);  // might change errno
         errno = errsave;
         return -6;
     }
-    if (ioctl(fds, I_PUSH, "ldterm") < 0) {
+    if (0 > ioctl(fds, I_PUSH, "ldterm")) {
         errsave = errno;
         close(fds);  // might change errno
         errno = errsave;
@@ -255,20 +255,20 @@ int pmix_ptysopen(int fdm, char *pts_name)
 
 #    else
 
-    int gid;
+    gid_t gid;
     struct group *grptr;
 
     grptr = getgrnam("tty");
-    if (grptr != NULL) {
+    if (NULL != grptr) {
         gid = grptr->gr_gid;
     } else {
-        gid = -1; /* group tty is not in the group file */
+        gid = (gid_t) -1; /* group tty is not in the group file */
     }
     /* following two functions don't work unless we're root */
     lchown(pts_name, getuid(), gid);  // DO NOT FOLLOW LINKS
     chmod(pts_name, S_IRUSR | S_IWUSR | S_IWGRP);
     fds = open(pts_name, O_RDWR | O_NOCTTY);
-    if (fds < 0) {
+    if (0 > fds) {
         return -1;
     }
     return fds;
@@ -304,15 +304,15 @@ int pmix_openpty(int *amaster, int *aslave, char *name,
 {
     char line[20];
     *amaster = pmix_ptymopen(line, sizeof(line));
-    if (*amaster < 0) {
+    if (0 > *amaster) {
         return -1;
     }
     *aslave = pmix_ptysopen(*amaster, line);
-    if (*aslave < 0) {
+    if (0 > *aslave) {
         close(*amaster);
         return -1;
     }
-    if (name) {
+    if (NULL != name) {
         // We don't know the max length of name, but we do know the
         // max length of the source, so at least use that.
         pmix_string_copy(name, line, sizeof(line));
@@ -320,11 +320,11 @@ int pmix_openpty(int *amaster, int *aslave, char *name,
 #    ifndef TCSAFLUSH
 #        define TCSAFLUSH TCSETAF
 #    endif
-    if (termp) {
+    if (NULL != termp) {
         (void) tcsetattr(*aslave, TCSAFLUSH, termp);
     }
 #    ifdef TIOCSWINSZ
-    if (winp) {
+    if (NULL != winp) {
         (void) ioctl(*aslave, TIOCSWINSZ, (char *) winp);
     }
 #    endif

--- a/src/util/pmix_pty.h
+++ b/src/util/pmix_pty.h
@@ -37,6 +37,15 @@
 #        include <termio.h>
 #    endif
 #endif
+/* struct winsize appears in the prototypes below, and <termios.h> is not
+ * where it comes from - glibc keeps it in <sys/ioctl.h> and only leaks it
+ * out of <termios.h> under some feature-test settings.  macOS does leak
+ * it, which is why a consumer that forgot this include built there and
+ * failed on Linux with "declared inside parameter list".  This header is
+ * installed, so it has to bring its own types. */
+#ifdef HAVE_SYS_IOCTL_H
+#    include <sys/ioctl.h>
+#endif
 
 BEGIN_C_DECLS
 

--- a/src/util/pmix_pty.h
+++ b/src/util/pmix_pty.h
@@ -40,15 +40,99 @@
 
 BEGIN_C_DECLS
 
+/**
+ * @file
+ *
+ * Pseudo-terminal helpers.
+ *
+ * These are built only when configure found pty support; when it did
+ * not, `PMIX_ENABLE_PTY_SUPPORT` is 0 and every function below is a stub
+ * that fails, so a caller must always be prepared to fall back to a
+ * plain pipe.  Note the declarations differ between the two cases: the
+ * stubs take `void *` where the real functions take `struct termios *`
+ * and `struct winsize *`, because those types need not exist at all on a
+ * platform with no pty support.
+ *
+ * **None of these gives the caller a controlling terminal, and none of
+ * them may.** They run in the process that is *setting up* a pty for
+ * somebody else - a PMIx server arranging a child's output - and
+ * opening a terminal device from a session leader that has no
+ * controlling terminal makes it one.  A daemonized server is exactly
+ * that, so a helper that took one would tie the server's fate to a pty
+ * it merely handed to a child: closing the last master descriptor
+ * hangs up the terminal's foreground process group.  Every open here
+ * therefore passes `O_NOCTTY`.  A caller that genuinely wants a
+ * controlling terminal asks for one itself, in the child, after
+ * `setsid()` - which is what `forkpty()` does.
+ */
+
 #if PMIX_ENABLE_PTY_SUPPORT
 
+/**
+ * Open a pty and hand back both ends.
+ *
+ * @param amaster  filled in with the master descriptor
+ * @param aslave   filled in with the slave descriptor
+ * @param name     if not NULL, receives the slave's device name; it must
+ *                 be at least 20 bytes, which is all the fallback
+ *                 implementation can promise to respect
+ * @param termp    if not NULL, terminal settings to apply to the slave
+ * @param winp     if not NULL, window size to apply to the slave
+ * @return         0 on success, -1 on failure
+ *
+ * On failure neither descriptor is left open and the caller has nothing
+ * to clean up.  On success the caller owns both.
+ */
 PMIX_EXPORT int pmix_openpty(int *amaster, int *aslave, char *name,
                              struct termios *termp, struct winsize *winp);
 
+/**
+ * Open the master side of a pty and report the slave's device name.
+ *
+ * @param pts_name  buffer that receives the slave device name
+ * @param maxlen    size of that buffer, terminator included
+ * @return          the master descriptor, or a negative value on failure
+ *
+ * `maxlen` is honored: a buffer too small for the device name is a
+ * failure (-5, `errno` `EOVERFLOW`) rather than a truncated name.  The
+ * negative returns distinguish *where* the sequence failed - the open
+ * (-1), `grantpt` (-2), `unlockpt` (-3), `ptsname` (-4), the buffer
+ * (-5) - and `errno` is preserved across the cleanup in each case.
+ * Nothing is left open on failure.
+ *
+ * Note that `ptsname(3)` answers out of static storage, so two threads
+ * inside this function at once can read each other's answer.
+ */
 PMIX_EXPORT int pmix_ptymopen(char *pts_name, size_t maxlen);
 
+/**
+ * Open the slave side of a pty whose master is already open.
+ *
+ * @param fdm       the master descriptor, as returned by pmix_ptymopen
+ * @param pts_name  the slave device name it reported
+ * @return          the slave descriptor, or a negative value on failure
+ *
+ * **The master descriptor stays the caller's.** This function neither
+ * closes it nor keeps it - it is in the signature for the platforms
+ * whose STREAMS setup needs it - so a caller unwinding after a failure
+ * here must close it itself.  Nothing this function opened survives a
+ * failure.
+ */
 PMIX_EXPORT int pmix_ptysopen(int fdm, char *pts_name);
 
+/**
+ * fork(2) with the child's standard descriptors on a new pty.
+ *
+ * @param master  filled in, in the parent, with the master descriptor
+ * @param slave   if not NULL, receives the slave's device name
+ * @param sterm   if not NULL, terminal settings to apply to the slave
+ * @param sws     if not NULL, window size to apply to the slave
+ * @return        0 in the child, the child's pid in the parent, -1 on
+ *                failure
+ *
+ * Unlike the helpers above, the child of this call *does* get the pty as
+ * its controlling terminal - that is what forkpty(3) is for.
+ */
 PMIX_EXPORT pid_t pmix_forkpty(int *master, char *slave,
                                const struct termios *sterm,
                                const struct winsize *sws);

--- a/src/util/pmix_pty.h
+++ b/src/util/pmix_pty.h
@@ -113,10 +113,9 @@ PMIX_EXPORT int pmix_ptymopen(char *pts_name, size_t maxlen);
  * @return          the slave descriptor, or a negative value on failure
  *
  * **The master descriptor stays the caller's.** This function neither
- * closes it nor keeps it - it is in the signature for the platforms
- * whose STREAMS setup needs it - so a caller unwinding after a failure
- * here must close it itself.  Nothing this function opened survives a
- * failure.
+ * closes it nor keeps it - it remains in the signature only because the
+ * signature is frozen - so a caller unwinding after a failure here must
+ * close it itself.  Nothing this function opened survives a failure.
  */
 PMIX_EXPORT int pmix_ptysopen(int fdm, char *pts_name);
 

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -15,6 +15,7 @@
 #include "src/include/pmix_globals.h"
 #include "src/mca/gds/base/base.h"
 #include "src/util/pmix_error.h"
+#include "src/util/pmix_os_dirpath.h"
 #include "src/util/pmix_show_help.h"
 #include "src/util/pmix_string_copy.h"
 #include "src/util/pmix_vmem.h"
@@ -82,7 +83,10 @@ segment_attach(
     pmix_status_t rc = PMIX_SUCCESS;
     void *mmap_addr = MAP_FAILED;
 
-    const int fd = open(shmem->backing_path, O_RDWR);
+    /* opened relative to its directory rather than by name - see
+     * pmix_os_dirpath_open_file() - so a symlink at the backing path
+     * does not send the attach at some unrelated file */
+    const int fd = pmix_os_dirpath_open_file(shmem->backing_path, O_RDWR, 0);
     if (fd == -1) {
         rc = PMIX_ERR_FILE_OPEN_FAILURE;
         if (0 < pmix_output_get_verbosity(pmix_gds_base_framework.framework_output)) {
@@ -210,12 +214,38 @@ pmix_shmem_segment_create(
      * past the old end reads as zero. gds/shmem3's allocator relies on the
      * whole region being zero so it does not have to memset what it hands out;
      * see tma_carve() there. */
-    const int fd = open(backing_path, O_CREAT | O_TRUNC | O_RDWR, 0600);
+    /* O_EXCL, and opened relative to its directory rather than by name.
+     *
+     * This process composes the whole of backing_path out of its own
+     * naming scheme, so anything already sitting there is either a file
+     * left over from an earlier run - the name carries a pid, and pids
+     * get reused - or something this code did not put there. O_EXCL
+     * declines both, and with O_CREAT it declines a symlink in
+     * particular, which a bare O_CREAT | O_TRUNC would instead follow,
+     * truncating and overwriting some unrelated file.
+     *
+     * Two passes at most, matching write_rndz_file(): a leftover file is
+     * reclaimed once and the create retried. unlink() removes the name
+     * it is given and never follows it onward. */
+    int fd = -1;
+    for (int pass = 0; pass < 2; pass++) {
+        fd = pmix_os_dirpath_open_file(backing_path,
+                                       O_CREAT | O_EXCL | O_RDWR, 0600);
+        if (0 <= fd || EEXIST != errno) {
+            break;
+        }
+        if (0 != unlink(backing_path) && ENOENT != errno) {
+            break;
+        }
+    }
     if (fd == -1) {
         rc = PMIX_ERR_FILE_OPEN_FAILURE;
         goto out;
     }
-    // Size backing file.
+    /* A freshly created file is empty, so this only extends it - and an
+     * extension reads as zero, which is the guarantee gds/shmem3's
+     * allocator relies on (see tma_carve() there) so that it need not
+     * memset what it hands out. */
     if (0 != ftruncate(fd, real_size)) {
         rc = PMIX_ERROR;
         goto out;
@@ -345,10 +375,23 @@ pmix_shmem_segment_chmod(
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
 
-    if (chmod(shmem->backing_path, mode) != 0) {
+    /* Through a descriptor rather than by name. chmod() follows a
+     * symlink at the final component, so where its neighbour lchown()
+     * above deliberately acts on the link itself, this acted on whatever
+     * the link named, and the two disagreed about which object they were
+     * changing. A descriptor is bound to its inode at open() time, so
+     * the object inspected is the object modified. */
+    const int fd = pmix_os_dirpath_open_file(shmem->backing_path, O_RDONLY, 0);
+    if (0 > fd) {
+        rc = PMIX_ERROR;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    if (fchmod(fd, mode) != 0) {
         rc = PMIX_ERROR;
         PMIX_ERROR_LOG(rc);
     }
+    close(fd);
     return rc;
 }
 

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -71,7 +71,7 @@ static inline bool
 dec_ref_count(
     pmix_shmem_header_t *header
 ) {
-    return pmix_atomic_sub_fetch_32(&header->ref_count, 1) == 0;
+    return 0 == pmix_atomic_sub_fetch_32(&header->ref_count, 1);
 }
 
 static pmix_status_t
@@ -98,7 +98,7 @@ segment_attach(
      * pmix_os_dirpath_open_file() - so a symlink at the backing path
      * does not send the attach at some unrelated file */
     const int fd = pmix_os_dirpath_open_file(shmem->backing_path, O_RDWR, 0);
-    if (fd == -1) {
+    if (-1 == fd) {
         rc = PMIX_ERR_FILE_OPEN_FAILURE;
         if (0 < pmix_output_get_verbosity(pmix_gds_base_framework.framework_output)) {
             pmix_show_help("help-pmix-util.txt", "failed-file-open", true,
@@ -191,7 +191,7 @@ add_internal_segment_header(
     pmix_shmem_t *shmem,
     uint32_t layout_id
 ) {
-    int rc = PMIX_SUCCESS;
+    pmix_status_t rc = PMIX_SUCCESS;
     // The base address here is inconsequential because this is a temporary,
     // internal attachment site that should not be exposed to the caller.
     rc = segment_attach(shmem, (uintptr_t)NULL, 0);
@@ -218,7 +218,7 @@ pmix_shmem_segment_create(
     const char *backing_path,
     uint32_t layout_id
 ) {
-    int rc = PMIX_SUCCESS;
+    pmix_status_t rc = PMIX_SUCCESS;
     bool created = false;
     // Real size of the segment: the data region begins a full page in
     // (data_addr_from_base() rounds the header up to a page boundary), so
@@ -386,7 +386,7 @@ pmix_shmem_segment_chown(
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
 
-    if (lchown(shmem->backing_path, owner, group) != 0) {  // DO NOT FOLLOW LINKS
+    if (0 != lchown(shmem->backing_path, owner, group)) {  // DO NOT FOLLOW LINKS
         rc = PMIX_ERROR;
         PMIX_ERROR_LOG(rc);
     }
@@ -434,7 +434,7 @@ pmix_shmem_segment_chmod(
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    if (fchmod(fd, mode) != 0) {
+    if (0 != fchmod(fd, mode)) {
         rc = PMIX_ERROR;
         PMIX_ERROR_LOG(rc);
     }

--- a/src/util/pmix_shmem.c
+++ b/src/util/pmix_shmem.c
@@ -83,6 +83,17 @@ segment_attach(
     pmix_status_t rc = PMIX_SUCCESS;
     void *mmap_addr = MAP_FAILED;
 
+    /* A handle maps one segment at a time, and re-using an attached one
+     * has to be refused rather than absorbed. The failure path below
+     * hands the handle to pmix_shmem_segment_detach(), which for an
+     * attached handle drops its reference and, if it was the last one,
+     * takes the backing file with it - so a second attach that merely
+     * failed to find an address would have destroyed the segment the
+     * caller was already holding. Detach first, then attach again. */
+    if (shmem->attached) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* opened relative to its directory rather than by name - see
      * pmix_os_dirpath_open_file() - so a symlink at the backing path
      * does not send the attach at some unrelated file */
@@ -158,7 +169,18 @@ out:
          * the reservation it came out of, not simply drop it. */
         shmem->in_reservation = (0 != over_reservation);
     }
-    // Always set base addresses. On error it is useful for reporting.
+    if (PMIX_SUCCESS != rc) {
+        /* Nothing is mapped, so say so with the pointer that means it.
+         * Writing MAP_FAILED through here instead left the handle
+         * carrying (void *)-1, and data_address carrying that plus a
+         * page - which wraps to a small non-NULL address. A caller
+         * screening the handle with "NULL == hdr_address", as
+         * note_slot_in_use() in gds/shmem3 does, would not have caught
+         * either one. Reporting reads backing_path, not these. */
+        shmem->hdr_address = NULL;
+        shmem->data_address = NULL;
+        return rc;
+    }
     shmem->hdr_address = mmap_addr;
     shmem->data_address = data_addr_from_base(mmap_addr);
     return rc;
@@ -197,6 +219,7 @@ pmix_shmem_segment_create(
     uint32_t layout_id
 ) {
     int rc = PMIX_SUCCESS;
+    bool created = false;
     // Real size of the segment: the data region begins a full page in
     // (data_addr_from_base() rounds the header up to a page boundary), so
     // this is larger than what the caller asked to store. The arithmetic
@@ -238,10 +261,16 @@ pmix_shmem_segment_create(
             break;
         }
     }
-    if (fd == -1) {
+    if (-1 == fd) {
         rc = PMIX_ERR_FILE_OPEN_FAILURE;
         goto out;
     }
+    /* From here on the file exists because we made it, so every failure
+     * below has to take it away again. Nothing else will: the caller is
+     * being told the create failed, and shmem_destruct() only unlinks a
+     * segment it managed to attach. A file left here sits in the session
+     * directory under a name built from this pid, and pids get reused. */
+    created = true;
     /* A freshly created file is empty, so this only extends it - and an
      * extension reads as zero, which is the guarantee gds/shmem3's
      * allocator relies on (see tma_carve() there) so that it need not
@@ -260,6 +289,11 @@ out:
         (void)close(fd);
     }
     if (PMIX_SUCCESS != rc) {
+        if (created) {
+            (void)unlink(backing_path);
+            /* and do not leave the caller a path to a file that is gone */
+            memset(shmem->backing_path, 0, PMIX_PATH_MAX);
+        }
         PMIX_ERROR_LOG(rc);
     }
     return rc;
@@ -299,6 +333,7 @@ pmix_shmem_segment_attach(
     }
 
     inc_ref_count(shmem->hdr_address);
+    shmem->holds_ref = true;
     return rc;
 }
 
@@ -309,6 +344,18 @@ pmix_shmem_segment_detach(
     int rc = 0;
 
     if (shmem && shmem->attached) {
+        /* Give back the reference pmix_shmem_segment_attach() took, so a
+         * handle that is detached explicitly leaves the shared count in
+         * the same place a handle that is simply released does. Skipped
+         * for the internal attach that stamps a freshly created segment,
+         * which never took one. Must happen before the unmap: the count
+         * lives in the mapping being dropped. */
+        if (shmem->holds_ref) {
+            shmem->holds_ref = false;
+            if (dec_ref_count(shmem->hdr_address)) {
+                (void)pmix_shmem_segment_unlink(shmem);
+            }
+        }
         if (shmem->in_reservation) {
             /* This range was carved out of a reservation the caller is
              * still holding, and it expects to be able to place something
@@ -446,6 +493,7 @@ shmem_construct(
 ) {
     s->attached = false;
     s->in_reservation = false;
+    s->holds_ref = false;
     s->size = 0;
     s->hdr_address = NULL;
     s->data_address = NULL;
@@ -456,14 +504,10 @@ static void
 shmem_destruct(
     pmix_shmem_t *s
 ) {
-    // We don't have access to a reference count, so bail.
-    if (!s->attached) {
-        return;
-    }
-    // If our reference count has reached zero, then unlink the backing file.
-    if (dec_ref_count(s->hdr_address)) {
-        (void)pmix_shmem_segment_unlink(s);
-    }
+    /* Detach does the whole of it - drop our reference, unlink the
+     * backing file if it was the last one, unmap - so that releasing a
+     * handle and detaching it explicitly cannot come to different
+     * answers. A handle that is not attached holds nothing. */
     (void)pmix_shmem_segment_detach(s);
 }
 

--- a/src/util/pmix_shmem.h
+++ b/src/util/pmix_shmem.h
@@ -56,6 +56,11 @@ typedef struct pmix_shmem_t {
     /** True if this mapping was placed over a caller-held reservation,
      *  and so must be given back to it rather than simply unmapped. */
     bool in_reservation;
+    /** True while this handle holds a reference on the segment's shared
+     *  reference count. Only pmix_shmem_segment_attach() takes one - the
+     *  internal attach that stamps a freshly created segment does not -
+     *  so detach has to know which kind of attachment it is undoing. */
+    bool holds_ref;
     /** Size of shared-memory segment. */
     size_t size;
     /** Address of shared memory segment header. */
@@ -82,6 +87,16 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_shmem_t);
  * must be derived from the layout itself (sizeof/offsetof of the types that
  * go in), not hand-maintained. A number someone has to remember to bump is
  * a number that will not get bumped.
+ *
+ * A created segment is NOT attached and holds NO reference: the file
+ * exists, its header is stamped, and nothing is mapped. The creator has
+ * to call pmix_shmem_segment_attach() like anybody else if it means to
+ * keep the segment alive, because the reference count is the only thing
+ * that does - the first holder to let go of a segment nobody else has
+ * taken removes the backing file.
+ *
+ * On failure nothing is left behind: any file this call created is
+ * removed again, and the handle's backing path is cleared.
  */
 PMIX_EXPORT pmix_status_t
 pmix_shmem_segment_create(
@@ -99,6 +114,26 @@ pmix_shmem_segment_create(
  * a failed fixed-address map returns, so the caller can say which happened.
  * Callers are expected to treat either as "this datastore is unusable to
  * me" and fall back, not as fatal.
+ *
+ * Two fields of the handle are INPUTS here, and a process attaching to a
+ * segment somebody else created has to fill them in itself: backing_path,
+ * and size. "size" is the mapped footprint - the value the CREATOR's
+ * handle carried after pmix_shmem_segment_create() returned, which is
+ * pmix_shmem_utils_segment_footprint() of what it asked to store, not
+ * what it asked to store. Pass the smaller number and the mapping ends a
+ * page short of the data region, which nothing here can detect: the tail
+ * of the segment is simply not there, and the reader faults on it later.
+ * gds/shmem3 puts the creator's shmem->size on the wire for exactly this
+ * reason.
+ *
+ * On success the handle holds a reference on the segment; give it back
+ * with pmix_shmem_segment_detach() or by releasing the handle. On
+ * failure nothing is mapped, no reference is held, and the address
+ * fields read NULL.
+ *
+ * A handle maps one segment at a time: this refuses a handle that is
+ * already attached with PMIX_ERR_BAD_PARAM rather than replacing what
+ * it holds. Detach first.
  */
 PMIX_EXPORT pmix_status_t
 pmix_shmem_segment_attach(
@@ -108,18 +143,52 @@ pmix_shmem_segment_attach(
     uint32_t expected_layout_id
 );
 
+/**
+ * Drop this process's mapping of the segment.
+ *
+ * This releases the reference pmix_shmem_segment_attach() took, so the
+ * two are a matched pair and a handle that is detached explicitly leaves
+ * the shared count where a handle that is simply released would. Dropping
+ * the LAST reference unlinks the backing file - that is what makes a
+ * segment disappear once every holder has let go of it, and it means a
+ * handle whose detach was the last one cannot attach again: the segment
+ * is gone, which is the point.
+ *
+ * Detaching a handle that never completed a public attach - including
+ * one whose attach failed - releases nothing, so it is safe to call on
+ * an error path without knowing how far the attach got.
+ */
 PMIX_EXPORT pmix_status_t
 pmix_shmem_segment_detach(
     pmix_shmem_t *shmem
 );
 
+/**
+ * Remove the segment's backing file by name.
+ *
+ * Only the name goes: a process that has the segment mapped keeps a
+ * valid mapping afterwards, which is what lets one generation of a
+ * segment be handed off while readers are still on the previous one.
+ *
+ * Ordinarily nothing calls this - dropping the last reference through
+ * pmix_shmem_segment_detach() does it - and the exception is a caller
+ * unwinding a segment it created but never managed to attach, which no
+ * reference count knows about.
+ *
+ * The handle's backing path is cleared either way, so the handle no
+ * longer names a file after this returns.
+ */
 PMIX_EXPORT pmix_status_t
 pmix_shmem_segment_unlink(
     pmix_shmem_t *shmem
 );
 
 /**
- * Change ownership of given shmem. Similar to chown(2).
+ * Change ownership of the segment's backing file.
+ *
+ * Acts on the object at the name without following a symlink there -
+ * lchown(2) rather than chown(2) - so that this and its neighbour below
+ * cannot end up changing two different objects.
  */
 PMIX_EXPORT pmix_status_t
 pmix_shmem_segment_chown(
@@ -129,7 +198,18 @@ pmix_shmem_segment_chown(
 );
 
 /**
- * Change permissions of given shmem. Similar to chmod(2).
+ * Change permissions of the segment's backing file.
+ *
+ * Through a descriptor rather than by name, for the reason above:
+ * chmod(2) follows a symlink at the final component and lchown(2) does
+ * not, so the pair applied to a path would disagree about which object
+ * they were changing.
+ *
+ * Note what the mode has to allow. A peer maps the segment MAP_SHARED
+ * from a descriptor it opened O_RDWR - it writes the reference count,
+ * even when it never writes the data - so a mode that denies write to
+ * the processes meant to read the segment does not make it read-only to
+ * them, it makes it unopenable.
  */
 PMIX_EXPORT pmix_status_t
 pmix_shmem_segment_chmod(

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -54,6 +54,20 @@ static void local_delivery(const char *file,
 {
     pmix_shift_caddy_t *cd;
 
+    if (NULL == msg) {
+        /* nothing to deliver - and the load below would put a NULL
+         * string on the wire for the host to render */
+        return;
+    }
+    /* the file and topic only label the message; a caller that could not
+     * build one still gets the message itself delivered */
+    if (NULL == file) {
+        file = "";
+    }
+    if (NULL == topic) {
+        topic = "";
+    }
+
     if (!pmix_show_help_initialized ||
         0 == pmix_atomic_load_int(&pmix_show_help_enabled) ||
         NULL == pmix_globals.evbase) {
@@ -67,6 +81,12 @@ static void local_delivery(const char *file,
     }
 
     cd = PMIX_NEW(pmix_shift_caddy_t);
+    if (NULL == cd) {
+        /* losing the message entirely is worse than losing the
+         * aggregation, so say it here */
+        fprintf(stderr, "%s", msg);
+        return;
+    }
     cd->ninfo = 1;
     PMIX_INFO_CREATE(cd->info, cd->ninfo);
     PMIX_INFO_LOAD(&cd->info[0], PMIX_LOG_STDERR, msg, PMIX_STRING);
@@ -226,6 +246,13 @@ static pmix_status_t pmix_get_tli(const char *filename,
     }
     tli->tli_filename = strdup(filename);
     tli->tli_topic = strdup(topic);
+    if (NULL == tli->tli_filename || NULL == tli->tli_topic) {
+        /* match() hands both of these straight to strcmp(), so an entry
+         * carrying a NULL is a segfault on the very next lookup - and
+         * this list outlives the call that built it */
+        PMIX_RELEASE(tli);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
     pmix_list_append(&abd_tuples, &(tli->super));
     *tli_ = tli;
 
@@ -246,25 +273,39 @@ static void pmix_show_accumulated_duplicates(int fd, short event, void *context)
     {
         if (tli->tli_display && tli->tli_count_since_last_display > 0) {
             static bool first = true;
-            pmix_asprintf(&tmp, "%d more process%s sent help message %s / %s\n",
-                          tli->tli_count_since_last_display,
-                          (tli->tli_count_since_last_display > 1) ? "es have" : " has",
-                          tli->tli_filename, tli->tli_topic);
-            tli->tli_time_displayed = time(NULL);
             char stamp[50] = {0};
-            strftime(stamp, 50, "%Y-%m-%d %H:%M:%S", localtime(&tli->tli_time_displayed));
-            char *buf;
-            pmix_asprintf(&buf, "%s-%s", tli->tli_filename, stamp);
-            local_delivery(buf, tli->tli_topic, tmp);
+            char *buf = NULL;
+            struct tm *when;
+
+            if (0 > pmix_asprintf(&tmp, "%d more process%s sent help message %s / %s\n",
+                                  tli->tli_count_since_last_display,
+                                  (tli->tli_count_since_last_display > 1) ? "es have" : " has",
+                                  tli->tli_filename, tli->tli_topic)) {
+                continue;
+            }
+            tli->tli_time_displayed = time(NULL);
+            when = localtime(&tli->tli_time_displayed);
+            if (NULL != when) {
+                strftime(stamp, sizeof(stamp), "%Y-%m-%d %H:%M:%S", when);
+            }
+            /* the stamped name only labels the notice - if we cannot
+             * build it, deliver the notice under the bare filename
+             * rather than dropping it */
+            if (0 > pmix_asprintf(&buf, "%s-%s", tli->tli_filename, stamp)) {
+                buf = NULL;
+            }
+            local_delivery((NULL == buf) ? tli->tli_filename : buf,
+                           tli->tli_topic, tmp);
             free(buf);
             /* local_delivery copies the message, so we own tmp */
             free(tmp);
             tli->tli_count_since_last_display = 0;
 
             if (first) {
-                pmix_asprintf(&tmp, "%s", "Set MCA parameter \"base_help_aggregate\" to 0 to see all help / error messages\n");
-                local_delivery(tli->tli_filename, tli->tli_topic, tmp);
-                free(tmp);
+                if (0 <= pmix_asprintf(&tmp, "%s", "Set MCA parameter \"base_help_aggregate\" to 0 to see all help / error messages\n")) {
+                    local_delivery(tli->tli_filename, tli->tli_topic, tmp);
+                    free(tmp);
+                }
                 first = false;
             }
         }
@@ -281,6 +322,11 @@ pmix_status_t pmix_help_check_dups(const char *filename, const char *topic)
     tuple_list_item_t *tli;
     time_t now = time(NULL);
     int rc;
+
+    /* both of these reach strcmp() by way of match() */
+    if (NULL == filename || NULL == topic) {
+        return PMIX_ERR_BAD_PARAM;
+    }
 
     rc = pmix_get_tli(filename, topic, &tli);
     if (PMIX_SUCCESS == rc) {
@@ -350,17 +396,34 @@ pmix_status_t pmix_show_help_init(void)
     PMIX_CONSTRUCT(&lds, pmix_output_stream_t);
     lds.lds_want_stderr = true;
     output_stream = pmix_output_open(&lds);
+    PMIX_DESTRUCT(&lds);
     PMIX_CONSTRUCT(&abd_tuples, pmix_list_t);
 
     PMIX_CONSTRUCT(&data_arrays, pmix_list_t);
     da = PMIX_NEW(tuple_array_item_t);
+    if (NULL == da) {
+        goto failed;
+    }
     da->project = strdup("pmix");
+    if (NULL == da->project) {
+        PMIX_RELEASE(da);
+        goto failed;
+    }
     da->array = pmix_show_help_data;
     pmix_list_append(&data_arrays, &da->super);
 
     pmix_show_help_initialized = true;
 
     return PMIX_SUCCESS;
+
+failed:
+    /* leave nothing half-built: every caller of this function ignores
+     * what it answers, and the next one in re-enters it */
+    pmix_output_close(output_stream);
+    output_stream = -1;
+    PMIX_DESTRUCT(&data_arrays);
+    PMIX_DESTRUCT(&abd_tuples);
+    return PMIX_ERR_OUT_OF_RESOURCE;
 }
 
 pmix_status_t pmix_show_help_finalize(void)
@@ -369,12 +432,31 @@ pmix_status_t pmix_show_help_finalize(void)
         return PMIX_SUCCESS;
     }
 
+    /* Say what we were holding back.  pmix_help_check_dups() promises
+     * that accumulated duplicates are shown unconditionally at
+     * termination, and this is the only place left to do it - the list
+     * goes away below.  Clearing the initialized flag first sends them
+     * down local_delivery()'s direct path: pmix_rte_finalize() has
+     * already paused the progress thread by the time we are called, so
+     * anything thread-shifted onto the event base from here would never
+     * run and never be released. */
+    pmix_show_help_initialized = false;
+    pmix_show_accumulated_duplicates(0, 0, NULL);
+
+    /* This state is process-global and outlives a finalize: PMIx can be
+     * initialized again in the same process, and a timer flag left set
+     * would keep the aggregation timer from ever being armed again. */
+    if (show_help_timer_set) {
+        pmix_event_del(&show_help_timer_event);
+        show_help_timer_set = false;
+    }
+    show_help_time_last_displayed = 0;
+
     pmix_output_close(output_stream);
     output_stream = -1;
 
     PMIX_LIST_DESTRUCT(&abd_tuples);
     PMIX_LIST_DESTRUCT(&data_arrays);
-    pmix_show_help_initialized = false;
 
     return PMIX_SUCCESS;
 }
@@ -429,16 +511,80 @@ static pmix_status_t array2string(char **outstring,
     return PMIX_SUCCESS;
 }
 
+/* An "#include" chain has to terminate: a topic that includes itself,
+ * or two that include each other, would otherwise recurse until the
+ * stack runs out.  This content is generated from the help-*.txt files,
+ * so that is a typo away rather than an attack, but the failure is the
+ * same either way. */
+#define PMIX_SHOW_HELP_MAX_INCLUDE_DEPTH 16
+
+/*
+ * Parse an include directive - "#include#FILE#TOPIC", or
+ * "#include#PROJECT#FILE#TOPIC" - taking the fields from the right.
+ *
+ * The fields point into *line, which the caller owns and must free;
+ * *project is left NULL when the directive names none, and the caller
+ * supplies its own default.  Answers false, having freed nothing and
+ * set nothing, if the line is not a well-formed directive: it is
+ * generated content, so that is an authoring mistake, but it must not
+ * be a crash.
+ */
+static bool parse_include(const char *content, char **line,
+                          char **project, char **file, char **topic)
+{
+    char *work;
+    char *p;
+
+    work = strdup(content);
+    if (NULL == work) {
+        return false;
+    }
+
+    p = strrchr(work, '#');
+    if (NULL == p) {
+        free(work);
+        return false;
+    }
+    *p = '\0';
+    *topic = p + 1;
+
+    p = strrchr(work, '#');
+    if (NULL == p) {
+        free(work);
+        return false;
+    }
+    *p = '\0';
+    *file = p + 1;
+
+    p = strrchr(work, '#');
+    if (NULL == p) {
+        free(work);
+        return false;
+    }
+    ++p;
+    /* if this isn't pointing at "include", then it must be a project;
+     * otherwise the caller's default applies */
+    if (0 != strncmp(p, "include", strlen("include"))) {
+        *project = p;
+    } else {
+        *project = NULL;
+    }
+
+    *line = work;
+    return true;
+}
+
 static void get_content(char ***output,
                         char *project,
                         const char *filename,
-                        const char* topic)
+                        const char* topic,
+                        int depth)
 {
     tuple_array_item_t *da;
     pmix_show_help_file_t *fe;
     pmix_show_help_entry_t *ie;
     int i, j, m;
-    char *p, *tp, *file, *pj, *line;
+    char *tp, *file, *pj, *line;
 
     /* Both of these are handed straight to strcmp() below, so a caller
      * that has no file or topic to name has to be turned away here
@@ -462,26 +608,18 @@ static void get_content(char ***output,
                         for (m=0; NULL != ie->content[m]; m++) {
                             if (0 == strncmp(ie->content[m], "#include", strlen("#include"))) {
                                 // parse the project (if provided), file and
-                                // topic being included. Work on a writable
-                                // copy so we can NUL-terminate each field -
-                                // ie->content[m] is a read-only string literal.
-                                line = strdup(ie->content[m]);
-                                p = strrchr(line, '#');
-                                *p = '\0';
-                                tp = p + 1;
-                                p = strrchr(line, '#');
-                                *p = '\0';
-                                file = p + 1;
-                                p = strrchr(line, '#');
-                                ++p;
-                                // if this isn't pointing at "include", then it
-                                // must be a project; otherwise default to pmix
-                                if (0 != strncmp(p, "include", strlen("include"))) {
-                                    pj = p;
-                                } else {
-                                    pj = "pmix";
+                                // topic being included. parse_include works on
+                                // a writable copy so it can NUL-terminate each
+                                // field - ie->content[m] is a read-only string
+                                // literal.
+                                if (PMIX_SHOW_HELP_MAX_INCLUDE_DEPTH <= depth) {
+                                    continue;
                                 }
-                                get_content(output, pj, file, tp);
+                                if (!parse_include(ie->content[m], &line, &pj, &file, &tp)) {
+                                    continue;
+                                }
+                                get_content(output, (NULL == pj) ? "pmix" : pj,
+                                            file, tp, depth + 1);
                                 free(line);
                             } else {
                                 PMIx_Argv_append_nosize(output, ie->content[m]);
@@ -513,23 +651,15 @@ next:
                     if (0 == strcmp(ie->topic, topic)) {
                         for (m=0; NULL != ie->content[m]; m++) {
                             if (0 == strncmp(ie->content[m], "#include", strlen("#include"))) {
-                                line = strdup(ie->content[m]);
                                 // parse the project (if provided), file and topic being included
-                                p = strrchr(line, '#');
-                                *p = '\0';
-                                tp = p + 1;
-                                p = strrchr(line, '#');
-                                *p = '\0';
-                                file = p + 1;
-                                p = strrchr(line, '#');
-                                ++p;
-                                // if this isn't pointing at "include", then it must be a project
-                                if (0 != strncmp(p, "include", strlen("include"))) {
-                                    pj = p;
-                                } else {
-                                    pj = da->project;
+                                if (PMIX_SHOW_HELP_MAX_INCLUDE_DEPTH <= depth) {
+                                    continue;
                                 }
-                                get_content(output, pj, file, tp);
+                                if (!parse_include(ie->content[m], &line, &pj, &file, &tp)) {
+                                    continue;
+                                }
+                                get_content(output, (NULL == pj) ? da->project : pj,
+                                            file, tp, depth + 1);
                                 free(line);
                             } else {
                                 PMIx_Argv_append_nosize(output, ie->content[m]);
@@ -554,10 +684,17 @@ char *pmix_show_help_vstring(const char *filename,
     char *msg;
 
     /* Load the message */
-    get_content(&content, NULL, filename, topic);
+    get_content(&content, NULL, filename, topic, 0);
     if (NULL == content) {
-        pmix_asprintf(&msg, "%sSorry!  You were supposed to get help about:\n\n    Filename: %s\n    Topic: %s\n\nBut I couldn't find "
-                    "that help reference.\n\nSorry!\n%s", dash_line, filename, topic, dash_line);
+        /* a NULL here is a caller bug, but naming it in the notice is
+         * more use than passing it to a %s that has no defined answer
+         * for one */
+        if (0 > pmix_asprintf(&msg, "%sSorry!  You were supposed to get help about:\n\n    Filename: %s\n    Topic: %s\n\nBut I couldn't find "
+                              "that help reference.\n\nSorry!\n%s", dash_line,
+                              (NULL == filename) ? "(none given)" : filename,
+                              (NULL == topic) ? "(none given)" : topic, dash_line)) {
+            return NULL;
+        }
         local_delivery(filename, topic, msg);
         free(msg);
         return NULL;
@@ -623,6 +760,12 @@ pmix_status_t pmix_show_help_add_data(const char *project,
     pmix_show_help_file_t *fe;
     int i, j;
 
+    /* project reaches strcmp() and strdup() below, and array is walked
+     * without a guard of its own */
+    if (NULL == project || NULL == array) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     // check for duplicate entries
     PMIX_LIST_FOREACH(da, &data_arrays, tuple_array_item_t) {
         for (i = 0; NULL != da->array[i].filename; ++i) {
@@ -638,7 +781,15 @@ pmix_status_t pmix_show_help_add_data(const char *project,
         }
     }
     da = PMIX_NEW(tuple_array_item_t);
+    if (NULL == da) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
     da->project = strdup(project);
+    if (NULL == da->project) {
+        /* the search loop above compares this against strcmp() */
+        PMIX_RELEASE(da);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
     da->array = array;
     pmix_list_append(&data_arrays, &da->super);
     return PMIX_SUCCESS;

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -440,6 +440,15 @@ static void get_content(char ***output,
     int i, j, m;
     char *p, *tp, *file, *pj, *line;
 
+    /* Both of these are handed straight to strcmp() below, so a caller
+     * that has no file or topic to name has to be turned away here
+     * rather than crashing the lookup. Leaving *output alone makes this
+     * read as "no such help", which is what the caller does with every
+     * other lookup that finds nothing. */
+    if (NULL == filename || NULL == topic) {
+        return;
+    }
+
     if (!pmix_show_help_initialized || NULL == project ||
         0 == strcmp(project, "pmix")) {
         // restrict to local array

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -24,7 +24,6 @@
 #include "src/include/pmix_config.h"
 
 #include <errno.h>
-#include <locale.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -184,8 +183,9 @@ static pmix_status_t match(const char *a, const char *b)
     size_t min;
 
     /* Check straight string match first */
-    if (0 == strcmp(a, b))
+    if (0 == strcmp(a, b)) {
         return PMIX_SUCCESS;
+    }
 
     if (NULL != strchr(a, '*') || NULL != strchr(b, '*')) {
         tmp1 = strdup(a);
@@ -271,7 +271,7 @@ static void pmix_show_accumulated_duplicates(int fd, short event, void *context)
        yet */
     PMIX_LIST_FOREACH(tli, &abd_tuples, tuple_list_item_t)
     {
-        if (tli->tli_display && tli->tli_count_since_last_display > 0) {
+        if (tli->tli_display && 0 < tli->tli_count_since_last_display) {
             static bool first = true;
             char stamp[50] = {0};
             char *buf = NULL;
@@ -279,7 +279,7 @@ static void pmix_show_accumulated_duplicates(int fd, short event, void *context)
 
             if (0 > pmix_asprintf(&tmp, "%d more process%s sent help message %s / %s\n",
                                   tli->tli_count_since_last_display,
-                                  (tli->tli_count_since_last_display > 1) ? "es have" : " has",
+                                  (1 < tli->tli_count_since_last_display) ? "es have" : " has",
                                   tli->tli_filename, tli->tli_topic)) {
                 continue;
             }
@@ -491,9 +491,8 @@ static pmix_status_t array2string(char **outstring,
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
-    /* Fill the big string */
+    /* Fill the big string - calloc already left it terminated */
 
-    *(*outstring) = '\0';
     if (want_error_header) {
         strcat(*outstring, dash_line);
     }
@@ -679,7 +678,8 @@ char *pmix_show_help_vstring(const char *filename,
                              va_list arglist)
 {
     int rc;
-    char *single_string, *output;
+    char *single_string = NULL;
+    char *output = NULL;
     char **content = NULL;
     char *msg;
 

--- a/src/util/pmix_show_help.h
+++ b/src/util/pmix_show_help.h
@@ -24,12 +24,11 @@
  * The "show help" subsystem (SHS) in PMIX is intended to help the
  * developer convey meaningful information to the user (read longer
  * than is convenient in a single printf), particularly when errors
- * occur.  The SHS allows the storage of arbitrary-length help
- * messages in text files which can be parameterized by text filename,
- * message name, POSIX locale, and printf()-style parameters (e.g.,
- * "%s", "%d", etc.).  Note that the primary purpose of the SHS is to
- * display help messages, but it can actually be used to display any
- * arbitrary text messages.
+ * occur.  The SHS stores arbitrary-length help messages that are
+ * looked up by filename and topic and rendered with printf()-style
+ * parameters (e.g., "%s", "%d", etc.).  Note that the primary purpose
+ * of the SHS is to display help messages, but it can actually be used
+ * to display any arbitrary text messages.
  *
  * The function pmix_show_help() is used to find a help message and
  * display it.  Its important parameters are a filename, message name,
@@ -40,18 +39,30 @@
  * simple version of i18n-like support, but we got (strong) feedback
  * that i18n support was not desired.  So it never happened.
  *
- * As such, the file lookup is quite straightforward -- the caller
- * passes in the filename to find the help message, and the SHS looks
- * for that file in $pkgdatadir (typically $prefix/share/pmix).
+ * **The "filename" is a name, not a file.** Nothing here opens
+ * anything at run time, and installing a help file somewhere PMIx can
+ * see it accomplishes nothing.  The help-*.txt files in the source
+ * tree are read at *build* time by contrib/convert-help.py, which
+ * generates src/util/pmix_show_help_content.c - a static table that is
+ * compiled into libpmix - and the filename is simply the key that
+ * table is indexed by.  Two consequences:
  *
- * Once the file is successfully opened, the SHS looks for the
- * appropriate help message to display.  It looks for the message name
- * in the file, reads in the message, and displays it.  printf()-like
- * substitutions are performed (e.g., %d, %s, etc.) --
- * pmix_show_help() takes a variable length argument list that are
- * used for these substitutions.
+ * - After adding, removing or editing any show_help content you must
+ *   delete the generated pair and rebuild, or the library keeps
+ *   emitting the old text:
  *
- * The format of the help file is simplistic:
+ *       rm src/util/pmix_show_help_content.* && make
+ *
+ *   Under --enable-devel-check the generator also runs with --purge,
+ *   which makes a topic that no code references a hard build error.  So
+ *   removing the last caller of a topic breaks the build for whoever
+ *   regenerates next - on a fresh clone, that is CI.
+ *
+ * - A project outside this tree contributes its own messages by
+ *   generating a table of its own and registering it with
+ *   pmix_show_help_add_data(), not by installing a file.
+ *
+ * The format of a help file is simplistic:
  *
  * - Comments begin with #.  Any characters after a # on a line are
  *   ignored.  It is not possible to escape a #.
@@ -74,18 +85,23 @@
  * to the second line in the message for this example.
  * \verbatimend
  *
+ * A message may also pull in another one, by giving a line of the form
+ * "#include#FILE#TOPIC" or "#include#PROJECT#FILE#TOPIC"; with no
+ * project named, the including message's own project applies.  Include
+ * chains are bounded, so a topic that includes itself stops rather than
+ * running the stack out, and a directive that is not well formed is
+ * skipped.
+ *
  * It is expected that help messages will be grouped by filename;
  * similar messages should be in a single file.  For example, an MCA
- * component may install its own helpfile in PMIX's $pkgdatadir,
- * and therefore the component can invoke pmix_show_help() to display
- * its own help messages.
+ * component may carry its own help-*.txt, and the component can then
+ * invoke pmix_show_help() to display its own help messages.
  *
- * Message files in $pkgdatadir have a naming convention: they
- * generally start with the prefix "help-" and are followed by a name
- * descriptive of what kind of messages they contain.  MCA components
- * should generally abide by the MCA prefix rule, with the exception
- * that they should start the filename with "help-", as mentioned
- * previously.
+ * Message files have a naming convention: they generally start with
+ * the prefix "help-" and are followed by a name descriptive of what
+ * kind of messages they contain.  MCA components should generally
+ * abide by the MCA prefix rule, with the exception that they should
+ * start the filename with "help-", as mentioned previously.
  */
 
 #ifndef PMIX_SHOW_HELP_H
@@ -145,6 +161,12 @@ PMIX_EXPORT pmix_status_t pmix_show_help(const char *filename,
 /**
  * This function does the same thing as pmix_show_help(), but returns
  * its output in a string (that must be freed by the caller).
+ *
+ * Answers NULL when the message could not be produced - there is no
+ * such filename/topic, or the rendering failed.  Note that the
+ * not-found case is *not* silent: a "couldn't find that help
+ * reference" notice has already been displayed by the time NULL comes
+ * back, so a caller must not report the miss a second time.
  */
 PMIX_EXPORT char *pmix_show_help_string(const char *filename, const char *topic,
                                         int want_error_header, ...);
@@ -159,19 +181,47 @@ PMIX_EXPORT char *pmix_show_help_vstring(const char *filename,
                                          va_list ap);
 
 /**
- * This function adds another search location for the files that
- * back show_help messages. Locations will be searched starting
- * with the prefix installation directory, then cycled through
- * any additional directories in the order they were added
+ * Register another table of compiled-in help content, so that its
+ * messages can be looked up alongside PMIx's own.
+ *
+ * @param project Name this content belongs to, used to disambiguate a
+ * filename that appears in more than one table and as the default
+ * project for an "#include" directive within it.
+ * @param array Table of (filename, entries) pairs, terminated by an
+ * entry with a NULL filename.  It is *borrowed*, not copied, so it must
+ * outlive the show_help subsystem - a static table generated by
+ * convert-help.py is the intended shape.
+ *
+ * Tables are searched in the order they were added, after PMIx's own.
+ * A filename already claimed by another table is refused with
+ * PMIX_ERROR and a message naming both projects.
  */
 PMIX_EXPORT pmix_status_t pmix_show_help_add_data(const char *project,
                                                   pmix_show_help_file_t *array);
 
-// check for duplicate entries
+/**
+ * Record that this (filename, topic) is about to be displayed, and say
+ * whether it has been displayed before.
+ *
+ * Answers PMIX_SUCCESS if it is a duplicate - in which case it has been
+ * counted, and a summary of the accumulated duplicates will be
+ * displayed on a timer and again at finalize - PMIX_ERR_NOT_FOUND if
+ * this is the first time, and an error otherwise.  Note that
+ * PMIX_ERR_NOT_FOUND is the ordinary answer, not a failure.
+ *
+ * Neither argument may be NULL.  Must be called on the progress thread:
+ * the duplicate list is process-global and carries no lock.
+ */
 PMIX_EXPORT pmix_status_t pmix_help_check_dups(const char *filename,
                                                const char *topic);
 
-// output a previously rendered show-help message
+/**
+ * Deliver an already-rendered show-help message.
+ *
+ * No lookup and no substitution is done: output is delivered as it
+ * stands, and is copied, so the caller keeps ownership.  filename and
+ * topic only label the message for the log.
+ */
 PMIX_EXPORT pmix_status_t pmix_show_help_norender(const char *filename,
                                                   const char *topic,
                                                   const char *output);

--- a/src/util/pmix_string_copy.c
+++ b/src/util/pmix_string_copy.c
@@ -56,7 +56,7 @@ char *pmix_getline(FILE *fp)
     char input[1024];
     size_t len;
 
-    ret = fgets(input, 1024, fp);
+    ret = fgets(input, sizeof(input), fp);
     if (NULL != ret) {
         /* strip a trailing newline, if present.  fgets does not
          * guarantee one: a line longer than the buffer or a final

--- a/src/util/pmix_string_copy.h
+++ b/src/util/pmix_string_copy.h
@@ -80,6 +80,36 @@ PMIX_EXPORT void pmix_string_copy(char *dest, const char *src, size_t dest_len)
  */
 #define PMIX_MAX_SIZE_ALLOWED_BY_PMIX_STRING_COPY (128 * 1024)
 
+/**
+ * Read one line from an open stream, without its trailing newline.
+ *
+ * @param fp An open, readable stream. It is invalid to pass NULL.
+ * @retval A fresh allocation the CALLER frees.
+ * @retval NULL nothing more could be read.
+ *
+ * Three things about this are easy to assume and wrong:
+ *
+ * - **It reads at most 1023 bytes, and a longer line comes back in
+ *   pieces.** There is no error and no marker: the first call answers
+ *   the first 1023 bytes and the next call answers the rest, so a
+ *   caller reading successive lines is handed the tail of the previous
+ *   one where it expects the next line. Every file PMIx reads with this
+ *   is one PMIx wrote, and their lines are short; do not point it at a
+ *   file whose length you do not control.
+ *
+ * - **A returned line is not necessarily newline-terminated in the
+ *   file.** The newline is stripped when there is one, and there is none
+ *   for the last line of a file that does not end in one - or for the
+ *   1023-byte fragment above. So the absence of a newline says nothing
+ *   about where in the file the line came from.
+ *
+ * - **NULL is not specifically end-of-file.** A read error and a failed
+ *   allocation answer the same way, and this function has no other way
+ *   to say so. A caller that has to tell them apart must ask the stream
+ *   itself (feof/ferror); callers here treat NULL as "no more input",
+ *   which for the rendezvous files they read means the writer had not
+ *   finished.
+ */
 PMIX_EXPORT char *pmix_getline(FILE *fp);
 
 

--- a/src/util/pmix_timings.c
+++ b/src/util/pmix_timings.c
@@ -13,6 +13,7 @@
 
 #include "pmix_common.h"
 
+#include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -120,7 +121,7 @@ pmix_timing_event_t *pmix_timing_event_alloc(pmix_timing_t *t)
         double alloc_begin = t->get_ts();
 
         t->buffer = calloc(t->buffer_size, sizeof(pmix_timing_event_t));
-        if (t->buffer == NULL) {
+        if (NULL == t->buffer) {
             return NULL;
         }
 
@@ -155,7 +156,7 @@ void pmix_timing_init(pmix_timing_t *t)
 pmix_timing_prep_t pmix_timing_prep_ev(pmix_timing_t *t, const char *fmt, ...)
 {
     pmix_timing_event_t *ev = pmix_timing_event_alloc(t);
-    if (ev == NULL) {
+    if (NULL == ev) {
         pmix_timing_prep_t p = {t, NULL, PMIX_ERR_OUT_OF_RESOURCE};
         return p;
     }
@@ -175,9 +176,9 @@ pmix_timing_prep_t pmix_timing_prep_ev_end(pmix_timing_t *t, const char *fmt, ..
     pmix_timing_prep_t p = {t, NULL, 0};
     PMIX_HIDE_UNUSED_PARAMS(fmt);
 
-    if (t->current_id >= 0) {
+    if (0 <= t->current_id) {
         pmix_timing_event_t *ev = pmix_timing_event_alloc(t);
-        if (ev == NULL) {
+        if (NULL == ev) {
             pmix_timing_prep_t p2 = {t, NULL, PMIX_ERR_OUT_OF_RESOURCE};
             return p2;
         }
@@ -220,7 +221,7 @@ void pmix_timing_start_id(pmix_timing_t *t, int id, const char *func, const char
     /* No description is needed. If everything is OK
      * it'll be included in pmix_timing_start_init */
     pmix_timing_event_t *ev = pmix_timing_event_alloc(t);
-    if (ev == NULL) {
+    if (NULL == ev) {
         return;
     }
     PMIX_CONSTRUCT(ev, pmix_timing_event_t);
@@ -240,12 +241,12 @@ void pmix_timing_end(pmix_timing_t *t, int id, const char *func, const char *fil
     /* No description is needed. If everything is OK
      * it'll be included in pmix_timing_start_init */
     pmix_timing_event_t *ev = pmix_timing_event_alloc(t);
-    if (ev == NULL) {
+    if (NULL == ev) {
         return;
     }
     PMIX_CONSTRUCT(ev, pmix_timing_event_t);
 
-    if (id < 0) {
+    if (0 > id) {
         ev->id = t->current_id;
         t->current_id = -1;
     } else {
@@ -267,7 +268,7 @@ void pmix_timing_end_prep(pmix_timing_prep_t p, const char *func, const char *fi
     pmix_timing_event_t *ev = p.ev;
 
     if (!p.errcode && (NULL != ev)) {
-        assert(p.t->current_id >= 0);
+        assert(0 <= p.t->current_id);
         ev->id = p.t->current_id;
         p.t->current_id = -1;
         ev->func = func;
@@ -378,9 +379,9 @@ pmix_status_t pmix_timing_report(pmix_timing_t *t, char *fname)
     pmix_status_t rc = PMIX_SUCCESS;
     int nw;
 
-    if (fname != NULL) {
+    if (NULL != fname) {
         fp = fopen(fname, "a");
-        if (fp == NULL) {
+        if (NULL == fp) {
             pmix_output(0,
                         "pmix_timing_report: Cannot open %s file"
                         " for writing timing information!",
@@ -396,7 +397,7 @@ pmix_status_t pmix_timing_report(pmix_timing_t *t, char *fname)
     }
 
     buf = calloc((PMIX_TIMING_OUTBUF_SIZE + 1), sizeof(char));
-    if (buf == NULL) {
+    if (NULL == buf) {
         rc = PMIX_ERR_OUT_OF_RESOURCE;
         goto err_exit;
     }
@@ -417,7 +418,7 @@ pmix_status_t pmix_timing_report(pmix_timing_t *t, char *fname)
         case PMIX_TIMING_TRACE:
             nw = pmix_asprintf(&line, "[%s:%d] %s \"%s\" [PMIX_TRACE] %s:%d %.10lf\n",
                           report_nodename(),
-                          getpid(), report_jobid(), ev->descr, file, ev->line,
+                          (int) getpid(), report_jobid(), ev->descr, file, ev->line,
                           ev->ts + hnp_offs + overhead);
             break;
         case PMIX_TIMING_INTBEGIN:
@@ -428,7 +429,7 @@ pmix_status_t pmix_timing_report(pmix_timing_t *t, char *fname)
             }
             nw = pmix_asprintf(&line, "[%s:%d] %s \"%s [start]\" [PMIX_TRACE] %s:%d %.10lf\n",
                           report_nodename(),
-                          getpid(), report_jobid(), descr[ev->id].descr_ev->descr, file, ev->line,
+                          (int) getpid(), report_jobid(), descr[ev->id].descr_ev->descr, file, ev->line,
                           ev->ts + hnp_offs + overhead);
             break;
         case PMIX_TIMING_INTEND:
@@ -439,7 +440,7 @@ pmix_status_t pmix_timing_report(pmix_timing_t *t, char *fname)
             }
             nw = pmix_asprintf(&line, "[%s:%d] %s \"%s [stop]\" [PMIX_TRACE] %s:%d %.10lf\n",
                           report_nodename(),
-                          getpid(), report_jobid(), descr[ev->id].descr_ev->descr, file, ev->line,
+                          (int) getpid(), report_jobid(), descr[ev->id].descr_ev->descr, file, ev->line,
                           ev->ts + hnp_offs + overhead);
             break;
         }
@@ -457,7 +458,7 @@ pmix_status_t pmix_timing_report(pmix_timing_t *t, char *fname)
 
         if (buf_size + strlen(line) > (size_t) PMIX_TIMING_OUTBUF_SIZE) {
             // flush buffer to the file
-            if (fp != NULL) {
+            if (NULL != fp) {
                 fprintf(fp, "%s", buf);
                 fprintf(fp, "\n");
             } else {
@@ -488,7 +489,7 @@ pmix_status_t pmix_timing_report(pmix_timing_t *t, char *fname)
 
     if (0 < buf_size) {
         // flush buffer to the file
-        if (fp != NULL) {
+        if (NULL != fp) {
             fprintf(fp, "%s", buf);
             fprintf(fp, "\n");
         } else {
@@ -502,10 +503,10 @@ err_exit:
     if (NULL != descr) {
         free(descr);
     }
-    if (buf != NULL) {
+    if (NULL != buf) {
         free(buf);
     }
-    if (fp != NULL) {
+    if (NULL != fp) {
         fflush(fp);
         fclose(fp);
     }
@@ -525,9 +526,9 @@ pmix_status_t pmix_timing_deltas(pmix_timing_t *t, char *fname)
     int i, nw;
     size_t buf_size = 0, buf_used = 0, avail;
 
-    if (fname != NULL) {
+    if (NULL != fname) {
         fp = fopen(fname, "a");
-        if (fp == NULL) {
+        if (NULL == fp) {
             pmix_output(0,
                         "pmix_timing_report: Cannot open %s file"
                         " for writing timing information!",
@@ -559,13 +560,13 @@ pmix_status_t pmix_timing_deltas(pmix_timing_t *t, char *fname)
 
         /* we already process all PMIX_TIMING_DESCR events
          * and we ignore PMIX_TIMING_EVENT */
-        if (ev->type == PMIX_TIMING_INTDESCR || ev->type == PMIX_TIMING_TRACE) {
+        if (PMIX_TIMING_INTDESCR == ev->type || PMIX_TIMING_TRACE == ev->type) {
             /* skip */
             continue;
         }
 
         id = ev->id;
-        if (id < 0 || id >= t->next_id_cntr) {
+        if (0 > id || id >= t->next_id_cntr) {
             char *file = pmix_basename(ev->file);
             pmix_output(0, "pmix_timing_deltas: bad interval event id: %d at %s:%d:%s (maxid=%d)",
                         id, file, ev->line, ev->func, t->next_id_cntr - 1);
@@ -577,7 +578,7 @@ pmix_status_t pmix_timing_deltas(pmix_timing_t *t, char *fname)
         /* id's assigned auomatically. There shouldn't be any gaps in descr[] */
         assert(NULL != descr[id].descr_ev);
 
-        if (ev->type == PMIX_TIMING_INTBEGIN) {
+        if (PMIX_TIMING_INTBEGIN == ev->type) {
             if (NULL != descr[id].begin_ev) {
                 /* the measurement on this interval was already
                  * started! */
@@ -598,7 +599,7 @@ pmix_status_t pmix_timing_deltas(pmix_timing_t *t, char *fname)
             continue;
         }
 
-        if (ev->type == PMIX_TIMING_INTEND) {
+        if (PMIX_TIMING_INTEND == ev->type) {
             if (NULL == descr[id].begin_ev) {
                 /* the measurement on this interval wasn't started! */
                 char *file = pmix_basename(ev->file);
@@ -621,7 +622,7 @@ pmix_status_t pmix_timing_deltas(pmix_timing_t *t, char *fname)
     }
 
     buf = calloc((PMIX_TIMING_OUTBUF_SIZE + 1), sizeof(char));
-    if (buf == NULL) {
+    if (NULL == buf) {
         rc = PMIX_ERR_OUT_OF_RESOURCE;
         goto err_exit;
     }
@@ -631,7 +632,7 @@ pmix_status_t pmix_timing_deltas(pmix_timing_t *t, char *fname)
         char *line = NULL;
         size_t line_size;
         nw = pmix_asprintf(&line, "[%s:%d] %s \"%s\" [PMIX_OVHD] %le\n", report_nodename(),
-                      getpid(), report_jobid(),
+                      (int) getpid(), report_jobid(),
                       descr[i].descr_ev->descr, descr[i].interval - descr[i].overhead);
         if (0 > nw || NULL == line) {
             rc = PMIX_ERR_OUT_OF_RESOURCE;
@@ -680,7 +681,7 @@ pmix_status_t pmix_timing_deltas(pmix_timing_t *t, char *fname)
 
     if (buf_used > 0) {
         // flush buffer to the file
-        if (fp != NULL) {
+        if (NULL != fp) {
             fprintf(fp, "%s", buf);
             fprintf(fp, "\n");
         } else {
@@ -697,7 +698,7 @@ err_exit:
     if (NULL != buf) {
         free(buf);
     }
-    if (fp != NULL) {
+    if (NULL != fp) {
         fflush(fp);
         fclose(fp);
     }
@@ -708,7 +709,7 @@ void pmix_timing_release(pmix_timing_t *t)
 {
     int cnt = pmix_list_get_size(t->events);
 
-    if (cnt > 0) {
+    if (0 < cnt) {
         pmix_list_t *tmp = PMIX_NEW(pmix_list_t);
         int i;
         for (i = 0; i < cnt; i++) {

--- a/src/util/pmix_timings.c
+++ b/src/util/pmix_timings.c
@@ -41,6 +41,7 @@
 #include "src/util/pmix_basename.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_printf.h"
+#include "src/runtime/pmix_rte.h"
 
 #include "src/util/pmix_timings.h"
 
@@ -57,14 +58,41 @@ pmix_timing_prep_t pmix_timing_prep_ev(pmix_timing_t *t, const char *fmt, ...);
 
 static PMIX_CLASS_INSTANCE(pmix_timing_event_t, pmix_list_item_t, NULL, NULL);
 
-static char *nodename = NULL;
-static char *jobid = "";
+/* "<nspace>:<rank>", once somebody tells us - see pmix_init_id(). */
+static char *jobid = NULL;
 static double hnp_offs = 0;
-static bool pmix_timing_overhead = false;
+
+/* Every line this file writes begins "[node:pid] jobid ...". Both names
+ * are answered through these rather than read directly, because neither
+ * is necessarily known yet: a report can be taken before pmix_rte_init()
+ * has settled the hostname, and nothing is obliged to call
+ * pmix_init_id() at all. Neither ever answers NULL - a "%s" of one is
+ * "(null)" at best, and it is what kept this file from compiling: the
+ * node name was a file-static NULL that nothing ever assigned, which gcc
+ * can see, so every asprintf below was a -Werror=format-overflow error
+ * and --enable-pmix-timing did not build. */
+static const char *report_nodename(void)
+{
+    return (NULL != pmix_globals.hostname) ? pmix_globals.hostname : "unknown";
+}
+
+static const char *report_jobid(void)
+{
+    return (NULL != jobid) ? jobid : "";
+}
 
 void pmix_init_id(char *nspace, int rank)
 {
-    pmix_asprintf(&jobid, "%s:%d", nspace, rank);
+    char *tmp = NULL;
+
+    if (0 > pmix_asprintf(&tmp, "%s:%d", nspace, rank) || NULL == tmp) {
+        /* keep whatever we had rather than blanking it */
+        return;
+    }
+    if (NULL != jobid) {
+        free(jobid);
+    }
+    jobid = tmp;
 }
 
 /* Get current timestamp. Derived from MPI_Wtime */
@@ -253,16 +281,29 @@ void pmix_timing_end_prep(pmix_timing_prep_t p, const char *func, const char *fi
 static int _prepare_descriptions(pmix_timing_t *t, struct interval_descr **__descr)
 {
     struct interval_descr *descr;
-    pmix_timing_event_t *ev, *next;
+    pmix_timing_event_t *ev;
 
-    if (t->next_id_cntr == 0) {
-        return 0;
+    /* The sweep below has to run even when no interval was ever
+     * described, because that is exactly when an interval event on the
+     * list has no slot to be resolved against: returning early left
+     * those events in place for pmix_timing_report() to index a
+     * descriptor array that is still NULL. */
+    if (0 < t->next_id_cntr) {
+        *__descr = calloc(t->next_id_cntr, sizeof(struct interval_descr));
+        if (NULL == *__descr) {
+            return -1;
+        }
     }
-
-    *__descr = calloc(t->next_id_cntr, sizeof(struct interval_descr));
     descr = *__descr;
 
-    PMIX_LIST_FOREACH_SAFE (ev, next, t->events, pmix_timing_event_t) {
+    /* Nothing is taken OFF this list. Every event lives inside a block
+     * of PMIX_TIMING_BUFSIZE that pmix_timing_event_alloc() allocated,
+     * and the only pointer to that block is the first event in it -
+     * which is on this list, and is how pmix_timing_release() finds the
+     * block to free. Removing an event therefore leaked its whole block
+     * whenever the event happened to be the block's first. A malformed
+     * event is marked unusable instead, and both consumers skip it. */
+    PMIX_LIST_FOREACH (ev, t->events, pmix_timing_event_t) {
 
         /* pmix_output(0,"EVENT: type = %d, id=%d, ts = %.12le, ovh = %.12le %s",
                     ev->type, ev->id, ev->ts, ev->ts_ovh,
@@ -270,12 +311,11 @@ static int _prepare_descriptions(pmix_timing_t *t, struct interval_descr **__des
         */
         switch (ev->type) {
         case PMIX_TIMING_INTDESCR: {
-            if (ev->id >= t->next_id_cntr) {
+            if (0 > ev->id || ev->id >= t->next_id_cntr) {
                 char *file = pmix_basename(ev->file);
-                pmix_output(0, "pmix_timing: bad event id at %s:%d:%s, ignore and remove", file,
+                pmix_output(0, "pmix_timing: bad event id at %s:%d:%s, ignoring", file,
                             ev->line, ev->func);
                 free(file);
-                pmix_list_remove_item(t->events, (pmix_list_item_t *) ev);
                 continue;
             }
             if (NULL != descr[ev->id].descr_ev) {
@@ -288,7 +328,6 @@ static int _prepare_descriptions(pmix_timing_t *t, struct interval_descr **__des
                             file, ev->line, ev->func, file_prev, prev->line, prev->func);
                 free(file);
                 free(file_prev);
-                pmix_list_remove_item(t->events, (pmix_list_item_t *) ev);
                 continue;
             }
 
@@ -300,12 +339,22 @@ static int _prepare_descriptions(pmix_timing_t *t, struct interval_descr **__des
         }
         case PMIX_TIMING_INTBEGIN:
         case PMIX_TIMING_INTEND: {
-            if (ev->id >= t->next_id_cntr || (NULL == descr[ev->id].descr_ev)) {
+            /* The lower bound is not decoration: PMIX_TIMING_MSTOP on a
+             * handler with no measurement running records an id of -1
+             * (pmix_timing_end() copies current_id), and the report loop
+             * below would then index descr[-1]. pmix_timing_deltas()
+             * screens for it on its own account; this is where both are
+             * covered. */
+            if (0 > ev->id || ev->id >= t->next_id_cntr ||
+                (NULL == descr[ev->id].descr_ev)) {
                 char *file = pmix_basename(ev->file);
-                pmix_output(0, "pmix_timing: bad event id at %s:%d:%s, ignore and remove", file,
+                pmix_output(0, "pmix_timing: bad event id at %s:%d:%s, ignoring", file,
                             ev->line, ev->func);
                 free(file);
-                pmix_list_remove_item(t->events, (pmix_list_item_t *) ev);
+                /* Say so on the event itself: it stays on the list, and
+                 * an id nothing described is what the consumers below
+                 * would otherwise use to index the descriptor array. */
+                ev->id = -1;
                 continue;
             }
             break;
@@ -319,14 +368,15 @@ static int _prepare_descriptions(pmix_timing_t *t, struct interval_descr **__des
 
 /* Output lines in portions that doesn't
  * exceed PMIX_TIMING_OUTBUF_SIZE for later automatic processing */
-int pmix_timing_report(pmix_timing_t *t, char *fname)
+pmix_status_t pmix_timing_report(pmix_timing_t *t, char *fname)
 {
     pmix_timing_event_t *ev;
     FILE *fp = NULL;
     char *buf = NULL;
-    int buf_size = 0;
+    size_t buf_size = 0, avail;
     struct interval_descr *descr = NULL;
-    int rc = PMIX_SUCCESS;
+    pmix_status_t rc = PMIX_SUCCESS;
+    int nw;
 
     if (fname != NULL) {
         fp = fopen(fname, "a");
@@ -340,7 +390,10 @@ int pmix_timing_report(pmix_timing_t *t, char *fname)
         }
     }
 
-    _prepare_descriptions(t, &descr);
+    if (0 > _prepare_descriptions(t, &descr)) {
+        rc = PMIX_ERR_OUT_OF_RESOURCE;
+        goto err_exit;
+    }
 
     buf = calloc((PMIX_TIMING_OUTBUF_SIZE + 1), sizeof(char));
     if (buf == NULL) {
@@ -350,44 +403,59 @@ int pmix_timing_report(pmix_timing_t *t, char *fname)
 
     double overhead = 0;
     PMIX_LIST_FOREACH (ev, t->events, pmix_timing_event_t) {
-        char *line, *file;
+        char *line = NULL, *file;
+        nw = -1;
         if (ev->fib && pmix_timing_overhead) {
             overhead += ev->ts_ovh;
         }
         file = pmix_basename(ev->file);
         switch (ev->type) {
         case PMIX_TIMING_INTDESCR:
-            // Service event, skip it.
+            // Service event, skip it - and give back the name taken above.
+            free(file);
             continue;
         case PMIX_TIMING_TRACE:
-            rc = pmix_asprintf(&line, "[%s:%d] %s \"%s\" [PMIX_TRACE] %s:%d %.10lf\n", nodename,
-                          getpid(), jobid, ev->descr, file, ev->line, ev->ts + hnp_offs + overhead);
+            nw = pmix_asprintf(&line, "[%s:%d] %s \"%s\" [PMIX_TRACE] %s:%d %.10lf\n",
+                          report_nodename(),
+                          getpid(), report_jobid(), ev->descr, file, ev->line,
+                          ev->ts + hnp_offs + overhead);
             break;
         case PMIX_TIMING_INTBEGIN:
-            rc = pmix_asprintf(&line, "[%s:%d] %s \"%s [start]\" [PMIX_TRACE] %s:%d %.10lf\n", nodename,
-                          getpid(), jobid, descr[ev->id].descr_ev->descr, file, ev->line,
+            if (0 > ev->id) {
+                /* marked unusable by _prepare_descriptions() */
+                free(file);
+                continue;
+            }
+            nw = pmix_asprintf(&line, "[%s:%d] %s \"%s [start]\" [PMIX_TRACE] %s:%d %.10lf\n",
+                          report_nodename(),
+                          getpid(), report_jobid(), descr[ev->id].descr_ev->descr, file, ev->line,
                           ev->ts + hnp_offs + overhead);
             break;
         case PMIX_TIMING_INTEND:
-            rc = pmix_asprintf(&line, "[%s:%d] %s \"%s [stop]\" [PMIX_TRACE] %s:%d %.10lf\n", nodename,
-                          getpid(), jobid, descr[ev->id].descr_ev->descr, file, ev->line,
+            if (0 > ev->id) {
+                /* marked unusable by _prepare_descriptions() */
+                free(file);
+                continue;
+            }
+            nw = pmix_asprintf(&line, "[%s:%d] %s \"%s [stop]\" [PMIX_TRACE] %s:%d %.10lf\n",
+                          report_nodename(),
+                          getpid(), report_jobid(), descr[ev->id].descr_ev->descr, file, ev->line,
                           ev->ts + hnp_offs + overhead);
             break;
         }
         free(file);
 
-        if (rc < 0) {
+        if (0 > nw || NULL == line) {
             rc = PMIX_ERR_OUT_OF_RESOURCE;
             goto err_exit;
         }
-        rc = 0;
 
         /* Sanity check: this shouldn't happen since description
          * is event only 1KB long and other fields should never
          * exceed 9KB */
         assert(strlen(line) <= PMIX_TIMING_OUTBUF_SIZE);
 
-        if (buf_size + strlen(line) > PMIX_TIMING_OUTBUF_SIZE) {
+        if (buf_size + strlen(line) > (size_t) PMIX_TIMING_OUTBUF_SIZE) {
             // flush buffer to the file
             if (fp != NULL) {
                 fprintf(fp, "%s", buf);
@@ -402,13 +470,23 @@ int pmix_timing_report(pmix_timing_t *t, char *fname)
          * the previous "snprintf(buf, STR_LEN, \"%s%s\", buf, line)" both
          * aliased buf as source and destination (undefined behavior) and
          * capped the whole buffer at PMIX_TIMING_STR_LEN (1024) rather than
-         * the OUTBUF_SIZE it was sized for, silently dropping output */
-        snprintf(buf + buf_size, (PMIX_TIMING_OUTBUF_SIZE + 1) - buf_size, "%s", line);
-        buf_size += strlen(line);
+         * the OUTBUF_SIZE it was sized for, silently dropping output.
+         *
+         * Advance by what was WRITTEN, not by the length of the line.
+         * snprintf answers what it would have written, so a line the
+         * buffer could not hold - the assert above is a debug build's
+         * only guard against one - would otherwise put the next append
+         * past the end of the buffer, with a remaining capacity that
+         * went negative and then converted to an enormous size_t. */
+        avail = (size_t) (PMIX_TIMING_OUTBUF_SIZE + 1) - buf_size;
+        nw = snprintf(buf + buf_size, avail, "%s", line);
+        if (0 < nw) {
+            buf_size += ((size_t) nw < avail) ? (size_t) nw : (avail - 1);
+        }
         free(line);
     }
 
-    if (buf_size > 0) {
+    if (0 < buf_size) {
         // flush buffer to the file
         if (fp != NULL) {
             fprintf(fp, "%s", buf);
@@ -437,14 +515,15 @@ err_exit:
 /* Output events as one buffer so the data won't be mixed
  * with other output. This function is supposed to be human readable.
  * The output goes only to stdout. */
-int pmix_timing_deltas(pmix_timing_t *t, char *fname)
+pmix_status_t pmix_timing_deltas(pmix_timing_t *t, char *fname)
 {
     pmix_timing_event_t *ev;
     FILE *fp = NULL;
     char *buf = NULL;
     struct interval_descr *descr = NULL;
-    int i, rc = PMIX_SUCCESS;
-    size_t buf_size = 0, buf_used = 0;
+    pmix_status_t rc = PMIX_SUCCESS;
+    int i, nw;
+    size_t buf_size = 0, buf_used = 0, avail;
 
     if (fname != NULL) {
         fp = fopen(fname, "a");
@@ -458,7 +537,10 @@ int pmix_timing_deltas(pmix_timing_t *t, char *fname)
         }
     }
 
-    _prepare_descriptions(t, &descr);
+    if (0 > _prepare_descriptions(t, &descr)) {
+        rc = PMIX_ERR_OUT_OF_RESOURCE;
+        goto err_exit;
+    }
 
     PMIX_LIST_FOREACH (ev, t->events, pmix_timing_event_t) {
         int id;
@@ -548,13 +630,13 @@ int pmix_timing_deltas(pmix_timing_t *t, char *fname)
     for (i = 0; i < t->next_id_cntr; i++) {
         char *line = NULL;
         size_t line_size;
-        rc = pmix_asprintf(&line, "[%s:%d] %s \"%s\" [PMIX_OVHD] %le\n", nodename, getpid(), jobid,
+        nw = pmix_asprintf(&line, "[%s:%d] %s \"%s\" [PMIX_OVHD] %le\n", report_nodename(),
+                      getpid(), report_jobid(),
                       descr[i].descr_ev->descr, descr[i].interval - descr[i].overhead);
-        if (rc < 0) {
+        if (0 > nw || NULL == line) {
             rc = PMIX_ERR_OUT_OF_RESOURCE;
             goto err_exit;
         }
-        rc = 0;
         line_size = strlen(line);
 
         /* Sanity check: this shouldn't happen since description
@@ -568,24 +650,31 @@ int pmix_timing_deltas(pmix_timing_t *t, char *fname)
                 buf_size += PMIX_TIMING_OUTBUF_SIZE + 1;
             }
             if (buf_size > DELTAS_SANE_LIMIT) {
-                pmix_output(0, "pmix_timing_report: delta sane limit overflow (%u > %u)!\n",
+                pmix_output(0, "pmix_timing_deltas: delta sane limit overflow (%u > %u)!\n",
                             (unsigned int) buf_size, DELTAS_SANE_LIMIT);
                 free(line);
                 rc = PMIX_ERR_OUT_OF_RESOURCE;
                 goto err_exit;
             }
-            buf = realloc(buf, buf_size);
-            if (buf == NULL) {
+            /* through a temporary: assigning realloc's answer straight
+             * back over buf loses the original block when it fails */
+            char *newbuf = realloc(buf, buf_size);
+            if (NULL == newbuf) {
                 pmix_output(0, "pmix_timing_deltas: Out of memory!\n");
+                free(line);
                 rc = PMIX_ERR_OUT_OF_RESOURCE;
                 goto err_exit;
             }
+            buf = newbuf;
         }
         /* append at the current end using the real remaining capacity
          * (see the matching fix in pmix_timing_report): the old form
          * aliased buf as src+dst and ignored the grown buffer size */
-        snprintf(buf + buf_used, buf_size - buf_used, "%s", line);
-        buf_used += line_size;
+        avail = buf_size - buf_used;
+        nw = snprintf(buf + buf_used, avail, "%s", line);
+        if (0 < nw) {
+            buf_used += ((size_t) nw < avail) ? (size_t) nw : (avail - 1);
+        }
         free(line);
     }
 

--- a/src/util/pmix_timings.h
+++ b/src/util/pmix_timings.h
@@ -189,8 +189,9 @@ static inline int pmix_timing_start_init(pmix_timing_prep_t p, const char *func,
                                          int line)
 {
     int id = pmix_timing_descr(p, func, file, line);
-    if (id < 0)
+    if (0 > id) {
         return id;
+    }
     pmix_timing_start_id(p.t, id, func, file, line);
     return id;
 }

--- a/src/util/pmix_timings.h
+++ b/src/util/pmix_timings.h
@@ -65,6 +65,24 @@ typedef struct {
     int errcode;
 } pmix_timing_prep_t;
 
+/* Both are MCA parameters, registered by pmix_register_params(). They
+ * are declared HERE, rather than only in src/runtime/pmix_rte.h where
+ * they used to be, because PMIX_TIMING_REPORT and PMIX_TIMING_DELTAS
+ * below expand to a use of pmix_timing_output - and pmix_rte.h is not an
+ * installed header, so those two macros did not compile for anyone
+ * outside this tree.
+ *
+ * pmix_timing_overhead has a second reason to live here: src/util's
+ * implementation defined a file-static of the same name, which shadowed
+ * this one for the only two places that read it, so the parameter was
+ * inert and the overhead accounting it switches never ran. */
+
+/** Where a report is written; NULL sends it to the PMIx debug channel. */
+PMIX_EXPORT extern char *pmix_timing_output;
+/** Whether to charge the timing code's own allocations against the
+ *  intervals they fall inside. */
+PMIX_EXPORT extern bool pmix_timing_overhead;
+
 /* Pass down our namespace and rank for pretty-print purposes */
 PMIX_EXPORT void pmix_init_id(char *nspace, int rank);
 
@@ -199,8 +217,6 @@ PMIX_EXPORT void pmix_timing_end_prep(pmix_timing_prep_t p, const char *func, co
  * disappear.
  *
  * @param t timing handler
- * @param account_overhead consider malloc overhead introduced by timing code
- * @param prefix prefix to use when no fname was specified to ease grep'ing
  * @param fname name of the output file (may be NULL)
  *
  * @retval PMIX_SUCCESS On success
@@ -217,7 +233,6 @@ PMIX_EXPORT pmix_status_t pmix_timing_report(pmix_timing_t *t, char *fname);
  * disappear.
  *
  * @param t timing handler
- * @param account_overhead consider malloc overhead introduced by timing code
  * @param fname name of the output file (may be NULL)
  *
  * @retval PMIX_SUCCESS On success
@@ -238,7 +253,9 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
  * Macro for passing down process id - compiled out
  * when configured without --enable-timing
  */
-#    define PMIX_TIMING_ID(n, r) pmix_timing_id((n), (r));
+/* pmix_timing_id() has never existed - the function is pmix_init_id(),
+ * so any use of this macro was an undefined symbol at link time. */
+#    define PMIX_TIMING_ID(n, r) pmix_init_id((n), (r))
 
 /**
  * Main macro for use in declaring pmix timing handler;
@@ -276,7 +293,7 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
  * @see pmix_timing_add_step()
  */
 #    define PMIX_TIMING_EVENT(x) \
-        pmix_timing_add_step(pmix_timing_prep_ev x, __FUNCTION__, __FILE__, __LINE__)
+        pmix_timing_add_step(pmix_timing_prep_ev x, __func__, __FILE__, __LINE__)
 
 /**
  * MDESCR: Measurement DESCRiption
@@ -288,7 +305,7 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
  * @see pmix_timing_descr()
  */
 #    define PMIX_TIMING_MDESCR(x) \
-        pmix_timing_descr(pmix_timing_prep_ev x, __FUNCTION__, __FILE__, __LINE__)
+        pmix_timing_descr(pmix_timing_prep_ev x, __func__, __FILE__, __LINE__)
 
 /**
  * MSTART_ID: Measurement START by ID.
@@ -300,7 +317,7 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
  * @see pmix_timing_start_id()
  */
 #    define PMIX_TIMING_MSTART_ID(t, id) \
-        pmix_timing_start_id(t, id, __FUNCTION__, __FILE__, __LINE__)
+        pmix_timing_start_id(t, id, __func__, __FILE__, __LINE__)
 
 /**
  * MSTART: Measurement START
@@ -312,7 +329,7 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
  * @see pmix_timing_start_init()
  */
 #    define PMIX_TIMING_MSTART(x) \
-        pmix_timing_start_init(pmix_timing_prep_ev x, __FUNCTION__, __FILE__, __LINE__)
+        pmix_timing_start_init(pmix_timing_prep_ev x, __func__, __FILE__, __LINE__)
 
 /**
  * MSTOP: STOP Measurement
@@ -322,7 +339,7 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
  *
  * @see pmix_timing_end()
  */
-#    define PMIX_TIMING_MSTOP(t) pmix_timing_end(t, -1, __FUNCTION__, __FILE__, __LINE__)
+#    define PMIX_TIMING_MSTOP(t) pmix_timing_end(t, -1, __func__, __FILE__, __LINE__)
 
 /**
  * MSTOP_ID: STOP Measurement with ID=id.
@@ -332,7 +349,7 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
  *
  * @see pmix_timing_end()
  */
-#    define PMIX_TIMING_MSTOP_ID(t, id) pmix_timing_end(t, id, __FUNCTION__, __FILE__, __LINE__)
+#    define PMIX_TIMING_MSTOP_ID(t, id) pmix_timing_end(t, id, __func__, __FILE__, __LINE__)
 
 /**
  * MNEXT: start NEXT Measurement
@@ -348,8 +365,8 @@ PMIX_EXPORT void pmix_timing_release(pmix_timing_t *t);
  * @see pmix_timing_start_init()
  */
 #    define PMIX_TIMING_MNEXT(x)                                                            \
-        (pmix_timing_end_prep(pmix_timing_prep_ev_end x, __FUNCTION__, __FILE__, __LINE__), \
-         pmix_timing_start_init(pmix_timing_prep_ev x, __FUNCTION__, __FILE__, __LINE__))
+        (pmix_timing_end_prep(pmix_timing_prep_ev_end x, __func__, __FILE__, __LINE__), \
+         pmix_timing_start_init(pmix_timing_prep_ev x, __func__, __FILE__, __LINE__))
 
 /**
  * The macro for use in reporting collected events with absolute values;

--- a/src/util/pmix_tty.c
+++ b/src/util/pmix_tty.c
@@ -45,10 +45,8 @@
 #endif
 
 #include <errno.h>
-#include <stdio.h>
 #include <string.h>
 
-#include "src/util/pmix_output.h"
 #include "src/util/pmix_tty.h"
 
 /* Bits that can appear in c_lflag but are *status* rather than
@@ -165,12 +163,11 @@ pmix_status_t pmix_setwinsz(int fd, struct winsize *ws)
 pmix_status_t pmix_setraw(int fd, struct termios *prior)
 {
     struct termios terms;
-    int rc;
+    pmix_status_t rc;
 
     rc = pmix_gettermios(fd, &terms);
-
-    if (0 != rc) {
-        return PMIX_ERROR;
+    if (PMIX_SUCCESS != rc) {
+        return rc;
     }
 
     if (NULL != prior) {
@@ -192,6 +189,5 @@ pmix_status_t pmix_setraw(int fd, struct termios *prior)
     terms.c_cc[VMIN] = 1;                   /* Character-at-a-time input */
     terms.c_cc[VTIME] = 0;                  /* with blocking */
 
-    rc = pmix_settermios(fd, &terms);
-    return rc;
+    return pmix_settermios(fd, &terms);
 }

--- a/src/util/pmix_tty.c
+++ b/src/util/pmix_tty.c
@@ -51,6 +51,33 @@
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_tty.h"
 
+/* Bits that can appear in c_lflag but are *status* rather than
+ * settings: the driver turns them on and off for itself.  PENDIN says
+ * queued input has yet to be retyped - which is exactly what happens
+ * when canonical mode is re-enabled - FLUSHO says output is being
+ * discarded, and EXTPROC can be turned on from the master end of a pty
+ * without the slave's caller ever asking for it.  A caller handing
+ * back settings it read a moment ago will legitimately disagree with
+ * the read-back on all three, so they take no part in the check that
+ * a requested set actually took. */
+#ifdef FLUSHO
+#    define PMIX_TTY_FLUSHO FLUSHO
+#else
+#    define PMIX_TTY_FLUSHO 0
+#endif
+#ifdef PENDIN
+#    define PMIX_TTY_PENDIN PENDIN
+#else
+#    define PMIX_TTY_PENDIN 0
+#endif
+#ifdef EXTPROC
+#    define PMIX_TTY_EXTPROC EXTPROC
+#else
+#    define PMIX_TTY_EXTPROC 0
+#endif
+#define PMIX_TTY_LFLAG_STATUS \
+    ((tcflag_t) (PMIX_TTY_FLUSHO | PMIX_TTY_PENDIN | PMIX_TTY_EXTPROC))
+
 pmix_status_t pmix_gettermios(int fd, struct termios *terms)
 {
     int rc;
@@ -76,41 +103,49 @@ pmix_status_t pmix_getwinsz(int fd, struct winsize *ws)
 pmix_status_t pmix_settermios(int fd, struct termios *terms)
 {
     struct termios old, check;
-    int rc, err;
+    pmix_status_t rc;
+    int err;
 
     rc = pmix_gettermios(fd, &old);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
 
-    if (0 != rc) {
+    if (0 != tcsetattr(fd, TCSANOW, terms)) {
+        /* a failure says nothing about how much of the request was
+         * applied, so put the terminal back the way we found it and
+         * report the original error */
+        err = errno;  // preserve original error
+        (void) tcsetattr(fd, TCSANOW, &old);
+        errno = err;
         return PMIX_ERROR;
     }
 
-    rc = tcsetattr(fd, TCSANOW, terms);
-    if (0 != rc) {
-        // attempt to reset it
-        err = errno;  // preserve original error
-        tcsetattr(fd, TCSANOW, &old);
+    /* check that it was fully successful - tcsetattr returns
+     * success if ANY change succeeded. Compare the individual POSIX
+     * termios fields rather than memcmp'ing the whole struct: the
+     * struct carries padding and (on some platforms) speed fields the
+     * kernel canonicalizes, so a byte-exact compare gives spurious
+     * failures even when every requested setting was applied.  The
+     * driver-maintained bits of c_lflag are excluded for the same
+     * reason - see PMIX_TTY_LFLAG_STATUS above. */
+    rc = pmix_gettermios(fd, &check);
+    if (PMIX_SUCCESS != rc) {
+        err = errno;
+        (void) tcsetattr(fd, TCSANOW, &old);
         errno = err;
-
-    } else {
-
-        /* check that it was fully successful - tcsetattr returns
-         * success if ANY change succeeded. Compare the individual POSIX
-         * termios fields rather than memcmp'ing the whole struct: the
-         * struct carries padding and (on some platforms) speed fields the
-         * kernel canonicalizes, so a byte-exact compare gives spurious
-         * failures even when every requested setting was applied. */
-        rc = pmix_gettermios(fd, &check);
-        if (0 != rc) {
-            return PMIX_ERROR;
-        }
-        if (terms->c_iflag != check.c_iflag ||
-            terms->c_oflag != check.c_oflag ||
-            terms->c_cflag != check.c_cflag ||
-            terms->c_lflag != check.c_lflag ||
-            0 != memcmp(terms->c_cc, check.c_cc, sizeof(terms->c_cc))) {
-            errno = EINVAL;
-            return PMIX_ERROR;
-        }
+        return rc;
+    }
+    if (terms->c_iflag != check.c_iflag ||
+        terms->c_oflag != check.c_oflag ||
+        terms->c_cflag != check.c_cflag ||
+        (terms->c_lflag & ~PMIX_TTY_LFLAG_STATUS)
+            != (check.c_lflag & ~PMIX_TTY_LFLAG_STATUS) ||
+        0 != memcmp(terms->c_cc, check.c_cc, sizeof(terms->c_cc))) {
+        /* only part of the request took - leave nothing half-applied */
+        (void) tcsetattr(fd, TCSANOW, &old);
+        errno = EINVAL;
+        return PMIX_ERROR;
     }
 
     return PMIX_SUCCESS;

--- a/src/util/pmix_tty.h
+++ b/src/util/pmix_tty.h
@@ -37,14 +37,90 @@
 
 BEGIN_C_DECLS
 
+/*
+ * Wrappers over tcgetattr/tcsetattr and the winsize ioctls.
+ *
+ * Every one of these takes a descriptor that must already refer to a
+ * terminal, answers PMIX_SUCCESS or PMIX_ERROR, and leaves `errno` set
+ * by the call that failed - the status says only that something did.
+ *
+ * They hold no state of their own and neither allocate nor lock, so
+ * they are reentrant and safe to call from any thread or between fork
+ * and exec.  What is *not* atomic is a read-modify-write of one
+ * terminal: pmix_settermios() reads the current settings so it can put
+ * them back, and pmix_setraw() reads them so it can hand them to the
+ * caller, so two threads driving the same terminal can each undo the
+ * other.  Serialize that in the caller.
+ */
+
+/**
+ * Read a terminal's current settings.
+ *
+ * @param fd     descriptor referring to a terminal
+ * @param terms  filled in with the current settings
+ * @return       PMIX_SUCCESS, or PMIX_ERROR with `errno` set
+ */
 PMIX_EXPORT pmix_status_t pmix_gettermios(int fd, struct termios *terms);
 
+/**
+ * Read a terminal's current window size.
+ *
+ * @param fd  descriptor referring to a terminal
+ * @param ws  filled in with the current window size
+ * @return    PMIX_SUCCESS, or PMIX_ERROR with `errno` set
+ */
 PMIX_EXPORT pmix_status_t pmix_getwinsz(int fd, struct winsize *ws);
 
+/**
+ * Apply terminal settings, all of them or none of them.
+ *
+ * @param fd     descriptor referring to a terminal
+ * @param terms  the settings to apply
+ * @return       PMIX_SUCCESS, or PMIX_ERROR with `errno` set
+ *
+ * tcsetattr(3) reports success when *any* part of the request was
+ * applied, which is not something a caller can act on, so this reads
+ * the settings back and requires them to match.  Anything short of a
+ * full match - including a tcsetattr() that failed outright - puts the
+ * terminal back the way it was found and reports PMIX_ERROR, so a
+ * failure never leaves settings half-applied.  `errno` is EINVAL when
+ * the set was accepted but did not take.
+ *
+ * The status bits the driver maintains for itself in c_lflag - FLUSHO,
+ * PENDIN, EXTPROC - are not part of the comparison: they are not
+ * settings, and requiring them to match makes an ordinary
+ * pmix_setraw()/restore pair report a failure that did not happen.
+ */
 PMIX_EXPORT pmix_status_t pmix_settermios(int fd, struct termios *terms);
 
+/**
+ * Set a terminal's window size.
+ *
+ * @param fd  descriptor referring to a terminal
+ * @param ws  the window size to set
+ * @return    PMIX_SUCCESS, or PMIX_ERROR with `errno` set
+ */
 PMIX_EXPORT pmix_status_t pmix_setwinsz(int fd, struct winsize *ws);
 
+/**
+ * Put a terminal into raw mode.
+ *
+ * @param fd     descriptor referring to a terminal
+ * @param prior  if not NULL, receives the settings being replaced, so
+ *               the caller can restore them with pmix_settermios()
+ * @return       PMIX_SUCCESS, or PMIX_ERROR with `errno` set
+ *
+ * "Raw" here means the line discipline is out of the way: no canonical
+ * mode, no echo, no signal or extended-input processing, no input or
+ * output post-processing, and one character at a time with a blocking
+ * read.  The control modes (c_cflag) are deliberately left alone - a
+ * caller that also wants a particular character size or parity has to
+ * ask for it - which is what makes this usable on a pty, where those
+ * bits mean nothing.
+ *
+ * On failure the terminal is unchanged, and `prior` - if it was
+ * filled in at all - describes the settings still in effect.
+ */
 PMIX_EXPORT pmix_status_t pmix_setraw(int fd, struct termios *prior);
 
 END_C_DECLS

--- a/src/util/pmix_vmem.c
+++ b/src/util/pmix_vmem.c
@@ -13,25 +13,14 @@
 
 #include "src/include/pmix_globals.h"
 #include "src/util/pmix_error.h"
-#include "src/util/pmix_string_copy.h"
 
-#ifdef HAVE_ERRNO_H
-#include "errno.h"
-#endif
+#include <stdio.h>
+#include <stdlib.h>
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif
-#ifdef HAVE_SYS_STAT_H
-#include <sys/stat.h>
-#endif
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
 #endif
 #include <sys/mman.h>
 
@@ -59,7 +48,7 @@ typedef enum {
     VMEM_MAP_OTHER = 4
 } pmix_vmem_map_kind_t;
 
-static int
+static pmix_status_t
 parse_map_line(
     const char *line,
     unsigned long *beginp,
@@ -88,7 +77,6 @@ parse_map_line(
         return PMIX_ERROR;
     }
     *endp = (unsigned long) value;
-    tmp = next;
 
     if (*next != ' ') {
         return PMIX_ERROR;

--- a/src/util/pmix_vmem.c
+++ b/src/util/pmix_vmem.c
@@ -108,10 +108,15 @@ parse_map_line(
             } else if (!strncmp(next, "[stack]", 7)) {
                 *kindp = VMEM_MAP_STACK;
             } else {
-                char *end;
-                if ((end = strchr(next, '\n')) != NULL) {
-                    *end = '\0';
-                }
+                /* Do NOT truncate the line here.  An earlier version
+                 * replaced the newline with a NUL for the sake of a
+                 * tag string nothing reads, and find_hole() decides
+                 * whether it has the whole line by looking for that
+                 * newline - so every bracketed tag other than [heap]
+                 * and [stack] made it swallow the *following* map
+                 * entry as a continuation.  A swallowed entry is
+                 * invisible to the gap arithmetic, which then reports
+                 * a hole spanning a range that is mapped. */
                 *kindp = VMEM_MAP_OTHER;
             }
         } else {
@@ -126,7 +131,7 @@ static pmix_status_t
 use_hole(
     unsigned long holebegin,
     unsigned long holesize,
-    unsigned long *addrp,
+    size_t *addrp,
     unsigned long size
 ) {
     unsigned long aligned;
@@ -204,7 +209,7 @@ static pmix_status_t
 use_hole_offset(
     unsigned long holebegin,
     unsigned long holesize,
-    unsigned long *addrp,
+    size_t *addrp,
     unsigned long size,
     uint64_t scatter,
     bool scattered
@@ -257,6 +262,7 @@ use_hole_offset(
 
 static pmix_status_t
 find_hole(
+    const char *mapfile,
     pmix_vmem_hole_kind_t hkind,
     size_t *addrp,
     size_t size,
@@ -271,7 +277,24 @@ find_hole(
     FILE *file;
     char line[96];
 
-    file = fopen("/proc/self/maps", "r");
+    /* Screen the kind before opening anything.  The scan has nothing to
+     * do for a kind it does not implement, and this used to be an
+     * assert(0) in the switch below - so VMEM_HOLE_NONE or
+     * VMEM_HOLE_CUSTOM, both of which a caller can name from the
+     * installed header, aborted the process in a debug build. */
+    switch (hkind) {
+        case VMEM_HOLE_BEGIN:
+        case VMEM_HOLE_AFTER_HEAP:
+        case VMEM_HOLE_BEFORE_STACK:
+        case VMEM_HOLE_IN_LIBS:
+        case VMEM_HOLE_BIGGEST:
+        case VMEM_HOLE_BIGGEST_OFFSET:
+            break;
+        default:
+            return PMIX_ERR_BAD_PARAM;
+    }
+
+    file = fopen(mapfile, "r");
     if (!file) {
         return PMIX_ERROR;
     }
@@ -279,8 +302,10 @@ find_hole(
     while (fgets(line, sizeof(line), file) != NULL) {
         unsigned long begin = 0, end = 0;
         pmix_vmem_map_kind_t mkind = VMEM_MAP_OTHER;
+        bool parsed;
 
-        if (!parse_map_line(line, &begin, &end, &mkind)) {
+        parsed = (PMIX_SUCCESS == parse_map_line(line, &begin, &end, &mkind));
+        if (parsed) {
             switch (hkind) {
                 case VMEM_HOLE_BEGIN:
                     fclose(file);
@@ -327,14 +352,25 @@ find_hole(
                     break;
 
                 default:
-                    assert(0);
+                    /* unreachable: screened above */
+                    break;
             }
         }
 
+        /* the entry may be longer than our buffer - drain the rest of it
+         * before reading the next one */
         while (!strchr(line, '\n')) {
             if (!fgets(line, sizeof(line), file)) {
                 goto done;
             }
+        }
+
+        if (!parsed) {
+            /* Nothing was learned about this range, so it must not move
+             * prevend: carrying a zeroed end forward would put the next
+             * gap's start at address 0 and manufacture a "hole"
+             * spanning everything below the next mapping. */
+            continue;
         }
 
         if (mkind == VMEM_MAP_STACK) {
@@ -362,13 +398,19 @@ done:
     return PMIX_ERROR;
 }
 
+/* The map every caller means.  Only the test hook below names another. */
+#define PMIX_VMEM_SELF_MAPS "/proc/self/maps"
+
 pmix_status_t
 pmix_vmem_find_hole(
     pmix_vmem_hole_kind_t hkind,
     size_t *addrp,
     size_t size
 ) {
-    return find_hole(hkind, addrp, size, 0, false);
+    if (NULL == addrp) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    return find_hole(PMIX_VMEM_SELF_MAPS, hkind, addrp, size, 0, false);
 }
 
 pmix_status_t
@@ -378,7 +420,25 @@ pmix_vmem_find_hole_scattered(
     size_t *addrp,
     size_t size
 ) {
-    return find_hole(hkind, addrp, size, scatter, true);
+    if (NULL == addrp) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    return find_hole(PMIX_VMEM_SELF_MAPS, hkind, addrp, size, scatter, true);
+}
+
+pmix_status_t
+pmix_vmem_find_hole_in_map(
+    const char *mapfile,
+    pmix_vmem_hole_kind_t hkind,
+    uint64_t scatter,
+    bool scattered,
+    size_t *addrp,
+    size_t size
+) {
+    if (NULL == mapfile || NULL == addrp) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    return find_hole(mapfile, hkind, addrp, size, scatter, scattered);
 }
 
 /**
@@ -431,7 +491,13 @@ pmix_vmem_reserve(
      * input would simply fail the same way eight times. */
     enum { MAX_RESERVE_ATTEMPTS = 8 };
 
+    if (NULL == base) {
+        return PMIX_ERR_BAD_PARAM;
+    }
     *base = 0;
+    if (0 == size) {
+        return PMIX_ERR_BAD_PARAM;
+    }
     for (uint64_t attempt = 0; attempt < MAX_RESERVE_ATTEMPTS; ++attempt) {
         size_t addr = 0;
         pmix_status_t rc = pmix_vmem_find_hole_scattered(

--- a/src/util/pmix_vmem.h
+++ b/src/util/pmix_vmem.h
@@ -37,6 +37,20 @@ typedef enum {
     VMEM_HOLE_BIGGEST_OFFSET = 6
 } pmix_vmem_hole_kind_t;
 
+/**
+ * Find a hole in this process's address space big enough for "size".
+ *
+ * Answers PMIX_ERR_BAD_PARAM for a hole kind this does not implement -
+ * VMEM_HOLE_NONE and VMEM_HOLE_CUSTOM are named in the enum above but
+ * have no search behind them, and are the caller's to screen or avoid.
+ * Answers PMIX_ERROR when there is no map to scan, which is every
+ * platform without /proc/self/maps.
+ *
+ * The address is only an observation about a moment: nothing holds it,
+ * and anything that maps - another thread, the loader, the allocator
+ * growing an arena - can take it before the caller does. Use
+ * pmix_vmem_reserve() for a range that has to still be there later.
+ */
 PMIX_EXPORT pmix_status_t
 pmix_vmem_find_hole(
     pmix_vmem_hole_kind_t hkind,
@@ -71,6 +85,32 @@ PMIX_EXPORT pmix_status_t
 pmix_vmem_find_hole_scattered(
     pmix_vmem_hole_kind_t hkind,
     uint64_t scatter,
+    size_t *addrp,
+    size_t size
+);
+
+/**
+ * As pmix_vmem_find_hole()/_scattered(), but scanning a named map file
+ * rather than this process's own.
+ *
+ * This exists so the placement rules can be held against a map whose
+ * shape is chosen rather than inherited. Everything the scan has to get
+ * right - which gap is the biggest, where the heap and the stack end a
+ * search, an entry too long for the read buffer, an entry it cannot
+ * parse - is a property of the map it is given, and a live
+ * /proc/self/maps is neither reproducible nor steerable. It is also the
+ * only way to reach any of this on a host that has no /proc at all.
+ *
+ * "mapfile" must be in the format of /proc/self/maps. Not for ordinary
+ * use: a hole found in someone else's map says nothing about this
+ * process's address space.
+ */
+PMIX_EXPORT pmix_status_t
+pmix_vmem_find_hole_in_map(
+    const char *mapfile,
+    pmix_vmem_hole_kind_t hkind,
+    uint64_t scatter,
+    bool scattered,
     size_t *addrp,
     size_t size
 );

--- a/test/unit/ptl_uri.c
+++ b/test/unit/ptl_uri.c
@@ -250,6 +250,16 @@ int main(int argc, char **argv)
     static pmix_server_module_t mymodule = {0};
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
+    /* A port range the parser cannot read expands to nothing, and the
+     * ptl frame indexed element 0 of the result to see whether the user
+     * had asked for the wildcard - so "-" (and now any non-numeric
+     * value) in this parameter dereferenced a NULL and took the process
+     * down inside PMIx_server_init. Setting it here costs nothing: the
+     * fallback is the ephemeral port, which is what an unset value asks
+     * for anyway. Against an unfixed library this binary dies on a
+     * signal before printing a line, rather than failing a case. */
+    setenv("PMIX_MCA_ptl_base_ipv4_ports", "-", 1);
+
     /* the parsers emit verbose output through the ptl framework, so the
      * frameworks have to be open - server_init is the cheapest way to
      * get a fully initialized library */

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -25,3 +25,4 @@ util_getid
 util_vmem
 hash_perf
 util_keyval
+util_pty

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -20,5 +20,6 @@ util_parse_options
 util_os_path
 util_fd
 util_few
+util_getcwd
 util_vmem
 hash_perf

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -21,5 +21,6 @@ util_os_path
 util_fd
 util_few
 util_getcwd
+util_getid
 util_vmem
 hash_perf

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -18,5 +18,6 @@ util_net
 util_if
 util_parse_options
 util_os_path
+util_fd
 util_vmem
 hash_perf

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -26,3 +26,4 @@ util_vmem
 hash_perf
 util_keyval
 util_pty
+util_shmem

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -24,3 +24,4 @@ util_getcwd
 util_getid
 util_vmem
 hash_perf
+util_keyval

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -27,3 +27,4 @@ hash_perf
 util_keyval
 util_pty
 util_shmem
+util_tty

--- a/test/unit/util/.gitignore
+++ b/test/unit/util/.gitignore
@@ -19,5 +19,6 @@ util_if
 util_parse_options
 util_os_path
 util_fd
+util_few
 util_vmem
 hash_perf

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -18,7 +18,8 @@ check_PROGRAMS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_fd util_few util_vmem util_getcwd util_getid util_keyval hash_perf
+    util_fd util_few util_vmem util_getcwd util_getid util_keyval util_pty \
+    hash_perf
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
@@ -26,7 +27,8 @@ TESTS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_fd util_few util_vmem util_getcwd util_getid util_keyval hash_perf
+    util_fd util_few util_vmem util_getcwd util_getid util_keyval util_pty \
+    hash_perf
 
 util_keyval_SOURCES = util_keyval.c
 util_keyval_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -110,6 +112,11 @@ util_alfg_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_alfg_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+util_pty_SOURCES = util_pty.c
+util_pty_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_pty_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 util_printf_SOURCES = util_printf.c
 util_printf_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_printf_LDADD = \
@@ -178,4 +185,5 @@ clean-local:
 	    util_basename util_string_copy util_argv util_path \
 	    util_environ util_alfg util_printf util_os_dirpath \
 	    util_net util_if util_parse_options util_os_path \
-	    util_fd util_few util_vmem util_getcwd util_getid util_keyval hash_perf
+	    util_fd util_few util_vmem util_getcwd util_getid util_keyval util_pty \
+    hash_perf

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -19,7 +19,7 @@ check_PROGRAMS = util_hash util_name_fns \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
     util_fd util_few util_vmem util_getcwd util_getid util_keyval util_pty \
-    util_shmem hash_perf
+    util_tty util_shmem hash_perf
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
@@ -28,7 +28,7 @@ TESTS = util_hash util_name_fns \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
     util_fd util_few util_vmem util_getcwd util_getid util_keyval util_pty \
-    util_shmem hash_perf
+    util_tty util_shmem hash_perf
 
 util_keyval_SOURCES = util_keyval.c
 util_keyval_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -117,6 +117,15 @@ util_pty_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_pty_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+# termios/winsize helpers. Needs a real terminal, so every case runs
+# against a pty; the failure case needs three processes to build the
+# only position POSIX lets tcsetattr fail from. See the header comment
+# in util_tty.c.
+util_tty_SOURCES = util_tty.c
+util_tty_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_tty_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 util_printf_SOURCES = util_printf.c
 util_printf_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_printf_LDADD = \
@@ -191,4 +200,4 @@ clean-local:
 	    util_environ util_alfg util_printf util_os_dirpath \
 	    util_net util_if util_parse_options util_os_path \
 	    util_fd util_few util_vmem util_getcwd util_getid util_keyval util_pty \
-	    util_shmem hash_perf
+	    util_tty util_shmem hash_perf

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -18,7 +18,7 @@ check_PROGRAMS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_vmem hash_perf
+    util_fd util_vmem hash_perf
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
@@ -26,7 +26,7 @@ TESTS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_vmem hash_perf
+    util_fd util_vmem hash_perf
 
 util_hash_SOURCES = util_hash.c
 util_hash_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -135,6 +135,13 @@ util_os_path_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_os_path_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+# Descriptor helpers. Forks a child for the mass-close test, which would
+# otherwise take the harness's own descriptors with it.
+util_fd_SOURCES = util_fd.c
+util_fd_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_fd_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 # Address placement and reservation. Skips itself where there is no
 # /proc/self/maps to scan; see the header comment in util_vmem.c.
 util_vmem_SOURCES = util_vmem.c
@@ -149,4 +156,4 @@ clean-local:
 	    util_basename util_string_copy util_argv util_path \
 	    util_environ util_alfg util_printf util_os_dirpath \
 	    util_net util_if util_parse_options util_os_path \
-	    util_vmem hash_perf
+	    util_fd util_vmem hash_perf

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -170,13 +170,15 @@ util_few_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_few_LDADD = \
     $(top_builddir)/src/libpmix.la
 
-# Address placement and reservation. Skips itself where there is no
-# /proc/self/maps to scan; see the header comment in util_vmem.c.
 util_shmem_SOURCES = util_shmem.c
 util_shmem_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_shmem_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+# Address placement and reservation. The scan runs everywhere, against
+# maps the test writes; only the cases needing this process's own map
+# skip where there is no /proc/self/maps. See the header comment in
+# util_vmem.c.
 util_vmem_SOURCES = util_vmem.c
 util_vmem_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_vmem_LDADD = \

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -18,7 +18,7 @@ check_PROGRAMS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_fd util_few util_vmem util_getcwd util_getid hash_perf
+    util_fd util_few util_vmem util_getcwd util_getid util_keyval hash_perf
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
@@ -26,7 +26,12 @@ TESTS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_fd util_few util_vmem util_getcwd util_getid hash_perf
+    util_fd util_few util_vmem util_getcwd util_getid util_keyval hash_perf
+
+util_keyval_SOURCES = util_keyval.c
+util_keyval_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_keyval_LDADD = \
+    $(top_builddir)/src/libpmix.la
 
 util_hash_SOURCES = util_hash.c
 util_hash_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -173,4 +178,4 @@ clean-local:
 	    util_basename util_string_copy util_argv util_path \
 	    util_environ util_alfg util_printf util_os_dirpath \
 	    util_net util_if util_parse_options util_os_path \
-	    util_fd util_few util_vmem util_getcwd util_getid hash_perf
+	    util_fd util_few util_vmem util_getcwd util_getid util_keyval hash_perf

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -19,7 +19,7 @@ check_PROGRAMS = util_hash util_name_fns \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
     util_fd util_few util_vmem util_getcwd util_getid util_keyval util_pty \
-    hash_perf
+    util_shmem hash_perf
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
@@ -28,7 +28,7 @@ TESTS = util_hash util_name_fns \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
     util_fd util_few util_vmem util_getcwd util_getid util_keyval util_pty \
-    hash_perf
+    util_shmem hash_perf
 
 util_keyval_SOURCES = util_keyval.c
 util_keyval_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -163,6 +163,11 @@ util_few_LDADD = \
 
 # Address placement and reservation. Skips itself where there is no
 # /proc/self/maps to scan; see the header comment in util_vmem.c.
+util_shmem_SOURCES = util_shmem.c
+util_shmem_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_shmem_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 util_vmem_SOURCES = util_vmem.c
 util_vmem_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_vmem_LDADD = \
@@ -186,4 +191,4 @@ clean-local:
 	    util_environ util_alfg util_printf util_os_dirpath \
 	    util_net util_if util_parse_options util_os_path \
 	    util_fd util_few util_vmem util_getcwd util_getid util_keyval util_pty \
-    hash_perf
+	    util_shmem hash_perf

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -18,7 +18,7 @@ check_PROGRAMS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_fd util_few util_vmem util_getcwd hash_perf
+    util_fd util_few util_vmem util_getcwd util_getid hash_perf
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
@@ -26,7 +26,7 @@ TESTS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_fd util_few util_vmem util_getcwd hash_perf
+    util_fd util_few util_vmem util_getcwd util_getid hash_perf
 
 util_hash_SOURCES = util_hash.c
 util_hash_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -161,6 +161,11 @@ util_getcwd_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_getcwd_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+util_getid_SOURCES = util_getid.c
+util_getid_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_getid_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
 	rm -f util_hash util_name_fns \
 	    util_output util_error util_cmd_line \
@@ -168,4 +173,4 @@ clean-local:
 	    util_basename util_string_copy util_argv util_path \
 	    util_environ util_alfg util_printf util_os_dirpath \
 	    util_net util_if util_parse_options util_os_path \
-	    util_fd util_few util_vmem util_getcwd hash_perf
+	    util_fd util_few util_vmem util_getcwd util_getid hash_perf

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -18,7 +18,7 @@ check_PROGRAMS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_fd util_vmem hash_perf
+    util_fd util_few util_vmem hash_perf
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
@@ -26,7 +26,7 @@ TESTS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_fd util_vmem hash_perf
+    util_fd util_few util_vmem hash_perf
 
 util_hash_SOURCES = util_hash.c
 util_hash_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -142,6 +142,13 @@ util_fd_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_fd_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+# fork/exec/wait. The stdio regression only shows up when stdout is a
+# pipe, so that case runs in a child of the test's own.
+util_few_SOURCES = util_few.c
+util_few_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_few_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 # Address placement and reservation. Skips itself where there is no
 # /proc/self/maps to scan; see the header comment in util_vmem.c.
 util_vmem_SOURCES = util_vmem.c
@@ -156,4 +163,4 @@ clean-local:
 	    util_basename util_string_copy util_argv util_path \
 	    util_environ util_alfg util_printf util_os_dirpath \
 	    util_net util_if util_parse_options util_os_path \
-	    util_fd util_vmem hash_perf
+	    util_fd util_few util_vmem hash_perf

--- a/test/unit/util/Makefile.am
+++ b/test/unit/util/Makefile.am
@@ -18,7 +18,7 @@ check_PROGRAMS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_fd util_few util_vmem hash_perf
+    util_fd util_few util_vmem util_getcwd hash_perf
 
 TESTS = util_hash util_name_fns \
     util_output util_error util_cmd_line \
@@ -26,7 +26,7 @@ TESTS = util_hash util_name_fns \
     util_basename util_string_copy util_argv util_path \
     util_environ util_alfg util_printf util_os_dirpath \
     util_net util_if util_parse_options util_os_path \
-    util_fd util_few util_vmem hash_perf
+    util_fd util_few util_vmem util_getcwd hash_perf
 
 util_hash_SOURCES = util_hash.c
 util_hash_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -156,6 +156,11 @@ util_vmem_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 util_vmem_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+util_getcwd_SOURCES = util_getcwd.c
+util_getcwd_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+util_getcwd_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
 clean-local:
 	rm -f util_hash util_name_fns \
 	    util_output util_error util_cmd_line \
@@ -163,4 +168,4 @@ clean-local:
 	    util_basename util_string_copy util_argv util_path \
 	    util_environ util_alfg util_printf util_os_dirpath \
 	    util_net util_if util_parse_options util_os_path \
-	    util_fd util_few util_vmem hash_perf
+	    util_fd util_few util_vmem util_getcwd hash_perf

--- a/test/unit/util/util_argv.c
+++ b/test/unit/util/util_argv.c
@@ -351,6 +351,97 @@ static void test_copy_strip_null(void)
     report("copy_strip NULL returns NULL", NULL == dupv);
 }
 
+static void test_copy_strip_readonly_source(void)
+{
+    /* String literals live in read-only storage. pmix_argv_copy_strip()
+     * used to mark the end of the strip by punching a temporary NUL
+     * into the caller's element and putting the quote back afterwards;
+     * that faults on an argv whose elements are literals, which is a
+     * perfectly ordinary thing to hand a function that promises a copy.
+     * Without the fix this test dies on a signal rather than failing. */
+    char *ro[3];
+    char **dupv;
+
+    ro[0] = (char *) "\"quoted\"";
+    ro[1] = (char *) "plain";
+    ro[2] = NULL;
+
+    dupv = pmix_argv_copy_strip(ro);
+    report("copy_strip read-only source: non-NULL result", NULL != dupv);
+    report("copy_strip read-only source: quotes removed",
+           dupv && 0 == strcmp(dupv[0], "quoted"));
+    report("copy_strip read-only source: plain unchanged",
+           dupv && 0 == strcmp(dupv[1], "plain"));
+    report("copy_strip read-only source: NULL terminated",
+           dupv && NULL == dupv[2]);
+    report("copy_strip read-only source: source untouched",
+           0 == strcmp(ro[0], "\"quoted\""));
+    PMIx_Argv_free(dupv);
+}
+
+static void test_copy_strip_lone_quote(void)
+{
+    char **argv = NULL;
+    char **dupv;
+
+    /* a single quote character is both the leading and the trailing
+     * quote - stripping both must not run the length below zero */
+    PMIx_Argv_append_nosize(&argv, "\"");
+    PMIx_Argv_append_nosize(&argv, "\"a");
+    PMIx_Argv_append_nosize(&argv, "a\"");
+
+    dupv = pmix_argv_copy_strip(argv);
+    report("copy_strip lone quote: element 0 == \"\"",
+           dupv && 0 == strcmp(dupv[0], ""));
+    report("copy_strip lone quote: leading-only stripped",
+           dupv && 0 == strcmp(dupv[1], "a"));
+    report("copy_strip lone quote: trailing-only stripped",
+           dupv && 0 == strcmp(dupv[2], "a"));
+    report("copy_strip lone quote: NULL terminated", dupv && NULL == dupv[3]);
+    PMIx_Argv_free(dupv);
+    PMIx_Argv_free(argv);
+}
+
+static void test_append_unique_idx_null_args(void)
+{
+    char **argv = NULL;
+    int idx = -99;
+
+    PMIx_Argv_append_nosize(&argv, "foo");
+
+    /* the public twin (PMIx_Argv_append_unique_nosize) refuses these
+     * with BAD_PARAM; this one used to hand a NULL arg to strcmp */
+    report("append_unique_idx NULL arg is refused",
+           PMIX_ERR_BAD_PARAM == pmix_argv_append_unique_idx(&idx, &argv, NULL));
+    report("append_unique_idx NULL argv is refused",
+           PMIX_ERR_BAD_PARAM == pmix_argv_append_unique_idx(&idx, NULL, "x"));
+    report("append_unique_idx NULL idx is refused",
+           PMIX_ERR_BAD_PARAM == pmix_argv_append_unique_idx(NULL, &argv, "x"));
+    report("append_unique_idx refusal left the array alone",
+           1 == PMIx_Argv_count(argv));
+    PMIx_Argv_free(argv);
+}
+
+static void test_insert_empty_source(void)
+{
+    char **target = NULL;
+    char **source = NULL;
+    int argc = 0;
+
+    pmix_argv_append(&argc, &target, "a");
+    pmix_argv_append(&argc, &target, "b");
+    source = (char **) malloc(sizeof(char *));
+    source[0] = NULL;
+
+    report("insert empty source returns SUCCESS",
+           PMIX_SUCCESS == pmix_argv_insert(&target, 1, source));
+    report("insert empty source: argv[0] == \"a\"", 0 == strcmp(target[0], "a"));
+    report("insert empty source: argv[1] == \"b\"", 0 == strcmp(target[1], "b"));
+    report("insert empty source: NULL terminated", NULL == target[2]);
+    PMIx_Argv_free(target);
+    free(source);
+}
+
 /* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
@@ -384,6 +475,10 @@ int main(int argc, char **argv)
     test_copy_strip_quotes();
     test_copy_strip_empty_element();
     test_copy_strip_null();
+    test_copy_strip_readonly_source();
+    test_copy_strip_lone_quote();
+    test_append_unique_idx_null_args();
+    test_insert_empty_source();
 
     test_append_unique_idx_new();
     test_append_unique_idx_duplicate();

--- a/test/unit/util/util_basename.c
+++ b/test/unit/util/util_basename.c
@@ -167,15 +167,30 @@ static void test_dirname_root_cases(void)
      * current directory. The libgen-backed branch of pmix_dirname()
      * gets this right; the hand-rolled fallback used on a platform
      * without dirname(3) answered "." until it was corrected, and
-     * nothing here would have noticed. */
+     * nothing here would have noticed.
+     *
+     * WHICH root is not ours to pin down. POSIX says a pathname
+     * beginning with exactly two slashes may be interpreted in an
+     * implementation-defined manner, and the implementations disagree
+     * accordingly: glibc answers "//" for "//" where macOS answers "/".
+     * Both are conforming, so what is asserted is that the answer names
+     * a root at all - which is what the defect this case exists for got
+     * wrong, by answering ".". */
     const char *cases[] = {"/", "//", "///", NULL};
     char *r;
     int n;
+    size_t i;
+    bool rooted;
 
     for (n = 0; NULL != cases[n]; n++) {
         r = pmix_dirname(cases[n]);
-        report("dirname of an all-separator path is the root",
-               NULL != r && 0 == strcmp(r, "/"));
+        rooted = (NULL != r && '\0' != r[0]);
+        for (i = 0; rooted && '\0' != r[i]; i++) {
+            if ('/' != r[i] && '\\' != r[i]) {
+                rooted = false;
+            }
+        }
+        report("dirname of an all-separator path is the root", rooted);
         free(r);
     }
 }
@@ -189,38 +204,45 @@ static void test_dirname_corpus(void)
     static const struct {
         const char *in;
         const char *out;
+        /* A second conforming answer, where POSIX permits one. Only the
+         * two inputs that begin with exactly two slashes have one: such
+         * a pathname "may be interpreted in an implementation-defined
+         * manner", and glibc keeps the "//" while macOS collapses it.
+         * Every other row is a single required answer, and pinning them
+         * is the point of this table. */
+        const char *alt;
     } corpus[] = {
-        {"", "."},
-        {".", "."},
-        {"..", "."},
-        {"foo.txt", "."},
-        {"foo/", "."},
-        {"foo//", "."},
-        {"a/", "."},
-        {"./x", "."},
-        {"../x", ".."},
-        {"/", "/"},
-        {"//", "/"},
-        {"///", "/"},
-        {"/foo", "/"},
-        {"//foo", "/"},
-        {"///foo", "/"},
-        {"/foo/", "/"},
-        {"/foo//", "/"},
-        {"/a", "/"},
-        {"/yow.c", "/"},
-        {"/.", "/"},
-        {"/..", "/"},
-        {"/foo/bar", "/foo"},
-        {"/foo/bar/", "/foo"},
-        {"/foo//bar", "/foo"},
-        {"/foo//bar//", "/foo"},
-        {"foo/bar", "foo"},
-        {"foo/bar/", "foo"},
-        {"a/b/c/d", "a/b/c"},
-        {"x//y//z", "x//y"},
-        {"/usr/local/lib/pmix", "/usr/local/lib"},
-        {NULL, NULL}
+        {"", ".", NULL},
+        {".", ".", NULL},
+        {"..", ".", NULL},
+        {"foo.txt", ".", NULL},
+        {"foo/", ".", NULL},
+        {"foo//", ".", NULL},
+        {"a/", ".", NULL},
+        {"./x", ".", NULL},
+        {"../x", "..", NULL},
+        {"/", "/", NULL},
+        {"//", "/", "//"},
+        {"///", "/", NULL},
+        {"/foo", "/", NULL},
+        {"//foo", "/", "//"},
+        {"///foo", "/", NULL},
+        {"/foo/", "/", NULL},
+        {"/foo//", "/", NULL},
+        {"/a", "/", NULL},
+        {"/yow.c", "/", NULL},
+        {"/.", "/", NULL},
+        {"/..", "/", NULL},
+        {"/foo/bar", "/foo", NULL},
+        {"/foo/bar/", "/foo", NULL},
+        {"/foo//bar", "/foo", NULL},
+        {"/foo//bar//", "/foo", NULL},
+        {"foo/bar", "foo", NULL},
+        {"foo/bar/", "foo", NULL},
+        {"a/b/c/d", "a/b/c", NULL},
+        {"x//y//z", "x//y", NULL},
+        {"/usr/local/lib/pmix", "/usr/local/lib", NULL},
+        {NULL, NULL, NULL}
     };
     char msg[256];
     char *r;
@@ -228,9 +250,17 @@ static void test_dirname_corpus(void)
 
     for (n = 0; NULL != corpus[n].in; n++) {
         r = pmix_dirname(corpus[n].in);
-        snprintf(msg, sizeof(msg), "dirname(\"%s\") == \"%s\"",
-                 corpus[n].in, corpus[n].out);
-        report(msg, NULL != r && 0 == strcmp(r, corpus[n].out));
+        if (NULL == corpus[n].alt) {
+            snprintf(msg, sizeof(msg), "dirname(\"%s\") == \"%s\"",
+                     corpus[n].in, corpus[n].out);
+        } else {
+            snprintf(msg, sizeof(msg), "dirname(\"%s\") == \"%s\" or \"%s\"",
+                     corpus[n].in, corpus[n].out, corpus[n].alt);
+        }
+        report(msg, NULL != r
+                        && (0 == strcmp(r, corpus[n].out)
+                            || (NULL != corpus[n].alt
+                                && 0 == strcmp(r, corpus[n].alt))));
         free(r);
     }
 }

--- a/test/unit/util/util_basename.c
+++ b/test/unit/util/util_basename.c
@@ -161,6 +161,80 @@ static void test_dirname_deep_path(void)
     free(r);
 }
 
+static void test_dirname_root_cases(void)
+{
+    /* A path that is nothing but separators names the root, not the
+     * current directory. The libgen-backed branch of pmix_dirname()
+     * gets this right; the hand-rolled fallback used on a platform
+     * without dirname(3) answered "." until it was corrected, and
+     * nothing here would have noticed. */
+    const char *cases[] = {"/", "//", "///", NULL};
+    char *r;
+    int n;
+
+    for (n = 0; NULL != cases[n]; n++) {
+        r = pmix_dirname(cases[n]);
+        report("dirname of an all-separator path is the root",
+               NULL != r && 0 == strcmp(r, "/"));
+        free(r);
+    }
+}
+
+static void test_dirname_corpus(void)
+{
+    /* Pin the full answer table. pmix_dirname() has two independent
+     * implementations selected at configure time, and only one of them
+     * is ever compiled on a given host, so a divergence between them is
+     * invisible to a build that does not check the answers themselves. */
+    static const struct {
+        const char *in;
+        const char *out;
+    } corpus[] = {
+        {"", "."},
+        {".", "."},
+        {"..", "."},
+        {"foo.txt", "."},
+        {"foo/", "."},
+        {"foo//", "."},
+        {"a/", "."},
+        {"./x", "."},
+        {"../x", ".."},
+        {"/", "/"},
+        {"//", "/"},
+        {"///", "/"},
+        {"/foo", "/"},
+        {"//foo", "/"},
+        {"///foo", "/"},
+        {"/foo/", "/"},
+        {"/foo//", "/"},
+        {"/a", "/"},
+        {"/yow.c", "/"},
+        {"/.", "/"},
+        {"/..", "/"},
+        {"/foo/bar", "/foo"},
+        {"/foo/bar/", "/foo"},
+        {"/foo//bar", "/foo"},
+        {"/foo//bar//", "/foo"},
+        {"foo/bar", "foo"},
+        {"foo/bar/", "foo"},
+        {"a/b/c/d", "a/b/c"},
+        {"x//y//z", "x//y"},
+        {"/usr/local/lib/pmix", "/usr/local/lib"},
+        {NULL, NULL}
+    };
+    char msg[256];
+    char *r;
+    int n;
+
+    for (n = 0; NULL != corpus[n].in; n++) {
+        r = pmix_dirname(corpus[n].in);
+        snprintf(msg, sizeof(msg), "dirname(\"%s\") == \"%s\"",
+                 corpus[n].in, corpus[n].out);
+        report(msg, NULL != r && 0 == strcmp(r, corpus[n].out));
+        free(r);
+    }
+}
+
 /* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
@@ -187,6 +261,8 @@ int main(int argc, char **argv)
     test_dirname_single_component();
     test_dirname_local_file();
     test_dirname_deep_path();
+    test_dirname_root_cases();
+    test_dirname_corpus();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/util/util_cmd_line.c
+++ b/test/unit/util/util_cmd_line.c
@@ -222,6 +222,7 @@ static struct option tblopts[] = {
     PMIX_OPTION_DEFINE(PMIX_CLI_URI, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_PMIXMCA, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_INFO_VERSION, PMIX_ARG_OPTIONAL),
+    PMIX_OPTION_DEFINE(PMIX_CLI_PREPEND_ENVAR, PMIX_ARG_REQD),
     PMIX_OPTION_SHORT_DEFINE("np", PMIX_ARG_REQD, 'n'),
     PMIX_OPTION_END
 };
@@ -453,6 +454,50 @@ static parse_case_t cases[] = {
      {"prog", "--show-version", "-v", NULL}, PMIX_SUCCESS,
      PMIX_CLI_INFO_VERSION, "", PMIX_CLI_VERBOSE, "1", NULL, NULL},
 
+    /* ---- tokens the parser claims for itself -----------------------
+     * getopt is told these options take one argument; the second token
+     * is taken from argv[optind] by the parser. Taking it without first
+     * checking that it is there claimed the NULL that terminates argv as
+     * a value and stepped optind PAST the end of the array - which the
+     * loop's "optind == argc" test then failed to catch, so the next
+     * iteration read past the end and dereferenced what it found. Each
+     * of these three dies on a signal, not with a failed assertion, if
+     * that comes back. */
+    {"two-token: --prepend-env with only one token is refused",
+     {"prog", "--prepend-env", "FOO", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    {"two-token: --prepend-env with both tokens",
+     {"prog", "--prepend-env", "FOO", "bar", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_PREPEND_ENVAR, "FOO|bar", NULL, NULL, NULL, NULL},
+
+    {"two-token: --pmixmca with no value is refused",
+     {"prog", "--pmixmca", "p", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    {"two-token: -np with no count is refused",
+     {"prog", "-np", NULL}, PMIX_ERR_SILENT,
+     NULL, NULL, NULL, NULL, NULL, NULL},
+
+    /* ---- a bare "-" ------------------------------------------------
+     * "-" names stdin by convention, not an option, and getopt agrees:
+     * it stops there without consuming the token. The loop only asked
+     * whether the token began with a dash, so it called getopt anyway,
+     * got the "no more options" answer, and then reasoned about
+     * argv[optind-1] - the token BEFORE the dash - reporting an option
+     * that had been given its argument as though it were missing one. */
+    {"bare dash: is the tail, not an option",
+     {"prog", "-", NULL}, PMIX_SUCCESS,
+     NULL, NULL, NULL, NULL, NULL, "-"},
+
+    {"bare dash: after a flag",
+     {"prog", "--verbose", "-", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_VERBOSE, "1", NULL, NULL, NULL, "-"},
+
+    {"bare dash: after an option that took an argument",
+     {"prog", "--timeout", "30", "-", "app", NULL}, PMIX_SUCCESS,
+     PMIX_CLI_TIMEOUT, "30", NULL, NULL, NULL, "- app"},
+
     {NULL, {NULL}, 0, NULL, NULL, NULL, NULL, NULL, NULL}
 };
 
@@ -578,6 +623,71 @@ static void run_table(void)
 
     if (0 <= devnull) {
         close(devnull);
+    }
+    if (0 <= saved_err) {
+        close(saved_err);
+    }
+}
+
+/* ================================================================== */
+/* The help option's optional argument                                */
+/* ================================================================== */
+
+/* "--help topic" and "--help=topic" (and "-htopic") are the same request.
+ * getopt reports an optional argument in optarg when it was attached to
+ * the option and leaves it at argv[optind] when it was the next token, and
+ * only the second was ever looked at - so the attached spelling fell
+ * through to an "unrecognized option" complaint naming the topic itself.
+ *
+ * All three answer PMIX_OPERATION_SUCCEEDED: the parse is over, the tool
+ * has said its piece and should exit. The one that used to be wrong
+ * answered PMIX_ERR_SILENT. */
+static void test_help_optional_argument(void)
+{
+    char *spaced[] = {"prog", "--help", "version", NULL};
+    char *attached[] = {"prog", "--help=version", NULL};
+    char *shortform[] = {"prog", "-hversion", NULL};
+    char *bare[] = {"prog", "--help", NULL};
+    struct { const char *desc; char **argv; } t[] = {
+        {"help: \"--help topic\"", spaced},
+        {"help: \"--help=topic\"", attached},
+        {"help: \"-htopic\"", shortform},
+        {"help: no topic at all", bare},
+        {NULL, NULL}
+    };
+    pmix_cli_result_t res;
+    int rc, n, saved_out, saved_err, devnull;
+
+    /* every one of these prints a help block - park both streams */
+    saved_out = dup(fileno(stdout));
+    saved_err = dup(fileno(stderr));
+    devnull = open("/dev/null", O_WRONLY);
+
+    for (n = 0; NULL != t[n].desc; n++) {
+        PMIX_CONSTRUCT(&res, pmix_cli_result_t);
+        if (0 <= devnull) {
+            fflush(stdout);
+            fflush(stderr);
+            dup2(devnull, fileno(stdout));
+            dup2(devnull, fileno(stderr));
+        }
+        rc = pmix_cmd_line_parse(t[n].argv, tblshorts, tblopts,
+                                 NULL, &res, "help-cli.txt");
+        if (0 <= saved_out) {
+            fflush(stdout);
+            fflush(stderr);
+            dup2(saved_out, fileno(stdout));
+            dup2(saved_err, fileno(stderr));
+        }
+        report(t[n].desc, PMIX_OPERATION_SUCCEEDED == rc);
+        PMIX_DESTRUCT(&res);
+    }
+
+    if (0 <= devnull) {
+        close(devnull);
+    }
+    if (0 <= saved_out) {
+        close(saved_out);
     }
     if (0 <= saved_err) {
         close(saved_err);
@@ -807,6 +917,21 @@ static void test_check_cli_option(void)
     /* Case-insensitive */
     report("check_cli: case-insensitive",
            pmix_check_cli_option("VERB", "verbose"));
+    /* A string that is nothing but separators splits to NOTHING, not to a
+     * one-element array - so the segment walk had a NULL array to read.
+     * These die on a signal, not with a failed assertion, if that comes
+     * back. */
+    report("check_cli: an all-dash input has no segments to match",
+           !pmix_check_cli_option("-", "system-server"));
+    report("check_cli: an all-dash target has no segments to match",
+           !pmix_check_cli_option("sys", "-"));
+    report("check_cli: all-dash on both sides",
+           !pmix_check_cli_option("--", "--"));
+    /* strdup() is not handed a NULL either */
+    report("check_cli: a NULL input matches nothing",
+           !pmix_check_cli_option(NULL, "verbose"));
+    report("check_cli: a NULL target matches nothing",
+           !pmix_check_cli_option("verbose", NULL));
 }
 
 /* ------------------------------------------------------------------ */
@@ -830,6 +955,15 @@ static void test_convert_time(void)
     /* zero */
     report("convert_time: \"0\" → 0",
            0 == pmix_convert_string_to_time("0"));
+    /* A string carrying no fields at all splits to NOTHING, so the walk
+     * up from the last field read tmp[-1] off a NULL array. Signal, not
+     * assertion, if this comes back. */
+    report("convert_time: an empty string is no time",
+           0 == pmix_convert_string_to_time(""));
+    report("convert_time: nothing but separators is no time",
+           0 == pmix_convert_string_to_time(":"));
+    report("convert_time: a NULL string is no time",
+           0 == pmix_convert_string_to_time(NULL));
 }
 
 /* ------------------------------------------------------------------ */
@@ -859,6 +993,8 @@ int main(int argc, char **argv)
     fprintf(stdout, "\n--- command-line table ---\n");
     run_table();
     fprintf(stdout, "\n");
+
+    test_help_optional_argument();
 
     test_order_interleaved();
     test_order_reversed();

--- a/test/unit/util/util_context_fns.c
+++ b/test/unit/util/util_context_fns.c
@@ -104,9 +104,61 @@ static void test_check_cwd_chdir_bad_user(void)
     free(p);
 }
 
+/* The $HOME fallback: a directory the user did NOT ask for, which we
+ * cannot reach, is not an error - we go to $HOME instead and say so in
+ * *incwd. That worked only while $HOME was set. With it unset,
+ * pmix_home_directory() falls back to the passwd entry, and the uid it
+ * was asked about was the sentinel (uid_t)-1, which has no passwd entry -
+ * so the fallback never fired in the one case it was written for, and
+ * *incwd was left naming a directory the process is not in. */
+static void test_check_cwd_home_fallback_no_HOME(void)
+{
+    char *saved = getenv("HOME");
+    char *keep = (NULL == saved) ? NULL : strdup(saved);
+    char *p = strdup("/nonexistent_path_xyz_abc_123");
+    char here[PMIX_PATH_MAX];
+    pmix_status_t rc;
+
+    if (NULL == getcwd(here, sizeof(here))) {
+        report("check_cwd_home_fallback: getcwd", 0);
+        free(p);
+        free(keep);
+        return;
+    }
+    unsetenv("HOME");
+    rc = pmix_util_check_context_cwd(&p, true, false);
+    if (NULL != keep) {
+        setenv("HOME", keep, 1);
+        free(keep);
+    }
+
+    report("check_cwd_home_fallback: returns SUCCESS", PMIX_SUCCESS == rc);
+    /* the whole point: we were moved somewhere real, and *incwd names it */
+    report("check_cwd_home_fallback: cwd was replaced",
+           NULL != p && 0 != strcmp(p, "/nonexistent_path_xyz_abc_123"));
+    report("check_cwd_home_fallback: the reported cwd is reachable",
+           NULL != p && 0 == access(p, X_OK));
+    free(p);
+    if (0 != chdir(here)) {
+        report("check_cwd_home_fallback: restore cwd", 0);
+    }
+}
+
 /* ------------------------------------------------------------------ */
 /* pmix_util_check_context_app                                        */
 /* ------------------------------------------------------------------ */
+
+static void test_check_app_null_input(void)
+{
+    /* Its sibling screens a NULL out-param and a NULL string; this one
+     * did not, and handed the NULL straight to strlen(). A spawn request
+     * carrying no cmd at all reaches here. */
+    char *cmd = NULL;
+    report("check_app_null_incmd: ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_util_check_context_app(NULL, NULL, NULL));
+    report("check_app_null_cmd: ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_util_check_context_app(&cmd, NULL, NULL));
+}
 
 static void test_check_app_abs_good(void)
 {
@@ -180,6 +232,8 @@ int main(int argc, char **argv)
     test_check_cwd_no_chdir();
     test_check_cwd_chdir_success();
     test_check_cwd_chdir_bad_user();
+    test_check_cwd_home_fallback_no_HOME();
+    test_check_app_null_input();
     test_check_app_abs_good();
     test_check_app_abs_bad();
     test_check_app_naked_not_found();

--- a/test/unit/util/util_environ.c
+++ b/test/unit/util/util_environ.c
@@ -8,7 +8,11 @@
  *
  * Unit tests for pmix_environ utility functions:
  *   pmix_getenv, pmix_unsetenv, pmix_environ_merge,
- *   pmix_environ_merge_inplace, pmix_tmp_directory.
+ *   pmix_environ_merge_inplace, pmix_tmp_directory,
+ *   pmix_util_harvest_envars.
+ *
+ * PMIx_Init is called first (the harvest builds pmix_kval_t objects);
+ * PMIX_ERR_UNREACH is treated as normal.
  *
  * Exit 0 if all tests pass, 1 otherwise.
  */
@@ -202,6 +206,23 @@ static void test_merge_inplace_no_override(void)
     PMIx_Argv_free(env);
 }
 
+/* The header states that orig cannot be environ - we extend it with
+ * PMIx_Argv_append_nosize(), which reallocs, and environ may not be
+ * realloc'd. That was enforced by an assert(), which -DNDEBUG compiles
+ * out of exactly the build that has to be protected. */
+static void test_merge_inplace_refuses_environ(void)
+{
+    const char *adds[] = {"PMIX_UT_MERGE_ZZZ=1", NULL};
+    char **a = make_env(adds);
+    char **before = environ;
+    pmix_status_t rc = pmix_environ_merge_inplace(&environ, a);
+
+    report("merge_inplace_environ: refused with ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == rc);
+    report("merge_inplace_environ: environ untouched", before == environ);
+    PMIx_Argv_free(a);
+}
+
 /* ------------------------------------------------------------------ */
 /* pmix_tmp_directory                                                  */
 /* ------------------------------------------------------------------ */
@@ -213,10 +234,126 @@ static void test_tmp_directory_nonnull(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* pmix_util_harvest_envars                                            */
+/* ------------------------------------------------------------------ */
+
+/* Harvest "inc" out of the environment and report how many entries
+ * landed on the list. */
+static int harvest_count(char **inc, char **exc, pmix_status_t *rc)
+{
+    pmix_list_t l;
+    int n;
+
+    PMIX_CONSTRUCT(&l, pmix_list_t);
+    *rc = pmix_util_harvest_envars(inc, exc, &l);
+    n = (int) pmix_list_get_size(&l);
+    PMIX_LIST_DESTRUCT(&l);
+    return n;
+}
+
+/* An include entry is the NAME of a variable unless it ends in '*', in
+ * which case it is a prefix. Both directions are pinned here because
+ * both have callers: a family of variables is spelled "FOO_*", and a
+ * single one is spelled "FOO" and must not also take "FOOBAR".
+ *
+ * This is not academic - src/mca/pmdl/base spells its harvest of the
+ * local MCA params "PMIX_MCA_", and while that read as a prefix it
+ * worked; the day it became an exact name it silently matched nothing,
+ * because no variable is called "PMIX_MCA_". */
+static void test_harvest_exact_vs_wildcard(void)
+{
+    char *exact[] = {"PMIX_UT_HARV", NULL};
+    char *wild[] = {"PMIX_UT_HARV*", NULL};
+    pmix_status_t rc;
+
+    setenv("PMIX_UT_HARV", "one", 1);
+    setenv("PMIX_UT_HARV_EXTRA", "two", 1);
+
+    report("harvest_exact: a bare name takes only that name",
+           1 == harvest_count(exact, NULL, &rc) && PMIX_SUCCESS == rc);
+    report("harvest_wild: a trailing '*' takes the family",
+           2 == harvest_count(wild, NULL, &rc) && PMIX_SUCCESS == rc);
+
+    unsetenv("PMIX_UT_HARV");
+    unsetenv("PMIX_UT_HARV_EXTRA");
+}
+
+static void test_harvest_exclude(void)
+{
+    char *wild[] = {"PMIX_UT_HARV*", NULL};
+    char *exc[] = {"PMIX_UT_HARV_EXTRA", NULL};
+    pmix_status_t rc;
+
+    setenv("PMIX_UT_HARV", "one", 1);
+    setenv("PMIX_UT_HARV_EXTRA", "two", 1);
+    report("harvest_exclude: an exact exclusion drops just that one",
+           1 == harvest_count(wild, exc, &rc) && PMIX_SUCCESS == rc);
+    unsetenv("PMIX_UT_HARV");
+    unsetenv("PMIX_UT_HARV_EXTRA");
+}
+
+static void test_harvest_null_lists(void)
+{
+    pmix_list_t l;
+    pmix_status_t rc;
+
+    /* No include list is "nothing to harvest", the way no exclude list
+     * is "nothing to drop". It used to walk the NULL array. */
+    report("harvest_null_include: SUCCESS, harvests nothing",
+           0 == harvest_count(NULL, NULL, &rc) && PMIX_SUCCESS == rc);
+
+    PMIX_CONSTRUCT(&l, pmix_list_t);
+    (void) l;
+    PMIX_LIST_DESTRUCT(&l);
+    report("harvest_null_ilist: ERR_BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_util_harvest_envars(NULL, NULL, NULL));
+}
+
+/* The list is the caller's, and an envar kval on it need not carry a
+ * value - PMIx_Envar_load() leaves the value alone when it is handed
+ * NULL. Harvesting a variable of the same name compared the two with
+ * strcmp() regardless. */
+static void test_harvest_existing_valueless_entry(void)
+{
+    char *inc[] = {"PMIX_UT_HARV", NULL};
+    pmix_list_t l;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+
+    setenv("PMIX_UT_HARV", "one", 1);
+    PMIX_CONSTRUCT(&l, pmix_list_t);
+    PMIX_KVAL_NEW(kv, PMIX_SET_ENVAR);
+    kv->value->type = PMIX_ENVAR;
+    kv->value->data.envar.envar = strdup("PMIX_UT_HARV");
+    kv->value->data.envar.value = NULL;
+    kv->value->data.envar.separator = ':';
+    pmix_list_append(&l, &kv->super);
+
+    rc = pmix_util_harvest_envars(inc, NULL, &l);
+    report("harvest_valueless: returns SUCCESS", PMIX_SUCCESS == rc);
+    report("harvest_valueless: the entry was filled in, not duplicated",
+           1 == pmix_list_get_size(&l));
+    kv = (pmix_kval_t *) pmix_list_get_first(&l);
+    report("harvest_valueless: it now carries the value",
+           NULL != kv->value->data.envar.value &&
+           0 == strcmp(kv->value->data.envar.value, "one"));
+    PMIX_LIST_DESTRUCT(&l);
+    unsetenv("PMIX_UT_HARV");
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
+    pmix_proc_t myproc;
+    pmix_status_t irc;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    irc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != irc && PMIX_ERR_UNREACH != irc) {
+        fprintf(stderr, "PMIx_Init: %s\n", PMIx_Error_string(irc));
+        return 1;
+    }
 
     fprintf(stdout, "\n=== pmix_environ unit tests ===\n\n");
 
@@ -237,9 +374,16 @@ int main(int argc, char **argv)
 
     test_merge_inplace_adds_missing();
     test_merge_inplace_no_override();
+    test_merge_inplace_refuses_environ();
 
     test_tmp_directory_nonnull();
 
+    test_harvest_exact_vs_wildcard();
+    test_harvest_exclude();
+    test_harvest_null_lists();
+    test_harvest_existing_valueless_entry();
+
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    PMIx_Finalize(NULL, 0);
     return (nfail > 0) ? 1 : 0;
 }

--- a/test/unit/util/util_error.c
+++ b/test/unit/util/util_error.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "pmix.h"
@@ -70,6 +71,98 @@ static void test_error_string_distinct_codes(void)
     const char *s_not_found = PMIx_Error_string(PMIX_ERR_NOT_FOUND);
     report("error_string_distinct: SUCCESS != NOT_FOUND",
            s_success != s_not_found);
+}
+
+/* ------------------------------------------------------------------ */
+/* PMIx_Error_code                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_error_code_known_names(void)
+{
+    report("error_code_TIMEOUT: recovers the code",
+           PMIX_ERR_TIMEOUT == PMIx_Error_code("PMIX_ERR_TIMEOUT"));
+    report("error_code_SUCCESS: recovers the code",
+           PMIX_SUCCESS == PMIx_Error_code("PMIX_SUCCESS"));
+    /* an internal-only constant, harvested out of pmix_error.h */
+    report("error_code_TAKE_NEXT_OPTION: recovers the code",
+           PMIX_ERR_TAKE_NEXT_OPTION == PMIx_Error_code("PMIX_ERR_TAKE_NEXT_OPTION"));
+}
+
+static void test_error_code_case_insensitive(void)
+{
+    /* the lookup is documented as case-insensitive */
+    report("error_code_case: lower case name matches",
+           PMIX_ERR_TIMEOUT == PMIx_Error_code("pmix_err_timeout"));
+}
+
+static void test_error_code_unknown(void)
+{
+    /* INT32_MIN is the documented "name not recognized" sentinel, and it
+     * has to be a sentinel rather than a negative return because every
+     * real status is itself negative */
+    report("error_code_unknown: returns INT32_MIN",
+           INT32_MIN == PMIx_Error_code("PMIX_NO_SUCH_CONSTANT"));
+}
+
+static void test_error_code_empty_name(void)
+{
+    /* the table is terminated by an entry whose name is "" and whose
+     * code is -1; PMIX_EVENT_INDEX_BOUNDARY must stop the scan before
+     * it, so an empty name is simply unknown.  A scan that walked one
+     * entry too far would answer PMIX_ERROR (-1) here instead. */
+    report("error_code_empty: empty name is not the terminator",
+           INT32_MIN == PMIx_Error_code(""));
+}
+
+static void test_error_code_null(void)
+{
+    /* a NULL name is a name the table does not hold.  Without the
+     * screen this reaches strcasecmp(name, NULL) on the first entry and
+     * the test binary dies on a signal rather than failing here. */
+    report("error_code_NULL: returns INT32_MIN instead of crashing",
+           INT32_MIN == PMIx_Error_code(NULL));
+}
+
+static void test_error_code_roundtrip(void)
+{
+    const pmix_status_t codes[] = {PMIX_SUCCESS, PMIX_ERROR, PMIX_ERR_NOT_FOUND,
+                                   PMIX_ERR_BAD_PARAM, PMIX_ERR_NOMEM,
+                                   PMIX_ERR_UNREACH, PMIX_ERR_TIMEOUT,
+                                   PMIX_ERR_FABRIC_NOT_PARSEABLE,
+                                   PMIX_ERR_TEMP_UNAVAILABLE};
+    size_t n;
+    int ok = 1;
+
+    /* PMIx_Error_code is documented as the inverse of PMIx_Error_string */
+    for (n = 0; n < sizeof(codes) / sizeof(codes[0]); n++) {
+        if (codes[n] != PMIx_Error_code(PMIx_Error_string(codes[n]))) {
+            ok = 0;
+        }
+    }
+    report("error_code_roundtrip: code(string(x)) == x", ok);
+}
+
+static void test_error_string_prefers_current_name(void)
+{
+    /* Several codes carry both a current name and a deprecated alias -
+     * a rename is the one case where two constants may legitimately
+     * share a value.  The generated table lists pmix_common.h.in before
+     * pmix_deprecated.h and PMIx_Error_string returns the first match,
+     * which is what keeps error output naming the current spelling.
+     * Reordering the harvest would silently change every such message. */
+    report("error_string_current_name: -11 is PMIX_ERR_EXISTS not PMIX_EXISTS",
+           0 == strcmp("PMIX_ERR_EXISTS", PMIx_Error_string(PMIX_ERR_EXISTS)));
+    report("error_string_current_name: -231 is PMIX_EVENT_NODE_DOWN",
+           0 == strcmp("PMIX_EVENT_NODE_DOWN", PMIx_Error_string(PMIX_EVENT_NODE_DOWN)));
+}
+
+static void test_error_string_unknown(void)
+{
+    /* PMIX_EXTERNAL_ERR_BASE is deliberately not in the table */
+    const char *s = PMIx_Error_string(PMIX_EXTERNAL_ERR_BASE - 1);
+    report("error_string_unknown: non-NULL for an unknown code", NULL != s);
+    report("error_string_unknown: not the empty terminator name",
+           NULL != s && 0 != strlen(s));
 }
 
 /* ------------------------------------------------------------------ */
@@ -135,6 +228,14 @@ int main(int argc, char **argv)
     test_error_string_success();
     test_error_string_standard_codes();
     test_error_string_distinct_codes();
+    test_error_string_prefers_current_name();
+    test_error_string_unknown();
+    test_error_code_known_names();
+    test_error_code_case_insensitive();
+    test_error_code_unknown();
+    test_error_code_empty_name();
+    test_error_code_null();
+    test_error_code_roundtrip();
     test_error_log_no_crash();
     test_error_log_silent();
     test_internal_constants_distinct();

--- a/test/unit/util/util_fd.c
+++ b/test/unit/util/util_fd.c
@@ -1,0 +1,500 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the pmix_fd utilities:
+ *   pmix_fd_read / pmix_fd_write over a pipe (round trip, EOF, degenerate
+ *   lengths), pmix_fd_set_cloexec, the fstat type predicates,
+ *   pmix_fd_get_peer_name over real sockets, pmix_fd_dup2, and
+ *   pmix_close_open_file_descriptors.
+ *
+ * The last of those closes every descriptor it can find, so it is
+ * exercised in a forked child that reports its findings back over the
+ * one descriptor it was told to protect - running it in-process would
+ * take the test harness's own descriptors down with it.
+ *
+ * No PMIx_Init: everything here is a leaf utility over raw descriptors.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include "src/util/pmix_fd.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_fd_read / pmix_fd_write                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_read_write_roundtrip(void)
+{
+    /* larger than a pipe's atomic write, so both loops go around more
+     * than once and the b += rc / l2 -= rc bookkeeping is actually
+     * exercised rather than being a single pass */
+    const int len = 256 * 1024;
+    char *out, *in;
+    int p[2];
+    pid_t child;
+    pmix_status_t rc;
+    int n, ok = 1;
+
+    out = malloc(len);
+    in = calloc(1, len);
+    if (NULL == out || NULL == in || 0 != pipe(p)) {
+        report("read_write_roundtrip: fixture", 0);
+        free(out);
+        free(in);
+        return;
+    }
+    for (n = 0; n < len; n++) {
+        out[n] = (char) (n & 0xff);
+    }
+
+    /* a pipe holds far less than len, so the writer has to be a
+     * separate process or it deadlocks against itself */
+    child = fork();
+    if (0 == child) {
+        close(p[0]);
+        rc = pmix_fd_write(p[1], len, out);
+        close(p[1]);
+        _exit(PMIX_SUCCESS == rc ? 0 : 1);
+    }
+    close(p[1]);
+    rc = pmix_fd_read(p[0], len, in);
+    close(p[0]);
+    report("fd_read: full buffer returns SUCCESS", PMIX_SUCCESS == rc);
+
+    if (0 < child) {
+        int wstatus = 0;
+        waitpid(child, &wstatus, 0);
+        report("fd_write: full buffer returns SUCCESS",
+               WIFEXITED(wstatus) && 0 == WEXITSTATUS(wstatus));
+    }
+
+    for (n = 0; n < len; n++) {
+        if (in[n] != out[n]) {
+            ok = 0;
+            break;
+        }
+    }
+    report("fd_read/fd_write: bytes survive the round trip", ok);
+
+    free(out);
+    free(in);
+}
+
+static void test_read_eof(void)
+{
+    int p[2];
+    char buf[4];
+    pmix_status_t rc;
+
+    if (0 != pipe(p)) {
+        report("read_eof: fixture", 0);
+        return;
+    }
+    close(p[1]);
+    /* the documented answer for "the fd closed before we had it all" */
+    rc = pmix_fd_read(p[0], sizeof(buf), buf);
+    close(p[0]);
+    report("fd_read: short read reports PMIX_ERR_TIMEOUT", PMIX_ERR_TIMEOUT == rc);
+}
+
+static void test_read_partial_then_eof(void)
+{
+    int p[2];
+    char buf[8];
+    pmix_status_t rc;
+
+    if (0 != pipe(p)) {
+        report("read_partial_then_eof: fixture", 0);
+        return;
+    }
+    if (2 != write(p[1], "hi", 2)) {
+        report("read_partial_then_eof: fixture", 0);
+        close(p[0]);
+        close(p[1]);
+        return;
+    }
+    close(p[1]);
+    /* fewer bytes than asked for, then EOF - still TIMEOUT, not SUCCESS */
+    rc = pmix_fd_read(p[0], sizeof(buf), buf);
+    close(p[0]);
+    report("fd_read: partial then EOF reports PMIX_ERR_TIMEOUT", PMIX_ERR_TIMEOUT == rc);
+}
+
+static void test_degenerate_lengths(void)
+{
+    char buf[1];
+
+    /* both are answered without ever touching the descriptor, so a
+     * closed fd is a fine thing to hand them here */
+    report("fd_read: len 0 succeeds without touching the fd",
+           PMIX_SUCCESS == pmix_fd_read(-1, 0, buf));
+    report("fd_write: len 0 succeeds without touching the fd",
+           PMIX_SUCCESS == pmix_fd_write(-1, 0, buf));
+    report("fd_read: negative len is BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_fd_read(-1, -1, buf));
+    report("fd_write: negative len is BAD_PARAM",
+           PMIX_ERR_BAD_PARAM == pmix_fd_write(-1, -1, buf));
+}
+
+static void test_write_to_closed_fd(void)
+{
+    char buf[1] = {'x'};
+    /* EBADF is not EAGAIN/EINTR, so this must come straight back out
+     * rather than spinning */
+    report("fd_write: a bad fd is IN_ERRNO, not a spin",
+           PMIX_ERR_IN_ERRNO == pmix_fd_write(-1, 1, buf));
+    report("fd_read: a bad fd is IN_ERRNO, not a spin",
+           PMIX_ERR_IN_ERRNO == pmix_fd_read(-1, 1, buf));
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_fd_set_cloexec                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_set_cloexec(void)
+{
+    int p[2];
+    int flags;
+
+    if (0 != pipe(p)) {
+        report("set_cloexec: fixture", 0);
+        return;
+    }
+    report("set_cloexec: returns SUCCESS", PMIX_SUCCESS == pmix_fd_set_cloexec(p[0]));
+    flags = fcntl(p[0], F_GETFD, 0);
+    report("set_cloexec: FD_CLOEXEC is actually set", 0 <= flags && 0 != (flags & FD_CLOEXEC));
+    /* the other end must be untouched */
+    flags = fcntl(p[1], F_GETFD, 0);
+    report("set_cloexec: leaves other descriptors alone",
+           0 <= flags && 0 == (flags & FD_CLOEXEC));
+    close(p[0]);
+    close(p[1]);
+
+    report("set_cloexec: a bad fd is IN_ERRNO", PMIX_ERR_IN_ERRNO == pmix_fd_set_cloexec(-1));
+}
+
+/* ------------------------------------------------------------------ */
+/* the fstat type predicates                                           */
+/* ------------------------------------------------------------------ */
+
+static void test_type_predicates(void)
+{
+    char tmpl[] = "/tmp/pmix_util_fd_XXXXXX";
+    int fd, devnull, p[2];
+
+    fd = mkstemp(tmpl);
+    if (0 > fd) {
+        report("type_predicates: fixture", 0);
+        return;
+    }
+    unlink(tmpl);
+    report("is_regular: true for a regular file", pmix_fd_is_regular(fd));
+    report("is_chardev: false for a regular file", !pmix_fd_is_chardev(fd));
+    report("is_blkdev: false for a regular file", !pmix_fd_is_blkdev(fd));
+    close(fd);
+
+    devnull = open("/dev/null", O_RDWR);
+    if (0 <= devnull) {
+        report("is_chardev: true for /dev/null", pmix_fd_is_chardev(devnull));
+        report("is_regular: false for /dev/null", !pmix_fd_is_regular(devnull));
+        report("is_blkdev: false for /dev/null", !pmix_fd_is_blkdev(devnull));
+        close(devnull);
+    }
+
+    if (0 == pipe(p)) {
+        report("is_regular: false for a pipe", !pmix_fd_is_regular(p[0]));
+        report("is_chardev: false for a pipe", !pmix_fd_is_chardev(p[0]));
+        close(p[0]);
+        close(p[1]);
+    }
+
+    /* an fd that cannot be fstat'd answers false rather than reporting
+     * the error - all three of them */
+    report("is_regular: false for a bad fd", !pmix_fd_is_regular(-1));
+    report("is_chardev: false for a bad fd", !pmix_fd_is_chardev(-1));
+    report("is_blkdev: false for a bad fd", !pmix_fd_is_blkdev(-1));
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_fd_get_peer_name                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_peer_name_not_a_socket(void)
+{
+    int p[2];
+    const char *name;
+
+    if (0 != pipe(p)) {
+        report("peer_name_not_a_socket: fixture", 0);
+        return;
+    }
+    /* getpeername fails on a pipe.  The caller is promised a printable
+     * string either way - a NULL here is a crash in whatever prints it */
+    name = pmix_fd_get_peer_name(p[0]);
+    report("get_peer_name: non-socket is named, not NULL", NULL != name);
+    report("get_peer_name: non-socket reads as Unknown",
+           NULL != name && 0 == strcmp("Unknown", name));
+    close(p[0]);
+    close(p[1]);
+
+    name = pmix_fd_get_peer_name(-1);
+    report("get_peer_name: bad fd is named, not NULL", NULL != name);
+}
+
+static void test_peer_name_unix_socket(void)
+{
+    int sv[2];
+    const char *name;
+
+    if (0 != socketpair(AF_UNIX, SOCK_STREAM, 0, sv)) {
+        report("peer_name_unix_socket: fixture", 0);
+        return;
+    }
+    /* getpeername succeeds, but AF_UNIX is not a family this renders -
+     * the family fall-through must still produce a string */
+    name = pmix_fd_get_peer_name(sv[0]);
+    report("get_peer_name: unrendered family is named, not NULL", NULL != name);
+    report("get_peer_name: unrendered family reads as Unknown",
+           NULL != name && 0 == strcmp("Unknown", name));
+    close(sv[0]);
+    close(sv[1]);
+}
+
+static void test_peer_name_loopback(void)
+{
+    int lsock = -1, csock = -1, asock = -1;
+    struct sockaddr_in sin;
+    socklen_t slen = sizeof(sin);
+    const char *name;
+
+    lsock = socket(AF_INET, SOCK_STREAM, 0);
+    if (0 > lsock) {
+        report("peer_name_loopback: fixture (no AF_INET)", 0);
+        return;
+    }
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = 0; /* let the kernel choose */
+    sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (0 != bind(lsock, (struct sockaddr *) &sin, sizeof(sin)) || 0 != listen(lsock, 1)
+        || 0 != getsockname(lsock, (struct sockaddr *) &sin, &slen)) {
+        report("peer_name_loopback: fixture (bind/listen)", 0);
+        close(lsock);
+        return;
+    }
+    csock = socket(AF_INET, SOCK_STREAM, 0);
+    if (0 > csock || 0 != connect(csock, (struct sockaddr *) &sin, sizeof(sin))) {
+        report("peer_name_loopback: fixture (connect)", 0);
+        close(lsock);
+        if (0 <= csock) {
+            close(csock);
+        }
+        return;
+    }
+    asock = accept(lsock, NULL, NULL);
+
+    /* the one path that actually renders an address */
+    name = pmix_fd_get_peer_name(csock);
+    report("get_peer_name: loopback peer renders as 127.0.0.1",
+           NULL != name && 0 == strcmp("127.0.0.1", name));
+
+    if (0 <= asock) {
+        name = pmix_fd_get_peer_name(asock);
+        report("get_peer_name: accepted end renders as 127.0.0.1",
+               NULL != name && 0 == strcmp("127.0.0.1", name));
+        close(asock);
+    }
+    close(csock);
+    close(lsock);
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_fd_dup2                                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_dup2(void)
+{
+    int p[2];
+    char buf[4];
+    int target = 37;
+
+    if (0 != pipe(p)) {
+        report("dup2: fixture", 0);
+        return;
+    }
+    /* a target above 2 is passed straight to dup2 */
+    report("fd_dup2: returns the target it was given", target == pmix_fd_dup2(p[0], target));
+    if (2 != write(p[1], "ok", 2)) {
+        report("dup2: fixture (write)", 0);
+    } else {
+        memset(buf, 0, sizeof(buf));
+        report("fd_dup2: the duplicate reads the same pipe",
+               2 == read(target, buf, 2) && 0 == strcmp("ok", buf));
+    }
+    close(target);
+    close(p[0]);
+    close(p[1]);
+
+    report("fd_dup2: a bad source is -1", -1 == pmix_fd_dup2(-1, target));
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_close_open_file_descriptors                                    */
+/* ------------------------------------------------------------------ */
+
+/* what the child reports back to us */
+typedef struct {
+    int nclosed;   /* how many of the fds it opened are now closed */
+    int nopened;   /* how many it opened */
+    int protected_alive;
+    int std_alive; /* 0, 1 and 2 all still open */
+} closed_report_t;
+
+#define NEXTRA 12
+
+static void run_close_child(int report_fd)
+{
+    int extra[NEXTRA];
+    closed_report_t rep;
+    int n;
+
+    memset(&rep, 0, sizeof(rep));
+
+    for (n = 0; n < NEXTRA; n++) {
+        extra[n] = open("/dev/null", O_RDONLY);
+        if (0 <= extra[n]) {
+            rep.nopened++;
+        }
+    }
+
+    /* Seed a stale errno of exactly the kind the scan tests for.  strtol
+     * only ever sets errno, it never clears it, so a scan that reads
+     * errno without zeroing it first abandons the directory listing here
+     * and falls back to closing by bound instead.  Either route has to
+     * end with the same descriptors closed. */
+    errno = ERANGE;
+
+    pmix_close_open_file_descriptors(report_fd);
+
+    for (n = 0; n < NEXTRA; n++) {
+        if (0 <= extra[n] && 0 > fcntl(extra[n], F_GETFD, 0)) {
+            rep.nclosed++;
+        }
+    }
+    rep.protected_alive = (0 <= fcntl(report_fd, F_GETFD, 0));
+    rep.std_alive = (0 <= fcntl(0, F_GETFD, 0)) && (0 <= fcntl(1, F_GETFD, 0))
+                    && (0 <= fcntl(2, F_GETFD, 0));
+
+    (void) pmix_fd_write(report_fd, sizeof(rep), &rep);
+    close(report_fd);
+    _exit(0);
+}
+
+static void test_close_open_file_descriptors(void)
+{
+    int p[2];
+    pid_t child;
+    closed_report_t rep;
+    pmix_status_t rc;
+    int wstatus = 0;
+
+    if (0 != pipe(p)) {
+        report("close_open_fds: fixture", 0);
+        return;
+    }
+    child = fork();
+    if (0 > child) {
+        report("close_open_fds: fixture (fork)", 0);
+        close(p[0]);
+        close(p[1]);
+        return;
+    }
+    if (0 == child) {
+        close(p[0]);
+        run_close_child(p[1]);
+        /* not reached */
+    }
+    close(p[1]);
+    memset(&rep, 0, sizeof(rep));
+    rc = pmix_fd_read(p[0], sizeof(rep), &rep);
+    close(p[0]);
+    waitpid(child, &wstatus, 0);
+
+    if (PMIX_SUCCESS != rc) {
+        report("close_open_fds: child reported back", 0);
+        return;
+    }
+    report("close_open_fds: child opened its fixtures", NEXTRA == rep.nopened);
+    /* the whole point of the call.  A bound that truncated to a
+     * negative int, or a scan abandoned on a stale errno, shows up here
+     * as descriptors still open */
+    report("close_open_fds: every unprotected fd was closed", rep.nclosed == rep.nopened);
+    report("close_open_fds: the protected fd survived", 0 != rep.protected_alive);
+    report("close_open_fds: stdin/stdout/stderr survived", 0 != rep.std_alive);
+    /* NOTE: this exercises whichever route the host OS offers, which on
+     * both Linux and macOS is the directory scan.  The close-by-bound
+     * fallback is only taken where there is no /proc/self/fd or /dev/fd
+     * to read, so a unit test cannot reach it here; it was verified by
+     * hand by pointing the opendir at a path that does not exist. */
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_fd unit tests ===\n\n");
+
+    test_read_write_roundtrip();
+    test_read_eof();
+    test_read_partial_then_eof();
+    test_degenerate_lengths();
+    test_write_to_closed_fd();
+    test_set_cloexec();
+    test_type_predicates();
+    test_peer_name_not_a_socket();
+    test_peer_name_unix_socket();
+    test_peer_name_loopback();
+    test_dup2();
+    test_close_open_file_descriptors();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/util/util_few.c
+++ b/test/unit/util/util_few.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for pmix_few(): fork, exec, wait for a child.
+ *
+ * Includes the regression for the child's exit path.  A forked child
+ * shares the parent's stdio buffers, so if it leaves through exit()
+ * rather than _exit() it flushes whatever the parent had written and
+ * not yet flushed - and that output appears twice.  That case is run
+ * inside a child of our own, with its stdout on a pipe so it is fully
+ * buffered, because it cannot be observed on a terminal.
+ *
+ * No PMIx_Init: pmix_few is a leaf utility, and its own header warns
+ * that it must not be used once a SIGCHLD handler is in place.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "src/util/pmix_few.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+static bool have_sh(void)
+{
+    struct stat sb;
+    return (0 == stat("/bin/sh", &sb));
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_child_exit_code(void)
+{
+    char *argv[] = {"/bin/sh", "-c", "exit 7", NULL};
+    /* poison it, so a status the callee never writes is visible as such */
+    int status = 0x5a5a5a5a;
+    pmix_status_t rc;
+
+    rc = pmix_few(argv, &status);
+    report("few: a child that ran returns SUCCESS", PMIX_SUCCESS == rc);
+    report("few: status decodes as a normal exit", WIFEXITED(status));
+    report("few: the child's exit code comes through",
+           WIFEXITED(status) && 7 == WEXITSTATUS(status));
+}
+
+static void test_child_signal(void)
+{
+    char *argv[] = {"/bin/sh", "-c", "kill -TERM $$", NULL};
+    int status = 0x5a5a5a5a;
+    pmix_status_t rc;
+
+    /* a child that dies on a signal is still a child that ran */
+    rc = pmix_few(argv, &status);
+    report("few: a signalled child still returns SUCCESS", PMIX_SUCCESS == rc);
+    report("few: status decodes as a signal death",
+           WIFSIGNALED(status) && SIGTERM == WTERMSIG(status));
+}
+
+static void test_path_search(void)
+{
+    char *argv[] = {"sh", "-c", "exit 3", NULL};
+    int status = 0x5a5a5a5a;
+    pmix_status_t rc;
+
+    /* argv[0] is handed to execvp, so a bare name is searched for on
+     * PATH - that is the documented contract */
+    rc = pmix_few(argv, &status);
+    report("few: a bare name is resolved against PATH",
+           PMIX_SUCCESS == rc && WIFEXITED(status) && 3 == WEXITSTATUS(status));
+}
+
+static void test_exec_failure_reports_errno(void)
+{
+    char *argv[] = {"/nonexistent/pmix-util-few-probe", NULL};
+    int status = 0x5a5a5a5a;
+    pmix_status_t rc;
+
+    /* the fork and the wait both worked, so this is a success as far as
+     * pmix_few is concerned; the failure shows up as the child's exit
+     * status, which carries errno */
+    rc = pmix_few(argv, &status);
+    report("few: a failed exec is still SUCCESS (the child ran and exited)",
+           PMIX_SUCCESS == rc);
+    report("few: the child carries errno out as its exit status",
+           WIFEXITED(status) && ENOENT == WEXITSTATUS(status));
+}
+
+/* ------------------------------------------------------------------ */
+/* the stdio regression                                                */
+/* ------------------------------------------------------------------ */
+
+#define MARKER "PMIX-FEW-BUFFERED-MARKER"
+
+static void run_flush_child(int write_fd)
+{
+    char *argv[] = {"/nonexistent/pmix-util-few-probe", NULL};
+    int status = 0;
+
+    if (write_fd != STDOUT_FILENO) {
+        if (0 > dup2(write_fd, STDOUT_FILENO)) {
+            _exit(1);
+        }
+        close(write_fd);
+    }
+    /* stdout is a pipe now, so this sits in the buffer unflushed */
+    printf("%s\n", MARKER);
+
+    /* the exec inside here fails, and the grandchild leaves.  If it
+     * leaves through exit() it flushes OUR buffer on the way out. */
+    (void) pmix_few(argv, &status);
+
+    /* exactly one flush is owed, and it is this one */
+    fflush(stdout);
+    _exit(0);
+}
+
+static int count_markers(const char *buf)
+{
+    const char *p = buf;
+    int n = 0;
+
+    while (NULL != (p = strstr(p, MARKER))) {
+        n++;
+        p += strlen(MARKER);
+    }
+    return n;
+}
+
+static void test_child_does_not_flush_our_stdio(void)
+{
+    int p[2];
+    pid_t child;
+    char buf[4096];
+    ssize_t got, total = 0;
+    int wstatus = 0;
+
+    if (0 != pipe(p)) {
+        report("few_no_double_flush: fixture", 0);
+        return;
+    }
+    child = fork();
+    if (0 > child) {
+        report("few_no_double_flush: fixture (fork)", 0);
+        close(p[0]);
+        close(p[1]);
+        return;
+    }
+    if (0 == child) {
+        close(p[0]);
+        run_flush_child(p[1]);
+        /* not reached */
+    }
+    close(p[1]);
+    memset(buf, 0, sizeof(buf));
+    while (0 < (got = read(p[0], buf + total, sizeof(buf) - 1 - (size_t) total))) {
+        total += got;
+        if ((size_t) total >= sizeof(buf) - 1) {
+            break;
+        }
+    }
+    close(p[0]);
+    waitpid(child, &wstatus, 0);
+
+    /* two of these means the grandchild flushed a buffer it did not
+     * own - which is what exit() does and _exit() does not */
+    report("few: the exec'd child does not flush the parent's stdio",
+           1 == count_markers(buf));
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_few unit tests ===\n\n");
+
+    if (!have_sh()) {
+        fprintf(stdout, "  /bin/sh not present - skipping the shell cases\n");
+    } else {
+        test_child_exit_code();
+        test_child_signal();
+        test_path_search();
+    }
+    test_exec_failure_reports_errno();
+    test_child_does_not_flush_our_stdio();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/util/util_getcwd.c
+++ b/test/unit/util/util_getcwd.c
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for pmix_getcwd().
+ *
+ * Two properties here have been broken before and are what this test
+ * exists to pin down:
+ *
+ *  - the buffer-length test is ">=", not ">": a buffer exactly as long
+ *    as the path leaves no room for the terminating NUL, and must be
+ *    reported as a truncation rather than as success;
+ *  - $PWD is *not* authoritative. It is used only when it is textually
+ *    identical to getcwd(), which makes getcwd() the answer in every
+ *    case. An implementation that trusted a stale or symlink-preserving
+ *    $PWD would pass a naive test but hand callers a directory the
+ *    process is not actually in.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+
+#include "src/util/pmix_basename.h"
+#include "src/util/pmix_getcwd.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+/* The authoritative answer, captured once at startup. */
+static char truth[PMIX_PATH_MAX];
+
+/* A canary byte follows every destination buffer so that a copy which
+ * runs one past the caller's length is caught rather than tolerated. */
+#define CANARY 0x5a
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Bozo checks                                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_null_buffer(void)
+{
+    int rc = pmix_getcwd(NULL, PMIX_PATH_MAX);
+    report("getcwd(NULL, n) == PMIX_ERR_BAD_PARAM", PMIX_ERR_BAD_PARAM == rc);
+}
+
+static void test_absurd_size(void)
+{
+    char buf[PMIX_PATH_MAX];
+    int rc;
+
+    if (SIZE_MAX <= (size_t) INT_MAX) {
+        /* size_t cannot express a value larger than INT_MAX here, so
+         * there is nothing to reject */
+        report("getcwd(buf, >INT_MAX) == PMIX_ERR_BAD_PARAM (n/a)", 1);
+        return;
+    }
+    rc = pmix_getcwd(buf, (size_t) INT_MAX + 1);
+    report("getcwd(buf, >INT_MAX) == PMIX_ERR_BAD_PARAM", PMIX_ERR_BAD_PARAM == rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* The happy path                                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_ample_buffer(void)
+{
+    char buf[PMIX_PATH_MAX];
+    int rc;
+
+    memset(buf, CANARY, sizeof(buf));
+    rc = pmix_getcwd(buf, sizeof(buf));
+    report("getcwd(buf, PMIX_PATH_MAX) == PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("getcwd fills buf with the real cwd", 0 == strcmp(buf, truth));
+}
+
+static void test_exact_fit(void)
+{
+    size_t len = strlen(truth);
+    char *buf = (char *) malloc(len + 2);
+    int rc;
+
+    if (NULL == buf) {
+        report("getcwd exact-fit buffer succeeds (alloc failed)", 0);
+        return;
+    }
+    memset(buf, CANARY, len + 2);
+    /* len + 1 is precisely enough: the path plus its NUL */
+    rc = pmix_getcwd(buf, len + 1);
+    report("getcwd(buf, strlen+1) == PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("getcwd(buf, strlen+1) copies the whole path", 0 == strcmp(buf, truth));
+    report("getcwd(buf, strlen+1) respects the buffer end", CANARY == buf[len + 1]);
+    free(buf);
+}
+
+static void test_one_byte_short(void)
+{
+    size_t len = strlen(truth);
+    char *buf = (char *) malloc(len + 1);
+    char *base;
+    int rc;
+
+    if (NULL == buf) {
+        report("getcwd one-byte-short buffer truncates (alloc failed)", 0);
+        return;
+    }
+    memset(buf, CANARY, len + 1);
+    /* len leaves no room for the NUL, so this is a truncation */
+    rc = pmix_getcwd(buf, len);
+    report("getcwd(buf, strlen) == PMIX_ERR_OUT_OF_RESOURCE", PMIX_ERR_OUT_OF_RESOURCE == rc);
+    report("getcwd(buf, strlen) respects the buffer end", CANARY == buf[len]);
+
+    /* what it hands back instead is (as much as fits of) the basename */
+    base = pmix_basename(truth);
+    if (NULL != base) {
+        size_t keep = strlen(base);
+        if (keep > len - 1) {
+            keep = len - 1;
+        }
+        report("getcwd truncation yields the basename",
+               0 == strncmp(buf, base, keep) && '\0' == buf[keep]);
+        free(base);
+    } else {
+        report("getcwd truncation yields the basename (basename failed)", 0);
+    }
+    free(buf);
+}
+
+static void test_tiny_buffer(void)
+{
+    char buf[2];
+    int rc;
+
+    memset(buf, CANARY, sizeof(buf));
+    rc = pmix_getcwd(buf, 1);
+    report("getcwd(buf, 1) == PMIX_ERR_OUT_OF_RESOURCE", PMIX_ERR_OUT_OF_RESOURCE == rc);
+    report("getcwd(buf, 1) writes only the NUL", '\0' == buf[0] && CANARY == buf[1]);
+}
+
+static void test_zero_size(void)
+{
+    char buf[1];
+    int rc;
+
+    memset(buf, CANARY, sizeof(buf));
+    rc = pmix_getcwd(buf, 0);
+    report("getcwd(buf, 0) == PMIX_ERR_OUT_OF_RESOURCE", PMIX_ERR_OUT_OF_RESOURCE == rc);
+    report("getcwd(buf, 0) writes nothing", CANARY == buf[0]);
+}
+
+/* ------------------------------------------------------------------ */
+/* $PWD is never authoritative                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_pwd_unset(void)
+{
+    char buf[PMIX_PATH_MAX];
+    int rc;
+
+    unsetenv("PWD");
+    rc = pmix_getcwd(buf, sizeof(buf));
+    report("getcwd with no $PWD == PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("getcwd with no $PWD answers getcwd()", 0 == strcmp(buf, truth));
+}
+
+static void test_pwd_bogus(void)
+{
+    char buf[PMIX_PATH_MAX];
+    int rc;
+
+    setenv("PWD", "/no/such/directory/anywhere", 1);
+    rc = pmix_getcwd(buf, sizeof(buf));
+    report("getcwd with a stale $PWD == PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("getcwd ignores a stale $PWD", 0 == strcmp(buf, truth));
+    unsetenv("PWD");
+}
+
+static void test_pwd_matching(void)
+{
+    char buf[PMIX_PATH_MAX];
+    int rc;
+
+    setenv("PWD", truth, 1);
+    rc = pmix_getcwd(buf, sizeof(buf));
+    report("getcwd with a matching $PWD == PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    report("getcwd with a matching $PWD answers getcwd()", 0 == strcmp(buf, truth));
+    unsetenv("PWD");
+}
+
+int main(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    if (NULL == getcwd(truth, sizeof(truth))) {
+        fprintf(stderr, "cannot determine the working directory - skipping\n");
+        return 77;
+    }
+
+    fprintf(stdout, "\n=== pmix_getcwd ===\n");
+    test_null_buffer();
+    test_absurd_size();
+    test_ample_buffer();
+    test_exact_fit();
+    test_one_byte_short();
+    test_tiny_buffer();
+    test_zero_size();
+    test_pwd_unset();
+    test_pwd_bogus();
+    test_pwd_matching();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/util/util_getid.c
+++ b/test/unit/util/util_getid.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for pmix_util_getid().
+ *
+ * pmix_util_getid() has no caller in PMIx and none in PRRTE, but
+ * pmix_getid.h is installed and the symbol is exported, so it is API and
+ * has to keep working. Nothing else in the tree exercises it, which is
+ * what this test is for: it pins the two things a consumer is entitled
+ * to - that a connected AF_UNIX socket yields this process's own
+ * credentials, and that a descriptor which is not a socket is refused
+ * rather than answered with whatever the stack held.
+ *
+ * Exit 0 if all tests pass, 1 otherwise, 77 to skip.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#ifdef HAVE_SYS_TYPES_H
+#    include <sys/types.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+
+#include "src/util/pmix_getid.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* A socketpair is the only portable way to get a connected AF_UNIX
+ * socket without a filesystem rendezvous, and both ends belong to this
+ * process - so the credentials the kernel reports are ours, whichever
+ * of the two routes pmix_util_getid() was compiled with. */
+static void test_socketpair_reports_us(void)
+{
+    int sd[2];
+    uid_t uid = (uid_t) -1;
+    gid_t gid = (gid_t) -1;
+    pmix_status_t rc;
+
+    if (0 != socketpair(AF_UNIX, SOCK_STREAM, 0, sd)) {
+        report("getid on a socketpair (socketpair failed)", 0);
+        return;
+    }
+
+    rc = pmix_util_getid(sd[0], &uid, &gid);
+    report("getid on a socketpair == PMIX_SUCCESS", PMIX_SUCCESS == rc);
+    if (PMIX_SUCCESS == rc) {
+        report("getid reports our own uid", uid == geteuid());
+        /* the two routes disagree about which group id they report -
+         * SO_PEERCRED gives the real gid, getpeereid the effective one -
+         * so accept either rather than encode a platform difference */
+        report("getid reports one of our own gids", gid == getegid() || gid == getgid());
+    } else {
+        report("getid reports our own uid (skipped)", 0);
+        report("getid reports one of our own gids (skipped)", 0);
+    }
+
+    close(sd[0]);
+    close(sd[1]);
+}
+
+/* Both ends are symmetric; ask the other one too, since a route that
+ * consulted the listening side rather than the descriptor it was given
+ * would still pass the test above. */
+static void test_both_ends_agree(void)
+{
+    int sd[2];
+    uid_t uid0 = (uid_t) -1, uid1 = (uid_t) -2;
+    gid_t gid0 = (gid_t) -1, gid1 = (gid_t) -2;
+    pmix_status_t rc0, rc1;
+
+    if (0 != socketpair(AF_UNIX, SOCK_STREAM, 0, sd)) {
+        report("getid agrees on both ends (socketpair failed)", 0);
+        return;
+    }
+
+    rc0 = pmix_util_getid(sd[0], &uid0, &gid0);
+    rc1 = pmix_util_getid(sd[1], &uid1, &gid1);
+    report("getid agrees on both ends of a socketpair",
+           rc0 == rc1 && (PMIX_SUCCESS != rc0 || (uid0 == uid1 && gid0 == gid1)));
+
+    close(sd[0]);
+    close(sd[1]);
+}
+
+/* A pipe is a descriptor, not a socket. Both routes ask the kernel about
+ * a socket and both are told ENOTSOCK, so this must come back as a
+ * refusal - never as PMIX_SUCCESS over an untouched uid. */
+static void test_not_a_socket(void)
+{
+    int fds[2];
+    uid_t uid = (uid_t) 4242;
+    gid_t gid = (gid_t) 4242;
+    pmix_status_t rc;
+
+    if (0 != pipe(fds)) {
+        report("getid on a pipe (pipe failed)", 0);
+        return;
+    }
+
+    rc = pmix_util_getid(fds[0], &uid, &gid);
+    report("getid on a pipe != PMIX_SUCCESS", PMIX_SUCCESS != rc);
+    report("getid on a pipe leaves the out-params alone",
+           (uid_t) 4242 == uid && (gid_t) 4242 == gid);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+static void test_closed_fd(void)
+{
+    uid_t uid = (uid_t) 4242;
+    gid_t gid = (gid_t) 4242;
+    pmix_status_t rc;
+    int sd[2];
+
+    if (0 != socketpair(AF_UNIX, SOCK_STREAM, 0, sd)) {
+        report("getid on a closed fd (socketpair failed)", 0);
+        return;
+    }
+    close(sd[0]);
+    close(sd[1]);
+
+    rc = pmix_util_getid(sd[0], &uid, &gid);
+    report("getid on a closed fd != PMIX_SUCCESS", PMIX_SUCCESS != rc);
+}
+
+int main(int argc, char **argv)
+{
+    int sd[2];
+    uid_t uid;
+    gid_t gid;
+
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* A platform with neither SO_PEERCRED nor getpeereid() answers
+     * PMIX_ERR_NOT_SUPPORTED to everything; there is nothing here to
+     * test on it. */
+    if (0 == socketpair(AF_UNIX, SOCK_STREAM, 0, sd)) {
+        pmix_status_t rc = pmix_util_getid(sd[0], &uid, &gid);
+        close(sd[0]);
+        close(sd[1]);
+        if (PMIX_ERR_NOT_SUPPORTED == rc) {
+            fprintf(stdout, "pmix_util_getid is not supported here - skipping\n");
+            return 77;
+        }
+    }
+
+    fprintf(stdout, "\n=== pmix_util_getid ===\n");
+    test_socketpair_reports_us();
+    test_both_ends_agree();
+    test_not_a_socket();
+    test_closed_fd();
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/util/util_hash.c
+++ b/test/unit/util/util_hash.c
@@ -269,6 +269,48 @@ static void test_remove_then_fetch(void)
     PMIX_RELEASE(t);
 }
 
+/* A wildcard removal with a NULL key means "everything, for every
+ * rank". Each rank's proc_data is released - and the table it was
+ * reached through has to let go of it in the same breath, or it is left
+ * holding a pointer to a freed object that the very next lookup hands
+ * back. That the entries are gone is the observable part, so check the
+ * table is empty rather than fetching through a pointer that may or may
+ * not still look valid. */
+static void test_remove_wildcard_empties_the_table(void)
+{
+    pmix_hash_table_t *t = new_table();
+    pmix_kval_t *kv0 = make_kval_str("unit.key.wc", "rank0val");
+    pmix_kval_t *kv1 = make_kval_str("unit.key.wc", "rank1val");
+    pmix_list_t kvals;
+    pmix_status_t rc;
+    uint32_t id;
+    void *pd = NULL, *node = NULL;
+
+    pmix_hash_store(t, 0, kv0, NULL, 0, NULL);
+    pmix_hash_store(t, 1, kv1, NULL, 0, NULL);
+    PMIX_RELEASE(kv0);
+    PMIX_RELEASE(kv1);
+
+    /* both ranks are there to start with */
+    rc = pmix_hash_table_get_first_key_uint32(t, &id, &pd, &node);
+    report("remove_wildcard: table populated before", PMIX_SUCCESS == rc);
+
+    pmix_hash_remove_data(t, PMIX_RANK_WILDCARD, NULL, NULL);
+
+    node = NULL;
+    pd = NULL;
+    rc = pmix_hash_table_get_first_key_uint32(t, &id, &pd, &node);
+    report("remove_wildcard: table holds no entries after",
+           PMIX_SUCCESS != rc);
+
+    PMIX_CONSTRUCT(&kvals, pmix_list_t);
+    rc = pmix_hash_fetch(t, 0, "unit.key.wc", NULL, 0, &kvals, NULL);
+    report("remove_wildcard: fetch returns ERR_NOT_FOUND", PMIX_ERR_NOT_FOUND == rc);
+    drain_list(&kvals);
+    PMIX_DESTRUCT(&kvals);
+    PMIX_RELEASE(t);
+}
+
 /* ------------------------------------------------------------------ */
 /* Multiple ranks                                                       */
 /* ------------------------------------------------------------------ */
@@ -396,6 +438,7 @@ int main(int argc, char **argv)
     test_fetch_wrong_key();
     test_store_overwrite();
     test_remove_then_fetch();
+    test_remove_wildcard_empties_the_table();
     test_multiple_ranks();
     test_store_fetch_qualified();
 

--- a/test/unit/util/util_if.c
+++ b/test/unit/util/util_if.c
@@ -119,6 +119,77 @@ static void teardown_if_list(void)
     PMIX_DESTRUCT(&pmix_if_list);
 }
 
+/*
+ * pmix_ifaddrtoname() walks the same mixed-family list, and used to
+ * compare a resolved address against every entry on it regardless of the
+ * entry's family.  Reading a sockaddr_in out of an AF_INET6 entry yields
+ * that entry's flow label, and reading a sockaddr_in6 out of an AF_INET
+ * entry yields the zero padding behind the address - so an all-zero
+ * query matched the first entry of the *other* family and the function
+ * answered with an interface that does not carry the address at all.
+ * pmix_ifislocal() is a thin wrapper over this, so the same confusion
+ * declares a remote node local.
+ */
+static void check_name(const char *label, const char *addr, const char *expected)
+{
+    char name[PMIX_IF_NAMESIZE + 1];
+    int rc;
+
+    name[0] = '\0';
+    rc = pmix_ifaddrtoname(addr, name, sizeof(name));
+    if (NULL == expected) {
+        report(label, PMIX_SUCCESS != rc);
+    } else {
+        report(label, PMIX_SUCCESS == rc && 0 == strcmp(expected, name));
+    }
+}
+
+static void test_ifaddrtoname(void)
+{
+    build_if_list();
+
+    /* an address the list really carries is still found, by either family */
+    check_name("v4 address finds its interface", "172.17.0.2", "eth0");
+    check_name("v6 address finds its interface", "fe80::1", "eth0");
+    check_name("v4 loopback finds lo", "127.0.0.1", "lo");
+    check_name("v6 loopback finds lo", "::1", "lo");
+
+    /* the cross-family regressions: no interface here holds either of
+     * these, and before the family screen both were reported as "lo" */
+    check_name("v4 unspecified addr is not local", "0.0.0.0", NULL);
+    check_name("v6 unspecified addr is not local", "::", NULL);
+    report("ifislocal agrees v4 unspecified is not local", !pmix_ifislocal("0.0.0.0"));
+    report("ifislocal agrees v6 unspecified is not local", !pmix_ifislocal("::"));
+
+    /* an address on none of the interfaces is not found */
+    check_name("unrelated address not found", "203.0.113.7", NULL);
+
+    teardown_if_list();
+}
+
+/*
+ * A node can come up with nothing discovered - a container in a network
+ * namespace of its own, or a platform none of the pif components can
+ * read.  pmix_list_get_first() answers the list's *sentinel* on an empty
+ * list, never NULL, so pmix_ifbegin()'s NULL test never fired and it read
+ * an if_index out of a pmix_pif_t laid over the sentinel, which is past
+ * the end of the pmix_list_t.  The ptl listener starts its interface walk
+ * at whatever came back.
+ */
+static void test_ifbegin_empty(void)
+{
+    PMIX_CONSTRUCT(&pmix_if_list, pmix_list_t);
+    report("ifcount is zero on an empty list", 0 == pmix_ifcount());
+    report("ifbegin answers -1 on an empty list", -1 == pmix_ifbegin());
+    report("ifnext answers -1 on an empty list", -1 == pmix_ifnext(0));
+    PMIX_DESTRUCT(&pmix_if_list);
+
+    /* and it still finds the first entry when there is one */
+    build_if_list();
+    report("ifbegin answers the first entry", 1 == pmix_ifbegin());
+    teardown_if_list();
+}
+
 /* Every route to "the kernel index of this interface" has to give the
  * same answer.  It did not: the field holds an unsigned index, and
  * pmix_ifindextokindex() returns it as an int, but pmix_ifnametokindex()
@@ -256,11 +327,26 @@ int main(int argc, char **argv)
     /* out-of-range octet */
     check_err("octet > 255 rejected", "192.168.1.300/24");
 
+    /* a suffix with no digits in it must be reported, not read as the
+     * prefix length 0 that strtol() answers for it.  /0 is legal CIDR
+     * meaning "match everything", so swallowing these turned a typo in
+     * an if_include entry into a mask that matches no interface at all -
+     * and suppressed the invalid-net-mask warning that used to fire. */
+    check_err("empty cidr suffix rejected", "192.168.1.0/");
+    check_err("non-numeric cidr suffix rejected", "10.0.0.0/abc");
+    check_err("trailing junk after cidr rejected", "10.0.0.0/24x");
+
     fprintf(stdout, "\n=== pmix_ifmatches unit tests ===\n\n");
     fprintf(stdout, "-- one case drives an invalid netmask;"
                     " the warning it prints is expected --\n");
 
     test_ifmatches();
+
+    fprintf(stdout, "\n=== pmix_ifaddrtoname unit tests ===\n\n");
+    test_ifaddrtoname();
+
+    fprintf(stdout, "\n=== empty interface list unit tests ===\n\n");
+    test_ifbegin_empty();
 
     fprintf(stdout, "\n=== kernel index width unit tests ===\n\n");
     test_large_kernel_index();

--- a/test/unit/util/util_keyval.c
+++ b/test/unit/util/util_keyval.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for src/util/pmix_keyval_parse.c: the flex-driven parser
+ * for MCA parameter files.  Everything in that file is process-global -
+ * the key buffer, the accumulated "-x" string, the lock - so the cases
+ * that matter most are about what survives an init/finalize cycle, not
+ * about any one parse.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+
+#include "pmix_common.h"
+#include "src/util/pmix_keyval_parse.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* What the callback saw, in the order it saw it. */
+#define MAX_SEEN 16
+static char *seen_name[MAX_SEEN];
+static char *seen_value[MAX_SEEN];
+static int nseen = 0;
+
+static void reset_seen(void)
+{
+    int i;
+
+    for (i = 0; i < nseen; i++) {
+        free(seen_name[i]);
+        free(seen_value[i]);
+    }
+    nseen = 0;
+}
+
+/* The parser documents that both strings point into buffers it may
+ * overwrite the moment we return, so copy them out. */
+static void collect(const char *file, int lineno, const char *name,
+                    const char *value, void *cbdata)
+{
+    PMIX_HIDE_UNUSED_PARAMS(file, lineno, cbdata);
+
+    if (nseen >= MAX_SEEN) {
+        return;
+    }
+    seen_name[nseen] = (NULL == name) ? NULL : strdup(name);
+    seen_value[nseen] = (NULL == value) ? NULL : strdup(value);
+    nseen++;
+}
+
+static int find_seen(const char *name)
+{
+    int i;
+
+    for (i = 0; i < nseen; i++) {
+        if (NULL != seen_name[i] && 0 == strcmp(name, seen_name[i])) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static char tmpfile_path[512];
+
+static int write_file(const char *contents)
+{
+    FILE *fp;
+
+    fp = fopen(tmpfile_path, "w");
+    if (NULL == fp) {
+        return -1;
+    }
+    fputs(contents, fp);
+    fclose(fp);
+    return 0;
+}
+
+static void test_basic_pairs(void)
+{
+    int rc, idx;
+
+    if (0 != write_file("# a comment\n"
+                        "alpha = one\n"
+                        "\n"
+                        "beta = two three\n")) {
+        report("could not write the fixture file", 0);
+        return;
+    }
+
+    reset_seen();
+    rc = pmix_util_keyval_parse(tmpfile_path, collect, NULL);
+    report("a well-formed file parses", PMIX_SUCCESS == rc);
+
+    idx = find_seen("alpha");
+    report("first pair is delivered",
+           0 <= idx && NULL != seen_value[idx] && 0 == strcmp("one", seen_value[idx]));
+    idx = find_seen("beta");
+    report("a value with a space in it is delivered whole",
+           0 <= idx && NULL != seen_value[idx] && 0 == strcmp("two three", seen_value[idx]));
+    report("the comment and the blank line are not pairs", 2 == nseen);
+    reset_seen();
+}
+
+/*
+ * The caller (pmix_mca_base_var_cache_files) treats PMIX_ERR_NOT_FOUND
+ * as "no such file, carry on", and every other code as fatal, so an
+ * absent file has to answer with exactly that one.
+ */
+static void test_missing_file(void)
+{
+    char missing[600];
+    int rc;
+
+    snprintf(missing, sizeof(missing), "%s.does.not.exist", tmpfile_path);
+    reset_seen();
+    rc = pmix_util_keyval_parse(missing, collect, NULL);
+    report("a missing file answers NOT_FOUND", PMIX_ERR_NOT_FOUND == rc);
+    report("a missing file delivers no pairs", 0 == nseen);
+    reset_seen();
+}
+
+/*
+ * "-x FOO=bar" lines are not delivered as they are read.  They pile up
+ * in one process-global string that is handed over, and released, by
+ * pmix_util_keyval_save_internal_envars().
+ */
+static void test_env_directives(void)
+{
+    int rc, idx;
+
+    if (0 != write_file("-x FOO=bar\n"
+                        "-x BAZ=qux\n")) {
+        report("could not write the fixture file", 0);
+        return;
+    }
+
+    reset_seen();
+    rc = pmix_util_keyval_parse(tmpfile_path, collect, NULL);
+    report("a file of -x directives parses", PMIX_SUCCESS == rc);
+    report("-x directives are not delivered by the parse", 0 == nseen);
+
+    rc = pmix_util_keyval_save_internal_envars(collect, NULL);
+    report("saving the internal envars succeeds", PMIX_SUCCESS == rc);
+    idx = find_seen("mca_base_env_list_internal");
+    report("both -x directives arrive in one pair",
+           0 <= idx && NULL != seen_value[idx]
+               && NULL != strstr(seen_value[idx], "FOO=bar")
+               && NULL != strstr(seen_value[idx], "BAZ=qux"));
+
+    /* the hand-off releases the string, so a second ask delivers nothing */
+    reset_seen();
+    rc = pmix_util_keyval_save_internal_envars(collect, NULL);
+    report("a second save delivers nothing", PMIX_SUCCESS == rc && 0 == nseen);
+    reset_seen();
+}
+
+/*
+ * The regression this file exists for.  pmix_util_keyval_parse_finalize()
+ * released the key buffer but not the accumulated -x string, and
+ * pmix_init_util() runs again after pmix_finalize_util() - so a run that
+ * ended without reaching the hand-off (pmix_mca_base_var_cache_files
+ * returns on the first file that fails to parse, before the store) left
+ * its variables standing, and the *next* run was handed them.
+ */
+static void test_finalize_drops_pending_envars(void)
+{
+    int rc;
+
+    if (0 != write_file("-x LEAKED=fromfirstrun\n")) {
+        report("could not write the fixture file", 0);
+        return;
+    }
+
+    reset_seen();
+    rc = pmix_util_keyval_parse(tmpfile_path, collect, NULL);
+    report("the first run parses its -x directive", PMIX_SUCCESS == rc);
+
+    /* end the run without ever asking for the accumulated variables */
+    pmix_util_keyval_parse_finalize();
+    rc = pmix_util_keyval_parse_init();
+    report("the parser re-initializes", PMIX_SUCCESS == rc);
+
+    reset_seen();
+    rc = pmix_util_keyval_save_internal_envars(collect, NULL);
+    report("a new run is not handed the previous run's -x variables",
+           PMIX_SUCCESS == rc && -1 == find_seen("mca_base_env_list_internal"));
+    reset_seen();
+}
+
+int main(int argc, char **argv)
+{
+    const char *tmpdir;
+    int rc;
+
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    tmpdir = getenv("TMPDIR");
+    if (NULL == tmpdir || '\0' == tmpdir[0]) {
+        tmpdir = "/tmp";
+    }
+    snprintf(tmpfile_path, sizeof(tmpfile_path), "%s/pmix_util_keyval_test.%ld", tmpdir,
+             (long) getpid());
+
+    rc = pmix_util_keyval_parse_init();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "pmix_util_keyval_parse_init failed: %d\n", rc);
+        return 1;
+    }
+
+    fprintf(stdout, "\n=== pmix_util_keyval_parse unit tests ===\n\n");
+    test_basic_pairs();
+    test_missing_file();
+    test_env_directives();
+    test_finalize_drops_pending_envars();
+
+    pmix_util_keyval_parse_finalize();
+    reset_seen();
+    unlink(tmpfile_path);
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/util/util_name_fns.c
+++ b/test/unit/util/util_name_fns.c
@@ -56,6 +56,34 @@ static void test_print_rank_positive(void)
     report("print_rank_positive", s != NULL && 0 == strcmp(s, "5"));
 }
 
+/*
+ * The reserved band runs from PMIX_RANK_VALID (UINT32_MAX-50) up, and
+ * only five of its members have names, so this function has to render
+ * raw values that do not fit a signed 32-bit int.  It used to cast the
+ * uint32_t rank to long and print it with %ld: exact on a 64-bit
+ * platform, implementation-defined where long is 32 bits, so the same
+ * rank appeared as a large positive number on one machine and a
+ * negative one on another.
+ *
+ * Note this case cannot fail on a 64-bit build - it is here to pin the
+ * contract for the 32-bit ones, where it can.
+ */
+static void test_print_rank_above_int32(void)
+{
+    char buf[32];
+    char *s;
+
+    s = pmix_util_print_rank(3000000000u);
+    report("print_rank_above_int32", NULL != s && 0 == strcmp(s, "3000000000"));
+
+    /* an unnamed member of the reserved band renders as its own value,
+     * and in particular never as a negative number */
+    snprintf(buf, sizeof(buf), "%u", (unsigned int) (PMIX_RANK_VALID + 10));
+    s = pmix_util_print_rank(PMIX_RANK_VALID + 10);
+    report("print_rank_reserved_band_unsigned",
+           NULL != s && 0 == strcmp(s, buf) && NULL == strchr(s, '-'));
+}
+
 static void test_print_rank_undef(void)
 {
     char *s = pmix_util_print_rank(PMIX_RANK_UNDEF);
@@ -214,6 +242,7 @@ int main(int argc, char **argv)
 
     test_print_rank_zero();
     test_print_rank_positive();
+    test_print_rank_above_int32();
     test_print_rank_undef();
     test_print_rank_wildcard();
     test_print_rank_invalid();

--- a/test/unit/util/util_net.c
+++ b/test/unit/util/util_net.c
@@ -27,6 +27,8 @@
 #    include <arpa/inet.h>
 #endif
 
+#include "src/runtime/pmix_init_util.h"
+#include "src/runtime/pmix_rte.h"
 #include "src/util/pmix_net.h"
 
 static int npass = 0;
@@ -86,6 +88,18 @@ static bool islocalhost_v4(const char *ip)
     return pmix_net_islocalhost((struct sockaddr *) &sa);
 }
 
+static bool islocalhost_v6(const char *ip)
+{
+    struct sockaddr_in6 sa;
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sin6_family = AF_INET6;
+    if (1 != inet_pton(AF_INET6, ip, &sa.sin6_addr)) {
+        return false;
+    }
+    return pmix_net_islocalhost((struct sockaddr *) &sa);
+}
+
 static void test_islocalhost(void)
 {
     report("islocalhost(127.0.0.1) == true", islocalhost_v4("127.0.0.1"));
@@ -93,6 +107,55 @@ static void test_islocalhost(void)
     report("islocalhost(10.0.0.1) == false", !islocalhost_v4("10.0.0.1"));
     /* Regression: 255.x must not be mistaken for the 127/8 range */
     report("islocalhost(255.1.2.3) == false", !islocalhost_v4("255.1.2.3"));
+    report("islocalhost(::1) == true", islocalhost_v6("::1"));
+    report("islocalhost(2001:db8::1) == false", !islocalhost_v6("2001:db8::1"));
+    /* an IPv4-mapped address carries an ordinary IPv4 address in its low
+     * 32 bits, so the whole of 127.0.0.0/8 names this host through it */
+    report("islocalhost(::ffff:127.0.0.1) == true", islocalhost_v6("::ffff:127.0.0.1"));
+    report("islocalhost(::ffff:127.9.9.9) == true", islocalhost_v6("::ffff:127.9.9.9"));
+    report("islocalhost(::ffff:8.8.8.8) == false", !islocalhost_v6("::ffff:8.8.8.8"));
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_net_addr_isipv6linklocal                                       */
+/* ------------------------------------------------------------------ */
+
+static void check_linklocal(const char *addr, bool expect)
+{
+    struct sockaddr_in6 sa;
+    char label[96];
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sin6_family = AF_INET6;
+    if (1 != inet_pton(AF_INET6, addr, &sa.sin6_addr)) {
+        snprintf(label, sizeof(label), "inet_pton6(%s)", addr);
+        report(label, 0);
+        return;
+    }
+    snprintf(label, sizeof(label), "isipv6linklocal(%s) == %s", addr,
+             expect ? "true" : "false");
+    report(label, expect == pmix_net_addr_isipv6linklocal((struct sockaddr *) &sa));
+}
+
+/* PMIX_ENABLE_IPV6 is 0 in a default build, but the pif IPv6 discovery
+ * components are gated on the OS rather than on that flag, so an AF_INET6
+ * address is ordinary here. Guarding the AF_INET6 arm on PMIX_ENABLE_IPV6
+ * made every one of these answer false - after complaining about an
+ * "unhandled sa_family" on stream 0. */
+static void test_isipv6linklocal(void)
+{
+    struct sockaddr_in v4;
+
+    check_linklocal("fe80::1", true);
+    check_linklocal("fe80::dead:beef", true);
+    check_linklocal("fe81::1", false);
+    check_linklocal("2001:db8::1", false);
+    check_linklocal("::1", false);
+
+    memset(&v4, 0, sizeof(v4));
+    v4.sin_family = AF_INET;
+    report("isipv6linklocal(v4) == false",
+           !pmix_net_addr_isipv6linklocal((struct sockaddr *) &v4));
 }
 
 /* ------------------------------------------------------------------ */
@@ -221,6 +284,65 @@ static void test_samenetwork(void)
     report("samenetwork(v4, v6, /64) == false", !pmix_net_samenetwork(&v4, &v6, 64));
 }
 
+/* ------------------------------------------------------------------ */
+/* pmix_net_addr_isipv4public                                          */
+/* ------------------------------------------------------------------ */
+
+static void check_public(const char *addr, bool expect)
+{
+    struct sockaddr_in sa;
+    char label[96];
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family = AF_INET;
+    if (1 != inet_pton(AF_INET, addr, &sa.sin_addr)) {
+        snprintf(label, sizeof(label), "inet_pton(%s)", addr);
+        report(label, 0);
+        return;
+    }
+    snprintf(label, sizeof(label), "isipv4public(%s) == %s", addr,
+             expect ? "true" : "false");
+    report(label, expect == pmix_net_addr_isipv4public((struct sockaddr *) &sa));
+}
+
+/* The table of private networks comes from an MCA parameter, and the
+ * parameter system does not have the value until pmix_register_params()
+ * runs - which is well after pmix_init_util(), where the network helper
+ * is initialized. Parsing it at pmix_net_init() time therefore saw only
+ * the NULL initializer and left every address, RFC1918 included, looking
+ * public; the MCA parameter was inert. Everything below answers "public"
+ * if that regresses.
+ *
+ * The list is supplied through the environment rather than left at its
+ * default so that the test also proves the *user's* value is the one
+ * being consulted: 172.16.0.0/12 is private by default and public here. */
+static void test_isipv4public(void)
+{
+    struct sockaddr_in6 sa6;
+
+    setenv("PMIX_MCA_pmix_net_private_ipv4", "10.0.0.0/8;192.168.0.0/16", 1);
+
+    if (PMIX_SUCCESS != pmix_init_util(NULL, 0, NULL)) {
+        report("pmix_init_util", 0);
+        return;
+    }
+    if (PMIX_SUCCESS != pmix_register_params()) {
+        report("pmix_register_params", 0);
+        return;
+    }
+
+    check_public("10.1.2.3", false);
+    check_public("192.168.1.1", false);
+    check_public("172.16.5.5", true);
+    check_public("8.8.8.8", true);
+
+    /* an IPv6 address is never an IPv4 public address */
+    memset(&sa6, 0, sizeof(sa6));
+    sa6.sin6_family = AF_INET6;
+    report("isipv4public(::1) == false",
+           !pmix_net_addr_isipv4public((struct sockaddr *) &sa6));
+}
+
 #endif /* HAVE_STRUCT_SOCKADDR_IN */
 
 /* ------------------------------------------------------------------ */
@@ -237,6 +359,9 @@ int main(int argc, char **argv)
     test_get_port();
     test_isaddr();
     test_samenetwork();
+    test_isipv6linklocal();
+    /* last - it initializes the library */
+    test_isipv4public();
 #else
     fprintf(stdout, "  SKIP: no struct sockaddr_in on this platform\n");
 #endif

--- a/test/unit/util/util_os_dirpath.c
+++ b/test/unit/util/util_os_dirpath.c
@@ -65,6 +65,17 @@ static void test_create_null(void)
     report("create_null: returns ERR_BAD_PARAM", PMIX_ERR_BAD_PARAM == rc);
 }
 
+/* An empty path names nothing, but mkdir("") answers ENOENT - the same
+ * errno that means "the parent components are missing, go build the
+ * tree". An empty path then splits to no components at all, the build
+ * loop never runs, and the function reported that it had created a
+ * directory tree while doing nothing at all. */
+static void test_create_empty(void)
+{
+    int rc = pmix_os_dirpath_create("", S_IRWXU);
+    report("create_empty: returns ERR_BAD_PARAM", PMIX_ERR_BAD_PARAM == rc);
+}
+
 static void test_create_new(void)
 {
     char path[512];
@@ -460,6 +471,7 @@ int main(int argc, char **argv)
     fprintf(stdout, "\n=== pmix_os_dirpath unit tests ===\n\n");
 
     test_create_null();
+    test_create_empty();
     test_create_new();
     test_create_existing();
     test_create_nested();

--- a/test/unit/util/util_os_dirpath.c
+++ b/test/unit/util/util_os_dirpath.c
@@ -29,6 +29,8 @@
 #    include <sys/stat.h>
 #endif
 
+#include <fcntl.h>
+
 #include "pmix.h"
 #include "src/util/pmix_os_dirpath.h"
 
@@ -458,6 +460,123 @@ static void test_destroy_callback_veto_in_subdir(void)
 
 /* ------------------------------------------------------------------ */
 
+/* ------------------------------------------------------------------ */
+/* pmix_os_dirpath_create_under / _open_file_under                     */
+/* ------------------------------------------------------------------ */
+
+/* The root is taken as given and must still work when it is reached
+ * through a symlink - which is not an exotic case: /tmp and /var are
+ * themselves symlinks on macOS, so the default PMIx temporary directory
+ * is one. A walk that declined a link at every component would decline
+ * the platform. */
+static void test_under_trusted_root_may_be_a_symlink(void)
+{
+    char real[512], link[512], leaf[600];
+    int rc;
+
+    snprintf(real, sizeof(real), "%s/realroot", tmpbase);
+    snprintf(link, sizeof(link), "%s/linkroot", tmpbase);
+    if (0 != mkdir(real, S_IRWXU)) {
+        report("under: fixture", 0);
+        return;
+    }
+    unlink(link);
+    if (0 != symlink(real, link)) {
+        report("under: fixture", 0);
+        return;
+    }
+
+    rc = pmix_os_dirpath_create_under(link, "ns/rank.0", S_IRWXU);
+    report("under: symlinked root is accepted", PMIX_SUCCESS == rc);
+    snprintf(leaf, sizeof(leaf), "%s/ns/rank.0", real);
+    report("under: tree built through it", dir_exists(leaf));
+
+    rmdir(leaf);
+    snprintf(leaf, sizeof(leaf), "%s/ns", real);
+    rmdir(leaf);
+    unlink(link);
+    rmdir(real);
+}
+
+/* ...but a component of the tail is a name PMIx composes itself, so a
+ * symlink there is not one this code put in place. Building through it
+ * would put the tree - and every output file in it - somewhere the
+ * caller never named. */
+static void test_under_declines_a_tail_symlink(void)
+{
+    char root[512], linkname[600], elsewhere[512], leaf[600];
+    int rc, fd;
+
+    snprintf(root, sizeof(root), "%s/troot", tmpbase);
+    snprintf(elsewhere, sizeof(elsewhere), "%s/elsewhere", tmpbase);
+    if (0 != mkdir(root, S_IRWXU) || 0 != mkdir(elsewhere, S_IRWXU)) {
+        report("under: fixture", 0);
+        return;
+    }
+    /* something else reached the namespace component first */
+    snprintf(linkname, sizeof(linkname), "%s/ns", root);
+    if (0 != symlink(elsewhere, linkname)) {
+        report("under: fixture", 0);
+        return;
+    }
+
+    rc = pmix_os_dirpath_create_under(root, "ns/rank.0", S_IRWXU);
+    report("under: tail symlink declined", PMIX_SUCCESS != rc);
+    snprintf(leaf, sizeof(leaf), "%s/rank.0", elsewhere);
+    report("under: nothing built past the link", !dir_exists(leaf));
+
+    /* and the file open makes the same decision on its own account */
+    fd = pmix_os_dirpath_open_file_under(root, "ns/rank.0/stdout",
+                                         O_CREAT | O_RDWR | O_TRUNC, 0644);
+    report("under: file not opened past the link", 0 > fd);
+    if (0 <= fd) {
+        close(fd);
+    }
+
+    rmdir(leaf);
+    unlink(linkname);
+    rmdir(elsewhere);
+    rmdir(root);
+}
+
+/* More than one composed level below the root - which is what an IOF
+ * pattern like "%h/%n/rank-%R" produces - has to be built a component at
+ * a time all the way down, not just at the last one. A symlink at the
+ * FIRST composed level is the case a single O_NOFOLLOW never sees: it
+ * applies to the end of the name, and by then the resolution has already
+ * gone elsewhere. */
+static void test_under_declines_a_midway_symlink(void)
+{
+    char root[512], linkname[600], elsewhere[512], leaf[600];
+    int rc;
+
+    snprintf(root, sizeof(root), "%s/mroot", tmpbase);
+    snprintf(elsewhere, sizeof(elsewhere), "%s/melsewhere", tmpbase);
+    if (0 != mkdir(root, S_IRWXU) || 0 != mkdir(elsewhere, S_IRWXU)) {
+        report("midway: fixture", 0);
+        return;
+    }
+    /* the first of three composed levels is already a link */
+    snprintf(linkname, sizeof(linkname), "%s/host", root);
+    if (0 != symlink(elsewhere, linkname)) {
+        report("midway: fixture", 0);
+        return;
+    }
+
+    rc = pmix_os_dirpath_create_under(root, "host/ns/rank.0", S_IRWXU);
+    report("midway: symlink at the first level declined", PMIX_SUCCESS != rc);
+    snprintf(leaf, sizeof(leaf), "%s/ns", elsewhere);
+    report("midway: nothing built past it", !dir_exists(leaf));
+
+    snprintf(leaf, sizeof(leaf), "%s/ns/rank.0", elsewhere);
+    rmdir(leaf);
+    snprintf(leaf, sizeof(leaf), "%s/ns", elsewhere);
+    rmdir(leaf);
+    unlink(linkname);
+    rmdir(elsewhere);
+    rmdir(root);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -472,6 +591,9 @@ int main(int argc, char **argv)
 
     test_create_null();
     test_create_empty();
+    test_under_trusted_root_may_be_a_symlink();
+    test_under_declines_a_tail_symlink();
+    test_under_declines_a_midway_symlink();
     test_create_new();
     test_create_existing();
     test_create_nested();

--- a/test/unit/util/util_os_path.c
+++ b/test/unit/util/util_os_path.c
@@ -46,6 +46,59 @@ static void check(const char *label, char *got, const char *expected)
     }
 }
 
+/* The length test is applied to an estimate, and the estimate used to
+ * count the separator ahead of each element twice - once while measuring
+ * and again in the num_elements term - so a name that fits was refused.
+ * Three elements totalling 1021 characters assemble to exactly
+ * PMIX_PATH_MAX - 1 (1024) plus the terminator, which is the largest
+ * name this function will build; the old estimate came to 1028 and
+ * answered NULL. One character more really is too long.
+ *
+ * The two cases share a builder so that the only difference between the
+ * accepted and the rejected one is that single character. */
+static char *assemble_of_total(size_t total)
+{
+    size_t first = total / 3, second = total / 3;
+    size_t third = total - first - second;
+    char *a, *b, *c, *got;
+
+    a = malloc(first + 1);
+    b = malloc(second + 1);
+    c = malloc(third + 1);
+    if (NULL == a || NULL == b || NULL == c) {
+        free(a);
+        free(b);
+        free(c);
+        return NULL;
+    }
+    memset(a, 'a', first);
+    a[first] = '\0';
+    memset(b, 'b', second);
+    b[second] = '\0';
+    memset(c, 'c', third);
+    c[third] = '\0';
+
+    got = pmix_os_path(false, a, b, c, NULL);
+    free(a);
+    free(b);
+    free(c);
+    return got;
+}
+
+static void test_length_boundary(void)
+{
+    char *got;
+
+    got = assemble_of_total(PMIX_PATH_MAX - 4);
+    report("longest name that fits is assembled",
+           NULL != got && (PMIX_PATH_MAX - 1) == (int) strlen(got));
+    free(got);
+
+    got = assemble_of_total(PMIX_PATH_MAX - 3);
+    report("one character longer is refused", NULL == got);
+    free(got);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -61,6 +114,11 @@ int main(int argc, char **argv)
      * doubled slash */
     check("leading-separator element", pmix_os_path(false, "/a", "b", NULL), "/a/b");
     check("single element", pmix_os_path(false, "usr", NULL), "/usr");
+
+    /* an empty element contributes nothing but still gets its separator */
+    check("empty element", pmix_os_path(false, "a", "", "b", NULL), "/a//b");
+
+    test_length_boundary();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/util/util_output.c
+++ b/test/unit/util/util_output.c
@@ -24,7 +24,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include "pmix.h"
+#include "src/util/pmix_environ.h"
 #include "src/util/pmix_output.h"
 
 static int npass = 0;
@@ -126,6 +131,103 @@ static void test_output_switch(void)
     pmix_output_close(h);
 }
 
+/* Disabling a stream does not close it - pmix_output_switch() only
+ * discards what is written to it - so a close that follows must still
+ * release the descriptor's strdup'ed strings and give the slot back.
+ * When the close was gated on the stream being enabled, the slot stayed
+ * marked "used" forever and the second open landed somewhere else. */
+static void test_output_close_disabled_reclaims_slot(void)
+{
+    pmix_output_stream_t lds;
+    int a, b;
+
+    PMIX_CONSTRUCT(&lds, pmix_output_stream_t);
+    lds.lds_want_stderr = true;
+    lds.lds_prefix = strdup("[disabled-stream] ");
+
+    a = pmix_output_open(&lds);
+    pmix_output_switch(a, false);
+    pmix_output_close(a);
+
+    b = pmix_output_open(&lds);
+
+    free(lds.lds_prefix);
+    lds.lds_prefix = NULL;
+    PMIX_DESTRUCT(&lds);
+
+    report("output_close_disabled: slot reclaimed", 0 <= a && a == b);
+    pmix_output_close(b);
+}
+
+/* ------------------------------------------------------------------ */
+/* file streams sharing one output file                                */
+/* ------------------------------------------------------------------ */
+
+/* Two streams naming the same output file share the open file rather
+ * than opening it twice (a second O_TRUNC open would discard what the
+ * first had written). They must not share the *descriptor*: closing
+ * either one then closed the file out from under the other, which went
+ * on writing into whatever descriptor the OS handed out next. */
+static void test_output_file_shared_between_streams(void)
+{
+    pmix_output_stream_t lds;
+    char *olddir = NULL, *oldprefix = NULL;
+    char prefix[64], path[PMIX_PATH_MAX], buf[4096];
+    const char *dir;
+    int a, b, fd;
+    ssize_t n;
+
+    dir = pmix_tmp_directory();
+    snprintf(prefix, sizeof(prefix), "util-output-%d-", (int) getpid());
+    pmix_output_set_output_file_info(dir, prefix, &olddir, &oldprefix);
+    snprintf(path, sizeof(path), "%s/%sshared.txt", dir, prefix);
+
+    PMIX_CONSTRUCT(&lds, pmix_output_stream_t);
+    lds.lds_want_file = true;
+    lds.lds_file_suffix = strdup("shared.txt");
+    a = pmix_output_open(&lds);
+    b = pmix_output_open(&lds);
+    PMIX_DESTRUCT(&lds);
+
+    if (0 > a || 0 > b) {
+        report("output_file_shared: streams opened", 0);
+        goto restore;
+    }
+
+    /* the first write is what actually opens the file; the second joins
+     * the file the first one opened */
+    pmix_output(a, "AAA-opener");
+    pmix_output(b, "BBB-joiner");
+
+    pmix_output_close(a);
+    pmix_output(b, "CCC-after-peer-close");
+    pmix_output_close(b);
+
+    memset(buf, 0, sizeof(buf));
+    fd = open(path, O_RDONLY);
+    if (0 > fd) {
+        report("output_file_shared: file created", 0);
+        goto restore;
+    }
+    n = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    unlink(path);
+    if (0 > n) {
+        report("output_file_shared: file readable", 0);
+        goto restore;
+    }
+
+    report("output_file_shared: opener wrote", NULL != strstr(buf, "AAA-opener"));
+    report("output_file_shared: joiner wrote", NULL != strstr(buf, "BBB-joiner"));
+    report("output_file_shared: joiner survives peer close",
+           NULL != strstr(buf, "CCC-after-peer-close"));
+
+restore:
+    pmix_output_set_output_file_info(olddir, oldprefix, NULL, NULL);
+    free(olddir);
+    free(oldprefix);
+}
+
 /* ------------------------------------------------------------------ */
 /* pmix_output_set/get_verbosity                                       */
 /* ------------------------------------------------------------------ */
@@ -190,6 +292,8 @@ int main(int argc, char **argv)
     test_output_open_stdout();
     test_output_close_invalid_no_crash();
     test_output_switch();
+    test_output_close_disabled_reclaims_slot();
+    test_output_file_shared_between_streams();
     test_output_verbosity();
     test_output_file_info();
 

--- a/test/unit/util/util_output.c
+++ b/test/unit/util/util_output.c
@@ -159,6 +159,30 @@ static void test_output_close_disabled_reclaims_slot(void)
     pmix_output_close(b);
 }
 
+/* A stream that asks for syslog has to actually get it. The support was
+ * compiled behind HAVE_SYSLOG, which nothing in this tree defines, so
+ * every syslog path was dead: a stream that asked for syslog was simply
+ * given no destination at all. Nothing is written to the log here - we
+ * only ask the descriptor what it was set up to do. */
+static void test_output_syslog_stream_is_marked(void)
+{
+#ifdef HAVE_SYSLOG_H
+    pmix_output_stream_t lds;
+    int h;
+
+    PMIX_CONSTRUCT(&lds, pmix_output_stream_t);
+    lds.lds_want_syslog = true;
+    h = pmix_output_open(&lds);
+    PMIX_DESTRUCT(&lds);
+
+    report("output_syslog: stream marked for syslog",
+           0 <= h && pmix_output_info[h].ldi_syslog);
+    pmix_output_close(h);
+#else
+    report("output_syslog: no syslog.h, skipped", 1);
+#endif
+}
+
 /* ------------------------------------------------------------------ */
 /* file streams sharing one output file                                */
 /* ------------------------------------------------------------------ */
@@ -293,6 +317,7 @@ int main(int argc, char **argv)
     test_output_close_invalid_no_crash();
     test_output_switch();
     test_output_close_disabled_reclaims_slot();
+    test_output_syslog_stream_is_marked();
     test_output_file_shared_between_streams();
     test_output_verbosity();
     test_output_file_info();

--- a/test/unit/util/util_parse_options.c
+++ b/test/unit/util/util_parse_options.c
@@ -119,6 +119,41 @@ int main(int argc, char **argv)
         check_range("embedded bare dash skipped", in, exp);
     }
 
+    {
+        /* Regression: an element too big for an int used to narrow to
+         * -1 - which this parser reads as the wildcard - so a mistyped
+         * port range silently threw the caller's whole list away and
+         * replaced it with "any". It is malformed input: report it,
+         * skip it, and leave what the caller already had alone. */
+        char **out = NULL;
+        const char *const exp[] = {"7", NULL};
+        char seed[] = "7";
+        char in[] = "4294967295";
+        pmix_util_parse_range_options(seed, &out);
+        pmix_util_parse_range_options(in, &out);
+        report("out-of-range value is not the wildcard", argv_equals(out, exp));
+        PMIx_Argv_free(out);
+    }
+    {
+        const char *const exp[] = {NULL};
+        char in[] = "abc";
+        check_range("non-numeric element yields nothing", in, exp);
+    }
+    {
+        /* the end of a range has to be a number too - "1-abc" used to
+         * read as 1..0 and quietly expand to nothing, while "abc-1"
+         * read as 0..1 and invented two values */
+        const char *const exp[] = {NULL};
+        char in[] = "abc-1";
+        check_range("non-numeric range start yields nothing", in, exp);
+    }
+    {
+        /* whitespace around an element is tolerated, as it always was */
+        const char *const exp[] = {"1", "3", "4", NULL};
+        char in[] = "1 , 3 - 4";
+        check_range("whitespace around elements", in, exp);
+    }
+
     /* NULL input is a documented no-op */
     {
         char **out = NULL;

--- a/test/unit/util/util_path.c
+++ b/test/unit/util/util_path.c
@@ -7,7 +7,8 @@
  * $HEADER$
  *
  * Unit tests for path utility functions:
- *   pmix_path_is_absolute, pmix_os_path.
+ *   pmix_path_is_absolute, pmix_os_path, pmix_path_find,
+ *   pmix_path_findv, pmix_path_df.
  *
  * Exit 0 if all tests pass, 1 otherwise.
  */
@@ -18,6 +19,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "src/util/pmix_path.h"
 #include "src/util/pmix_os_path.h"
@@ -124,6 +127,92 @@ static void test_os_path_single_component(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* pmix_path_find / pmix_path_findv                                    */
+/* ------------------------------------------------------------------ */
+
+/* pathv belongs to the caller. Resolving a "$VAR" prefix used to mark
+ * the end of the variable name by punching a temporary NUL into the
+ * caller's string and putting it back, which faults outright on the
+ * string literals an ordinary caller passes - and races any other
+ * thread reading the same array. This case dies on a signal rather
+ * than failing an assertion if that comes back. */
+static void test_path_find_does_not_write_through_pathv(void)
+{
+    char *pathv[] = {(char *) "$PMIX_UTIL_PATH_TEST_UNSET/bin", NULL};
+    char *r;
+
+    unsetenv("PMIX_UTIL_PATH_TEST_UNSET");
+    r = pmix_path_find((char *) "no-such-file-here", pathv, R_OK, NULL);
+    report("path_find: undefined $VAR prefix finds nothing", NULL == r);
+    report("path_find: leaves the caller's pathv intact",
+           0 == strcmp(pathv[0], "$PMIX_UTIL_PATH_TEST_UNSET/bin"));
+    free(r);
+}
+
+/* NULL used to reach pmix_path_is_absolute(), which dereferenced it */
+static void test_path_null_arguments(void)
+{
+    report("is_absolute(NULL) is false", !pmix_path_is_absolute(NULL));
+    report("path_access(NULL) is NULL", NULL == pmix_path_access(NULL, NULL, R_OK));
+    report("find_absolute_path(NULL) is NULL", NULL == pmix_find_absolute_path(NULL));
+}
+
+/* The documented behavior of a wrkdir: it replaces every "." in the
+ * search path, and when there was no "." it is appended, so a wrkdir is
+ * always searched. Also pins that the search reads $PATH out of envv
+ * without modifying it. */
+static void test_path_findv_searches_wrkdir(void)
+{
+    char dir[] = "/tmp/pmix-util-path-XXXXXX";
+    char *envv[] = {(char *) "PATH=/nonexistent-a:/nonexistent-b", NULL};
+    char file[512];
+    char *found;
+    FILE *fp;
+
+    if (NULL == mkdtemp(dir)) {
+        report("path_findv: made a temp dir", 0);
+        return;
+    }
+    snprintf(file, sizeof(file), "%s/pmix-util-path-probe", dir);
+    fp = fopen(file, "w");
+    if (NULL == fp) {
+        report("path_findv: made a probe file", 0);
+        rmdir(dir);
+        return;
+    }
+    fclose(fp);
+
+    found = pmix_path_findv((char *) "pmix-util-path-probe", R_OK, envv, dir);
+    report("path_findv: wrkdir is searched even without a \".\" in PATH",
+           NULL != found && 0 == strcmp(found, file));
+    report("path_findv: leaves the caller's envv intact",
+           0 == strcmp(envv[0], "PATH=/nonexistent-a:/nonexistent-b"));
+    free(found);
+    unlink(file);
+    rmdir(dir);
+}
+
+/* ------------------------------------------------------------------ */
+/* pmix_path_df                                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_path_df(void)
+{
+    uint64_t avail = 12345;
+
+    report("path_df: NULL path is an error", PMIX_SUCCESS != pmix_path_df(NULL, &avail));
+    report("path_df: NULL out is an error", PMIX_SUCCESS != pmix_path_df("/", NULL));
+
+    avail = 12345;
+    report("path_df: a path that does not exist is an error",
+           PMIX_SUCCESS != pmix_path_df("/no/such/path/at/all", &avail));
+    report("path_df: out_avail is zeroed even on failure", 0 == avail);
+
+    report("path_df: /tmp reports some free space",
+           PMIX_SUCCESS == pmix_path_df("/tmp", &avail) && 0 < avail);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -143,6 +232,11 @@ int main(int argc, char **argv)
     test_os_path_relative_two_components();
     test_os_path_no_components_absolute();
     test_os_path_no_components_relative();
+
+    test_path_null_arguments();
+    test_path_find_does_not_write_through_pathv();
+    test_path_findv_searches_wrkdir();
+    test_path_df();
     test_os_path_single_component();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);

--- a/test/unit/util/util_printf.c
+++ b/test/unit/util/util_printf.c
@@ -18,7 +18,10 @@
 #include "src/include/pmix_config.h"
 #include "src/include/pmix_globals.h"
 
+#include <math.h>
 #include <stdarg.h>
+#include <stdint.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -148,6 +151,133 @@ static void test_asprintf_sets_ptr_on_success(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Conversion coverage                                                  */
+/*                                                                      */
+/* On a platform that has asprintf(3)/vsnprintf(3) these simply confirm */
+/* that the wrappers pass everything through untouched.  On a platform  */
+/* that has neither, pmix_vasprintf() has to size the result itself by  */
+/* walking the format, and these are the cases that walk has to get     */
+/* right: an argument it fails to recognize is an argument it fails to  */
+/* consume, which makes every conversion after it read the wrong slot,  */
+/* and a width or precision it fails to account for undersizes the      */
+/* buffer that vsprintf() then writes into unbounded.                   */
+/* ------------------------------------------------------------------ */
+
+/* Compare pmix_asprintf against the platform's own rendering of the
+ * same format, and confirm the documented "returns the length" contract
+ * holds for both. */
+#define CHECK_FMT(name, ...)                                                  \
+    do {                                                                      \
+        char expect[8192];                                                    \
+        char *got = NULL;                                                     \
+        int elen = snprintf(expect, sizeof(expect), __VA_ARGS__);             \
+        int glen = pmix_asprintf(&got, __VA_ARGS__);                          \
+        report(name ": content", NULL != got && 0 == strcmp(got, expect));    \
+        report(name ": length is strlen", NULL != got                         \
+                                              && glen == (int) strlen(got));  \
+        report(name ": length matches platform", glen == elen);               \
+        free(got);                                                            \
+    } while (0)
+
+static void test_conversions(void)
+{
+    /* a literal percent takes no argument: a walk that mistakes the
+     * second '%' for the start of a conversion consumes one that was
+     * never passed */
+    CHECK_FMT("conv_percent", "100%% of %s", "it");
+
+    /* the integer family, across every length modifier */
+    CHECK_FMT("conv_int", "%d|%i|%u|%o|%x|%X", -1, 2, 3u, 8u, 255u, 255u);
+    CHECK_FMT("conv_short", "%hd|%hhd|%hu", (short) -1, (signed char) -2,
+              (unsigned short) 3);
+    CHECK_FMT("conv_long", "%ld|%lu|%lx", -1L, 2UL, 255UL);
+    CHECK_FMT("conv_longlong", "%lld|%llu", -1LL, 2ULL);
+    CHECK_FMT("conv_intmax", "%jd|%ju", (intmax_t) -1, (uintmax_t) 2);
+    CHECK_FMT("conv_size", "%zu|%zd", (size_t) 4096, (size_t) 4096);
+    CHECK_FMT("conv_ptrdiff", "%td", (ptrdiff_t) -3);
+
+    /* the floating family; %f of a large double is 300-odd digits, and
+     * a precision widens it further */
+    CHECK_FMT("conv_double", "%f|%e|%g", 1.5, 1.5, 1.5);
+    CHECK_FMT("conv_double_big", "%f", 1.0e300);
+    CHECK_FMT("conv_double_prec", "%.200f", 1.0e300);
+    CHECK_FMT("conv_longdouble", "%Lf", (long double) 1.5);
+
+    /* infinity and NaN render short, but a size estimate that divides
+     * the value down to zero never terminates on either */
+    CHECK_FMT("conv_inf", "%f|%f", (double) INFINITY, (double) -INFINITY);
+    CHECK_FMT("conv_nan", "%f", (double) NAN);
+
+    /* characters, strings and pointers */
+    CHECK_FMT("conv_char", "%c%c", 'a', 'b');
+    CHECK_FMT("conv_string", "%s|%.3s", "hello", "hello");
+    CHECK_FMT("conv_pointer", "%p", (void *) &npass);
+
+    /* flags, field widths and precisions - none of which are arguments,
+     * but all of which change how much room the result needs */
+    CHECK_FMT("conv_width", "%200d", 7);
+    CHECK_FMT("conv_flags", "%-12.4x|%+ld|%08.3f", 255, 9L, 1.5);
+
+    /* a '*' width or precision IS an argument, and an extra one */
+    CHECK_FMT("conv_star_width", "%*d|%s", 60, 7, "tail");
+    CHECK_FMT("conv_star_prec", "%.*f|%s", 12, 1.5, "tail");
+
+    /* a mixture, in the order PMIx actually writes them */
+    CHECK_FMT("conv_mixed", "[%s:%u] %zu bytes at %p (%d%%)", "nspace", 3u,
+              (size_t) 64, (void *) &nfail, 50);
+}
+
+/* ------------------------------------------------------------------ */
+/* Failure and edge behavior                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_snprintf_zero_size(void)
+{
+    char buf[8];
+    int n;
+
+    memset(buf, 'Z', sizeof(buf));
+    /* a non-NULL buffer with a zero size: nothing may be written, but
+     * the would-be length is still reported */
+    n = pmix_snprintf(buf, 0, "test %d", 99);
+    report("snprintf_zero_size: returns would-be length",
+           n == (int) strlen("test 99"));
+    report("snprintf_zero_size: buffer untouched", 'Z' == buf[0]);
+}
+
+static void test_snprintf_size_one(void)
+{
+    char buf[8];
+    int n;
+
+    memset(buf, 'Z', sizeof(buf));
+    n = pmix_snprintf(buf, 1, "test %d", 99);
+    report("snprintf_size_one: returns would-be length",
+           n == (int) strlen("test 99"));
+    report("snprintf_size_one: only the terminator is written",
+           '\0' == buf[0] && 'Z' == buf[1]);
+}
+
+static void test_vasprintf_null_string_arg(void)
+{
+    /* volatile so the compiler cannot see the NULL and reject the call
+     * outright under -Wformat-overflow */
+    static char *volatile nullstr = NULL;
+    char *s = NULL;
+    int n;
+
+    /* a NULL %s argument is a caller bug, but it must not be a crash:
+     * every implementation we build against renders it as some short
+     * placeholder, and the length still has to describe what was
+     * produced */
+    n = pmix_asprintf(&s, "a%sb", nullstr);
+    report("asprintf_null_arg: ptr non-NULL", NULL != s);
+    report("asprintf_null_arg: length is strlen",
+           NULL != s && n == (int) strlen(s));
+    free(s);
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -166,6 +296,11 @@ int main(int argc, char **argv)
     test_asprintf_no_conversions();
     test_asprintf_multiple_args();
     test_asprintf_sets_ptr_on_success();
+
+    test_conversions();
+    test_snprintf_zero_size();
+    test_snprintf_size_one();
+    test_vasprintf_null_string_arg();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
     return (nfail > 0) ? 1 : 0;

--- a/test/unit/util/util_pty.c
+++ b/test/unit/util/util_pty.c
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the pmix_pty helpers.
+ *
+ * The interesting property here is one that does not show up in the
+ * returned descriptors at all: opening a terminal device from a session
+ * leader that has no controlling terminal *gives* it one, and these
+ * helpers run in the process that is setting a child up, not in the
+ * child.  A PMIx server started as a daemon is exactly a session leader
+ * with no controlling terminal, so a helper that takes one on its behalf
+ * ties the server's fate to a pty it merely handed to a child.
+ *
+ * Every case runs in a forked child that calls setsid() first, so the
+ * starting state is the same whether or not the test harness itself has
+ * a terminal.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "src/util/pmix_pty.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* Exit codes a probe child can hand back. */
+#define PROBE_OK        0
+#define PROBE_HAS_CTTY  1
+#define PROBE_SETUP     2
+#define PROBE_FAILED    3
+/* Not an exit code: the child died on a signal.  This is a *symptom* of
+ * the same defect - once a process has taken the pty as its controlling
+ * terminal, closing the last master descriptor hangs it up, so the child
+ * is killed by SIGHUP before it can report anything. */
+#define PROBE_SIGNALED  4
+
+static int have_ctty(void)
+{
+    int fd = open("/dev/tty", O_RDWR);
+    if (0 <= fd) {
+        close(fd);
+        return 1;
+    }
+    return 0;
+}
+
+/* Run body() in a child that is a session leader with no controlling
+ * terminal, and return the child's exit status. */
+static int run_probe(int (*body)(void))
+{
+    pid_t pid;
+    int status = 0;
+
+    pid = fork();
+    if (0 > pid) {
+        return PROBE_SETUP;
+    }
+    if (0 == pid) {
+        /* nothing here should block, but a pty read that does would
+         * otherwise wedge make check rather than fail it */
+        alarm(30);
+        if (0 > setsid()) {
+            _exit(PROBE_SETUP);
+        }
+        if (have_ctty()) {
+            /* setsid() should have detached us from any terminal */
+            _exit(PROBE_SETUP);
+        }
+        _exit(body());
+    }
+    if (0 > waitpid(pid, &status, 0)) {
+        return PROBE_SETUP;
+    }
+    if (!WIFEXITED(status)) {
+        return PROBE_SIGNALED;
+    }
+    return WEXITSTATUS(status);
+}
+
+/* ------------------------------------------------------------------ */
+
+static int probe_openpty(void)
+{
+    int master = -1;
+    int slave = -1;
+    char buf[8];
+    ssize_t n;
+
+    if (0 != pmix_openpty(&master, &slave, NULL, NULL, NULL)) {
+        return PROBE_FAILED;
+    }
+    if (0 > master || 0 > slave) {
+        return PROBE_FAILED;
+    }
+    /* The pair has to actually carry data.  The slave comes up in
+     * canonical mode, so the line has to be terminated or the read
+     * below never returns. */
+    if (3 != write(master, "hi\n", 3)) {
+        return PROBE_FAILED;
+    }
+    n = read(slave, buf, sizeof(buf));
+    if (2 > n || 0 != memcmp(buf, "hi", 2)) {
+        return PROBE_FAILED;
+    }
+    if (have_ctty()) {
+        return PROBE_HAS_CTTY;
+    }
+    close(master);
+    close(slave);
+    return PROBE_OK;
+}
+
+static void test_openpty(void)
+{
+    int rc = run_probe(probe_openpty);
+
+    if (PROBE_SETUP == rc) {
+        report("openpty: probe setup (skipped)", 1);
+        return;
+    }
+    report("openpty: opens a working master/slave pair", PROBE_FAILED != rc);
+    report("openpty: leaves the caller without a controlling terminal",
+           PROBE_OK == rc);
+}
+
+#if PMIX_ENABLE_PTY_SUPPORT
+
+static int probe_ptymopen(void)
+{
+    char name[64];
+    int master;
+    int slave;
+
+    master = pmix_ptymopen(name, sizeof(name));
+    if (0 > master) {
+        return PROBE_FAILED;
+    }
+    if (have_ctty()) {
+        close(master);
+        return PROBE_HAS_CTTY;
+    }
+    slave = pmix_ptysopen(master, name);
+    if (0 > slave) {
+        close(master);
+        return PROBE_FAILED;
+    }
+    if (have_ctty()) {
+        close(master);
+        close(slave);
+        return PROBE_HAS_CTTY;
+    }
+    close(master);
+    close(slave);
+    return PROBE_OK;
+}
+
+static void test_ptymopen(void)
+{
+    int rc = run_probe(probe_ptymopen);
+
+    if (PROBE_SETUP == rc) {
+        report("ptymopen: probe setup (skipped)", 1);
+        return;
+    }
+    report("ptymopen/ptysopen: open a master and its slave",
+           PROBE_FAILED != rc);
+    report("ptymopen/ptysopen: leave the caller without a controlling terminal",
+           PROBE_OK == rc);
+}
+
+static void test_ptysopen_does_not_close_the_master(void)
+{
+    char name[64];
+    int master;
+    int rc;
+
+    master = pmix_ptymopen(name, sizeof(name));
+    if (0 > master) {
+        report("ptysopen: master open (skipped)", 1);
+        return;
+    }
+
+    /* a slave name that cannot be opened: the failure must be reported
+     * without closing the descriptor the caller handed in, or the
+     * caller's own close of it is a double close */
+    rc = pmix_ptysopen(master, "/dev/null/no-such-pts");
+    report("ptysopen: reports a failure it cannot recover from", 0 > rc);
+    report("ptysopen: does not close the master it was handed",
+           -1 != fcntl(master, F_GETFD));
+
+    close(master);
+}
+
+static void test_ptymopen_short_buffer(void)
+{
+    char buf[8];
+    int rc;
+
+    memset(buf, 'Z', sizeof(buf));
+    buf[sizeof(buf) - 1] = '\0';
+
+    /* Too small to hold even the master device name.  strncpy() would
+     * fill the buffer without a terminator and the open() that follows
+     * would read past the end of it; the size has to be honored. */
+    rc = pmix_ptymopen(buf, 4);
+    report("ptymopen: refuses a buffer too small for the device name",
+           0 > rc);
+    report("ptymopen: leaves a too-small buffer untouched",
+           0 == strcmp(buf, "ZZZZZZZ"));
+    if (0 <= rc) {
+        close(rc);
+    }
+}
+
+#endif /* PMIX_ENABLE_PTY_SUPPORT */
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_pty unit tests ===\n\n");
+
+    test_openpty();
+#if PMIX_ENABLE_PTY_SUPPORT
+    test_ptymopen();
+    test_ptysopen_does_not_close_the_master();
+    test_ptymopen_short_buffer();
+#else
+    fprintf(stdout, "  (PMIX_ENABLE_PTY_SUPPORT is 0: helper cases skipped)\n");
+#endif
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/util/util_shmem.c
+++ b/test/unit/util/util_shmem.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the backing-file handling in src/util/pmix_shmem.c.
+ *
+ * A segment's backing path is composed by PMIx out of its own naming
+ * scheme, so the name may already be occupied when the segment is
+ * created, and what is sitting there decides what has to happen:
+ *
+ *   - a regular file is left over from an earlier run - the name carries
+ *     a pid, and pids get reused - and has to be reclaimed, or the
+ *     segment cannot be created at all;
+ *   - a symlink is not something this code put there, and must not be
+ *     followed: the operation would land on some unrelated file instead
+ *     of on the segment, truncating and re-permissioning it.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+#include <fcntl.h>
+#ifdef HAVE_SYS_STAT_H
+#    include <sys/stat.h>
+#endif
+
+#include "pmix_common.h"
+#include "src/util/pmix_shmem.h"
+#include "src/util/pmix_string_copy.h"
+
+static int npass = 0;
+static int nfail = 0;
+static char tmpbase[256];
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+/* An unrelated file, with contents and permissions we can recognize
+ * again afterwards. */
+static int make_bystander(const char *path, struct stat *before)
+{
+    static const char content[] = "UNRELATED CONTENT";
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0600);
+
+    if (0 > fd) {
+        return -1;
+    }
+    if ((ssize_t) sizeof(content) != write(fd, content, sizeof(content))) {
+        close(fd);
+        return -1;
+    }
+    close(fd);
+    return stat(path, before);
+}
+
+/* A symlink sitting at the backing path must not carry the segment
+ * creation through to whatever it names. open() with O_CREAT | O_TRUNC
+ * and no O_NOFOLLOW followed it, and chmod() followed it again - while
+ * the lchown() between them does not, so the three calls acted on two
+ * different objects. */
+static void test_create_does_not_follow_a_symlink(void)
+{
+    char other[512], seg[512];
+    struct stat before, after;
+    pmix_shmem_t *shmem;
+
+    snprintf(other, sizeof(other), "%s/other", tmpbase);
+    snprintf(seg, sizeof(seg), "%s/linked.seg", tmpbase);
+
+    if (0 != make_bystander(other, &before)) {
+        report("symlink: fixture", 0);
+        return;
+    }
+    unlink(seg);
+    if (0 != symlink(other, seg)) {
+        report("symlink: fixture", 0);
+        return;
+    }
+
+    shmem = PMIX_NEW(pmix_shmem_t);
+    if (NULL == shmem) {
+        report("symlink: fixture", 0);
+        return;
+    }
+    /* Whether the create succeeds is deliberately not asserted: it may
+     * decline outright, or it may discard the link and build its own
+     * file at that name. Both are correct. What may not happen is
+     * anything at all to the file the link names. */
+    (void) pmix_shmem_segment_create(shmem, 4096, seg, 1);
+    (void) pmix_shmem_segment_chmod(shmem, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+
+    if (0 != stat(other, &after)) {
+        report("symlink: other file still exists", 0);
+    } else {
+        report("symlink: other file not truncated", before.st_size == after.st_size);
+        report("symlink: other file mode unchanged",
+               (before.st_mode & 07777) == (after.st_mode & 07777));
+    }
+
+    PMIX_RELEASE(shmem);
+    unlink(seg);
+    unlink(other);
+}
+
+/* The other half of the same decision: a leftover file really does have
+ * to be reclaimed, or a reused pid leaves a server unable to create its
+ * segment. A change that simply declined whatever was already at the
+ * name would pass the test above and break this one. */
+static void test_create_reclaims_a_stale_file(void)
+{
+    char seg[512];
+    pmix_shmem_t *shmem;
+    char buf[8] = {0};
+    int fd, rc;
+
+    snprintf(seg, sizeof(seg), "%s/stale.seg", tmpbase);
+    unlink(seg);
+
+    fd = open(seg, O_CREAT | O_WRONLY | O_TRUNC, 0600);
+    if (0 > fd || 4 != write(fd, "STAL", 4)) {
+        report("stale: fixture", 0);
+        if (0 <= fd) {
+            close(fd);
+        }
+        return;
+    }
+    close(fd);
+
+    shmem = PMIX_NEW(pmix_shmem_t);
+    if (NULL == shmem) {
+        report("stale: fixture", 0);
+        return;
+    }
+    rc = pmix_shmem_segment_create(shmem, 4096, seg, 1);
+    report("stale: leftover file reclaimed", PMIX_SUCCESS == rc);
+
+    /* and its bytes are gone rather than left under the new segment -
+     * gds/shmem3's allocator hands out storage it never writes, on the
+     * strength of a fresh segment reading as zero */
+    fd = open(seg, O_RDONLY);
+    if (0 > fd || 4 != read(fd, buf, 4)) {
+        report("stale: leftover bytes replaced", 0);
+    } else {
+        report("stale: leftover bytes replaced", 0 != memcmp(buf, "STAL", 4));
+    }
+    if (0 <= fd) {
+        close(fd);
+    }
+
+    PMIX_RELEASE(shmem);
+    unlink(seg);
+}
+
+/* pmix_shmem_segment_chmod() is a public entry point of its own, and
+ * gds/shmem3 calls it (through shmem3_segment_fix_perms) separately from
+ * the create - so it has to make the same decision on its own account
+ * rather than relying on the create having already settled it. chmod(2)
+ * follows a symlink at the last component; its neighbour lchown(2) does
+ * not, so the two acted on different objects. Drive it directly, since a
+ * create beforehand replaces the link and leaves nothing to follow. */
+static void test_chmod_does_not_follow_a_symlink(void)
+{
+    char other[512], seg[512];
+    struct stat before, after;
+    pmix_shmem_t *shmem;
+
+    snprintf(other, sizeof(other), "%s/chmod-other", tmpbase);
+    snprintf(seg, sizeof(seg), "%s/chmod-linked.seg", tmpbase);
+
+    if (0 != make_bystander(other, &before)) {
+        report("chmod: fixture", 0);
+        return;
+    }
+    unlink(seg);
+    if (0 != symlink(other, seg)) {
+        report("chmod: fixture", 0);
+        return;
+    }
+
+    shmem = PMIX_NEW(pmix_shmem_t);
+    if (NULL == shmem) {
+        report("chmod: fixture", 0);
+        return;
+    }
+    pmix_string_copy(shmem->backing_path, seg, PMIX_PATH_MAX);
+    (void) pmix_shmem_segment_chmod(shmem, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+
+    if (0 != stat(other, &after)) {
+        report("chmod: other file still exists", 0);
+    } else {
+        report("chmod: other file mode unchanged",
+               (before.st_mode & 07777) == (after.st_mode & 07777));
+    }
+
+    PMIX_RELEASE(shmem);
+    unlink(seg);
+    unlink(other);
+}
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_shmem unit tests ===\n\n");
+
+    snprintf(tmpbase, sizeof(tmpbase), "/tmp/pmix-util-shmem-test-%u",
+             (unsigned) getpid());
+    if (0 != mkdir(tmpbase, S_IRWXU)) {
+        fprintf(stderr, "could not create %s: %s\n", tmpbase, strerror(errno));
+        return 1;
+    }
+
+    test_create_does_not_follow_a_symlink();
+    test_create_reclaims_a_stale_file();
+    test_chmod_does_not_follow_a_symlink();
+
+    rmdir(tmpbase);
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/util/util_shmem.c
+++ b/test/unit/util/util_shmem.c
@@ -218,6 +218,186 @@ static void test_chmod_does_not_follow_a_symlink(void)
     unlink(other);
 }
 
+/* attach() takes a reference on the count that lives inside the segment;
+ * detach() has to give it back. It did not - only the destructor did, and
+ * only for a handle that was still attached - so a handle that was
+ * detached explicitly left its reference standing for the life of the
+ * node. The count is what decides when the backing file goes away, so the
+ * visible consequence is a file nobody will ever remove, at a name built
+ * from a pid, and pids get reused.
+ *
+ * Assert it through the file, since the count itself is private: after
+ * the only holder detaches, the backing file must be gone. */
+static void test_detach_releases_the_reference(void)
+{
+    char seg[512];
+    pmix_shmem_t *shmem;
+    struct stat sb;
+    int rc;
+
+    snprintf(seg, sizeof(seg), "%s/refcount.seg", tmpbase);
+    unlink(seg);
+
+    shmem = PMIX_NEW(pmix_shmem_t);
+    if (NULL == shmem) {
+        report("refcount: fixture", 0);
+        return;
+    }
+    rc = pmix_shmem_segment_create(shmem, 4096, seg, 1);
+    if (PMIX_SUCCESS != rc) {
+        report("refcount: fixture", 0);
+        PMIX_RELEASE(shmem);
+        return;
+    }
+    rc = pmix_shmem_segment_attach(shmem, (uintptr_t) NULL, 0, 1);
+    report("refcount: attach", PMIX_SUCCESS == rc);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(shmem);
+        unlink(seg);
+        return;
+    }
+    /* still the only holder, so the file is still there */
+    report("refcount: file present while attached", 0 == stat(seg, &sb));
+
+    rc = pmix_shmem_segment_detach(shmem);
+    report("refcount: detach", PMIX_SUCCESS == rc);
+    report("refcount: last detach unlinks the backing file",
+           0 != stat(seg, &sb) && ENOENT == errno);
+
+    PMIX_RELEASE(shmem);
+    unlink(seg);
+}
+
+/* The internal attach that stamps a freshly created segment must NOT be
+ * counted as a holder: it is undone with the same detach, and a detach
+ * that released a reference nobody took would drive the count negative -
+ * so the first real holder to let go would find it non-zero and leave the
+ * file behind forever.
+ *
+ * A create leaves the segment unattached, so this is observable as: after
+ * create alone, one attach followed by one detach still empties it. */
+static void test_create_takes_no_reference(void)
+{
+    char seg[512];
+    pmix_shmem_t *creator, *holder;
+    struct stat sb;
+    int rc;
+
+    snprintf(seg, sizeof(seg), "%s/stamp.seg", tmpbase);
+    unlink(seg);
+
+    creator = PMIX_NEW(pmix_shmem_t);
+    holder = PMIX_NEW(pmix_shmem_t);
+    if (NULL == creator || NULL == holder) {
+        report("stamp: fixture", 0);
+        return;
+    }
+    rc = pmix_shmem_segment_create(creator, 4096, seg, 1);
+    if (PMIX_SUCCESS != rc) {
+        report("stamp: fixture", 0);
+        goto done;
+    }
+    /* a second handle on the same segment, as a peer process would have */
+    holder->size = creator->size;
+    pmix_string_copy(holder->backing_path, seg, PMIX_PATH_MAX);
+
+    rc = pmix_shmem_segment_attach(holder, (uintptr_t) NULL, 0, 1);
+    if (PMIX_SUCCESS != rc) {
+        report("stamp: fixture", 0);
+        goto done;
+    }
+    (void) pmix_shmem_segment_detach(holder);
+    report("stamp: creator's internal attach is not a reference",
+           0 != stat(seg, &sb) && ENOENT == errno);
+
+done:
+    PMIX_RELEASE(creator);
+    PMIX_RELEASE(holder);
+    unlink(seg);
+}
+
+/* A create that fails partway has to take its own backing file with it.
+ * Nothing else can: the caller is being told the create failed, and the
+ * destructor only unlinks a segment it managed to attach. Provoke the
+ * failure with a size no ftruncate() will accept.
+ *
+ * The file is also what the retry loop above reclaims, so a leftover is
+ * not fatal - it is a file in the session directory that survives the
+ * job, under a name built from a pid. */
+static void test_failed_create_leaves_no_file(void)
+{
+    char seg[512];
+    pmix_shmem_t *shmem;
+    struct stat sb;
+    int rc;
+
+    snprintf(seg, sizeof(seg), "%s/toobig.seg", tmpbase);
+    unlink(seg);
+
+    shmem = PMIX_NEW(pmix_shmem_t);
+    if (NULL == shmem) {
+        report("failed-create: fixture", 0);
+        return;
+    }
+    /* SIZE_MAX/2 rounds up to a length no filesystem will grant, and the
+     * failure lands after the file has been created. */
+    rc = pmix_shmem_segment_create(shmem, (size_t) 1 << 62, seg, 1);
+    if (PMIX_SUCCESS == rc) {
+        /* a filesystem that granted it is not a failure of the code -
+         * say so rather than asserting something we did not provoke */
+        report("failed-create: could not provoke a failure (skipped)", 1);
+        (void) pmix_shmem_segment_unlink(shmem);
+        PMIX_RELEASE(shmem);
+        unlink(seg);
+        return;
+    }
+    report("failed-create: backing file removed",
+           0 != stat(seg, &sb) && ENOENT == errno);
+
+    PMIX_RELEASE(shmem);
+    unlink(seg);
+}
+
+/* One handle maps one segment. An attach on a handle that is already
+ * attached has to be refused outright: the attach's own failure path
+ * detaches, and a detach of the last holder unlinks the backing file, so
+ * absorbing the call would let a second attach that merely failed to
+ * find an address destroy the segment the caller was already holding. */
+static void test_attach_on_attached_handle_is_refused(void)
+{
+    char seg[512];
+    pmix_shmem_t *shmem;
+    struct stat sb;
+    int rc;
+
+    snprintf(seg, sizeof(seg), "%s/reattach.seg", tmpbase);
+    unlink(seg);
+
+    shmem = PMIX_NEW(pmix_shmem_t);
+    if (NULL == shmem) {
+        report("reattach: fixture", 0);
+        return;
+    }
+    if (PMIX_SUCCESS != pmix_shmem_segment_create(shmem, 4096, seg, 1) ||
+        PMIX_SUCCESS != pmix_shmem_segment_attach(shmem, (uintptr_t) NULL, 0, 1)) {
+        report("reattach: fixture", 0);
+        PMIX_RELEASE(shmem);
+        unlink(seg);
+        return;
+    }
+    /* an address that cannot be honored, so the attach fails on its own
+     * account rather than succeeding somewhere harmless */
+    rc = pmix_shmem_segment_attach(shmem, (uintptr_t) 0x1000,
+                                   PMIX_SHMEM_MUST_MAP_AT_RADDR, 1);
+    report("reattach: refused", PMIX_SUCCESS != rc);
+    report("reattach: the held segment survives",
+           shmem->attached && NULL != shmem->hdr_address &&
+           0 == stat(seg, &sb));
+
+    PMIX_RELEASE(shmem);
+    unlink(seg);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
@@ -234,6 +414,10 @@ int main(int argc, char **argv)
     test_create_does_not_follow_a_symlink();
     test_create_reclaims_a_stale_file();
     test_chmod_does_not_follow_a_symlink();
+    test_detach_releases_the_reference();
+    test_create_takes_no_reference();
+    test_failed_create_leaves_no_file();
+    test_attach_on_attached_handle_is_refused();
 
     rmdir(tmpbase);
 

--- a/test/unit/util/util_show_help.c
+++ b/test/unit/util/util_show_help.c
@@ -25,6 +25,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
 #include <string.h>
 
 #include "pmix.h"
@@ -140,6 +142,167 @@ static void test_help_check_dups_first_call(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* pmix_help_check_dups / pmix_show_help_add_data argument screening   */
+/* ------------------------------------------------------------------ */
+
+static void test_check_dups_null_args(void)
+{
+    /* Both arguments reach strcmp() by way of match(), and the list
+     * entry built from them outlives this call - a NULL stored there is
+     * a segfault on the next lookup, not on this one. */
+    report("check_dups_null_file: refused",
+           PMIX_SUCCESS != pmix_help_check_dups(NULL, "topic"));
+    report("check_dups_null_topic: refused",
+           PMIX_SUCCESS != pmix_help_check_dups("help-cli.txt", NULL));
+}
+
+static void test_add_data_null_args(void)
+{
+    report("add_data_null_project: refused",
+           PMIX_SUCCESS != pmix_show_help_add_data(NULL, pmix_show_help_data));
+    report("add_data_null_array: refused",
+           PMIX_SUCCESS != pmix_show_help_add_data("unit-test-null", NULL));
+}
+
+/* ------------------------------------------------------------------ */
+/* The "#include" directive                                            */
+/*                                                                     */
+/* Content normally comes from the generated pmix_show_help_content.c, */
+/* but pmix_show_help_add_data() lets a caller register an array of its */
+/* own, which is the only way to drive the include parser from a test. */
+/* Nothing in the tree uses "#include" yet, so these are the cases its  */
+/* first user will write by accident.                                  */
+/* ------------------------------------------------------------------ */
+
+static const char *content_plain[] = {"the included text", NULL};
+/* well formed: pull in the topic above */
+static const char *content_good[] = {"#include#help-unit-inc.txt#plain", NULL};
+/* malformed: no fields at all after the directive */
+static const char *content_bare[] = {"#include", NULL};
+/* malformed: one field where two are needed */
+static const char *content_short[] = {"#include#help-unit-inc.txt", NULL};
+/* a topic that includes itself */
+static const char *content_loop[] = {"#include#help-unit-inc.txt#loop", NULL};
+
+static pmix_show_help_entry_t unit_entries[] = {
+    {.topic = "plain", .content = content_plain},
+    {.topic = "good", .content = content_good},
+    {.topic = "bare", .content = content_bare},
+    {.topic = "short", .content = content_short},
+    {.topic = "loop", .content = content_loop},
+    {.topic = NULL, .content = NULL}
+};
+
+static pmix_show_help_file_t unit_files[] = {
+    {.filename = "help-unit-inc.txt", .entries = unit_entries},
+    {.filename = NULL, .entries = NULL}
+};
+
+static void test_include(void)
+{
+    char *s;
+    pmix_status_t rc;
+
+    rc = pmix_show_help_add_data("unit-test", unit_files);
+    if (PMIX_SUCCESS != rc) {
+        report("include: registering the test array (skipped)", 1);
+        return;
+    }
+
+    s = pmix_show_help_string("help-unit-inc.txt", "good", 0);
+    report("include_good: pulls in the included text",
+           NULL != s && NULL != strstr(s, "the included text"));
+    free(s);
+
+    /* A directive the parser cannot read must be skipped, not followed
+     * off the end of the string it is walking backwards through. */
+    s = pmix_show_help_string("help-unit-inc.txt", "bare", 0);
+    report("include_bare: survives a directive with no fields", 1);
+    free(s);
+
+    s = pmix_show_help_string("help-unit-inc.txt", "short", 0);
+    report("include_short: survives a directive missing a field", 1);
+    free(s);
+
+    /* Self-reference: without a depth bound this recurses until the
+     * stack runs out. */
+    s = pmix_show_help_string("help-unit-inc.txt", "loop", 0);
+    report("include_loop: a topic that includes itself terminates", 1);
+    free(s);
+}
+
+/* ------------------------------------------------------------------ */
+/* Duplicates held back are still shown at finalize                    */
+/*                                                                     */
+/* pmix_help_check_dups() promises that accumulated duplicates are     */
+/* displayed unconditionally at termination.  The aggregation timer    */
+/* runs five seconds out, so a job that ends sooner - which is most of */
+/* them - only ever sees them if finalize flushes.  This has to run in */
+/* a child of its own: it needs a whole init/finalize cycle with       */
+/* stderr on a pipe, since the notice goes out directly once the       */
+/* progress thread has been paused.                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_duplicates_flushed_at_finalize(void)
+{
+    int fds[2];
+    pid_t pid;
+    int status = 0;
+    char buf[4096];
+    ssize_t n;
+    size_t total = 0;
+
+    if (0 != pipe(fds)) {
+        report("finalize_flush: pipe (skipped)", 1);
+        return;
+    }
+    pid = fork();
+    if (0 > pid) {
+        close(fds[0]);
+        close(fds[1]);
+        report("finalize_flush: fork (skipped)", 1);
+        return;
+    }
+    if (0 == pid) {
+        pmix_proc_t me;
+        pmix_status_t rc;
+        close(fds[0]);
+        if (0 > dup2(fds[1], fileno(stderr))) {
+            _exit(2);
+        }
+        close(fds[1]);
+        rc = PMIx_Init(&me, NULL, 0);
+        if (PMIX_SUCCESS != rc && PMIX_ERR_UNREACH != rc) {
+            _exit(2);   /* nothing to say about a library that never came up */
+        }
+        /* first sighting, then a duplicate that gets counted and held */
+        (void) pmix_help_check_dups("help-cli.txt", "finalize-flush-topic");
+        (void) pmix_help_check_dups("help-cli.txt", "finalize-flush-topic");
+        PMIx_Finalize(NULL, 0);
+        _exit(0);
+    }
+
+    close(fds[1]);
+    while (total < sizeof(buf) - 1) {
+        n = read(fds[0], buf + total, sizeof(buf) - 1 - total);
+        if (0 >= n) {
+            break;
+        }
+        total += (size_t) n;
+    }
+    buf[total] = '\0';
+    close(fds[0]);
+    waitpid(pid, &status, 0);
+
+    if (WIFEXITED(status) && 2 == WEXITSTATUS(status)) {
+        report("finalize_flush: child setup (skipped)", 1);
+        return;
+    }
+    report("finalize_flush: the held-back duplicate is reported",
+           NULL != strstr(buf, "sent help message"));
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(int argc, char **argv)
 {
@@ -147,13 +310,18 @@ int main(int argc, char **argv)
     pmix_status_t rc;
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
+    fprintf(stdout, "\n=== pmix_show_help unit tests ===\n\n");
+
+    /* Before our own PMIx_Init: this one needs a whole init/finalize
+     * cycle of its own, and a child forked from an already-initialized
+     * process would only be adjusting a reference count. */
+    test_duplicates_flushed_at_finalize();
+
     rc = PMIx_Init(&myproc, NULL, 0);
     if (PMIX_SUCCESS != rc && PMIX_ERR_UNREACH != rc) {
         fprintf(stderr, "PMIx_Init: %s\n", PMIx_Error_string(rc));
         return 1;
     }
-
-    fprintf(stdout, "\n=== pmix_show_help unit tests ===\n\n");
 
     test_show_help_init_idempotent();
     test_show_help_enabled();
@@ -163,6 +331,9 @@ int main(int argc, char **argv)
     test_show_help_string_null_args();
     test_show_help_norender();
     test_help_check_dups_first_call();
+    test_check_dups_null_args();
+    test_add_data_null_args();
+    test_include();
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
 

--- a/test/unit/util/util_show_help.c
+++ b/test/unit/util/util_show_help.c
@@ -96,6 +96,22 @@ static void test_show_help_string_unknown_topic(void)
     report("show_help_string_unknown_topic: returns NULL", s == NULL);
 }
 
+static void test_show_help_string_null_args(void)
+{
+    /* No file or no topic names nothing, so the answer is the same as any
+     * other lookup that finds nothing. Both arguments used to reach
+     * strcmp() unscreened - which is a crash, not a NULL, and it is
+     * reachable from pmix_cmd_line_parse() whenever a tool passes a NULL
+     * helpfile and the user asks for help. These die on a signal, not with
+     * a failed assertion, if that comes back. */
+    char *s = pmix_show_help_string(NULL, "usage", 0);
+    report("show_help_string_null_file: returns NULL", s == NULL);
+    s = pmix_show_help_string("help-cli.txt", NULL, 0);
+    report("show_help_string_null_topic: returns NULL", s == NULL);
+    s = pmix_show_help_string(NULL, NULL, 0);
+    report("show_help_string_null_both: returns NULL", s == NULL);
+}
+
 /* ------------------------------------------------------------------ */
 /* pmix_show_help_norender                                             */
 /* ------------------------------------------------------------------ */
@@ -144,6 +160,7 @@ int main(int argc, char **argv)
     test_show_help_string_known_topic();
     test_show_help_string_unknown_file();
     test_show_help_string_unknown_topic();
+    test_show_help_string_null_args();
     test_show_help_norender();
     test_help_check_dups_first_call();
 

--- a/test/unit/util/util_timings.c
+++ b/test/unit/util/util_timings.c
@@ -6,16 +6,15 @@
  *
  * $HEADER$
  *
- * Unit tests for pmix_timings utility.
+ * Unit tests for src/util/pmix_timings.c.
  *
- * PMIX_ENABLE_TIMING is 0 in this build, so all PMIX_TIMING_* macros
- * expand to no-ops.  The tests verify:
- *   - PMIX_ENABLE_TIMING == 0
- *   - the no-op macros compile cleanly and have no runtime effect
- *   - the conditional full-path code (guarded by #if PMIX_ENABLE_TIMING)
- *     is kept here for reference but not compiled in this build.
- *
- * No PMIx_Init required; no library functions are exercised at runtime.
+ * The whole subsystem is behind --enable-pmix-timing, so which half of
+ * this file runs is a build-time decision. Both halves assert behavior
+ * rather than the setting: with timing off, the macros must expand to
+ * nothing and do nothing; with it on, a handler must be able to be
+ * driven through the documented macros and reported on without taking
+ * the process down. Asserting the setting itself - which this file used
+ * to do - makes the test fail in the configuration it exists to cover.
  *
  * Exit 0 if all tests pass, 1 otherwise.
  */
@@ -25,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "pmix.h"
 #include "src/util/pmix_timings.h"
@@ -44,47 +44,199 @@ static void report(const char *name, int passed)
 }
 
 /* ------------------------------------------------------------------ */
-/* PMIX_ENABLE_TIMING constant                                         */
+/* The macros, in whichever form this build compiled them              */
 /* ------------------------------------------------------------------ */
 
-static void test_timing_disabled(void)
+PMIX_TIMING_DECLARE(macro_handle)
+
+static void test_timing_macros(void)
 {
-    report("PMIX_ENABLE_TIMING is zero", 0 == PMIX_ENABLE_TIMING);
+    /* Every macro has to compile and be callable in both arms. With
+     * timing off they expand to nothing; with it on they drive the real
+     * handler declared above. Either way, running them must not crash. */
+    PMIX_TIMING_INIT(&macro_handle);
+    PMIX_TIMING_EVENT((&macro_handle, "a trace event"));
+    PMIX_TIMING_MSTART((&macro_handle, "an interval"));
+    PMIX_TIMING_MSTOP(&macro_handle);
+    PMIX_TIMING_RELEASE(&macro_handle);
+    report("macros: declare/init/event/mstart/mstop/release", 1);
 }
 
 /* ------------------------------------------------------------------ */
-/* No-op macro smoke tests                                             */
-/* ------------------------------------------------------------------ */
-
-static void test_timing_macros_noop(void)
-{
-    /* All macros must compile to nothing when PMIX_ENABLE_TIMING == 0.
-     * PMIX_TIMING_RELEASE(NULL) is the one macro safe to call directly
-     * because NULL is a valid handle when timing is disabled. */
-    PMIX_TIMING_RELEASE(NULL);
-    report("PMIX_TIMING_RELEASE(NULL): no-op, no crash", 1);
-}
-
-/* ------------------------------------------------------------------ */
-/* Conditional full-path test (compiled only when timing is enabled)  */
+/* The enabled arm                                                     */
 /* ------------------------------------------------------------------ */
 
 #if PMIX_ENABLE_TIMING
-static void test_timing_full_path(void)
+
+/* Read a file back, so the assertions can be about what was written
+ * rather than about a return code. */
+static char *slurp(const char *path)
 {
+    long len;
+    char *buf;
+    FILE *fp = fopen(path, "r");
+
+    if (NULL == fp) {
+        return NULL;
+    }
+    if (0 != fseek(fp, 0, SEEK_END) || 0 > (len = ftell(fp))) {
+        fclose(fp);
+        return NULL;
+    }
+    rewind(fp);
+    buf = calloc((size_t) len + 1, 1);
+    if (NULL != buf && 0 < len) {
+        if (1 != fread(buf, (size_t) len, 1, fp)) {
+            free(buf);
+            buf = NULL;
+        }
+    }
+    fclose(fp);
+    return buf;
+}
+
+/* An ordinary report has to name the node and the job. Both come out of
+ * file-statics, and the node name was one that nothing ever assigned -
+ * so every line named the node "(null)", and gcc, seeing the constant
+ * NULL, refused to compile the file at all. */
+static void test_report_names_the_node(void)
+{
+    char path[512];
     pmix_timing_t t;
-    pmix_timing_prep_t p;
-    int id;
+    char *out;
+
+    snprintf(path, sizeof(path), "/tmp/pmix-util-timings-%u-report.txt",
+             (unsigned) getpid());
+    unlink(path);
+
+    pmix_init_id("myspace", 3);
+    pmix_timing_init(&t);
+    PMIX_TIMING_EVENT((&t, "a trace event"));
+    report("report: writes a file", PMIX_SUCCESS == pmix_timing_report(&t, path));
+
+    out = slurp(path);
+    if (NULL == out) {
+        report("report: file readable", 0);
+    } else {
+        report("report: node name is not (null)", NULL == strstr(out, "(null)"));
+        report("report: carries the job id", NULL != strstr(out, "myspace:3"));
+        report("report: carries the description", NULL != strstr(out, "a trace event"));
+        free(out);
+    }
+    pmix_timing_release(&t);
+    unlink(path);
+}
+
+/* pmix_init_id() replaces the string it holds, so calling it twice has
+ * to release the first rather than leak it - and a second call must be
+ * the one that shows up in the output. */
+static void test_init_id_replaces(void)
+{
+    char path[512];
+    pmix_timing_t t;
+    char *out;
+
+    snprintf(path, sizeof(path), "/tmp/pmix-util-timings-%u-id.txt",
+             (unsigned) getpid());
+    unlink(path);
+
+    pmix_init_id("first", 1);
+    pmix_init_id("second", 2);
+    pmix_timing_init(&t);
+    PMIX_TIMING_EVENT((&t, "e"));
+    (void) pmix_timing_report(&t, path);
+
+    out = slurp(path);
+    if (NULL == out) {
+        report("init_id: file readable", 0);
+    } else {
+        report("init_id: latest id is the one reported",
+               NULL != strstr(out, "second:2") && NULL == strstr(out, "first:1"));
+        free(out);
+    }
+    pmix_timing_release(&t);
+    unlink(path);
+}
+
+/* A stop with no measurement running records an interval id of -1 -
+ * pmix_timing_end() copies current_id, which is -1 when nothing was
+ * started. Both consumers index the descriptor array by that id, and
+ * only pmix_timing_deltas() screened for a negative one, so a report
+ * read descr[-1] and printed whatever it found there. */
+static void test_unmatched_stop_is_survivable(void)
+{
+    char path[512];
+    pmix_timing_t t;
+
+    snprintf(path, sizeof(path), "/tmp/pmix-util-timings-%u-unmatched.txt",
+             (unsigned) getpid());
+    unlink(path);
 
     pmix_timing_init(&t);
-    p = pmix_timing_prep_ev(&t, "step %d", 1);
-    pmix_timing_add_step(p, __func__, __FILE__, __LINE__);
-    id = pmix_timing_descr(pmix_timing_prep_ev(&t, "interval"),
-                           __func__, __FILE__, __LINE__);
-    pmix_timing_start_id(&t, id, __func__, __FILE__, __LINE__);
-    pmix_timing_end(&t, id, __func__, __FILE__, __LINE__);
+    /* no MSTART, and no interval was ever described, so next_id_cntr is
+     * zero and the descriptor array is not even allocated */
+    PMIX_TIMING_MSTOP(&t);
+    report("unmatched stop: report survives it",
+           PMIX_SUCCESS == pmix_timing_report(&t, path));
+    report("unmatched stop: deltas survives it",
+           PMIX_SUCCESS == pmix_timing_deltas(&t, path));
     pmix_timing_release(&t);
-    report("timing_full_path: init/add_step/descr/start/end/release", 1);
+    unlink(path);
+}
+
+/* And the ordinary interval case, which is what deltas exists for. */
+static void test_deltas_reports_an_interval(void)
+{
+    char path[512];
+    pmix_timing_t t;
+    char *out;
+
+    snprintf(path, sizeof(path), "/tmp/pmix-util-timings-%u-deltas.txt",
+             (unsigned) getpid());
+    unlink(path);
+
+    pmix_timing_init(&t);
+    PMIX_TIMING_MSTART((&t, "measured interval"));
+    PMIX_TIMING_MSTOP(&t);
+    report("deltas: writes a file", PMIX_SUCCESS == pmix_timing_deltas(&t, path));
+
+    out = slurp(path);
+    if (NULL == out) {
+        report("deltas: file readable", 0);
+    } else {
+        report("deltas: carries the interval description",
+               NULL != strstr(out, "measured interval"));
+        report("deltas: marks it as an overhead line",
+               NULL != strstr(out, "[PMIX_OVHD]"));
+        report("deltas: node name is not (null)", NULL == strstr(out, "(null)"));
+        free(out);
+    }
+    pmix_timing_release(&t);
+    unlink(path);
+}
+
+/* PMIX_TIMING_REPORT and PMIX_TIMING_DELTAS expand to a use of
+ * pmix_timing_output, and the overhead accounting is switched by
+ * pmix_timing_overhead. Both were declared only in
+ * src/runtime/pmix_rte.h, which is not installed - so those two macros
+ * did not compile for anyone outside this tree.
+ *
+ * This case is a COMPILE-time assertion wearing a runtime disguise: what
+ * it pins is that the two names are reachable from a translation unit
+ * that includes nothing but the installed pmix_timings.h. Move the
+ * declarations back and this file stops building. (The matching runtime
+ * defect - a file-static pmix_timing_overhead inside pmix_timings.c that
+ * shadowed the registered one, leaving the parameter inert - is now
+ * prevented by the compiler instead: a static definition following the
+ * header's extern declaration is an error.) */
+static void test_installed_header_declares_its_parameters(void)
+{
+    const bool saved_overhead = pmix_timing_overhead;
+    char *const saved_output = pmix_timing_output;
+
+    report("header: declares the parameters its macros use",
+           saved_overhead == pmix_timing_overhead &&
+           saved_output == pmix_timing_output);
 }
 #endif
 
@@ -96,10 +248,16 @@ int main(int argc, char **argv)
 
     fprintf(stdout, "\n=== pmix_timings unit tests ===\n\n");
 
-    test_timing_disabled();
-    test_timing_macros_noop();
+    test_timing_macros();
 #if PMIX_ENABLE_TIMING
-    test_timing_full_path();
+    test_report_names_the_node();
+    test_init_id_replaces();
+    test_unmatched_stop_is_survivable();
+    test_deltas_reports_an_interval();
+    test_installed_header_declares_its_parameters();
+#else
+    fprintf(stdout, "  (built without --enable-pmix-timing; the timing "
+                    "subsystem itself is not compiled)\n");
 #endif
 
     fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);

--- a/test/unit/util/util_tty.c
+++ b/test/unit/util/util_tty.c
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Unit tests for the pmix_tty helpers.
+ *
+ * These are thin wrappers over tcgetattr/tcsetattr and the winsize
+ * ioctls, so the round-trip cases below are cheap.  The case worth the
+ * setup is the one that does not appear in a round trip at all: a
+ * caller that is told a terminal is in raw mode when it is not will
+ * read line-buffered, echoed input forever, and nothing about the
+ * descriptor it holds says so.  pmix_settermios() therefore has to
+ * report a set it could not make.
+ *
+ * Making tcsetattr() fail on demand is the hard part.  POSIX gives one
+ * portable lever: tcsetattr() on a process's *controlling* terminal
+ * from a process group that is both in the background and orphaned
+ * fails with EIO, and no SIGTTOU is delivered.  Building that position
+ * takes three processes - a session leader that acquires the pty as its
+ * controlling terminal, a child that moves itself into its own process
+ * group, and a grandchild that is left orphaned when that child exits.
+ * The session leader has to stay alive throughout: when the controlling
+ * process dies the terminal is disassociated from the session and, on
+ * BSD-derived systems, the slave is revoked out from under the probe.
+ *
+ * The probe validates its own lever - it calls tcsetattr() directly
+ * first and skips if that succeeded - so a platform that does not
+ * implement the rule reports a skip rather than a spurious failure.
+ *
+ * Exit 0 if all tests pass, 1 otherwise.
+ */
+
+#include "src/include/pmix_config.h"
+#include "src/include/pmix_globals.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include "src/util/pmix_pty.h"
+#include "src/util/pmix_tty.h"
+
+static int npass = 0;
+static int nfail = 0;
+
+static void report(const char *name, int passed)
+{
+    if (passed) {
+        fprintf(stdout, "  PASS: %s\n", name);
+        npass++;
+    } else {
+        fprintf(stdout, "  FAIL: %s\n", name);
+        nfail++;
+    }
+}
+
+#if PMIX_ENABLE_PTY_SUPPORT
+
+/* Verdicts the orphaned-process-group probe hands back.  They are exit
+ * codes, so they have to be small and must not collide with the shell's
+ * signal encoding. */
+#define PROBE_REPORTED  0  /* pmix_settermios reported the failure */
+#define PROBE_SILENT    1  /* it claimed success - the defect */
+#define PROBE_SKIP      2  /* tcsetattr succeeded; lever unavailable */
+#define PROBE_SETUP     3  /* could not build the position at all */
+
+static int open_pty(int *master, int *slave)
+{
+    return pmix_openpty(master, slave, NULL, NULL, NULL);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_gettermios(void)
+{
+    struct termios t;
+    int master, slave, devnull;
+
+    if (0 != open_pty(&master, &slave)) {
+        report("gettermios: pty setup (skipped)", 1);
+        return;
+    }
+    report("gettermios: reads a terminal's settings",
+           PMIX_SUCCESS == pmix_gettermios(slave, &t));
+    close(slave);
+    close(master);
+
+    devnull = open("/dev/null", O_RDWR);
+    if (0 <= devnull) {
+        report("gettermios: refuses a descriptor that is not a terminal",
+               PMIX_SUCCESS != pmix_gettermios(devnull, &t));
+        report("settermios: refuses a descriptor that is not a terminal",
+               PMIX_SUCCESS != pmix_settermios(devnull, &t));
+        close(devnull);
+    }
+}
+
+static void test_winsize(void)
+{
+    struct winsize ws, back;
+    int master, slave;
+
+    if (0 != open_pty(&master, &slave)) {
+        report("winsize: pty setup (skipped)", 1);
+        return;
+    }
+
+    memset(&ws, 0, sizeof(ws));
+    ws.ws_row = 41;
+    ws.ws_col = 137;
+    report("setwinsz: sets a window size",
+           PMIX_SUCCESS == pmix_setwinsz(slave, &ws));
+
+    memset(&back, 0, sizeof(back));
+    report("getwinsz: reads a window size",
+           PMIX_SUCCESS == pmix_getwinsz(slave, &back));
+    report("getwinsz: reads back what setwinsz wrote",
+           41 == back.ws_row && 137 == back.ws_col);
+
+    close(slave);
+    close(master);
+}
+
+static void test_setraw(void)
+{
+    struct termios before, prior, now;
+    int master, slave;
+
+    if (0 != open_pty(&master, &slave)) {
+        report("setraw: pty setup (skipped)", 1);
+        return;
+    }
+    if (PMIX_SUCCESS != pmix_gettermios(slave, &before)) {
+        report("setraw: pty setup (skipped)", 1);
+        close(slave);
+        close(master);
+        return;
+    }
+
+    memset(&prior, 0, sizeof(prior));
+    report("setraw: succeeds on a terminal",
+           PMIX_SUCCESS == pmix_setraw(slave, &prior));
+    report("setraw: hands back the settings it replaced",
+           prior.c_iflag == before.c_iflag && prior.c_oflag == before.c_oflag
+               && prior.c_cflag == before.c_cflag
+               && prior.c_lflag == before.c_lflag);
+
+    if (PMIX_SUCCESS == pmix_gettermios(slave, &now)) {
+        report("setraw: turns off canonical mode, echo, signals and extensions",
+               0 == (now.c_lflag & (ICANON | ISIG | IEXTEN | ECHO)));
+        report("setraw: turns off input and output post-processing",
+               0 == (now.c_iflag & (BRKINT | ICRNL | IGNBRK | IGNCR | INLCR
+                                    | INPCK | ISTRIP | IXON | PARMRK))
+                   && 0 == (now.c_oflag & OPOST));
+        report("setraw: asks for character-at-a-time blocking input",
+               1 == now.c_cc[VMIN] && 0 == now.c_cc[VTIME]);
+    } else {
+        report("setraw: read back the raw settings", 0);
+    }
+
+    /* a NULL 'prior' is documented as "do not tell me what I replaced" */
+    report("setraw: accepts a NULL prior", PMIX_SUCCESS == pmix_setraw(slave, NULL));
+
+    /* and the settings setraw handed back must put the terminal back */
+    report("settermios: restores the settings setraw saved",
+           PMIX_SUCCESS == pmix_settermios(slave, &prior));
+    if (PMIX_SUCCESS == pmix_gettermios(slave, &now)) {
+        /* compare the settings, not the whole field: re-enabling
+         * canonical mode makes the driver raise its own status bits in
+         * c_lflag (PENDIN on macOS), which nobody asked for */
+        report("settermios: the restore actually took",
+               (now.c_lflag & (ICANON | ISIG | IEXTEN | ECHO))
+                       == (before.c_lflag & (ICANON | ISIG | IEXTEN | ECHO))
+                   && now.c_iflag == before.c_iflag
+                   && now.c_oflag == before.c_oflag);
+    } else {
+        report("settermios: read back the restored settings", 0);
+    }
+
+    close(slave);
+    close(master);
+}
+
+/* ------------------------------------------------------------------ */
+
+/* Runs in the grandchild: a background, orphaned process group whose
+ * controlling terminal is 'slave'.  Writes one verdict byte to 'wfd'. */
+static void orphan_probe(int slave, int wfd)
+{
+    struct termios t, want;
+    pid_t was = getppid();
+    char verdict;
+    int i;
+
+    /* wait to be reparented - the process group is not orphaned until
+     * the intermediate child is gone */
+    for (i = 0; i < 5000 && getppid() == was; i++) {
+        usleep(1000);
+    }
+
+    if (0 != tcgetattr(slave, &t)) {
+        verdict = PROBE_SETUP;
+        goto done;
+    }
+    want = t;
+    want.c_lflag &= ~ECHO;
+
+    /* validate the lever before trusting the result */
+    if (0 == tcsetattr(slave, TCSANOW, &want)) {
+        verdict = PROBE_SKIP;
+        goto done;
+    }
+
+    if (PMIX_SUCCESS == pmix_settermios(slave, &want)) {
+        verdict = PROBE_SILENT;
+    } else {
+        verdict = PROBE_REPORTED;
+    }
+
+done:
+    if (1 != write(wfd, &verdict, 1)) {
+        _exit(PROBE_SETUP);
+    }
+    _exit(0);
+}
+
+static int run_orphan_probe(void)
+{
+    int pfd[2], master, slave;
+    pid_t leader;
+    int status = 0;
+
+    if (0 != pipe(pfd)) {
+        return PROBE_SETUP;
+    }
+
+    leader = fork();
+    if (0 > leader) {
+        close(pfd[0]);
+        close(pfd[1]);
+        return PROBE_SETUP;
+    }
+
+    if (0 == leader) {
+        pid_t mid;
+        char verdict = PROBE_SETUP;
+
+        /* nothing here should block, but a wait that did would wedge
+         * make check rather than fail it */
+        alarm(30);
+        if (0 > setsid()) {
+            _exit(PROBE_SETUP);
+        }
+        if (0 != pmix_openpty(&master, &slave, NULL, NULL, NULL)) {
+            _exit(PROBE_SETUP);
+        }
+        /* pmix_openpty deliberately opens with O_NOCTTY, so ask for the
+         * controlling terminal explicitly - the background-process-group
+         * rules only apply to it */
+        if (0 != ioctl(slave, TIOCSCTTY, 0)) {
+            _exit(PROBE_SETUP);
+        }
+        mid = fork();
+        if (0 > mid) {
+            _exit(PROBE_SETUP);
+        }
+        if (0 == mid) {
+            if (0 > setpgid(0, 0)) {
+                _exit(PROBE_SETUP);
+            }
+            if (0 == fork()) {
+                orphan_probe(slave, pfd[1]);
+            }
+            /* exiting here is what orphans the probe's process group */
+            _exit(0);
+        }
+        waitpid(mid, NULL, 0);
+        close(pfd[1]);
+        if (1 != read(pfd[0], &verdict, 1)) {
+            _exit(PROBE_SETUP);
+        }
+        /* stay alive until the verdict is in: killing the controlling
+         * process disassociates the terminal and, on BSD, revokes the
+         * slave the probe is holding */
+        _exit((int) verdict);
+    }
+
+    close(pfd[0]);
+    close(pfd[1]);
+    if (0 > waitpid(leader, &status, 0)) {
+        return PROBE_SETUP;
+    }
+    if (!WIFEXITED(status)) {
+        return PROBE_SETUP;
+    }
+    return WEXITSTATUS(status);
+}
+
+static void test_reports_a_set_it_could_not_make(void)
+{
+    int rc = run_orphan_probe();
+
+    if (PROBE_SETUP == rc || PROBE_SKIP == rc) {
+        report("settermios: reports a set the terminal refused (skipped)", 1);
+        return;
+    }
+    report("settermios: reports a set the terminal refused",
+           PROBE_REPORTED == rc);
+}
+
+#endif /* PMIX_ENABLE_PTY_SUPPORT */
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char **argv)
+{
+    PMIX_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stdout, "\n=== pmix_tty unit tests ===\n\n");
+
+#if PMIX_ENABLE_PTY_SUPPORT
+    test_gettermios();
+    test_winsize();
+    test_setraw();
+    test_reports_a_set_it_could_not_make();
+#else
+    fprintf(stdout, "  (PMIX_ENABLE_PTY_SUPPORT is 0: no pty to test against)\n");
+#endif
+
+    fprintf(stdout, "\nResults: %d passed, %d failed\n\n", npass, nfail);
+    return (nfail > 0) ? 1 : 0;
+}

--- a/test/unit/util/util_vmem.c
+++ b/test/unit/util/util_vmem.c
@@ -32,9 +32,13 @@
  * and non-PIE executables. Neither is reachable from a test suite, but
  * the function underneath is, and it is decidable there. Hence this.
  *
- * SKIPS rather than fails where there is no /proc/self/maps to scan (any
- * non-Linux host, which is also where gds/shmem3 - the only caller - is
- * not built).
+ * The cases that need this process's own map SKIP rather than fail where
+ * there is no /proc/self/maps to scan (any non-Linux host, which is also
+ * where gds/shmem3 - the only caller - is not built). The scan itself is
+ * held against maps written by the test, through
+ * pmix_vmem_find_hole_in_map(), and those cases run everywhere: what the
+ * scan has to get right is a property of the map it is handed, and a
+ * live /proc/self/maps is neither reproducible nor steerable.
  *
  * Exit 0 if all tests pass, 1 otherwise.
  */
@@ -46,7 +50,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
+#include "src/util/pmix_string_copy.h"
 #include "src/util/pmix_vmem.h"
 
 #define ALIGN64MB (64 * 1024 * 1024UL)
@@ -228,19 +234,305 @@ static void test_reserve_rejects_nonsense(void)
     report("release of an empty range is harmless", 1);
 }
 
+
+/* ------------------------------------------------------------------ */
+/* Scanning a map we wrote ourselves.                                  */
+
+/* A synthetic /proc/self/maps.  The columns after the address range are
+ * what the kernel prints and what the parser skips past; only the range
+ * and the trailing name matter here. */
+#define MAP_COLS "r-xp 00000000 08:02 1234567 "
+
+static char mapdir[256];
+
+static const char *write_map(const char *name, const char *contents)
+{
+    static char path[512];
+    FILE *f;
+
+    snprintf(path, sizeof(path), "%s/%s", mapdir, name);
+    f = fopen(path, "w");
+    if (NULL == f) {
+        return NULL;
+    }
+    fputs(contents, f);
+    fclose(f);
+    return path;
+}
+
+static bool scan(const char *path, pmix_vmem_hole_kind_t hkind, size_t size,
+                 size_t *addr)
+{
+    *addr = 0;
+    return PMIX_SUCCESS == pmix_vmem_find_hole_in_map(
+        path, hkind, 0, false, addr, size);
+}
+
+static void test_biggest_gap(void)
+{
+    /* Three mappings, two gaps: 0x1000_0000 and 0x8000_0000.  The
+     * placement rule aims for the middle of the winner, so the answer
+     * has to land inside the second gap and nowhere else. */
+    const char *path = write_map("plain",
+        "10000000-20000000 " MAP_COLS "/lib/one.so\n"
+        "30000000-40000000 " MAP_COLS "/lib/two.so\n"
+        "c0000000-d0000000 " MAP_COLS "/lib/three.so\n");
+    size_t addr = 0;
+
+    if (NULL == path) {
+        report("biggest: wrote a map (skipped)", 1);
+        return;
+    }
+    if (!scan(path, VMEM_HOLE_BIGGEST, 0x1000000UL, &addr)) {
+        report("biggest: finds the larger of two gaps", 0);
+        return;
+    }
+    report("biggest: finds the larger of two gaps",
+           0x40000000UL <= addr && addr + 0x1000000UL <= 0xc0000000UL);
+}
+
+static void test_tagged_entry_does_not_swallow_the_next(void)
+{
+    /* [vdso] is neither [heap] nor [stack], so it takes the parser's
+     * "some other tag" arm.  That arm used to truncate the line at its
+     * newline, which made the scan read the NEXT entry as the tail of
+     * this one and never account for it - so the gap after [vdso] was
+     * measured to the entry after the one that was swallowed, and
+     * covered a range that is mapped.
+     *
+     * Here the swallowed entry is the 0x40000000-0xb0000000 library.
+     * Against the old code the biggest gap is 0x20001000-0xc0000000,
+     * whose midpoint sits squarely inside it. */
+    const char *path = write_map("tagged",
+        "10000000-20000000 " MAP_COLS "/lib/one.so\n"
+        "20000000-20001000 " MAP_COLS "[vdso]\n"
+        "40000000-b0000000 " MAP_COLS "/lib/big.so\n"
+        "c0000000-d0000000 " MAP_COLS "/lib/three.so\n");
+    size_t addr = 0;
+
+    if (NULL == path) {
+        report("tagged: wrote a map (skipped)", 1);
+        return;
+    }
+    if (!scan(path, VMEM_HOLE_BIGGEST, 0x1000000UL, &addr)) {
+        report("tagged: an entry after a tagged one is still accounted for", 0);
+        return;
+    }
+    report("tagged: an entry after a tagged one is still accounted for",
+           addr + 0x1000000UL <= 0x40000000UL
+               || 0xb0000000UL <= addr);
+}
+
+static void test_unparseable_entry_does_not_reach_back_to_zero(void)
+{
+    /* A line the parser cannot read tells us nothing about what is
+     * mapped.  Carrying its zeroed end forward as "the previous entry
+     * ended here" puts the next gap's start at address 0, and the hole
+     * that manufactures spans everything below the following entry -
+     * mappings included.
+     *
+     * The geometry matters, or the case proves nothing.  The bogus hole
+     * has to WIN, and the midpoint the placement rule then aims for has
+     * to land inside a range this map says is occupied.  Here the bogus
+     * hole is [0, 0x70000000), whose 64MB-aligned midpoint is
+     * 0x3c000000 - inside one.so.  With the entry skipped properly the
+     * winner is [0, 0x30000000) and the answer is 0x1c000000, which is
+     * free. */
+    const char *path = write_map("garbage",
+        "30000000-40000000 " MAP_COLS "/lib/one.so\n"
+        "not a map line at all\n"
+        "70000000-71000000 " MAP_COLS "/lib/two.so\n");
+    const size_t want = 0x1000000UL;
+    size_t addr = 0;
+
+    if (NULL == path) {
+        report("garbage: wrote a map (skipped)", 1);
+        return;
+    }
+    if (!scan(path, VMEM_HOLE_BIGGEST, want, &addr)) {
+        report("garbage: an unreadable entry does not manufacture a hole at 0",
+               0);
+        return;
+    }
+    report("garbage: an unreadable entry does not manufacture a hole at 0",
+           addr + want <= 0x30000000UL
+               || (0x40000000UL <= addr && addr + want <= 0x70000000UL)
+               || 0x71000000UL <= addr);
+}
+
+static void test_long_entry_is_one_entry(void)
+{
+    /* An entry longer than the scan's 96-byte read buffer arrives in
+     * pieces; the remainder must be drained rather than parsed as an
+     * entry of its own.  The long name here is what a deeply nested
+     * install prefix looks like. */
+    const char *path = write_map("longline",
+        "10000000-20000000 " MAP_COLS
+        "/a-very-long-directory-name/that-keeps-going/and-going/and-going"
+        "/and-going/and-going/and-going/libsomething.so.1.2.3\n"
+        "c0000000-d0000000 " MAP_COLS "/lib/three.so\n");
+    size_t addr = 0;
+
+    if (NULL == path) {
+        report("long: wrote a map (skipped)", 1);
+        return;
+    }
+    if (!scan(path, VMEM_HOLE_BIGGEST, 0x1000000UL, &addr)) {
+        report("long: an over-long entry is still one entry", 0);
+        return;
+    }
+    report("long: an over-long entry is still one entry",
+           0x20000000UL <= addr && addr + 0x1000000UL <= 0xc0000000UL);
+}
+
+static void test_heap_and_stack_bound_the_search(void)
+{
+    const char *path = write_map("heapstack",
+        "10000000-20000000 " MAP_COLS "/bin/prog\n"
+        "20000000-21000000 " MAP_COLS "[heap]\n"
+        "40000000-41000000 " MAP_COLS "/lib/one.so\n"
+        "50000000-51000000 " MAP_COLS "[stack]\n"
+        "60000000-70000000 " MAP_COLS "[vsyscall]\n");
+    size_t addr = 0;
+
+    if (NULL == path) {
+        report("heap/stack: wrote a map (skipped)", 1);
+        return;
+    }
+
+    if (scan(path, VMEM_HOLE_AFTER_HEAP, 0x1000000UL, &addr)) {
+        report("after-heap: places in the gap that follows the heap",
+               0x21000000UL <= addr && addr + 0x1000000UL <= 0x40000000UL);
+    } else {
+        report("after-heap: places in the gap that follows the heap", 0);
+    }
+
+    if (scan(path, VMEM_HOLE_BEFORE_STACK, 0x1000000UL, &addr)) {
+        report("before-stack: places in the gap that precedes the stack",
+               0x41000000UL <= addr && addr + 0x1000000UL <= 0x50000000UL);
+    } else {
+        report("before-stack: places in the gap that precedes the stack", 0);
+    }
+
+    if (scan(path, VMEM_HOLE_BEGIN, 0x1000000UL, &addr)) {
+        report("begin: places below the first mapping",
+               addr + 0x1000000UL <= 0x10000000UL);
+    } else {
+        report("begin: places below the first mapping", 0);
+    }
+
+    /* The scan stops at the stack, so the 0x51000000-0x60000000 gap
+     * beyond it is not a candidate however big it is. */
+    if (scan(path, VMEM_HOLE_BIGGEST, 0x1000000UL, &addr)) {
+        report("biggest: does not look past the stack",
+               addr + 0x1000000UL <= 0x50000000UL);
+    } else {
+        report("biggest: does not look past the stack", 0);
+    }
+}
+
+static void test_no_room_is_reported(void)
+{
+    /* The span below the first mapping counts as a gap - prevend starts
+     * at 0 - so the request has to be larger than that one too. */
+    const char *path = write_map("tight",
+        "10000000-20000000 " MAP_COLS "/lib/one.so\n"
+        "20001000-30000000 " MAP_COLS "/lib/two.so\n");
+    size_t addr = 0;
+
+    if (NULL == path) {
+        report("tight: wrote a map (skipped)", 1);
+        return;
+    }
+    report("a request larger than every gap is refused",
+           !scan(path, VMEM_HOLE_BIGGEST, 0x20000000UL, &addr));
+    report("the span below the first mapping is itself a gap",
+           scan(path, VMEM_HOLE_BIGGEST, 0x8000000UL, &addr)
+               && addr + 0x8000000UL <= 0x10000000UL);
+}
+
+static void test_bad_arguments(void)
+{
+    size_t addr = 0;
+
+    /* VMEM_HOLE_NONE and VMEM_HOLE_CUSTOM are in the enum but have no
+     * search behind them.  This used to be an assert(0) inside the scan
+     * loop, so a caller naming one took the process down. */
+    report("an unimplemented hole kind is refused, not asserted",
+           PMIX_ERR_BAD_PARAM == pmix_vmem_find_hole(
+               VMEM_HOLE_NONE, &addr, 0x1000UL));
+    report("VMEM_HOLE_CUSTOM is refused the same way",
+           PMIX_ERR_BAD_PARAM == pmix_vmem_find_hole(
+               VMEM_HOLE_CUSTOM, &addr, 0x1000UL));
+    report("a NULL out-parameter is refused",
+           PMIX_ERR_BAD_PARAM == pmix_vmem_find_hole(
+               VMEM_HOLE_BIGGEST, NULL, 0x1000UL));
+    report("a map that cannot be opened is reported",
+           PMIX_SUCCESS != pmix_vmem_find_hole_in_map(
+               "/nonexistent/no/such/maps", VMEM_HOLE_BIGGEST, 0, false,
+               &addr, 0x1000UL));
+    {
+        uintptr_t base = 1;
+        report("reserve refuses a zero size",
+               PMIX_ERR_BAD_PARAM == pmix_vmem_reserve(
+                   VMEM_HOLE_BIGGEST, 0, 0, &base));
+        report("reserve clears its out-parameter", 0 == base);
+        report("reserve refuses a NULL out-parameter",
+               PMIX_ERR_BAD_PARAM == pmix_vmem_reserve(
+                   VMEM_HOLE_BIGGEST, 0, 0x1000UL, NULL));
+    }
+}
+
+static void test_scan_a_map_we_wrote(void)
+{
+    char tmpl[256];
+    const char *tmp = getenv("TMPDIR");
+    size_t i;
+    static const char *const names[] = {
+        "plain", "tagged", "garbage", "longline", "heapstack", "tight"
+    };
+    char victim[512];
+
+    snprintf(tmpl, sizeof(tmpl), "%s/pmix_vmem_test_XXXXXX",
+             (NULL == tmp || '\0' == tmp[0]) ? "/tmp" : tmp);
+    if (NULL == mkdtemp(tmpl)) {
+        report("synthetic maps: made a scratch directory (skipped)", 1);
+        return;
+    }
+    pmix_string_copy(mapdir, tmpl, sizeof(mapdir));
+
+    test_biggest_gap();
+    test_tagged_entry_does_not_swallow_the_next();
+    test_unparseable_entry_does_not_reach_back_to_zero();
+    test_long_entry_is_one_entry();
+    test_heap_and_stack_bound_the_search();
+    test_no_room_is_reported();
+
+    for (i = 0; i < sizeof(names) / sizeof(names[0]); ++i) {
+        snprintf(victim, sizeof(victim), "%s/%s", mapdir, names[i]);
+        (void) unlink(victim);
+    }
+    (void) rmdir(mapdir);
+}
+
 int main(int argc, char **argv)
 {
     PMIX_HIDE_UNUSED_PARAMS(argc, argv);
 
     fprintf(stdout, "pmix_vmem tests\n");
 
+    /* These need no /proc, so they run on every platform. */
+    test_bad_arguments();
+    test_scan_a_map_we_wrote();
+
     if (!have_maps()) {
         /* No /proc/self/maps: nothing here can run, and gds/shmem3 is
          * not built on such a host either. Say so and pass. */
         fprintf(stdout,
-                "  SKIP: no usable /proc/self/maps on this platform\n");
-        fprintf(stdout, "SUMMARY: 0 passed, 0 failed (skipped)\n");
-        return 0;
+                "  SKIP: no usable /proc/self/maps on this platform - the\n"
+                "        cases needing this process's own map are skipped\n");
+        fprintf(stdout, "SUMMARY: %d passed, %d failed\n", npass, nfail);
+        return (0 == nfail) ? 0 : 1;
     }
 
     test_agreement();


### PR DESCRIPTION
A second, per-file deep review of `src/util` — all 29 `.c` files in the
directory, one at a time, each read through five separate lenses (memory
and lifetime, threading, error paths, portability, contracts). The first
pass was #4021; this one goes over the same ground with fresh eyes and
finds a different class of thing.

The headline is that **most of what turned up was not reachable from any
test, and in several cases had never been compiled by anyone.** That is
the shape of this directory: it is full of leaf helpers selected by
`configure`, and a helper nobody on your platform compiles is a helper
nobody has checked.

### The recurring shapes

- **A guard nothing defines.** `pmix_output.c` compiled its entire
  syslog capability behind `HAVE_SYSLOG`, which `configure` never sets —
  it probes for the *header*. So `PMIX_OUTPUT_REDIRECT=syslog`, which
  also turns stdout, stderr and file output off, silently discarded
  every line the library produced.
- **An arm no configuration here selects gets no compiler coverage.**
  `pmix_few`'s no-fork arm, `pmix_net`'s and `pmix_if`'s
  `!HAVE_STRUCT_SOCKADDR_IN` arms, `pmix_pty`'s stubs, `pmix_path_df`'s
  `HAVE_STATVFS` arm — none of them built. `pmix_if`'s was missing seven
  of the 21 entry points its header declares, which is a link failure
  rather than the graceful degradation the fallback exists for.
- **A whole subsystem behind a switch nobody turns on.**
  `--enable-pmix-timing` did not compile at all, and would have named
  every node `(null)` if it had.
- **Ordering, not memory.** `pmix_net_init()` parsed its MCA parameter
  from `pmix_init_util()`, which completes *before* `pmix_register_params()`
  gives the variable a value — so every RFC1918 address read as public
  and the parameter was inert in every shipped build.
- **A copy that writes through its source.** `pmix_argv_copy_strip()`
  and `pmix_path_find()` both punched a temporary NUL into the caller's
  string. Both are routinely handed arrays of string literals.
- **A `NULL` nobody documented is a `NULL` nobody screens.**
  `pmix_os_path()` answers `NULL` over `PMIX_PATH_MAX`, and five call
  sites used the answer unchecked — one straight into `strcmp()`.

### What is in it

Roughly forty behavioral fixes across the directory, each as its own
commit, plus a style/tidy commit per file kept separate so neither
review obscures the other. Notable ones beyond the above:

- `pmix_cmd_line` read off the end of its own argv copy for several
  options that take a second token on the parser's own account.
- `pmix_hash`'s wildcard removal left freed `proc_data` in the table it
  had just walked.
- `pmix_output` streams could share a file descriptor that each of them
  then closed.
- `pmix_shmem`'s `detach()` released nothing, so a segment's backing
  file was never unlinked by anyone.
- `pmix_settermios()` answered `PMIX_SUCCESS` when `tcsetattr()` had
  failed outright, so a `pmix_setraw()` that did nothing reported that
  the terminal was raw.
- `pmix_vmem`'s `/proc/self/maps` scan could report a hole over a range
  the map itself says is mapped, three different ways.
- `pmix_pty.h` — an installed header — declared `struct winsize *` with
  no `<sys/ioctl.h>`, so `test/unit/util/util_pty.c` **did not compile
  on Linux at all**.

Two dead-platform removals ride along (Solaris/Sun Studio, KAI), and
`config/oac` is documented as the third-party submodule it is, since a
`config/*.m4` sweep is exactly the thing that wants to edit it.

### Tests

New or extended `test/unit/util` programs for most of the above, all
wired into `make check`. **Every regression case was verified by
re-breaking its fix and confirming that case — and only that case —
fails.** That is not ceremony: three cases written during this work
passed against the unfixed library on the first attempt and had to be
rebuilt before they meant anything.

Two of the new test harnesses are worth knowing about:

- `util_tty.c` has to make `tcsetattr()` fail on demand. POSIX gives
  exactly one portable lever — a process group that is both in the
  background **and orphaned**, on the process's own controlling terminal
  — and building that position takes three processes. (Ignoring
  `SIGTTOU` makes the operation *succeed*, which is the obvious wrong
  answer.) The probe validates its own lever before trusting the result,
  so a platform without the rule reports a skip rather than a failure.
- `util_vmem.c` previously skipped itself in its entirety on any host
  without `/proc/self/maps` — i.e. on every macOS developer's machine —
  while three defects sat in the scan it was meant to cover. A new
  `pmix_vmem_find_hole_in_map()` lets the placement rules be held against
  maps the test writes, so seventeen cases now run everywhere.

### Verification

Built and `make check`ed warning-free under `--enable-devel-check` on
macOS/clang (174 tests) and on Ubuntu 24.04 in a container (30 tests in
`test/unit/util`, which is where the two Linux-only defects above
surfaced). `--enable-pmix-timing` and `--enable-test-build` were built
by hand, and the conditionally-compiled arms listed above were each
compiled by forcing their guards.

`src/util/AGENTS.md` carries the durable half of all of this — what was
refuted and why, which arms need forcing to compile-check, and the
invariants that were not written down anywhere.
