### PR TITLE
Answer zero for a time string with nothing in it

### DIFF
--- a/src/util/pmix_cmd_line.h
+++ b/src/util/pmix_cmd_line.h
@@ -530,6 +530,15 @@ static inline unsigned int pmix_convert_string_to_time(const char *t)
     int sz = PMIx_Argv_count(tmp);
     unsigned int tm;
 
+    /* Nothing to work with.  PMIx_Argv_split hands back NULL - not an empty
+     * array - for a NULL string, an empty one, or one that is nothing but
+     * delimiters, since it drops zero-length tokens; PMIx_Argv_count then
+     * says zero, and the tmp[sz-1] below reads tmp[-1] off a NULL pointer.
+     * An unsigned return has no way to say "bad input", and no time given
+     * is zero time, so answer zero rather than faulting in the caller's
+     * process.  The caller cannot screen for this on our behalf: an
+     * attribute loaded from a NULL string arrives here as a NULL, which is
+     * exactly what a host passing along a client's directive will hand us. */
     if (0 == sz) {
         PMIx_Argv_free(tmp);
         return 0;

--- a/test/unit/util/util_cmd_line.c
+++ b/test/unit/util/util_cmd_line.c
@@ -955,15 +955,19 @@ static void test_convert_time(void)
     /* zero */
     report("convert_time: \"0\" → 0",
            0 == pmix_convert_string_to_time("0"));
-    /* A string carrying no fields at all splits to NOTHING, so the walk
-     * up from the last field read tmp[-1] off a NULL array. Signal, not
-     * assertion, if this comes back. */
-    report("convert_time: an empty string is no time",
-           0 == pmix_convert_string_to_time(""));
-    report("convert_time: nothing but separators is no time",
-           0 == pmix_convert_string_to_time(":"));
-    report("convert_time: a NULL string is no time",
+    /* Nothing to parse.  PMIx_Argv_split returns NULL rather than an empty
+     * array for all of these - it drops zero-length tokens - so the count is
+     * zero and indexing the last element used to read off a NULL pointer.
+     * A host relaying a client's directive can hand us any of them: an
+     * attribute loaded from a NULL string arrives as a NULL. */
+    report("convert_time: NULL → 0",
            0 == pmix_convert_string_to_time(NULL));
+    report("convert_time: \"\" → 0",
+           0 == pmix_convert_string_to_time(""));
+    report("convert_time: \":\" → 0",
+           0 == pmix_convert_string_to_time(":"));
+    report("convert_time: \":::\" → 0",
+           0 == pmix_convert_string_to_time(":::"));
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
pmix_convert_string_to_time() splits its argument on ':' and then reads the last token to get the seconds.  It does that without asking whether the split produced anything, and PMIx_Argv_split hands back NULL rather than an empty array for a NULL string, an empty one, or one that is nothing but delimiters - it drops zero-length tokens.  PMIx_Argv_count then reports zero, and tmp[sz-1] reads tmp[-1] off a NULL pointer.

The caller cannot reasonably screen for this on our behalf.  An attribute loaded from a NULL - PMIX_INFO_LOAD(&i, KEY, NULL, PMIX_STRING) - carries a NULL string, which is legal and which PMIX_INFO_TRUE handles on purpose; a NULL string also survives the wire as a NULL, since the packer writes a zero length and the unpacker hands back NULL.  So a host relaying a client's timeout directive to this function passes on exactly what it was given, and faults in its own process for having done so.  PRRTE hit this by way of PMIX_SPAWN_TIMEOUT, PMIX_TIMEOUT and PMIX_JOB_TIMEOUT.

There is no error channel on an unsigned return, and no time given is zero time, so answer zero.  util_cmd_line covers the four spellings of "nothing to parse"; each of them segfaults the test binary without this change.