### PR TITLE
Add an allocation property giving acquisition order

### DIFF
--- a/contrib/dictionary_ids.txt
+++ b/contrib/dictionary_ids.txt
@@ -694,3 +694,4 @@ pmix.spwn.root         663   PMIX_SPAWN_TREE_ROOT
 pmix.spwn.actv         664   PMIX_SPAWN_TREE_ACTIVE
 pmix.spwn.alloc        665   PMIX_SPAWN_ALLOC
 pmix.alloc.dir         666   PMIX_ALLOC_REQ_DIRECTIVE
+pmix.alloc.seq         667   PMIX_ALLOC_SEQUENCE

--- a/docs/man/man3/PMIx_Allocation_request.3.rst
+++ b/docs/man/man3/PMIx_Allocation_request.3.rst
@@ -253,6 +253,9 @@ Controlling scheduling, timing, and lifecycle:
   (used with the ``PMIX_ALLOC_RELEASE`` directive).
 * ``PMIX_ALLOC_RELEASABLE`` (bool) |mdash| true if the entire allocation may be
   released.
+* ``PMIX_ALLOC_SEQUENCE`` (uint32_t) |mdash| index recording the order in which
+  the host environment acquired this allocation relative to the others it holds;
+  larger values were acquired later, and no other meaning is implied.
 * ``PMIX_ALLOC_NOSHELL`` (bool) |mdash| immediately exit after allocating
   resources, without running a command.
 * ``PMIX_ALLOC_NOT_WAITING`` (bool) |mdash| the requestor is not waiting for

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -944,6 +944,10 @@ typedef uint32_t pmix_rank_t;
                                                                     //         the allocated resources in, for example, a call to PMIx_Spawn
 #define PMIX_ALLOC_PROPERTY                 "pmix.alloc.property"   // (char*) name of an allocation property
 #define PMIX_ALLOC_RELEASABLE               "pmix.alloc.releasable" // (bool) true if the entire allocation may be released.
+#define PMIX_ALLOC_SEQUENCE                 "pmix.alloc.seq"        // (uint32_t) index recording the order in which the host
+                                                                    //         environment acquired this allocation relative to the
+                                                                    //         others it holds - larger values were acquired later,
+                                                                    //         and no other meaning is implied
 #define PMIX_ALLOC_NUM_NODES                "pmix.alloc.nnodes"     // (uint64_t) number of nodes
 #define PMIX_ALLOC_NODE_LIST                "pmix.alloc.nlist"      // (char*) regex of specific nodes
 #define PMIX_ALLOC_EXCLUDE                  "pmix.alloc.exclude"    // (char*) regex of nodes to exclude from scheduling consideration


### PR DESCRIPTION
One new allocation property, served through the existing
`PMIX_QUERY_ALLOC_PROPERTIES`: a `uint32_t` index recording the order in which
the host environment acquired the allocations it holds. Larger values were
acquired later.

## The gap

`PMIX_QUERY_ALLOC_IDS` tells a caller which allocations a server knows of. Nothing
tells it which one arrived first. The array it comes back in is a
`pmix_info_t` array and therefore unordered, and `PMIX_ALLOC_ID` is deliberately
opaque — a host-minted string with no required structure — so a caller holding
several allocations has no way to sort them.

## Use case

In our case, a LIFO policy for removing allocations. Which order a caller picks
matters less than being able to pick one at all: today a requestor that has to
give an allocation back has nothing to sort on, so the choice falls to whatever
order the query happened to return — and that shifts as allocations come and go,
so two identical runs shed different nodes for no stated reason. The same
property lets the allocations a server reports be listed in a stable,
comparable order.

## Why the caller cannot work it out for itself

Ordering by the requests it made itself covers only the allocations it
requested, and never the one its job was launched in. It does not survive a tool
exiting and another attaching later, which is ordinary against a persistent
server. And host identifiers do not order: under one resource manager the id is
a scheduler job id, under another a private counter, and an allocation the host
environment started with may have neither — three schemes that are not
comparable even within a single host environment. The host is the only party
that knows.

Credits: AccelCom @ Barcelona Supercomputing Center