### PR TITLE
Fail the python scheduler test instead of hanging it

### DIFF
--- a/test/python/client.py
+++ b/test/python/client.py
@@ -267,12 +267,24 @@ def main():
             print("Group destruct_nb result ", foo.error_string(rc))
             if PMIX_SUCCESS == rc and not grpDestructed.wait(timeout=30):
                 print("GROUP DESTRUCT TIMED OUT")
-    # wait for model event
-    while not termEvent.is_set():
-        time.sleep(0.001)
+    # Wait for the model event, with a bound - as the group waits above have.
+    #
+    # This is the event the whole test turns on, and it is the one the test
+    # is least sure of getting: the model is declared inside PMIx_Init, from
+    # the PMIX_PROGRAMMING_MODEL/PMIX_MODEL_LIBRARY_NAME passed to it, while
+    # the handler that catches it is not registered until several lines
+    # after init returns.  Losing that race has to fail this test, not hang
+    # it.  Unbounded, it wedged this process AND the scheduler that forked
+    # us - which cannot finish reading our pipes until we close them - so CI
+    # killed the pair after five minutes with no clue as to why.
+    timedout = not termEvent.wait(timeout=30)
+    if timedout:
+        print("MODEL EVENT TIMED OUT")
     # finalize
     info = []
     foo.finalize(info)
     print("Client finalize complete")
+    if timedout:
+        exit(1)
 if __name__ == '__main__':
     main()

--- a/test/python/sched.py
+++ b/test/python/sched.py
@@ -113,37 +113,53 @@ def main():
     # output as the process runs
     p = subprocess.Popen(args, env=env,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    # define storage to catch the output
-    stdout = []
-    stderr = []
-    # loop until the pipes close
-    while True:
-        reads = [p.stdout.fileno(), p.stderr.fileno()]
-        ret = select.select(reads, [], [])
+    # Drain the child's pipes until both reach EOF, then reap it.
+    #
+    # Three things this has to get right, and the loop that was here got
+    # none of them.  It must not wait forever on a child that has wedged:
+    # select() with no timeout meant a stuck client wedged the scheduler
+    # too, and CI killed the pair after five minutes with nothing to show
+    # for it.  It must not stop reading while a pipe still holds data: the
+    # done flags were reset on every iteration and cleared only for the
+    # descriptors select() happened to return, so an EOF on stderr while
+    # stdout was merely idle ended the loop and discarded the rest of the
+    # client's output.  And it must look at how the child exited - nothing
+    # ever reaped it, so a client that FAILED was reported as a pass.
+    #
+    # A pipe is dropped from the watch list when it reads EOF, so the loop
+    # ends when the child has closed both and not before.  The idle timer
+    # covers a child that stops talking; it is reset by any output, so a
+    # slow client is not mistaken for a stuck one.
+    idle_limit = 60
+    deadline = time.time() + idle_limit
+    reads = [p.stdout, p.stderr]
+    while reads:
+        ready, _, _ = select.select(reads, [], [], 1.0)
+        if not ready:
+            if time.time() > deadline:
+                print("CLIENT PRODUCED NO OUTPUT FOR %d SECONDS - KILLING IT"
+                      % idle_limit)
+                p.kill()
+                break
+            continue
+        for f in ready:
+            line = f.readline()
+            if not line:
+                # EOF on this pipe - stop watching it, keep the other
+                reads.remove(f)
+                continue
+            label = 'stdout: ' if f is p.stdout else 'stderr: '
+            print(label + line.decode('utf-8').rstrip())
+            deadline = time.time() + idle_limit
 
-        stdout_done = True
-        stderr_done = True
-
-        for fd in ret[0]:
-            # if the data
-            if fd == p.stdout.fileno():
-                read = p.stdout.readline()
-                if read:
-                    read = read.decode('utf-8').rstrip()
-                    print('stdout: ' + read)
-                    stdout_done = False
-            elif fd == p.stderr.fileno():
-                read = p.stderr.readline()
-                if read:
-                    read = read.decode('utf-8').rstrip()
-                    print('stderr: ' + read)
-                    stderr_done = False
-
-        if stdout_done and stderr_done:
-            break
+    status = p.wait()
+    print("CLIENT EXITED WITH", status)
 
     print("FINALIZING")
     foo.finalize()
+
+    if 0 != status:
+        exit(1)
 
 if __name__ == '__main__':
     global killer


### PR DESCRIPTION
### The problem

The "Run python bindings scheduler test" step times out after five minutes
leaving two orphan `python3` processes — intermittently, on any branch. The log
says nothing about why, because once either half of the test stops moving the
other can no longer report anything.

**`client.py` waits forever for an event it races against.** It ends with

```python
while not termEvent.is_set():
    time.sleep(0.001)
```

`termEvent` is set only by the `PMIX_MODEL_DECLARED` handler — and it is alone
among the waits in that file, the two above it use `timeout=30`. That event is
also the one the test is least sure of getting: the model is declared *inside*
`PMIx_Init`, from the `PMIX_PROGRAMMING_MODEL` / `PMIX_MODEL_LIBRARY_NAME`
handed to it, while the handler that catches it is not registered until several
lines after init returns. Losing that race should fail the test, not hang it.

**`sched.py` could not notice either way.** Its read loop called
`select.select(reads, [], [])` with no timeout and never polled the child, so a
client that stops talking stops the scheduler too — which is why both processes
had to be killed from outside.

### Two more defects in the same loop

Neither is tied to the hang, and one is worse than it:

- It never reaped the child or looked at its exit status, so **a client that
  failed was reported as a pass**. That is presumably why this test has been
  quieter than it should have been.
- `stdout_done` / `stderr_done` were reset on every iteration and cleared only
  for the descriptors `select()` happened to return, so an EOF on stderr during
  an iteration when stdout merely had nothing ready ended the loop and threw
  away the rest of the client's output.

### The change

Bound the client's wait and make it say what it was waiting for. Give the
scheduler's `select()` a timeout and kill a child that has gone silent for a
minute. Drop a pipe from the watch list when it reads EOF, so the loop ends
when the child has closed both and not before. Reap the child and fail on a
non-zero exit.

This does **not** fix the underlying race — it converts an undiagnosable
five-minute timeout into an immediate failure that names the missing event,
which is what anyone will need in order to chase it. Whether PMIx should be
delivering a cached `PMIX_MODEL_DECLARED` to a handler registered just after
init, or whether the test should not be depending on catching its own
declaration, is the real question and I have not touched it.

### Verification

Built with `--enable-python-bindings` and exercised all three paths:

| path | before | after |
|---|---|---|
| client wedges | hangs until CI kills it at 5m | killed and reported in 8s, exit 1 |
| client exits non-zero | reported as a **pass** | exit 1, `CLIENT EXITED WITH 3` |
| model event missing | hangs | `MODEL EVENT TIMED OUT`, exit 1 |

`test_bindings.py`, `server.py` and `sched.py` all pass unchanged on the happy
path.
