### PR TITLE
Open the pgpu framework for a launcher, as pnet already is

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -659,14 +659,15 @@ first:
   ``PMIx_server_IOF_deliver``, ``_IOF_flow_control``
   (``pmix_server_iof.c``);
   ``PMIx_server_dmodex_request`` (``pmix_server_dmodex.c``);
-  ``PMIx_server_collect_job_info`` (``pmix_server_fence.c``);
-  ``PMIx_server_setup_fork`` (``pmix_server.c``).  All four of those
-  files have since had their own per-file pass (2026-08-24) and none of
-  them added the screen, so this list is what the completed ``src/server``
-  per-file review left open rather than something it has not reached yet.
-* **Known must not get it** — ``PMIx_server_setup_application`` and
-  ``_setup_local_support`` (``pmix_server_setup.c``), for the reason
-  recorded above: a launcher calls them after ``PMIx_tool_init`` alone.
+  ``PMIx_server_collect_job_info`` (``pmix_server_fence.c``).  All three
+  of those files have since had their own per-file pass (2026-08-24) and
+  none of them added the screen, so this list is what the completed
+  ``src/server`` per-file review left open rather than something it has
+  not reached yet.
+* **Known must not get it** — ``PMIx_server_setup_application``,
+  ``_setup_local_support`` (``pmix_server_setup.c``) and
+  ``PMIx_server_setup_fork`` (``pmix_server.c``), for the reason recorded
+  above: a launcher calls them after ``PMIx_tool_init`` alone.
 * **Almost certainly must not get it** — pure helpers over ``preg`` and
   hwloc, both of which ``pmix_rte_init`` stands up for every role, so
   they work correctly in a client today: ``PMIx_generate_regex``,
@@ -681,10 +682,39 @@ first:
   changing either one changes init/finalize semantics rather than closing
   a crash.
 
-``PMIx_server_setup_fork`` is the one worth care: a launcher comes up
-through ``PMIx_tool_init`` and reads as a server long before
-``PMIx_server_init`` runs, so confirm no in-tree or PRRTE path calls it in
-that window before adding the screen.
+**``PMIx_server_setup_fork`` was listed here as "the one worth care" and
+is now closed (2026-08-26) — by the opposite change to the one this entry
+proposed.** The worry was that a launcher comes up through
+``PMIx_tool_init`` and reads as a server long before ``PMIx_server_init``
+runs, so the entry asked for its callers to be confirmed before adding
+the screen. Running it settled it: a launcher calling
+``PMIx_server_setup_fork`` did not need refusing, it needed the call to
+work, and it took SIGSEGV on the way — inside the blocking call, so
+nothing was returned to refuse with. The crash was in
+``pmix_pgpu_base_setup_fork``, not in ``pmix_server_globals`` at all.
+
+The three setup calls a launcher makes fan out to ``pnet`` and ``pgpu``
+side by side — ``pmix_server_setup.c:926/931``, ``:1057/1061`` and
+``pmix_server.c:1677/1689`` — and ``PMIx_tool_init`` opened only ``pnet``
+(for a launcher or scheduler), never ``pgpu``. A base function whose
+framework never opened walks an ``actives`` list that was never
+constructed. ``pmix_pgpu_base_allocate`` and ``_setup_local`` happen to
+open with a ``pmix_list_get_size()`` guard, so ``setup_application`` and
+``_setup_local_support`` survived — which meant the whole ``pgpu`` path
+was *dead* for a launcher rather than fatal, the same shape as the
+missing ``pmix_pgpu.setup_fork`` call that ``pmix_server.c:1685`` records.
+``pmix_pgpu_base_setup_fork`` has no such guard, so that one died.
+``PMIx_tool_init`` now opens and selects ``pgpu`` wherever it opens
+``pnet``, and ``PMIx_tool_finalize`` closes it; the three launcher cases
+in ``test/unit/server_setup.c`` hold it there.
+
+**The general lesson is worth more than the fix.** A screen at the entry
+point answers "may this caller be here at all". When the caller is
+entitled to be there and the code below it is not ready for the role it
+came in as, the screen is not a weaker version of the right fix — it is
+the wrong question, and adding it would have refused the one caller the
+API exists for. Ask which role the path is reached from and what that
+role's init actually stood up, before reaching for a flag.
 
 ``PMIX_GET_POINTER_VALUES`` is honored by three shortcuts and nothing else
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -251,7 +251,9 @@ review lands: on **2026-08-20** for the ``src/mca/pnet``, ``src/mca/preg``,
 ``src/mca/pif`` reviews, on **2026-08-21** when ``src/mca/gds/shmem3``
 was re-reviewed against its redesign, and on **2026-08-24**, when the
 per-file pass over ``src/server`` finished — all twenty ``.c`` files —
-and the last of ``src/client`` came inside a review.  Move an entry out
+and the last of ``src/client`` came inside a review, and on
+**2026-08-26**, when the per-file re-review of ``src/util`` finished —
+all twenty-nine of its ``.c`` files.  Move an entry out
 of "Not yet reviewed" as its review lands, and refresh the churn figures
 in "Reviewed, but changed materially since" when a re-review closes one.
 
@@ -271,22 +273,36 @@ Reviewed and current
 ``src/mca/gds/hash``, ``src/mca/gds/shmem3``, ``src/mca/pcompress``,
 ``src/mca/pgpu``, ``src/mca/pif``, ``src/mca/plog``, ``src/mca/pmdl``,
 ``src/mca/pnet``, ``src/mca/preg``, ``src/mca/psec``, ``src/mca/psensor``,
-``src/mca/pstat``, ``src/mca/ptl``, ``src/threads``, and
+``src/mca/pstat``, ``src/mca/ptl``, ``src/threads``, ``src/util``, and
 ``bindings/python``.
-``src/common``, ``src/hwloc`` and ``src/util`` were reviewed too, but
-have moved since — see below.
+``src/common`` and ``src/hwloc`` were reviewed too, but have moved
+since — see below.
 
-**``src/client`` and ``src/server`` are the only two directories the
-review has taken file by file**, a dedicated pass per file rather than a
-directory-wide one, and the difference is worth stating rather than
-flattening: a directory-wide sweep is real coverage, and it is not the
-same thing.  The dedicated pass found something in *every* file it
-read, including files that had already been through four or five
-directory-wide sweeps.  ``src/client`` reached that state on 2026-08-23
-and ``src/server`` on 2026-08-24 — eleven files and twenty, five lenses
-each, one file to a pass.  The per-file record is in the 2026-08-23 and
-later rows of ``.git/deep-review/ledger.tsv``; the reasoning is in each
-directory's ``AGENTS.md``.
+**``src/client``, ``src/server`` and ``src/util`` are the only three
+directories the review has taken file by file**, a dedicated pass per
+file rather than a directory-wide one, and the difference is worth
+stating rather than flattening: a directory-wide sweep is real coverage,
+and it is not the same thing.  The dedicated pass found something in
+*every* file it read, including files that had already been through four
+or five directory-wide sweeps.  ``src/client`` reached that state on
+2026-08-23, ``src/server`` on 2026-08-24 and ``src/util`` on 2026-08-26 —
+eleven files, twenty and twenty-nine, five lenses each, one file to a
+pass.  The per-file record is in the 2026-08-23 and later rows of
+``.git/deep-review/ledger.tsv``; the reasoning is in each directory's
+``AGENTS.md``.
+
+``src/util`` is the sharpest evidence for that difference, because it is
+the only one of the three that had already had a full directory review —
+the July 2026 pass — and the per-file re-review still came to
++5260/-1062 across 58 files in 57 commits, against 4672 lines of new
+test (eight new programs under ``test/unit/util``).  Two of the defects
+it found were invisible from macOS and needed a Linux container to see
+at all — one of them an installed header that failed to build on Linux
+at all; one whole
+subsystem, ``pmix_timings`` under ``--enable-pmix-timing``, turned out
+never to have been built by anybody.  The lesson to carry is in
+``src/util/AGENTS.md``: **a directory that has been reviewed once is
+not thereby covered file by file.**
 
 Two files fall short of that and are named here rather than rounded up,
 both in ``src/client``:
@@ -332,10 +348,14 @@ Each of these has an orientation guide and nothing else: no findings were
 ever recorded in it, and only drive-by fixes have landed.  Ordered by
 size, which is a rough proxy for how much there is to find.
 
-* ``src/util/keyval`` — 2397 lines of lexer and parser, and the only
-  directory in ``src/`` with **no** ``AGENTS.md`` at all.
 * ``src/mca/pdl``, ``src/mca/pinstalldirs`` — about 2200 lines between
   them, and the lowest risk of the group.
+* ``src/util/keyval`` — 138 lines of flex source (``keyval_lex.l``);
+  the 2327-line ``keyval_lex.c`` beside it is a generated build product
+  and is not review material.  It has no ``AGENTS.md`` of its own, but
+  the ``src/util`` re-review gave it a section in that directory's
+  guide and covered its only driver, ``pmix_keyval_parse.c``, so what
+  is left unread is the ``.l`` itself.
 
 Outside ``src/``, nothing has been reviewed: ``examples/`` (16678 lines,
 leak-swept only), ``test/simple`` (11011), ``test/unit/util`` and
@@ -346,13 +366,9 @@ Reviewed, but changed materially since
 
 Ordered by how much of the directory the review no longer covers.
 Figures are against the commit that recorded each review, measured
-2026-08-24.
+2026-08-24.  ``src/util`` stood at the head of this list until
+2026-08-26; the per-file re-review closed it.
 
-#. **``src/util``** — reviewed 2026-07-17/18, the oldest review in the
-   tree, and the gap keeps widening: 38 commits and +2024/-247 across 21
-   files since, none of it re-read.  The largest pieces are the CLI
-   option-parsing rework, the ``dirpath`` conversion to descriptor-based
-   operations, and the ``pmix_hash`` qualifier arrays.
 #. **``src/hwloc``** — reviewed 2026-08-02.  +1129/-205 across three
    files since — the device enumerator and the reworked distance
    computation, against a five-line touch to the guide.  Effectively new,

--- a/src/mca/pgpu/base/pgpu_base_fns.c
+++ b/src/mca/pgpu/base/pgpu_base_fns.c
@@ -48,6 +48,13 @@ pmix_status_t pmix_pgpu_base_allocate(char *nspace, pmix_info_t info[], size_t n
         return PMIX_ERR_BAD_PARAM;
     }
 
+    /* NOT a guard on the walk below - the walk is safe on an empty list,
+     * as every other PMIX_LIST_FOREACH in the tree relies on. This is an
+     * early-out that also skips the namespace object built for the
+     * modules to hang data on: with no module to receive it, publishing a
+     * bare namespace onto pmix_globals.nspaces would change what walkers
+     * of that list find (_dmodex_req takes its "we know this nspace"
+     * branch on the strength of an entry with no ranks). */
     if (0 == pmix_list_get_size(&pmix_pgpu_globals.actives)) {
         return PMIX_SUCCESS;
     }
@@ -103,6 +110,9 @@ pmix_status_t pmix_pgpu_base_setup_local(char *nspace, pmix_info_t info[], size_
         return PMIX_ERR_BAD_PARAM;
     }
 
+    /* NOT a guard on the walk below - see the note in allocate(). What
+     * this skips is the pmix_pgpu_globals.nspaces cache entry built for
+     * the modules; with none selected, nothing would ever read it. */
     if (0 == pmix_list_get_size(&pmix_pgpu_globals.actives)) {
         return PMIX_SUCCESS;
     }
@@ -373,10 +383,6 @@ void pmix_pgpu_base_child_finalized(pmix_proc_t *peer)
         return;
     }
 
-    if (0 == pmix_list_get_size(&pmix_pgpu_globals.actives)) {
-        return;
-    }
-
     PMIX_LIST_FOREACH (active, &pmix_pgpu_globals.actives, pmix_pgpu_base_active_module_t) {
         if (NULL != active->module->child_finalized) {
             active->module->child_finalized(peer);
@@ -395,10 +401,6 @@ void pmix_pgpu_base_local_app_finalized(pmix_namespace_t *nptr)
 
     /* protect against bozo inputs */
     if (NULL == nptr) {
-        return;
-    }
-
-    if (0 == pmix_list_get_size(&pmix_pgpu_globals.actives)) {
         return;
     }
 

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -51,6 +51,13 @@ pmix_status_t pmix_pnet_base_allocate(char *nspace, pmix_info_t info[], size_t n
         return PMIX_ERR_BAD_PARAM;
     }
 
+    /* NOT a guard on the walk below - the walk is safe on an empty list,
+     * as every other PMIX_LIST_FOREACH in the tree relies on. This is an
+     * early-out that also skips the namespace object built for the
+     * modules to hang data on: with no module to receive it, publishing a
+     * bare namespace onto pmix_globals.nspaces would change what walkers
+     * of that list find (_dmodex_req takes its "we know this nspace"
+     * branch on the strength of an entry with no ranks). */
     if (0 == pmix_list_get_size(&pmix_pnet_globals.actives)) {
         return PMIX_SUCCESS;
     }
@@ -113,6 +120,9 @@ pmix_status_t pmix_pnet_base_setup_local_network(char *nspace, pmix_info_t info[
         return PMIX_ERR_BAD_PARAM;
     }
 
+    /* NOT a guard on the walk below - see the note in allocate(). What
+     * this skips is the pmix_pnet_globals.nspaces cache entry built for
+     * the modules; with none selected, nothing would ever read it. */
     if (0 == pmix_list_get_size(&pmix_pnet_globals.actives)) {
         return PMIX_SUCCESS;
     }
@@ -406,10 +416,6 @@ void pmix_pnet_base_child_finalized(pmix_proc_t *peer)
         return;
     }
 
-    if (0 == pmix_list_get_size(&pmix_pnet_globals.actives)) {
-        return;
-    }
-
     PMIX_LIST_FOREACH (active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
         if (NULL != active->module->child_finalized) {
             active->module->child_finalized(peer);
@@ -428,10 +434,6 @@ void pmix_pnet_base_local_app_finalized(pmix_namespace_t *nptr)
 
     /* protect against bozo inputs */
     if (NULL == nptr) {
-        return;
-    }
-
-    if (0 == pmix_list_get_size(&pmix_pnet_globals.actives)) {
         return;
     }
 
@@ -561,6 +563,10 @@ pmix_status_t pmix_pnet_base_register_fabric(pmix_fabric_t *fabric, const pmix_i
     fabric->ninfo = 0;
     fabric->module = NULL;
 
+    /* NOT a guard on the walk below, which answers PMIX_ERR_NOT_FOUND
+     * when it ends without a claim. The two are different answers worth
+     * keeping apart: no component at all cannot support fabrics, while a
+     * component that declined this one simply did not find it. */
     if (0 == pmix_list_get_size(&pmix_pnet_globals.actives)) {
         return PMIX_ERR_NOT_SUPPORTED;
     }

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -59,6 +59,7 @@
 #include "src/mca/bfrops/base/base.h"
 #include "src/mca/gds/base/base.h"
 #include "src/mca/pmdl/base/base.h"
+#include "src/mca/pgpu/base/base.h"
 #include "src/mca/pnet/base/base.h"
 #include "src/mca/psec/psec.h"
 #include "src/mca/ptl/base/base.h"
@@ -1072,6 +1073,24 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc, pmix_info_t info[], size_t nin
             return rc;
         }
 
+        /* open the pgpu framework on the same terms as pnet, and for the
+         * same reason: the server-side calls a launcher makes to prepare
+         * a job - PMIx_server_setup_application, _setup_local_support and
+         * _setup_fork - fan out to the two side by side. Leaving pgpu
+         * closed did not make those calls skip it: pmix_pgpu_base_allocate
+         * and _setup_local open with a list-size guard and quietly did
+         * nothing, so a launcher never harvested the vendor envars at all,
+         * while _setup_fork has no such guard and walked the actives list
+         * a framework open would have constructed. */
+        rc = pmix_mca_base_framework_open(&pmix_pgpu_base_framework,
+                                          PMIX_MCA_BASE_OPEN_DEFAULT);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+        if (PMIX_SUCCESS != (rc = pmix_pgpu_base_select())) {
+            return rc;
+        }
+
         /* Bind our socket and publish how to reach it. We do NOT begin
          * accepting yet - that happens at the foot of this function, once
          * there is nothing left for this thread to do to shared state.
@@ -1818,6 +1837,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     }
 
     (void) pmix_mca_base_framework_close(&pmix_pnet_base_framework);
+    (void) pmix_mca_base_framework_close(&pmix_pgpu_base_framework);
     /* tear down every server_globals list that pmix_server_initialize
      * constructs on each init, so none of their contents leak across a
      * cycle. pmix_server_initialize (called unconditionally from

--- a/test/unit/server_setup.c
+++ b/test/unit/server_setup.c
@@ -59,6 +59,16 @@
  * re-running: SIGSEGV (exit 139) each time, with no output at all, since
  * stdout is block-buffered when the harness captures it. So a regression
  * here looks like an empty log and a signal, not like a FAIL line.
+ *
+ *   role completeness - the three setup calls a launcher makes fan out to
+ *     pnet and pgpu side by side, and PMIx_tool_init opened only pnet. A
+ *     base function whose framework never opened walks an actives list
+ *     that was never constructed, so PMIx_server_setup_fork took a
+ *     launcher down; setup_application and setup_local_support survived
+ *     only because their pgpu counterparts happen to open with a list-size
+ *     guard, which meant the whole pgpu path was silently dead for a
+ *     launcher instead. The launcher cases run in a forked child for the
+ *     same reason as the rest: this process becomes a server below.
  */
 
 #include "src/include/pmix_config.h"
@@ -879,6 +889,67 @@ static int setup_tool_child(int which)
     return (PMIX_SUCCESS == setup_status) ? 0 : 5;
 }
 
+/* The launcher shape, which is not the same as the tool shape above.
+ * PMIx_tool_init opens pnet and pgpu only for a launcher or a scheduler,
+ * and the three server-side setup calls a launcher makes fan out to both
+ * of those frameworks side by side. A launcher that came up without one
+ * of them reaches a base function whose actives list was never
+ * constructed - the walk starts at a NULL sentinel - so this comes up as
+ * prun does and requires all three calls to be answered and the process
+ * to still be alive afterwards.
+ *
+ * PMIx_server_setup_fork is the one that failed: pmix_pgpu_base_setup_fork
+ * walks its actives list with no size guard, and the call is blocking, so
+ * the child died before the API returned anything at all. */
+static int setup_launcher_child(int which)
+{
+    pmix_proc_t myproc, child;
+    pmix_info_t tinfo[2], info;
+    pmix_status_t rc;
+    char **env = NULL;
+    uint32_t one = 1;
+
+    PMIX_INFO_LOAD(&tinfo[0], PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&tinfo[1], PMIX_LAUNCHER, NULL, PMIX_BOOL);
+    rc = PMIx_tool_init(&myproc, tinfo, 2);
+    PMIX_INFO_DESTRUCT(&tinfo[0]);
+    PMIX_INFO_DESTRUCT(&tinfo[1]);
+    if (PMIX_SUCCESS != rc) {
+        return 3;
+    }
+
+    if (2 == which) {
+        /* the crash case - blocking, so surviving it IS the assertion */
+        PMIX_LOAD_PROCID(&child, myproc.nspace, 0);
+        rc = PMIx_server_setup_fork(&child, &env);
+        PMIx_Argv_free(env);
+        PMIx_tool_finalize();
+        return (PMIX_SUCCESS == rc) ? 0 : 1;
+    }
+
+    PMIX_INFO_LOAD(&info, SUT_KEY, &one, PMIX_UINT32);
+    if (0 == which) {
+        rc = PMIx_server_setup_application(myproc.nspace, &info, 1,
+                                           accepted_setup, NULL);
+    } else {
+        rc = PMIx_server_setup_local_support(myproc.nspace, &info, 1,
+                                             accepted_op, NULL);
+    }
+    PMIX_INFO_DESTRUCT(&info);
+    if (PMIX_SUCCESS != rc) {
+        PMIx_tool_finalize();
+        return 1;
+    }
+    for (int i = 0; i < 200 && !setup_fired; ++i) {
+        (void) PMIx_Get(&myproc, PMIX_UNIV_SIZE, NULL, 0, NULL);
+    }
+    PMIx_tool_finalize();
+    if (!setup_fired) {
+        return 4;
+    }
+    return (PMIX_SUCCESS == setup_status) ? 0 : 5;
+}
+
 static void check_client_refusal(const char *name, int which)
 {
     pid_t child;
@@ -887,6 +958,9 @@ static void check_client_refusal(const char *name, int which)
     fflush(stdout);
     child = fork();
     if (0 == child) {
+        if (20 <= which) {
+            _exit(setup_launcher_child(which - 20));
+        }
         _exit((which < 10) ? setup_client_child(which) : setup_tool_child(which - 10));
     }
     if (0 > child) {
@@ -920,6 +994,11 @@ int main(int argc, char **argv)
     /* and the case that actually regressed: a launcher, as prun is */
     check_client_refusal("setup_application works for a tool, as prun needs", 10);
     check_client_refusal("setup_local_support works for a tool", 11);
+    /* and the launcher, which is the role that actually opens pnet and
+     * pgpu - the third of these took the process down */
+    check_client_refusal("setup_application works for a launcher", 20);
+    check_client_refusal("setup_local_support works for a launcher", 21);
+    check_client_refusal("setup_fork works for a launcher", 22);
 
     rc = PMIx_server_init(&mymodule, NULL, 0);
     if (PMIX_SUCCESS != rc) {


### PR DESCRIPTION
The server-side calls a launcher makes to prepare a job fan out to `pnet` and `pgpu` side by side:

| call | pnet | pgpu |
|---|---|---|
| `PMIx_server_setup_application` | `pmix_server_setup.c:926` | `:931` |
| `PMIx_server_setup_local_support` | `:1057` | `:1061` |
| `PMIx_server_setup_fork` | `pmix_server.c:1677` | `:1689` |

`PMIx_server_init` opens both frameworks. `PMIx_tool_init` opened only `pnet`, and only for a launcher or a scheduler, so a launcher reached all three of those `pgpu` calls with the framework never opened and its `actives` list never constructed. PRRTE's `prun` inits with `PMIX_LAUNCHER` (`prun_common.c:662`) and lands in exactly that branch.

Leaving `pgpu` closed did not make those calls skip it:

* `pmix_pgpu_base_allocate` and `_setup_local` open with a `pmix_list_get_size()` guard, so they returned success having done nothing. A launcher never harvested the vendor environment variables and never cached them — the same dead-path shape as the missing `pmix_pgpu.setup_fork` call recorded at `pmix_server.c:1685`.
* `pmix_pgpu_base_setup_fork` has no such guard and walked a list whose sentinel a framework open would have built, so a launcher calling `PMIx_server_setup_fork` took SIGSEGV — inside the blocking call, before any status could come back to it.

The fix opens and selects `pgpu` wherever `pnet` is opened, and closes it beside `pnet` in `PMIx_tool_finalize`.

### Testing

Three new cases in `test/unit/server_setup.c` come up as `prun` does — `PMIx_tool_init` with `PMIX_LAUNCHER` — and require all three calls to be answered with the process still alive. Verified by re-breaking: with the fix reverted, `setup_fork works for a launcher` FAILs and the rest of the file still passes.

`make check` 21/21 and `test/unit` 100 pass / 2 skip on macOS, warning-free under `--enable-devel-check`.

### Documentation

`docs/todo.rst` listed `PMIx_server_setup_fork` as the entry point "worth care", asking whether it wanted the same initialization screen the other server entry points were given. It wanted the opposite — the launcher was entitled to be there, and refusing it would have broken the one caller the API exists for. That entry is closed and records why, since the shape recurs: a screen at the entry point answers "may this caller be here at all", and when the caller is entitled to be there and the code below is not ready for the role it came in as, the screen is the wrong question rather than a weaker version of the right fix.

This branch also carries a separate commit bringing the review-coverage record in `docs/todo.rst` up to date for the completed per-file `src/util` re-review.