### PR TITLE
Make job-control cleanup requests atomic, and run the epilog as the client

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -726,7 +726,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # -lrt might be needed for clock_gettime
     PMIX_SEARCH_LIBS_CORE([clock_gettime], [rt])
 
-    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate tcgetpgrp setpgid ptsname openpty setenv fork execve waitpid atexit forkpty posix_openpt fileno_unlocked isatty])
+    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred setgroups strnlen posix_fallocate tcgetpgrp setpgid ptsname openpty setenv fork execve waitpid atexit forkpty posix_openpt fileno_unlocked isatty])
 
     # On some hosts, htonl is a define, so the AC_CHECK_FUNC will get
     # confused.  On others, it's in the standard library, but stubbed with

--- a/docs/man/man3/PMIx_Job_control.3.rst
+++ b/docs/man/man3/PMIx_Job_control.3.rst
@@ -141,12 +141,22 @@ Required of supporting host environments:
 * ``PMIX_REGISTER_CLEANUP_DIR`` (char*) |mdash| comma-delimited list of
   directories to be removed upon termination of the specified processes.
 * ``PMIX_CLEANUP_RECURSIVE`` (bool) |mdash| recursively clean up all
-  subdirectories under the specified one(s).
-* ``PMIX_CLEANUP_EMPTY`` (bool) |mdash| only remove empty subdirectories.
+  subdirectories under the specified one(s) |mdash| i.e., remove all files
+  and then the directories that contained them.  Mutually exclusive with
+  ``PMIX_CLEANUP_EMPTY``.
+* ``PMIX_CLEANUP_EMPTY`` (bool) |mdash| remove all empty directories under
+  the specified one(s), leaving every file in place.  Mutually exclusive
+  with ``PMIX_CLEANUP_RECURSIVE``.
 * ``PMIX_CLEANUP_IGNORE`` (char*) |mdash| comma-delimited list of filenames that
   are not to be removed.
 * ``PMIX_CLEANUP_LEAVE_TOPDIR`` (bool) |mdash| when recursively cleaning
   subdirectories, do not remove the top-level directory.
+
+A request naming both ``PMIX_CLEANUP_RECURSIVE`` and ``PMIX_CLEANUP_EMPTY``
+is rejected with ``PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES``, as is one
+that asks for a path to be cleaned up when that path is already named by a
+``PMIX_CLEANUP_IGNORE`` directive.  A rejected request is applied in full
+or not at all |mdash| none of its directives take effect.
 
 Optional for supporting host environments:
 

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -250,7 +250,13 @@ each time somebody asks.
           applied in part before it fails, the server-wide envar hook
           nothing fills, and the allocation-failure injection the
           switchyard's out-of-memory arms need before any of them can be
-          tested.  One entry was opened and closed within the same day —
+          tested.  The cleanup entry is gone from the list below as of
+          2026-08-28: what had been recorded as a question for the
+          Standard turned out to rest on a reading of the code that did
+          not survive being checked, and the repair was a
+          stage-then-commit split of the one handler.
+
+          One entry was opened and closed within the same day —
           the ordering of a registration's acknowledgement against the
           cached events replayed behind it — because the push-back that
           had deferred it ("libevent ordering is too strong an
@@ -420,35 +426,6 @@ single job-level store the ``PMIx_Get`` review forced), and
 
 Open decisions
 --------------
-
-A conflicting cleanup request is applied in part before it fails
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``pmix_server_job_ctrl`` (``src/server/pmix_server_control.c``) applies a
-request's ``PMIX_CLEANUP_IGNORE`` directives to the target epilogs first,
-then its ``PMIX_REGISTER_CLEANUP_DIR`` and ``PMIX_REGISTER_CLEANUP``
-directives — and the latter two fail the whole request with
-``PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES`` when a path they were asked to
-clean is already on that epilog's ignore list.  By then this request's
-ignores, and any directories accepted ahead of the conflicting one, are
-already registered on lists that outlive the request.  So the client is
-told the request failed while the server keeps part of it.
-
-What survives is the conservative half — a path ends up ignored rather
-than deleted — which is why this is recorded rather than repaired.
-Making the request atomic means splitting the walk into a validation pass
-and an application pass, and the validation pass has to reproduce the
-duplicate-detection logic exactly or it will reject requests the current
-code accepts (a directory that duplicates an already-registered entry
-takes the flag-upgrade branch today and is never conflict-checked at
-all).  Whether a partially conflicting job-control request should be
-atomic is a question for the Standard rather than for this file.
-
-The same shape applies to the allocation-failure arms added alongside
-it: a ``strdup`` that fails midway through the walk returns
-``PMIX_ERR_NOMEM`` with the earlier entries registered.  That one is not
-worth a rollback on its own, but it would come out in the wash of a
-validate-then-apply split.
 
 Who owns a credential the host hands up
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1082,8 +1082,12 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_REGISTER_CLEANUP_DIR           "pmix.reg.cleanupdir"   // (char*) comma-delimited list of directories to
                                                                     //         be removed upon process termination
 #define PMIX_CLEANUP_RECURSIVE              "pmix.clnup.recurse"    // (bool) recursively cleanup all subdirectories under the
-                                                                    //        specified one(s)
-#define PMIX_CLEANUP_EMPTY                  "pmix.clnup.empty"      // (bool) only remove empty subdirectories
+                                                                    //        specified one(s) - i.e., remove all files and then
+                                                                    //        the directories that contained them. Mutually
+                                                                    //        exclusive with PMIX_CLEANUP_EMPTY
+#define PMIX_CLEANUP_EMPTY                  "pmix.clnup.empty"      // (bool) remove all empty directories under the specified
+                                                                    //        one(s), leaving every file in place. Mutually
+                                                                    //        exclusive with PMIX_CLEANUP_RECURSIVE
 #define PMIX_CLEANUP_IGNORE                 "pmix.clnup.ignore"     // (char*) comma-delimited list of filenames that are not
                                                                     //         to be removed
 #define PMIX_CLEANUP_LEAVE_TOPDIR           "pmix.clnup.lvtop"      // (bool) when recursively cleaning subdirs, do not remove

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -131,6 +131,7 @@ static void cdcon(pmix_cleanup_dir_t *p)
 {
     p->path = NULL;
     p->recurse = false;
+    p->empty = false;
     p->leave_topdir = false;
 }
 static void cddes(pmix_cleanup_dir_t *p)
@@ -855,22 +856,28 @@ static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd, pmix_epilog_t *e
         tst = opendir(filenm);
         if (NULL != tst) {
             closedir(tst);
-            /*
-             * If not recursively descending, then if we find a directory then fail
-             * since we were not told to remove it.
-             */
-            if (!cd->recurse) {
-                /* continue removing files */
-                free(filenm);
-                continue;
-            } else {
-                /* Directories are recursively destroyed */
+            /* Both flags descend, for different reasons:
+             * PMIX_CLEANUP_RECURSIVE to destroy the subdirectory, and
+             * PMIX_CLEANUP_EMPTY because the empty directories it is
+             * looking for may be at any depth - and because a directory
+             * holding nothing but empty ones becomes empty itself once
+             * they are gone, which is what makes the walk bottom-up.
+             * Given neither, we were not told to touch a subdirectory at
+             * all, so it is left where it is. */
+            if (cd->recurse || cd->empty) {
                 dirpath_destroy(filenm, cd, epi);
-                free(filenm);
             }
+            free(filenm);
         } else {
-            /* Files are removed right here */
-            unlink(filenm);
+            /* Files are removed right here - except under
+             * PMIX_CLEANUP_EMPTY, where the files are precisely what we
+             * were told to leave behind. Note this is also what stops
+             * that mode from emptying a directory and then removing it:
+             * the rmdir below only fires on a directory that is already
+             * empty. */
+            if (!cd->empty) {
+                unlink(filenm);
+            }
             free(filenm);
         }
     }

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -48,6 +48,12 @@
 #ifdef HAVE_DIRENT_H
 #    include <dirent.h>
 #endif /* HAVE_DIRENT_H */
+#ifdef HAVE_SYS_WAIT_H
+#    include <sys/wait.h>
+#endif /* HAVE_SYS_WAIT_H */
+#ifdef HAVE_GRP_H
+#    include <grp.h>
+#endif /* HAVE_GRP_H */
 
 #include "pmix_common.h"
 
@@ -157,6 +163,18 @@ static void nscon(pmix_namespace_t *p)
     p->local_app_fini_fired = false;
     PMIX_CONSTRUCT(&p->ranks, pmix_list_t);
     memset(&p->compat, 0, sizeof(p->compat));
+    /* Default the epilog's identity to our own. PMIX_NEW malloc's rather
+     * than calloc's, so these two are uninitialized heap until somebody
+     * assigns them, and the only thing that does is the connection
+     * handler, for a peer that actually completed a handshake. That was
+     * harmless for as long as nothing read them; pmix_execute_epilog now
+     * does, and "act as whatever this word happens to hold" is not a
+     * thing to leave in a function that unlinks files. Our own identity
+     * is the honest default: it makes an epilog nobody vouched for
+     * behave exactly as it always has, and reserves the privilege drop
+     * for a peer the host actually registered a uid and gid for. */
+    p->epilog.uid = geteuid();
+    p->epilog.gid = getegid();
     PMIX_CONSTRUCT(&p->epilog.cleanup_dirs, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.cleanup_files, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);
@@ -334,6 +352,10 @@ static void pcon(pmix_peer_t *p)
     p->send_msg = NULL;
     p->recv_msg = NULL;
     p->commit_cnt = 0;
+    /* see the note in nscon above - our own identity is the default, so
+     * an epilog nobody vouched for behaves as it always has */
+    p->epilog.uid = geteuid();
+    p->epilog.gid = getegid();
     PMIX_CONSTRUCT(&p->epilog.cleanup_dirs, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.cleanup_files, pmix_list_t);
     PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);
@@ -763,10 +785,16 @@ static bool epilog_ignored(pmix_epilog_t *epi, const char *path)
     return false;
 }
 
-void pmix_execute_epilog(pmix_epilog_t *epi)
+/* The removals themselves. Runs either directly or inside a forked
+ * child that has dropped to the requesting client's identity - see
+ * pmix_execute_epilog below - so it must touch nothing but the
+ * filesystem: no event base, no allocation the parent would have to see,
+ * and no change to the lists, which the caller drains once the walk is
+ * over so that a second call finds nothing to do. */
+static void epilog_walk(pmix_epilog_t *epi)
 {
-    pmix_cleanup_file_t *cf, *cfnext;
-    pmix_cleanup_dir_t *cd, *cdnext;
+    pmix_cleanup_file_t *cf;
+    pmix_cleanup_dir_t *cd;
     DIR *tst;
     int rc;
 
@@ -780,7 +808,7 @@ void pmix_execute_epilog(pmix_epilog_t *epi)
      * made against a string no constructed path ever equals. */
 
     /* start with any specified files */
-    PMIX_LIST_FOREACH_SAFE (cf, cfnext, &epi->cleanup_files, pmix_cleanup_file_t) {
+    PMIX_LIST_FOREACH (cf, &epi->cleanup_files, pmix_cleanup_file_t) {
         if (!epilog_ignored(epi, cf->path)) {
             rc = unlink(cf->path);
             if (0 > rc) {
@@ -788,20 +816,156 @@ void pmix_execute_epilog(pmix_epilog_t *epi)
                                     cf->path, strerror(errno));
             }
         }
-        pmix_list_remove_item(&epi->cleanup_files, &cf->super);
-        PMIX_RELEASE(cf);
     }
 
     /* now cleanup the directories */
-    PMIX_LIST_FOREACH_SAFE (cd, cdnext, &epi->cleanup_dirs, pmix_cleanup_dir_t) {
+    PMIX_LIST_FOREACH (cd, &epi->cleanup_dirs, pmix_cleanup_dir_t) {
         tst = opendir(cd->path);
         if (NULL != tst) {
             closedir(tst);
             dirpath_destroy(cd->path, cd, epi);
         }
-        pmix_list_remove_item(&epi->cleanup_dirs, &cd->super);
-        PMIX_RELEASE(cd);
     }
+}
+
+static void epilog_drain(pmix_epilog_t *epi)
+{
+    pmix_list_item_t *item;
+
+    /* the walk is done, so take the lists down - every caller of
+     * pmix_execute_epilog either destructs the epilog immediately
+     * afterwards or may reach it again through a later teardown, and the
+     * second visit must find nothing rather than removing the same paths
+     * a second time */
+    while (NULL != (item = pmix_list_remove_first(&epi->cleanup_files))) {
+        PMIX_RELEASE(item);
+    }
+    while (NULL != (item = pmix_list_remove_first(&epi->cleanup_dirs))) {
+        PMIX_RELEASE(item);
+    }
+}
+
+/* Remove what a client asked us to remove, as that client.
+ *
+ * The paths come off the wire from a peer, and the epilog records the
+ * uid and gid the *host* registered that peer with - the same vouched-for
+ * pair the connection handshake refuses to let a peer misstate. Until
+ * this was written both members were set and never read, so a PMIx server
+ * running with privilege unlinked whatever path a client named, as
+ * whatever user the server happened to be.
+ *
+ * Doing the walk under the client's own identity hands the decision to
+ * the kernel, which is the only thing that gets symlinks, "..", and every
+ * other traversal right without a check of our own racing the filesystem.
+ * There are two ways to get there and we take the cheap one when it
+ * applies:
+ *
+ *   - We are already that user. The ordinary case: a per-user PMIx server
+ *     has the client's identity to begin with, and the kernel is already
+ *     applying exactly the check we want. Walk in place. This compares
+ *     our own process credentials rather than anything on disk, so there
+ *     is no time-of-check window to lose - only another thread calling
+ *     seteuid() could invalidate it, and nothing in this library does.
+ *
+ *   - We are not, so fork and drop in the child. Only a privileged server
+ *     can drop to somebody else, and that is exactly the server this
+ *     matters for. An unprivileged server whose identity does not match
+ *     fails the drop, which is the right answer: it could not have
+ *     removed those paths anyway - the kernel would refuse the unlink -
+ *     so the child exits having done nothing.
+ *
+ * A child rather than seteuid() on the spot because credentials are
+ * per-process: glibc implements the POSIX semantics with a broadcast to
+ * every thread, so dropping here would run the whole server as the client
+ * for the duration of the walk. The epilog runs at job termination and
+ * never on a hot path, so a fork per privileged cleanup is affordable and
+ * the window simply does not exist.
+ */
+void pmix_execute_epilog(pmix_epilog_t *epi)
+{
+#if defined(HAVE_FORK) && defined(HAVE_WAITPID)
+    pid_t pid, r;
+    int status;
+#endif
+
+    if (0 == pmix_list_get_size(&epi->cleanup_files) &&
+        0 == pmix_list_get_size(&epi->cleanup_dirs)) {
+        /* nothing registered - do not pay for any of the below */
+        return;
+    }
+
+    if (geteuid() == epi->uid && getegid() == epi->gid) {
+        epilog_walk(epi);
+        epilog_drain(epi);
+        return;
+    }
+
+#if defined(HAVE_FORK) && defined(HAVE_WAITPID)
+    pid = fork();
+    if (0 > pid) {
+        /* we cannot get to the client's identity, and doing the removals
+         * as ourselves is the behavior this function exists to stop */
+        pmix_output_verbose(10, pmix_globals.debug_output,
+                            "epilog: cannot fork to drop privileges: %s", strerror(errno));
+        epilog_drain(epi);
+        return;
+    }
+    if (0 == pid) {
+        /* Child. Nothing here may return: every path out is _exit(), not
+         * exit(), because this is a forked child of a threaded process
+         * and running the parent's atexit handlers would tear down a
+         * library that is still very much alive in the parent. */
+#ifdef HAVE_SETGROUPS
+        /* setuid() does not touch the supplementary groups, so without
+         * this the child keeps *our* group memberships and can reach a
+         * file the client cannot. Dropping them all rather than adopting
+         * the client's own set errs toward removing too little, which is
+         * the safe direction for a deletion - and the epilog records only
+         * a uid and a gid, so the client's set is not ours to look up
+         * here anyway (getpwuid() in a forked child would reach NSS). */
+        if (0 != setgroups(0, NULL)) {
+            _exit(1);
+        }
+#endif
+        /* group first: once the uid is gone so is the privilege needed
+         * to change the gid */
+        if (0 != setgid(epi->gid)) {
+            _exit(1);
+        }
+        if (0 != setuid(epi->uid)) {
+            _exit(1);
+        }
+        /* a drop that silently did not take would have us doing the
+         * removals with our original identity, in a child, which is the
+         * whole thing we are avoiding */
+        if (geteuid() != epi->uid || getuid() != epi->uid) {
+            _exit(1);
+        }
+        epilog_walk(epi);
+        _exit(0);
+    }
+
+    /* Parent. Wait for our own child by pid, and only our own.
+     * PMIx installs no SIGCHLD handler - pfexec polls per-pid, see
+     * child_poll() in src/common/pmix_pfexec.c - but the host process we
+     * are embedded in may sweep with waitpid(-1) or set SIGCHLD to
+     * SIG_IGN, in which case our child is reaped out from under us and
+     * ECHILD means "already gone", not "failed". */
+    status = 0;
+    do {
+        r = waitpid(pid, &status, 0);
+    } while (0 > r && EINTR == errno);
+    if (pid == r && WIFEXITED(status) && 0 != WEXITSTATUS(status)) {
+        /* the child could not become the client and so removed nothing.
+         * That is the correct outcome, but it is also the one that looks
+         * exactly like a cleanup that quietly did not happen, so say so */
+        pmix_output_verbose(10, pmix_globals.debug_output,
+                            "epilog: could not assume uid %lu gid %lu - nothing removed",
+                            (unsigned long) epi->uid, (unsigned long) epi->gid);
+    }
+#endif
+
+    epilog_drain(epi);
 }
 
 static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd, pmix_epilog_t *epi)

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -740,41 +740,64 @@ PMIX_CLASS_INSTANCE(pmix_group_t,
                     pmix_list_item_t,
                     grcon, grdes);
 
+/* Is this path one the client asked us to leave alone? dirpath_destroy
+ * asks the same question of the directory it is descending and of every
+ * file inside it; the cleanup_files loop below did not ask it at all,
+ * so an ignore naming a path already registered for cleanup was
+ * recorded and then had no effect - the epilog went on unlinking a file
+ * the client had asked it to keep. pmix_server_job_ctrl refuses the
+ * reverse order with PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES, which is
+ * what says the two lists are meant to be exclusive; an ignore arriving
+ * second is the one way a path can reach both, and it is the ignore
+ * that has to win. */
+static bool epilog_ignored(pmix_epilog_t *epi, const char *path)
+{
+    pmix_cleanup_file_t *cf;
+
+    PMIX_LIST_FOREACH (cf, &epi->ignores, pmix_cleanup_file_t) {
+        if (0 == strcmp(cf->path, path)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void pmix_execute_epilog(pmix_epilog_t *epi)
 {
     pmix_cleanup_file_t *cf, *cfnext;
     pmix_cleanup_dir_t *cd, *cdnext;
     DIR *tst;
     int rc;
-    char **tmp;
-    size_t n;
+
+    /* Every entry on these two lists carries exactly one path.
+     * pmix_server_job_ctrl is the only thing in the tree that builds
+     * one, and it expands the comma-delimited value the client sent
+     * before anything is compared against it - which is what makes the
+     * ignore test here, and the top-directory test in dirpath_destroy,
+     * whole-path comparisons that can actually match. Do not re-split
+     * here: a second expansion point is how those comparisons came to be
+     * made against a string no constructed path ever equals. */
 
     /* start with any specified files */
     PMIX_LIST_FOREACH_SAFE (cf, cfnext, &epi->cleanup_files, pmix_cleanup_file_t) {
-        tmp = PMIx_Argv_split(cf->path, ',');
-        for (n = 0; NULL != tmp[n]; n++) {
-            rc = unlink(tmp[n]);
+        if (!epilog_ignored(epi, cf->path)) {
+            rc = unlink(cf->path);
             if (0 > rc) {
                 pmix_output_verbose(10, pmix_globals.debug_output, "File %s failed to unlink: %s",
-                                    tmp[n], strerror(errno));
+                                    cf->path, strerror(errno));
             }
         }
-        PMIx_Argv_free(tmp);
         pmix_list_remove_item(&epi->cleanup_files, &cf->super);
         PMIX_RELEASE(cf);
     }
 
     /* now cleanup the directories */
     PMIX_LIST_FOREACH_SAFE (cd, cdnext, &epi->cleanup_dirs, pmix_cleanup_dir_t) {
-        tmp = PMIx_Argv_split(cd->path, ',');
-        for (n = 0; NULL != tmp[n]; n++) {
-            tst = opendir(tmp[n]);
-            if (NULL != tst) {
-                closedir(tst);
-                dirpath_destroy(tmp[n], cd, epi);
-            }
+        tst = opendir(cd->path);
+        if (NULL != tst) {
+            closedir(tst);
+            dirpath_destroy(cd->path, cd, epi);
         }
-        PMIx_Argv_free(tmp);
         pmix_list_remove_item(&epi->cleanup_dirs, &cd->super);
         PMIX_RELEASE(cd);
     }
@@ -785,17 +808,14 @@ static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd, pmix_epilog_t *e
     DIR *dp, *tst;
     struct dirent *ep;
     char *filenm;
-    pmix_cleanup_file_t *cf;
 
     if (NULL == path) { /* protect against error */
         return;
     }
 
-    /* if this path is it to be ignored, then do so */
-    PMIX_LIST_FOREACH (cf, &epi->ignores, pmix_cleanup_file_t) {
-        if (0 == strcmp(cf->path, path)) {
-            return;
-        }
+    /* if this path is to be ignored, then do so */
+    if (epilog_ignored(epi, path)) {
+        return;
     }
 
     /* Open up the directory */
@@ -826,14 +846,8 @@ static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd, pmix_epilog_t *e
         }
 
         /* if this path is to be ignored, then do so */
-        PMIX_LIST_FOREACH (cf, &epi->ignores, pmix_cleanup_file_t) {
-            if (0 == strcmp(cf->path, filenm)) {
-                free(filenm);
-                filenm = NULL;
-                break;
-            }
-        }
-        if (NULL == filenm) {
+        if (epilog_ignored(epi, filenm)) {
+            free(filenm);
             continue;
         }
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -321,7 +321,13 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_cleanup_file_t);
 typedef struct {
     pmix_list_item_t super;
     char *path;
+    /* recurse and empty are mutually exclusive - PMIX_CLEANUP_RECURSIVE
+     * removes every file and then the directories that held them, while
+     * PMIX_CLEANUP_EMPTY removes only the directories that are empty and
+     * leaves every file alone. pmix_server_job_ctrl refuses a request
+     * asking for both */
     bool recurse;
+    bool empty;
     bool leave_topdir;
 } pmix_cleanup_dir_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_cleanup_dir_t);

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -2918,11 +2918,20 @@ misbehave by design).
   list that lives as long as the namespace or peer and that
   `dirpath_destroy` walks once per file; and an ignore naming a path
   already registered for cleanup was dropped, so the epilog deleted a
-  file the client had asked it to leave alone. Note that `ignores` is
-  read *only* by `dirpath_destroy` (`src/include/pmix_globals.c`), which
-  consults it for the directory itself and again for each file inside
-  it — so an entry there is meaningful whether or not the same path is
-  also on `cleanup_files`.
+  file the client had asked it to leave alone.
+
+  Recording the ignore was only half of that, and the other half was in
+  `pmix_execute_epilog` (`src/include/pmix_globals.c`). `ignores` was
+  consulted *only* by `dirpath_destroy`, for the directory it is
+  descending and for each file inside it; the `cleanup_files` loop
+  unlinked every path on its list without asking. So the ignore that now
+  gets recorded still had no effect on the case it was written for, and
+  the file was deleted anyway. Both readers go through
+  `epilog_ignored()` now. Which list wins is settled by the handler
+  refusing the opposite order with
+  `PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES`: the two lists are meant to
+  be exclusive, an ignore arriving second is the one way a path reaches
+  both, and the ignore is what the client asked for last.
 - **A job-control cleanup request is staged and then committed, and it
   has to stay that way.** The three epilog lists outlive the request —
   they live as long as the namespace or the peer — and nothing gives a
@@ -2946,7 +2955,27 @@ misbehave by design).
   on the epilog is *never* conflict-checked, because the question of
   whether that path may be registered for cleanup was answered when it
   was registered.
-
+- **A comma-delimited path list is expanded at registration, and must
+  not be expanded anywhere else.** `PMIX_REGISTER_CLEANUP`,
+  `PMIX_REGISTER_CLEANUP_DIR` and `PMIX_CLEANUP_IGNORE` are all
+  documented as comma-delimited lists, and the expansion used to happen
+  only in `pmix_execute_epilog` — so every comparison in between was
+  made against the unexpanded string, and three separate things silently
+  stopped working for a list of more than one path. `dirpath_destroy`
+  strcmp's an ignore against a filename it has just constructed, so an
+  ignore of `"/a,/b"` protected neither; it decides
+  `PMIX_CLEANUP_LEAVE_TOPDIR` by comparing the directory it is
+  descending against `cd->path`, which a list never equals, so the flag
+  was dropped; and neither the duplicate scan nor the conflict scan in
+  `pmix_server_job_ctrl` could see the paths inside one. A value naming
+  no path at all — `","` — was worse than any of them: `PMIx_Argv_split`
+  returns **NULL** rather than an empty array for a string with no
+  tokens, and the epilog indexed it, so a client could take the server
+  down at job termination with one directive. `epi_cache_files` /
+  `epi_cache_dirs` expand at registration and refuse a value that names
+  nothing; `pmix_server_job_ctrl` is the only thing in the tree that
+  builds an epilog entry, so after that no entry carries a comma and the
+  epilog has nothing left to split.
 - **Two things in `pmix_server_get.c` look like defects and are not.**
   `get_job_data` returns `PMIX_SUCCESS` with an empty buffer when the
   fetch finds nothing, and its callers pass that empty payload to the

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -2923,18 +2923,30 @@ misbehave by design).
   consults it for the directory itself and again for each file inside
   it — so an entry there is meaningful whether or not the same path is
   also on `cleanup_files`.
-- **A conflicting cleanup request is applied in part before it fails.**
-  The ignores are registered first, and the directory and file loops
-  then error with `PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES` when a path
-  they were asked to clean is on the ignore list — by which point this
-  request's ignores, and any directories accepted ahead of the
-  conflicting one, are already on long-lived epilogs. The client is told
-  the request failed and the server keeps half of it. What survives is
-  the conservative half (a path is ignored rather than deleted), which
-  is why this is recorded rather than repaired: making it atomic means a
-  validate-then-apply split, and the exact semantics of a partially
-  conflicting request is a decision for the Standard rather than for
-  this file. See `docs/todo.rst`.
+- **A job-control cleanup request is staged and then committed, and it
+  has to stay that way.** The three epilog lists outlive the request —
+  they live as long as the namespace or the peer — and nothing gives a
+  client a way to take an entry back off one. So a request refused with
+  `PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES` used to leave behind its own
+  ignores (registered first, which is what the conflict is detected
+  against), every directory accepted ahead of the conflicting one, and
+  any flag widening it had applied to already-registered entries — with
+  the client told the whole request had failed. The widening is the
+  sharpest of the three and the least obviously destructive: a duplicate
+  `PMIX_REGISTER_CLEANUP_DIR` carrying `PMIX_CLEANUP_RECURSIVE` turns an
+  existing non-recursive entry recursive, so a directory the client
+  believes untouched takes its whole subtree with it at termination. The
+  handler now builds every addition on per-epilog staging lists hanging
+  off `pmix_srvr_epi_caddy_t`, records pending widenings on a list of
+  `pmix_srvr_epi_upgrade_t`, and commits with `pmix_list_join` only once
+  nothing can fail — which covers the allocation arms too. **Do not put
+  an allocation or a fallible call below the commit comment**; that is
+  the whole basis of the guarantee. Note the one rule the staging pass
+  had to preserve exactly: a directory that duplicates an entry already
+  on the epilog is *never* conflict-checked, because the question of
+  whether that path may be registered for cleanup was answered when it
+  was registered.
+
 - **Two things in `pmix_server_get.c` look like defects and are not.**
   `get_job_data` returns `PMIX_SUCCESS` with an empty buffer when the
   fetch finds nothing, and its callers pass that empty payload to the

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -2976,6 +2976,32 @@ misbehave by design).
   nothing; `pmix_server_job_ctrl` is the only thing in the tree that
   builds an epilog entry, so after that no entry carries a comma and the
   epilog has nothing left to split.
+- **`PMIX_CLEANUP_RECURSIVE` and `PMIX_CLEANUP_EMPTY` are mutually
+  exclusive, and both descend.** Recursive removes every file and then
+  the directories that held them; empty removes only the directories
+  that are empty and leaves every file alone. A request naming both has
+  not said what it wants, and is refused with
+  `PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES`. `dirpath_destroy`
+  (`src/include/pmix_globals.c`) descends under *either* flag — the
+  empty mode has to, because the empty directories it is looking for may
+  be at any depth, and because a directory holding nothing but empty
+  ones becomes empty itself once they are gone, which is what makes the
+  walk bottom-up. What stops that mode from emptying a directory and
+  then removing it is simply that it never unlinks: the `rmdir` at the
+  foot only fires on a directory that is already empty. Given neither
+  flag, a subdirectory is left where it is.
+
+  `PMIX_CLEANUP_EMPTY` was defined, documented and advertised by
+  `src/common/pmix_attributes.c` without being read anywhere, and it was
+  not inert: `pmix_server_job_ctrl` decides whether a request is one it
+  can answer itself by counting the cleanup directives against the
+  total, and an uncounted cleanup key sent a request carrying nothing
+  else up to the host as well, to be registered a second time. **A new
+  directive in this family owes that `++cnt`.** Where the two modes meet
+  across *separate* requests — a duplicate directory directive widening
+  an entry already registered — the existing more-permissive-wins rule
+  decides it: recursive removes everything empty would have and the
+  files besides, so recursive dominates and clears the empty flag.
 - **Two things in `pmix_server_get.c` look like defects and are not.**
   `get_job_data` returns `PMIX_SUCCESS` with an empty buffer when the
   fetch finds nothing, and its callers pass that empty payload to the

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -2932,29 +2932,6 @@ misbehave by design).
   `PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES`: the two lists are meant to
   be exclusive, an ignore arriving second is the one way a path reaches
   both, and the ignore is what the client asked for last.
-- **A job-control cleanup request is staged and then committed, and it
-  has to stay that way.** The three epilog lists outlive the request —
-  they live as long as the namespace or the peer — and nothing gives a
-  client a way to take an entry back off one. So a request refused with
-  `PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES` used to leave behind its own
-  ignores (registered first, which is what the conflict is detected
-  against), every directory accepted ahead of the conflicting one, and
-  any flag widening it had applied to already-registered entries — with
-  the client told the whole request had failed. The widening is the
-  sharpest of the three and the least obviously destructive: a duplicate
-  `PMIX_REGISTER_CLEANUP_DIR` carrying `PMIX_CLEANUP_RECURSIVE` turns an
-  existing non-recursive entry recursive, so a directory the client
-  believes untouched takes its whole subtree with it at termination. The
-  handler now builds every addition on per-epilog staging lists hanging
-  off `pmix_srvr_epi_caddy_t`, records pending widenings on a list of
-  `pmix_srvr_epi_upgrade_t`, and commits with `pmix_list_join` only once
-  nothing can fail — which covers the allocation arms too. **Do not put
-  an allocation or a fallible call below the commit comment**; that is
-  the whole basis of the guarantee. Note the one rule the staging pass
-  had to preserve exactly: a directory that duplicates an entry already
-  on the epilog is *never* conflict-checked, because the question of
-  whether that path may be registered for cleanup was answered when it
-  was registered.
 - **A comma-delimited path list is expanded at registration, and must
   not be expanded anywhere else.** `PMIX_REGISTER_CLEANUP`,
   `PMIX_REGISTER_CLEANUP_DIR` and `PMIX_CLEANUP_IGNORE` are all
@@ -3002,6 +2979,83 @@ misbehave by design).
   an entry already registered — the existing more-permissive-wins rule
   decides it: recursive removes everything empty would have and the
   files besides, so recursive dominates and clears the empty flag.
+- **The epilog removes what a client named *as* that client, and the
+  identity it uses had better be initialized.** `pmix_epilog_t::uid` and
+  `::gid` were written by the connection handler
+  (`src/mca/ptl/base/ptl_base_connection_hdlr.c`, four sites) and read
+  nowhere, so `pmix_execute_epilog` unlinked and rmdir'd whatever path a
+  client named as whatever user the server happened to be — free rein
+  over a node for any client of a privileged system-level server.
+  `pmix_execute_epilog` now walks under the recorded identity, which
+  hands the decision to the kernel and so gets symlinks and `..` right
+  without a check of ours racing the filesystem. Two routes:
+
+  - **We are already that user** — the ordinary per-user server — so
+    walk in place. This compares our own process credentials, not
+    anything on disk, so there is no time-of-check window: only another
+    thread calling `seteuid()` could invalidate it and nothing here
+    does.
+  - **We are not**, so `fork()` and drop in the child
+    (`setgroups(0, NULL)`, then `setgid`, then `setuid` — group before
+    user, because dropping the uid first takes with it the privilege
+    needed to change the gid, and `setuid()` does not touch the
+    supplementary groups on its own). Only a privileged server can drop
+    to somebody else, which is exactly the server this is for; an
+    unprivileged one fails the drop and the child exits having done
+    nothing, which is right, because the kernel would have refused those
+    unlinks anyway.
+
+  **A child rather than `seteuid()` on the spot**, because credentials
+  are per-process: glibc implements the POSIX semantics with a broadcast
+  to every thread, so dropping here would run the whole server as the
+  client for the length of the walk. The epilog runs at job termination
+  and never on a hot path, so the fork is affordable and the window
+  simply does not exist. Every path out of the child is `_exit()`, never
+  `exit()` — this is a forked child of a threaded process and the
+  parent's atexit handlers would tear down a library that is still very
+  much alive in the parent.
+
+  **The parent waits per-pid and treats `ECHILD` as "already gone".**
+  PMIx installs no `SIGCHLD` handler — `child_poll()` in
+  `src/common/pmix_pfexec.c` polls per-pid for exactly this reason — but
+  the host process we are embedded in may sweep with `waitpid(-1)` or
+  set `SIGCHLD` to `SIG_IGN`, and then our child is reaped out from
+  under us.
+
+  **What made this a live hazard rather than a latent one is that
+  `PMIX_NEW` `malloc`s and does not `calloc`.** Neither `nscon` nor
+  `pcon` assigned those two members, so until a handshake wrote them
+  they were uninitialized heap — fine while nothing read them, and not
+  fine at all in a function that unlinks files. Both constructors now
+  default them to `geteuid()`/`getegid()`, which makes an epilog nobody
+  vouched for behave exactly as it always has and reserves the drop for
+  a peer the host actually registered an identity for. **Any new member
+  of an object here is uninitialized until a constructor says
+  otherwise** — do not read the absence of a crash as evidence that
+  something zeroed it.
+- **A job-control cleanup request is staged and then committed, and it
+  has to stay that way.** The three epilog lists outlive the request —
+  they live as long as the namespace or the peer — and nothing gives a
+  client a way to take an entry back off one. So a request refused with
+  `PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES` used to leave behind its own
+  ignores (registered first, which is what the conflict is detected
+  against), every directory accepted ahead of the conflicting one, and
+  any flag widening it had applied to already-registered entries — with
+  the client told the whole request had failed. The widening is the
+  sharpest of the three and the least obviously destructive: a duplicate
+  `PMIX_REGISTER_CLEANUP_DIR` carrying `PMIX_CLEANUP_RECURSIVE` turns an
+  existing non-recursive entry recursive, so a directory the client
+  believes untouched takes its whole subtree with it at termination. The
+  handler now builds every addition on per-epilog staging lists hanging
+  off `pmix_srvr_epi_caddy_t`, records pending widenings on a list of
+  `pmix_srvr_epi_upgrade_t`, and commits with `pmix_list_join` only once
+  nothing can fail — which covers the allocation arms too. **Do not put
+  an allocation or a fallible call below the commit comment**; that is
+  the whole basis of the guarantee. Note the one rule the staging pass
+  had to preserve exactly: a directory that duplicates an entry already
+  on the epilog is *never* conflict-checked, because the question of
+  whether that path may be registered for cleanup was answered when it
+  was registered.
 - **Two things in `pmix_server_get.c` look like defects and are not.**
   `get_job_data` returns `PMIX_SUCCESS` with an empty buffer when the
   fetch finds nothing, and its callers pass that empty payload to the

--- a/src/server/pmix_server_control.c
+++ b/src/server/pmix_server_control.c
@@ -367,11 +367,108 @@ exit:
     return rc;
 }
 
+/* One target epilog, plus what this request would add to it. The three
+ * staging lists are what make a job-control request atomic: nothing is
+ * put on an epilog until the whole request is known to be acceptable,
+ * because those lists outlive the request and the client that is told
+ * the request failed has no way to take anything back off them. */
 typedef struct {
     pmix_list_item_t super;
     pmix_epilog_t *epi;
+    pmix_list_t newignores;
+    pmix_list_t newdirs;
+    pmix_list_t newfiles;
 } pmix_srvr_epi_caddy_t;
-static PMIX_CLASS_INSTANCE(pmix_srvr_epi_caddy_t, pmix_list_item_t, NULL, NULL);
+static void epicon(pmix_srvr_epi_caddy_t *p)
+{
+    p->epi = NULL;
+    PMIX_CONSTRUCT(&p->newignores, pmix_list_t);
+    PMIX_CONSTRUCT(&p->newdirs, pmix_list_t);
+    PMIX_CONSTRUCT(&p->newfiles, pmix_list_t);
+}
+static void epides(pmix_srvr_epi_caddy_t *p)
+{
+    /* on the way out of an accepted request these are empty, the entries
+     * having been joined onto the epilog's own lists; on a refused one
+     * they still hold everything the request would have applied */
+    PMIX_LIST_DESTRUCT(&p->newignores);
+    PMIX_LIST_DESTRUCT(&p->newdirs);
+    PMIX_LIST_DESTRUCT(&p->newfiles);
+}
+static PMIX_CLASS_INSTANCE(pmix_srvr_epi_caddy_t, pmix_list_item_t, epicon, epides);
+
+/* A directory already registered on a target epilog whose flags this
+ * request would widen, per the RFC precedence rule. Staged rather than
+ * applied in place for the same reason as the lists above - and with
+ * more reason, since turning a non-recursive entry recursive is the most
+ * destructive thing this handler can do. */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_cleanup_dir_t *dir;
+} pmix_srvr_epi_upgrade_t;
+static PMIX_CLASS_INSTANCE(pmix_srvr_epi_upgrade_t, pmix_list_item_t, NULL, NULL);
+
+/* Is path already named on this list of cleanup files? Every entry
+ * carries a non-NULL path by construction, so the strcmp is unguarded. */
+static bool epi_has_file(pmix_list_t *list, const char *path)
+{
+    pmix_cleanup_file_t *cf;
+
+    PMIX_LIST_FOREACH (cf, list, pmix_cleanup_file_t) {
+        if (0 == strcmp(cf->path, path)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static pmix_cleanup_dir_t *epi_find_dir(pmix_list_t *list, const char *path)
+{
+    pmix_cleanup_dir_t *cd;
+
+    PMIX_LIST_FOREACH (cd, list, pmix_cleanup_dir_t) {
+        if (0 == strcmp(cd->path, path)) {
+            return cd;
+        }
+    }
+    return NULL;
+}
+
+/* Build a cleanup-file entry carrying its own copy of the path. Every
+ * scan above strcmp's that member, so an entry with a NULL path must
+ * never reach a list - which is why the strdup failure takes the entry
+ * with it. */
+static pmix_cleanup_file_t *epi_new_file(const char *path)
+{
+    pmix_cleanup_file_t *cf;
+
+    cf = PMIX_NEW(pmix_cleanup_file_t);
+    if (NULL == cf) {
+        return NULL;
+    }
+    cf->path = strdup(path);
+    if (NULL == cf->path) {
+        PMIX_RELEASE(cf);
+        return NULL;
+    }
+    return cf;
+}
+
+static pmix_cleanup_dir_t *epi_new_dir(const char *path)
+{
+    pmix_cleanup_dir_t *cdir;
+
+    cdir = PMIX_NEW(pmix_cleanup_dir_t);
+    if (NULL == cdir) {
+        return NULL;
+    }
+    cdir->path = strdup(path);
+    if (NULL == cdir->path) {
+        PMIX_RELEASE(cdir);
+        return NULL;
+    }
+    return cdir;
+}
 
 pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                                    pmix_info_cbfunc_t cbfunc,
@@ -384,10 +481,11 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
     pmix_peer_t *pr;
     pmix_proc_t proc;
     size_t n;
-    bool recurse = false, leave_topdir = false, duplicate;
-    pmix_list_t cachedirs, cachefiles, ignorefiles, epicache;
+    bool recurse = false, leave_topdir = false;
+    pmix_list_t cachedirs, cachefiles, ignorefiles, epicache, upgrades;
     pmix_srvr_epi_caddy_t *epicd = NULL;
-    pmix_cleanup_file_t *cf, *cf2, *cfptr;
+    pmix_srvr_epi_upgrade_t *upg;
+    pmix_cleanup_file_t *cf, *cfptr;
     pmix_cleanup_dir_t *cdir, *cdir2, *cdirptr;
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
@@ -415,6 +513,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
     PMIX_CONSTRUCT(&cachedirs, pmix_list_t);
     PMIX_CONSTRUCT(&cachefiles, pmix_list_t);
     PMIX_CONSTRUCT(&ignorefiles, pmix_list_t);
+    PMIX_CONSTRUCT(&upgrades, pmix_list_t);
 
     /* unpack the number of targets */
     cnt = 1;
@@ -570,17 +669,9 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 rc = PMIX_ERR_BAD_PARAM;
                 goto exit;
             }
-            cf = PMIX_NEW(pmix_cleanup_file_t);
+            cf = epi_new_file(cd->info[n].value.data.string);
             if (NULL == cf) {
                 /* return an error */
-                rc = PMIX_ERR_NOMEM;
-                goto exit;
-            }
-            cf->path = strdup(cd->info[n].value.data.string);
-            if (NULL == cf->path) {
-                /* every scan below strcmp's this member - do not put an
-                 * entry carrying a NULL path on any list */
-                PMIX_RELEASE(cf);
                 rc = PMIX_ERR_NOMEM;
                 goto exit;
             }
@@ -592,15 +683,9 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 rc = PMIX_ERR_BAD_PARAM;
                 goto exit;
             }
-            cdir = PMIX_NEW(pmix_cleanup_dir_t);
+            cdir = epi_new_dir(cd->info[n].value.data.string);
             if (NULL == cdir) {
                 /* return an error */
-                rc = PMIX_ERR_NOMEM;
-                goto exit;
-            }
-            cdir->path = strdup(cd->info[n].value.data.string);
-            if (NULL == cdir->path) {
-                PMIX_RELEASE(cdir);
                 rc = PMIX_ERR_NOMEM;
                 goto exit;
             }
@@ -614,15 +699,9 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 rc = PMIX_ERR_BAD_PARAM;
                 goto exit;
             }
-            cf = PMIX_NEW(pmix_cleanup_file_t);
+            cf = epi_new_file(cd->info[n].value.data.string);
             if (NULL == cf) {
                 /* return an error */
-                rc = PMIX_ERR_NOMEM;
-                goto exit;
-            }
-            cf->path = strdup(cd->info[n].value.data.string);
-            if (NULL == cf->path) {
-                PMIX_RELEASE(cf);
                 rc = PMIX_ERR_NOMEM;
                 goto exit;
             }
@@ -634,136 +713,149 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
         }
     }
     if (0 < cnt) {
-        /* handle any ignore directives first */
+        /* Stage the whole request against every target epilog before any
+         * of it is applied. The lists we would be appending to live as
+         * long as the namespace or the peer, so anything put on one
+         * outlives the request - and a request refused with
+         * PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES used to leave its
+         * ignores, the directories accepted ahead of the conflicting one,
+         * and any flag widening it had applied to already-registered
+         * entries sitting there with the client told the whole thing had
+         * failed. Widening is the sharpest of those: an entry the client
+         * believes untouched becomes recursive, and deletes a subtree at
+         * termination. The allocation arms had the same shape. So: build
+         * everything first, and commit only once nothing can fail. */
+
+        /* the ignores, which are what the two loops below conflict
+         * against - a directive naming a path this request is also asking
+         * to clean must be refused whichever order the info array put
+         * them in, exactly as before */
         PMIX_LIST_FOREACH (cf, &ignorefiles, pmix_cleanup_file_t) {
             PMIX_LIST_FOREACH (epicd, &epicache, pmix_srvr_epi_caddy_t) {
-                /* scan for a duplicate on the list we are about to append
-                 * to. This loop was cloned from the cleanup_files one
-                 * below and kept its scan list, so it asked whether the
-                 * path was already registered for *cleanup* and then
-                 * appended to "ignores" regardless of the answer. Both
-                 * halves of that were wrong: a repeat of the same ignore
-                 * directive was never recognized as a duplicate, so every
-                 * job-control request carrying one appended another copy
-                 * to a list that lives as long as the namespace or peer
-                 * and is walked once per file by dirpath_destroy; and an
-                 * ignore naming a path already registered for cleanup was
+                /* scan the list we are about to append to. This loop was
+                 * cloned from the cleanup_files one below and kept its
+                 * scan list, so it asked whether the path was already
+                 * registered for *cleanup* and then appended to "ignores"
+                 * regardless of the answer. Both halves of that were
+                 * wrong: a repeat of the same ignore directive was never
+                 * recognized as a duplicate, so every job-control request
+                 * carrying one appended another copy to a list that is
+                 * walked once per file by dirpath_destroy; and an ignore
+                 * naming a path already registered for cleanup was
                  * silently dropped, so the epilog deleted a file the
                  * client had asked it to leave alone */
-                duplicate = false;
-                PMIX_LIST_FOREACH (cf2, &epicd->epi->ignores, pmix_cleanup_file_t) {
-                    if (0 == strcmp(cf2->path, cf->path)) {
-                        duplicate = true;
-                        break;
-                    }
+                if (epi_has_file(&epicd->epi->ignores, cf->path) ||
+                    epi_has_file(&epicd->newignores, cf->path)) {
+                    continue;
                 }
-                if (!duplicate) {
-                    /* append a copy to the end of the list - cf itself is a
-                     * member of the local ignorefiles list (destructed below),
-                     * so appending &cf->super would put one item on two lists
-                     * and leave a dangling entry when ignorefiles is freed */
-                    cfptr = PMIX_NEW(pmix_cleanup_file_t);
-                    if (NULL == cfptr) {
-                        rc = PMIX_ERR_NOMEM;
-                        goto exit;
-                    }
-                    cfptr->path = strdup(cf->path);
-                    if (NULL == cfptr->path) {
-                        /* this list outlives the request - a NULL path
-                         * here is strcmp'd by every later job-control
-                         * request and by the epilog itself */
-                        PMIX_RELEASE(cfptr);
-                        rc = PMIX_ERR_NOMEM;
-                        goto exit;
-                    }
-                    pmix_list_append(&epicd->epi->ignores, &cfptr->super);
+                /* stage a copy - cf itself is a member of the local
+                 * ignorefiles list (destructed below), so staging
+                 * &cf->super would put one item on two lists and leave a
+                 * dangling entry when ignorefiles is freed */
+                cfptr = epi_new_file(cf->path);
+                if (NULL == cfptr) {
+                    rc = PMIX_ERR_NOMEM;
+                    goto exit;
                 }
+                pmix_list_append(&epicd->newignores, &cfptr->super);
             }
         }
         /* now look at the directories */
         PMIX_LIST_FOREACH (cdir, &cachedirs, pmix_cleanup_dir_t) {
             PMIX_LIST_FOREACH (epicd, &epicache, pmix_srvr_epi_caddy_t) {
                 /* scan the existing list of directories for any duplicate */
-                duplicate = false;
-                PMIX_LIST_FOREACH (cdir2, &epicd->epi->cleanup_dirs, pmix_cleanup_dir_t) {
-                    if (0 == strcmp(cdir2->path, cdir->path)) {
-                        /* duplicate - check for difference in flags per RFC
-                         * precedence rules. The entry that has to absorb the
-                         * more permissive flag is the one already registered
-                         * on the epilog (cdir2); cdir is the request-local
-                         * copy we are about to discard, and its flags are
-                         * never read, so upgrading it did nothing at all */
-                        if (!cdir2->recurse && recurse) {
-                            cdir2->recurse = recurse;
-                        }
-                        if (!cdir2->leave_topdir && leave_topdir) {
-                            cdir2->leave_topdir = leave_topdir;
-                        }
-                        duplicate = true;
-                        break;
-                    }
-                }
-                if (!duplicate) {
-                    /* check for conflict with ignore */
-                    PMIX_LIST_FOREACH (cf, &epicd->epi->ignores, pmix_cleanup_file_t) {
-                        if (0 == strcmp(cf->path, cdir->path)) {
-                            /* return an error */
-                            rc = PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES;
+                cdir2 = epi_find_dir(&epicd->epi->cleanup_dirs, cdir->path);
+                if (NULL != cdir2) {
+                    /* duplicate - check for difference in flags per RFC
+                     * precedence rules. The entry that has to absorb the
+                     * more permissive flag is the one already registered
+                     * on the epilog (cdir2); cdir is the request-local
+                     * copy we are about to discard, and its flags are
+                     * never read, so upgrading it did nothing at all.
+                     * Note that a duplicate is never conflict-checked,
+                     * here or before this change: the path is already
+                     * registered for cleanup, so the question of whether
+                     * it may be has been answered */
+                    if ((!cdir2->recurse && recurse) ||
+                        (!cdir2->leave_topdir && leave_topdir)) {
+                        upg = PMIX_NEW(pmix_srvr_epi_upgrade_t);
+                        if (NULL == upg) {
+                            rc = PMIX_ERR_NOMEM;
                             goto exit;
                         }
+                        upg->dir = cdir2;
+                        pmix_list_append(&upgrades, &upg->super);
                     }
-                    /* append it to the end of the list */
-                    cdirptr = PMIX_NEW(pmix_cleanup_dir_t);
-                    if (NULL == cdirptr) {
-                        rc = PMIX_ERR_NOMEM;
-                        goto exit;
-                    }
-                    cdirptr->path = strdup(cdir->path);
-                    if (NULL == cdirptr->path) {
-                        PMIX_RELEASE(cdirptr);
-                        rc = PMIX_ERR_NOMEM;
-                        goto exit;
-                    }
-                    cdirptr->recurse = recurse;
-                    cdirptr->leave_topdir = leave_topdir;
-                    pmix_list_append(&epicd->epi->cleanup_dirs, &cdirptr->super);
+                    continue;
                 }
+                if (NULL != epi_find_dir(&epicd->newdirs, cdir->path)) {
+                    /* an earlier copy in this same request already staged
+                     * it, and every entry this request stages carries the
+                     * request's own flags, so there is nothing to widen */
+                    continue;
+                }
+                /* check for conflict with an ignore - one already
+                 * registered, or one this request is adding */
+                if (epi_has_file(&epicd->epi->ignores, cdir->path) ||
+                    epi_has_file(&epicd->newignores, cdir->path)) {
+                    /* return an error */
+                    rc = PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES;
+                    goto exit;
+                }
+                cdirptr = epi_new_dir(cdir->path);
+                if (NULL == cdirptr) {
+                    rc = PMIX_ERR_NOMEM;
+                    goto exit;
+                }
+                cdirptr->recurse = recurse;
+                cdirptr->leave_topdir = leave_topdir;
+                pmix_list_append(&epicd->newdirs, &cdirptr->super);
             }
         }
         PMIX_LIST_FOREACH (cf, &cachefiles, pmix_cleanup_file_t) {
             PMIX_LIST_FOREACH (epicd, &epicache, pmix_srvr_epi_caddy_t) {
                 /* scan the existing list of files for any duplicate */
-                duplicate = false;
-                PMIX_LIST_FOREACH (cf2, &epicd->epi->cleanup_files, pmix_cleanup_file_t) {
-                    if (0 == strcmp(cf2->path, cf->path)) {
-                        duplicate = true;
-                        break;
-                    }
+                if (epi_has_file(&epicd->epi->cleanup_files, cf->path) ||
+                    epi_has_file(&epicd->newfiles, cf->path)) {
+                    continue;
                 }
-                if (!duplicate) {
-                    /* check for conflict with ignore */
-                    PMIX_LIST_FOREACH (cf2, &epicd->epi->ignores, pmix_cleanup_file_t) {
-                        if (0 == strcmp(cf->path, cf2->path)) {
-                            /* return an error */
-                            rc = PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES;
-                            goto exit;
-                        }
-                    }
-                    /* append it to the end of the list */
-                    cfptr = PMIX_NEW(pmix_cleanup_file_t);
-                    if (NULL == cfptr) {
-                        rc = PMIX_ERR_NOMEM;
-                        goto exit;
-                    }
-                    cfptr->path = strdup(cf->path);
-                    if (NULL == cfptr->path) {
-                        PMIX_RELEASE(cfptr);
-                        rc = PMIX_ERR_NOMEM;
-                        goto exit;
-                    }
-                    pmix_list_append(&epicd->epi->cleanup_files, &cfptr->super);
+                /* check for conflict with an ignore */
+                if (epi_has_file(&epicd->epi->ignores, cf->path) ||
+                    epi_has_file(&epicd->newignores, cf->path)) {
+                    /* return an error */
+                    rc = PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES;
+                    goto exit;
                 }
+                cfptr = epi_new_file(cf->path);
+                if (NULL == cfptr) {
+                    rc = PMIX_ERR_NOMEM;
+                    goto exit;
+                }
+                pmix_list_append(&epicd->newfiles, &cfptr->super);
             }
+        }
+
+        /* the request is acceptable in full - commit it. Nothing below
+         * here allocates or can fail, which is what makes the whole
+         * request either applied or not applied */
+        PMIX_LIST_FOREACH (upg, &upgrades, pmix_srvr_epi_upgrade_t) {
+            if (recurse) {
+                upg->dir->recurse = true;
+            }
+            if (leave_topdir) {
+                upg->dir->leave_topdir = true;
+            }
+        }
+        PMIX_LIST_FOREACH (epicd, &epicache, pmix_srvr_epi_caddy_t) {
+            pmix_list_join(&epicd->epi->ignores,
+                           pmix_list_get_end(&epicd->epi->ignores),
+                           &epicd->newignores);
+            pmix_list_join(&epicd->epi->cleanup_dirs,
+                           pmix_list_get_end(&epicd->epi->cleanup_dirs),
+                           &epicd->newdirs);
+            pmix_list_join(&epicd->epi->cleanup_files,
+                           pmix_list_get_end(&epicd->epi->cleanup_files),
+                           &epicd->newfiles);
         }
         if ((size_t) cnt == cd->ninfo) {
             /* nothing more to do */
@@ -786,6 +878,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
     PMIX_LIST_DESTRUCT(&cachedirs);
     PMIX_LIST_DESTRUCT(&cachefiles);
     PMIX_LIST_DESTRUCT(&ignorefiles);
+    PMIX_LIST_DESTRUCT(&upgrades);
     return PMIX_SUCCESS;
 
 exit:
@@ -794,6 +887,7 @@ exit:
     PMIX_LIST_DESTRUCT(&cachedirs);
     PMIX_LIST_DESTRUCT(&cachefiles);
     PMIX_LIST_DESTRUCT(&ignorefiles);
+    PMIX_LIST_DESTRUCT(&upgrades);
     return rc;
 }
 

--- a/src/server/pmix_server_control.c
+++ b/src/server/pmix_server_control.c
@@ -531,7 +531,6 @@ static pmix_status_t epi_cache_dirs(pmix_list_t *list, const char *paths)
     return PMIX_SUCCESS;
 }
 
-
 pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                                    pmix_info_cbfunc_t cbfunc,
                                    void *cbdata)
@@ -543,7 +542,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
     pmix_peer_t *pr;
     pmix_proc_t proc;
     size_t n;
-    bool recurse = false, leave_topdir = false;
+    bool recurse = false, empty = false, leave_topdir = false;
     pmix_list_t cachedirs, cachefiles, ignorefiles, epicache, upgrades;
     pmix_srvr_epi_caddy_t *epicd = NULL;
     pmix_srvr_epi_upgrade_t *upg;
@@ -751,6 +750,14 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_CLEANUP_RECURSIVE)) {
             recurse = PMIX_INFO_TRUE(&cd->info[n]);
             ++cnt;
+        } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_CLEANUP_EMPTY)) {
+            /* counted like the rest of the family: the count is what
+             * decides whether this is a request we answer ourselves, and
+             * leaving this key out of it sent a request carrying nothing
+             * but cleanup directives up to the host as well, to be
+             * registered a second time */
+            empty = PMIX_INFO_TRUE(&cd->info[n]);
+            ++cnt;
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_CLEANUP_IGNORE)) {
             if (PMIX_STRING != cd->info[n].value.type || NULL == cd->info[n].value.data.string) {
                 /* return an error */
@@ -781,6 +788,18 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
          * believes untouched becomes recursive, and deletes a subtree at
          * termination. The allocation arms had the same shape. So: build
          * everything first, and commit only once nothing can fail. */
+
+        /* PMIX_CLEANUP_RECURSIVE and PMIX_CLEANUP_EMPTY are mutually
+         * exclusive: the first removes every file and then the
+         * directories that held them, the second removes only the
+         * directories that are already empty and leaves every file
+         * alone. A request asking for both has not said what it wants,
+         * and guessing either way destroys or spares data the client did
+         * not ask us to destroy or spare */
+        if (recurse && empty) {
+            rc = PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES;
+            goto exit;
+        }
 
         /* the ignores, which are what the two loops below conflict
          * against - a directive naming a path this request is also asking
@@ -833,6 +852,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                      * registered for cleanup, so the question of whether
                      * it may be has been answered */
                     if ((!cdir2->recurse && recurse) ||
+                        (!cdir2->empty && empty && !cdir2->recurse) ||
                         (!cdir2->leave_topdir && leave_topdir)) {
                         upg = PMIX_NEW(pmix_srvr_epi_upgrade_t);
                         if (NULL == upg) {
@@ -864,6 +884,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                     goto exit;
                 }
                 cdirptr->recurse = recurse;
+                cdirptr->empty = empty;
                 cdirptr->leave_topdir = leave_topdir;
                 pmix_list_append(&epicd->newdirs, &cdirptr->super);
             }
@@ -896,7 +917,15 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
          * request either applied or not applied */
         PMIX_LIST_FOREACH (upg, &upgrades, pmix_srvr_epi_upgrade_t) {
             if (recurse) {
+                /* the two modes cannot both be set on an entry, and
+                 * recursive is the more permissive of them - it removes
+                 * everything the empty mode would have and the files as
+                 * well - so it is the one the precedence rule keeps */
                 upg->dir->recurse = true;
+                upg->dir->empty = false;
+            }
+            if (empty && !upg->dir->recurse) {
+                upg->dir->empty = true;
             }
             if (leave_topdir) {
                 upg->dir->leave_topdir = true;

--- a/src/server/pmix_server_control.c
+++ b/src/server/pmix_server_control.c
@@ -470,6 +470,68 @@ static pmix_cleanup_dir_t *epi_new_dir(const char *path)
     return cdir;
 }
 
+/* Expand a comma-delimited path list into one entry per path.
+ * PMIX_REGISTER_CLEANUP, PMIX_REGISTER_CLEANUP_DIR and
+ * PMIX_CLEANUP_IGNORE are all documented as comma-delimited lists, and
+ * the expansion used to happen only in pmix_execute_epilog - so every
+ * comparison in between was made against the unexpanded string, and
+ * three separate things silently stopped working for a list of more
+ * than one path. dirpath_destroy strcmp's an ignore against a filename
+ * it has just constructed, so an ignore of "/a,/b" protected neither;
+ * it decides PMIX_CLEANUP_LEAVE_TOPDIR by comparing the directory it is
+ * descending against cd->path, which a list never equals, so the flag
+ * was dropped; and neither the duplicate scan nor the conflict scan
+ * here could see the paths inside one. Expanding at registration makes
+ * every one of those a whole-path comparison, and leaves the epilog
+ * nothing left to split. */
+static pmix_status_t epi_cache_files(pmix_list_t *list, const char *paths)
+{
+    pmix_cleanup_file_t *cf;
+    char **tmp;
+    size_t n;
+
+    tmp = PMIx_Argv_split(paths, ',');
+    if (NULL == tmp) {
+        /* the value named no path at all - a string of nothing but
+         * delimiters, which reached pmix_execute_epilog as an entry
+         * whose own split then returned NULL and was indexed */
+        return PMIX_ERR_BAD_PARAM;
+    }
+    for (n = 0; NULL != tmp[n]; n++) {
+        cf = epi_new_file(tmp[n]);
+        if (NULL == cf) {
+            PMIx_Argv_free(tmp);
+            return PMIX_ERR_NOMEM;
+        }
+        pmix_list_append(list, &cf->super);
+    }
+    PMIx_Argv_free(tmp);
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t epi_cache_dirs(pmix_list_t *list, const char *paths)
+{
+    pmix_cleanup_dir_t *cdir;
+    char **tmp;
+    size_t n;
+
+    tmp = PMIx_Argv_split(paths, ',');
+    if (NULL == tmp) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    for (n = 0; NULL != tmp[n]; n++) {
+        cdir = epi_new_dir(tmp[n]);
+        if (NULL == cdir) {
+            PMIx_Argv_free(tmp);
+            return PMIX_ERR_NOMEM;
+        }
+        pmix_list_append(list, &cdir->super);
+    }
+    PMIx_Argv_free(tmp);
+    return PMIX_SUCCESS;
+}
+
+
 pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                                    pmix_info_cbfunc_t cbfunc,
                                    void *cbdata)
@@ -669,13 +731,11 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 rc = PMIX_ERR_BAD_PARAM;
                 goto exit;
             }
-            cf = epi_new_file(cd->info[n].value.data.string);
-            if (NULL == cf) {
+            rc = epi_cache_files(&cachefiles, cd->info[n].value.data.string);
+            if (PMIX_SUCCESS != rc) {
                 /* return an error */
-                rc = PMIX_ERR_NOMEM;
                 goto exit;
             }
-            pmix_list_append(&cachefiles, &cf->super);
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_REGISTER_CLEANUP_DIR)) {
             ++cnt;
             if (PMIX_STRING != cd->info[n].value.type || NULL == cd->info[n].value.data.string) {
@@ -683,13 +743,11 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 rc = PMIX_ERR_BAD_PARAM;
                 goto exit;
             }
-            cdir = epi_new_dir(cd->info[n].value.data.string);
-            if (NULL == cdir) {
+            rc = epi_cache_dirs(&cachedirs, cd->info[n].value.data.string);
+            if (PMIX_SUCCESS != rc) {
                 /* return an error */
-                rc = PMIX_ERR_NOMEM;
                 goto exit;
             }
-            pmix_list_append(&cachedirs, &cdir->super);
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_CLEANUP_RECURSIVE)) {
             recurse = PMIX_INFO_TRUE(&cd->info[n]);
             ++cnt;
@@ -699,13 +757,11 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer, pmix_buffer_t *buf,
                 rc = PMIX_ERR_BAD_PARAM;
                 goto exit;
             }
-            cf = epi_new_file(cd->info[n].value.data.string);
-            if (NULL == cf) {
+            rc = epi_cache_files(&ignorefiles, cd->info[n].value.data.string);
+            if (PMIX_SUCCESS != rc) {
                 /* return an error */
-                rc = PMIX_ERR_NOMEM;
                 goto exit;
             }
-            pmix_list_append(&ignorefiles, &cf->super);
             ++cnt;
         } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_CLEANUP_LEAVE_TOPDIR)) {
             leave_topdir = PMIX_INFO_TRUE(&cd->info[n]);

--- a/test/unit/server_control.c
+++ b/test/unit/server_control.c
@@ -99,6 +99,20 @@
  *      does nothing, so a second PMIx_Job_control asking for recursive
  *      cleanup of an already-registered directory never took effect.
  *      This case fails, rather than crashes, against an unfixed library.
+ *
+ *   job control: a refused cleanup request must apply none of itself
+ *      The three epilog lists outlive the request and a client has no
+ *      way to take an entry back off one, so a request refused with
+ *      PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES has to leave nothing
+ *      behind. It used to keep its own ignores (applied first, which is
+ *      what the conflict is detected against), every directory accepted
+ *      ahead of the conflicting one, and any flag widening it had
+ *      applied to an entry already registered - that last being the
+ *      destructive one, since a directory the client believes untouched
+ *      becomes recursive and takes its subtree with it at termination.
+ *      All three cases fail, rather than crash, against an unfixed
+ *      library.
+ *
  */
 
 #include "src/include/pmix_config.h"
@@ -1088,6 +1102,86 @@ int main(int argc, char **argv)
         nign = count_epilog_ignores();
         report("ignore of a registered cleanup path was recorded", 1 == nign);
         PMIX_INFO_DESTRUCT(&jc[0]);
+        drain_epilog_ignores();
+    }
+    /* --- a conflicting request must apply none of itself --------------- */
+    {
+        pmix_info_t at[4];
+        size_t nign, nd;
+        pmix_cleanup_dir_t *rd;
+        bool yes = true;
+
+        drain_epilog_ignores();
+        drain_epilog_dirs();
+
+        /* the simplest shape: one request naming the same path as both an
+         * ignore and a cleanup directory. The ignores are applied first,
+         * so the conflict is discovered with this request's own ignore
+         * already on a list that outlives it - and the client is told the
+         * request failed. A refused request must leave nothing behind, or
+         * that path is poisoned for every later request naming it */
+        PMIX_INFO_LOAD(&at[0], PMIX_CLEANUP_IGNORE, CTLUT_DIR "/both", PMIX_STRING);
+        PMIX_INFO_LOAD(&at[1], PMIX_REGISTER_CLEANUP_DIR, CTLUT_DIR "/both", PMIX_STRING);
+        rc = do_job_ctrl(at, 2);
+        report("a self-conflicting cleanup request is refused",
+               PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES == rc);
+        nign = count_epilog_ignores();
+        report("a refused request registered no ignore", 0 == nign);
+        only_epilog_dir(&nd);
+        report("a refused request registered no directory", 0 == nd);
+        PMIX_INFO_DESTRUCT(&at[0]);
+        PMIX_INFO_DESTRUCT(&at[1]);
+
+        /* and the same for a directory accepted ahead of the conflicting
+         * one - it used to be registered for deletion by a request the
+         * client was told had failed, which is the destructive direction */
+        PMIX_INFO_LOAD(&at[0], PMIX_REGISTER_CLEANUP_DIR, CTLUT_DIR "/ok", PMIX_STRING);
+        PMIX_INFO_LOAD(&at[1], PMIX_CLEANUP_IGNORE, CTLUT_DIR "/bad", PMIX_STRING);
+        PMIX_INFO_LOAD(&at[2], PMIX_REGISTER_CLEANUP_DIR, CTLUT_DIR "/bad", PMIX_STRING);
+        rc = do_job_ctrl(at, 3);
+        report("a partly conflicting cleanup request is refused",
+               PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES == rc);
+        only_epilog_dir(&nd);
+        report("a refused request kept no directory accepted ahead of the conflict",
+               0 == nd);
+        report("a refused request kept none of its ignores",
+               0 == count_epilog_ignores());
+        PMIX_INFO_DESTRUCT(&at[0]);
+        PMIX_INFO_DESTRUCT(&at[1]);
+        PMIX_INFO_DESTRUCT(&at[2]);
+
+        /* the sharpest arm: the flag widening a duplicate directive
+         * applies to the entry already on the epilog. Left applied by a
+         * request that then failed, a directory the client believes
+         * untouched has become recursive and takes a whole subtree with
+         * it at termination */
+        PMIX_INFO_LOAD(&at[0], PMIX_REGISTER_CLEANUP_DIR, CTLUT_DIR "/keep", PMIX_STRING);
+        rc = do_job_ctrl(at, 1);
+        report("directory registered for the widening case",
+               PMIX_OPERATION_SUCCEEDED == rc);
+        rd = only_epilog_dir(&nd);
+        report("the registered directory starts non-recursive",
+               1 == nd && NULL != rd && !rd->recurse);
+        PMIX_INFO_DESTRUCT(&at[0]);
+
+        PMIX_INFO_LOAD(&at[0], PMIX_REGISTER_CLEANUP_DIR, CTLUT_DIR "/keep", PMIX_STRING);
+        PMIX_INFO_LOAD(&at[1], PMIX_CLEANUP_RECURSIVE, &yes, PMIX_BOOL);
+        PMIX_INFO_LOAD(&at[2], PMIX_CLEANUP_IGNORE, CTLUT_DIR "/bad", PMIX_STRING);
+        PMIX_INFO_LOAD(&at[3], PMIX_REGISTER_CLEANUP_DIR, CTLUT_DIR "/bad", PMIX_STRING);
+        rc = do_job_ctrl(at, 4);
+        report("a conflicting request carrying a flag upgrade is refused",
+               PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES == rc);
+        rd = only_epilog_dir(&nd);
+        report("a refused request did not widen an existing entry",
+               1 == nd && NULL != rd && !rd->recurse);
+        report("a refused request added no second directory", 1 == nd);
+        report("a refused request added no ignore", 0 == count_epilog_ignores());
+        PMIX_INFO_DESTRUCT(&at[0]);
+        PMIX_INFO_DESTRUCT(&at[1]);
+        PMIX_INFO_DESTRUCT(&at[2]);
+        PMIX_INFO_DESTRUCT(&at[3]);
+
+        drain_epilog_dirs();
         drain_epilog_ignores();
     }
 

--- a/test/unit/server_control.c
+++ b/test/unit/server_control.c
@@ -127,6 +127,14 @@
  *      registered so that it reports as a failure instead of taking the
  *      epilog below it down.
  *
+ *   job control: the two cleanup modes, and what each one spares
+ *      PMIX_CLEANUP_RECURSIVE and PMIX_CLEANUP_EMPTY are mutually
+ *      exclusive - the first removes every file and then the
+ *      directories that held them, the second removes only the
+ *      directories that are empty and leaves every file alone - so a
+ *      request naming both is refused. Both are driven over a real tree
+ *      on disk, because what each one spares is as much the point as
+ *      what it removes.
  */
 
 #include "src/include/pmix_config.h"
@@ -145,6 +153,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #define CTLUT_DIR "/tmp/pmix-server-control-ut-no-such-dir"
@@ -1305,6 +1314,129 @@ int main(int argc, char **argv)
             rmdir(base);
         }
         drain_epilog_ignores();
+        drain_epilog_files();
+    }
+    /* --- PMIX_CLEANUP_EMPTY, and its exclusion with RECURSIVE --------- */
+    {
+        char tdir[] = "/tmp/pmix-ctlut-e-XXXXXX";
+        char tdir2[] = "/tmp/pmix-ctlut-r-XXXXXX";
+        char *base;
+        char demptyp[300], dfullp[300], dnestp[300], fkeepp[300];
+        pmix_info_t at[3];
+        FILE *fp;
+        bool yes = true;
+        pmix_cleanup_dir_t *rd;
+        size_t nd;
+
+        drain_epilog_ignores();
+        drain_epilog_dirs();
+        drain_epilog_files();
+
+        /* the two modes say opposite things about what happens to a
+         * file, so a request naming both has not said what it wants */
+        PMIX_INFO_LOAD(&at[0], PMIX_REGISTER_CLEANUP_DIR, CTLUT_DIR, PMIX_STRING);
+        PMIX_INFO_LOAD(&at[1], PMIX_CLEANUP_RECURSIVE, &yes, PMIX_BOOL);
+        PMIX_INFO_LOAD(&at[2], PMIX_CLEANUP_EMPTY, &yes, PMIX_BOOL);
+        rc = do_job_ctrl(at, 3);
+        report("recursive plus empty is refused",
+               PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES == rc);
+        only_epilog_dir(&nd);
+        report("the refused mode combination registered nothing", 0 == nd);
+        PMIX_INFO_DESTRUCT(&at[1]);
+        PMIX_INFO_DESTRUCT(&at[2]);
+
+        /* a request carrying nothing but cleanup directives is one we
+         * answer ourselves - PMIX_CLEANUP_EMPTY was not counted as one
+         * of them, so such a request went to the host as well */
+        PMIX_INFO_LOAD(&at[1], PMIX_CLEANUP_EMPTY, &yes, PMIX_BOOL);
+        rc = do_job_ctrl(at, 2);
+        report("a cleanup request naming empty is answered locally",
+               PMIX_OPERATION_SUCCEEDED == rc && !jobctrl_fired);
+        rd = only_epilog_dir(&nd);
+        report("the empty flag reached the registered entry",
+               1 == nd && NULL != rd && rd->empty && !rd->recurse);
+        PMIX_INFO_DESTRUCT(&at[0]);
+        PMIX_INFO_DESTRUCT(&at[1]);
+        drain_epilog_dirs();
+
+        /* and what it actually does: remove the empty directories at any
+         * depth, and leave every file exactly where it is */
+        base = mkdtemp(tdir);
+        if (NULL == base) {
+            report("made a scratch tree for the empty-cleanup case", false);
+        } else {
+            snprintf(demptyp, sizeof(demptyp), "%s/empty", base);
+            snprintf(dfullp, sizeof(dfullp), "%s/full", base);
+            snprintf(dnestp, sizeof(dnestp), "%s/empty/deeper", base);
+            snprintf(fkeepp, sizeof(fkeepp), "%s/full/keep", base);
+            mkdir(dfullp, 0700);
+            mkdir(demptyp, 0700);
+            mkdir(dnestp, 0700);
+            fp = fopen(fkeepp, "w");
+            if (NULL != fp) {
+                fclose(fp);
+            }
+            report("scratch tree built",
+                   0 == access(dnestp, F_OK) && 0 == access(fkeepp, F_OK));
+
+            PMIX_INFO_LOAD(&at[0], PMIX_REGISTER_CLEANUP_DIR, base, PMIX_STRING);
+            PMIX_INFO_LOAD(&at[1], PMIX_CLEANUP_EMPTY, &yes, PMIX_BOOL);
+            PMIX_INFO_LOAD(&at[2], PMIX_CLEANUP_LEAVE_TOPDIR, &yes, PMIX_BOOL);
+            rc = do_job_ctrl(at, 3);
+            report("the empty-cleanup directory registered",
+                   PMIX_OPERATION_SUCCEEDED == rc);
+            PMIX_INFO_DESTRUCT(&at[0]);
+            PMIX_INFO_DESTRUCT(&at[1]);
+            PMIX_INFO_DESTRUCT(&at[2]);
+
+            pmix_execute_epilog(&pmix_globals.mypeer->nptr->epilog);
+            report("an empty directory at depth was removed", 0 != access(dnestp, F_OK));
+            report("the directory that held only empty ones went too",
+                   0 != access(demptyp, F_OK));
+            report("a directory holding a file was left alone", 0 == access(dfullp, F_OK));
+            report("the file itself was left alone", 0 == access(fkeepp, F_OK));
+            report("leave-topdir kept the top directory", 0 == access(base, F_OK));
+
+            unlink(fkeepp);
+            rmdir(dnestp);
+            rmdir(demptyp);
+            rmdir(dfullp);
+            rmdir(base);
+        }
+        drain_epilog_dirs();
+
+        /* the other mode, over the same shape of tree - it takes the
+         * files as well as the directories, and this pins the branch the
+         * empty mode was threaded through */
+        base = mkdtemp(tdir2);
+        if (NULL == base) {
+            report("made a scratch tree for the recursive case", false);
+        } else {
+            snprintf(dfullp, sizeof(dfullp), "%s/full", base);
+            snprintf(fkeepp, sizeof(fkeepp), "%s/full/gone", base);
+            mkdir(dfullp, 0700);
+            fp = fopen(fkeepp, "w");
+            if (NULL != fp) {
+                fclose(fp);
+            }
+            PMIX_INFO_LOAD(&at[0], PMIX_REGISTER_CLEANUP_DIR, base, PMIX_STRING);
+            PMIX_INFO_LOAD(&at[1], PMIX_CLEANUP_RECURSIVE, &yes, PMIX_BOOL);
+            rc = do_job_ctrl(at, 2);
+            report("the recursive directory registered", PMIX_OPERATION_SUCCEEDED == rc);
+            PMIX_INFO_DESTRUCT(&at[0]);
+            PMIX_INFO_DESTRUCT(&at[1]);
+
+            pmix_execute_epilog(&pmix_globals.mypeer->nptr->epilog);
+            report("recursive cleanup removed the nested file", 0 != access(fkeepp, F_OK));
+            report("recursive cleanup removed the directory holding it",
+                   0 != access(dfullp, F_OK));
+            report("recursive cleanup removed the top directory", 0 != access(base, F_OK));
+
+            unlink(fkeepp);
+            rmdir(dfullp);
+            rmdir(base);
+        }
+        drain_epilog_dirs();
         drain_epilog_files();
     }
 

--- a/test/unit/server_control.c
+++ b/test/unit/server_control.c
@@ -113,6 +113,20 @@
  *      All three cases fail, rather than crash, against an unfixed
  *      library.
  *
+ *   job control: a comma-delimited path list, and what the epilog does
+ *      The three path attributes are documented as comma-delimited
+ *      lists, and the expansion used to happen only in
+ *      pmix_execute_epilog - so an ignore of "/a,/b" matched no filename
+ *      the epilog ever constructed, and a value of "," reached the
+ *      epilog as an entry whose own split returns NULL and was then
+ *      indexed. The last case here is the one the ignore list exists
+ *      for: real files on disk, one registered for cleanup and then
+ *      ignored, which the epilog deleted anyway because its
+ *      cleanup_files loop never consulted the ignores at all. These
+ *      cases fail rather than crash - the "," case drains the entry it
+ *      registered so that it reports as a failure instead of taking the
+ *      epilog below it down.
+ *
  */
 
 #include "src/include/pmix_config.h"
@@ -689,6 +703,29 @@ static size_t count_epilog_ignores(void)
     return n;
 }
 
+/* How many entries sit on our own namespace's epilog cleanup-file list. */
+static size_t count_epilog_files(void)
+{
+    pmix_epilog_t *epi = &pmix_globals.mypeer->nptr->epilog;
+    pmix_cleanup_file_t *cf;
+    size_t n = 0;
+
+    PMIX_LIST_FOREACH (cf, &epi->cleanup_files, pmix_cleanup_file_t) {
+        ++n;
+    }
+    return n;
+}
+
+static void drain_epilog_files(void)
+{
+    pmix_epilog_t *epi = &pmix_globals.mypeer->nptr->epilog;
+    pmix_list_item_t *item;
+
+    while (NULL != (item = pmix_list_remove_first(&epi->cleanup_files))) {
+        PMIX_RELEASE(item);
+    }
+}
+
 static void drain_epilog_ignores(void)
 {
     pmix_epilog_t *epi = &pmix_globals.mypeer->nptr->epilog;
@@ -832,6 +869,7 @@ int main(int argc, char **argv)
     static pmix_server_module_t mymodule = {0};
     pmix_status_t rc;
     pmix_info_t data, dirs[1], jc[2];
+    char cleanupval[600];
     pmix_cleanup_dir_t *cd;
     size_t ndirs;
     bool flag = true;
@@ -1183,6 +1221,91 @@ int main(int argc, char **argv)
 
         drain_epilog_dirs();
         drain_epilog_ignores();
+    }
+    /* --- the epilog must honor an ignore, and a comma-delimited list --- */
+    {
+        char tdir[] = "/tmp/pmix-ctlut-XXXXXX";
+        char *base, pgone[256], pkeep[256];
+        pmix_info_t at[2];
+        FILE *fp;
+        size_t nign;
+
+        drain_epilog_ignores();
+        drain_epilog_dirs();
+        drain_epilog_files();
+
+        /* PMIX_CLEANUP_IGNORE is documented as a comma-delimited list,
+         * and the expansion used to happen only inside the epilog - which
+         * compares an ignore against a filename it has constructed, so a
+         * list of more than one path matched nothing at all */
+        PMIX_INFO_LOAD(&at[0], PMIX_CLEANUP_IGNORE,
+                       CTLUT_DIR "/one," CTLUT_DIR "/two", PMIX_STRING);
+        rc = do_job_ctrl(at, 1);
+        report("a comma-delimited ignore is accepted", PMIX_OPERATION_SUCCEEDED == rc);
+        nign = count_epilog_ignores();
+        report("a comma-delimited ignore registers one entry per path", 2 == nign);
+        PMIX_INFO_DESTRUCT(&at[0]);
+        drain_epilog_ignores();
+
+        /* a value naming no path at all reached the epilog as an entry
+         * whose own split returned NULL and was then indexed */
+        PMIX_INFO_LOAD(&at[0], PMIX_REGISTER_CLEANUP, ",", PMIX_STRING);
+        rc = do_job_ctrl(at, 1);
+        report("a cleanup value naming no path is refused", PMIX_ERR_BAD_PARAM == rc);
+        report("a cleanup value naming no path registered nothing",
+               0 == count_epilog_files());
+        PMIX_INFO_DESTRUCT(&at[0]);
+        /* an unfixed library accepted it, and the entry it left behind
+         * takes the epilog below down with a NULL dereference. Drain it
+         * so this case reports as a failure rather than a signal */
+        drain_epilog_files();
+
+        /* and the whole point of an ignore: the epilog must not delete
+         * the file. The ignores list was consulted only for the contents
+         * of a cleanup *directory* - the cleanup_files loop unlinked
+         * every path on it unconditionally, so an ignore naming a path
+         * already registered for cleanup was recorded and then ignored */
+        base = mkdtemp(tdir);
+        if (NULL == base) {
+            report("made a scratch directory for the epilog case", false);
+        } else {
+            snprintf(pgone, sizeof(pgone), "%s/gone", base);
+            snprintf(pkeep, sizeof(pkeep), "%s/keep", base);
+            fp = fopen(pgone, "w");
+            if (NULL != fp) {
+                fclose(fp);
+            }
+            fp = fopen(pkeep, "w");
+            if (NULL != fp) {
+                fclose(fp);
+            }
+            report("scratch files created",
+                   0 == access(pgone, F_OK) && 0 == access(pkeep, F_OK));
+
+            snprintf(cleanupval, sizeof(cleanupval), "%s,%s", pgone, pkeep);
+            PMIX_INFO_LOAD(&at[0], PMIX_REGISTER_CLEANUP, cleanupval, PMIX_STRING);
+            rc = do_job_ctrl(at, 1);
+            report("both scratch files registered for cleanup",
+                   PMIX_OPERATION_SUCCEEDED == rc && 2 == count_epilog_files());
+            PMIX_INFO_DESTRUCT(&at[0]);
+
+            PMIX_INFO_LOAD(&at[0], PMIX_CLEANUP_IGNORE, pkeep, PMIX_STRING);
+            rc = do_job_ctrl(at, 1);
+            report("ignore of one of them accepted", PMIX_OPERATION_SUCCEEDED == rc);
+            PMIX_INFO_DESTRUCT(&at[0]);
+
+            pmix_execute_epilog(&pmix_globals.mypeer->nptr->epilog);
+            report("the epilog removed the file it was asked to remove",
+                   0 != access(pgone, F_OK));
+            report("the epilog kept the file it was asked to ignore",
+                   0 == access(pkeep, F_OK));
+
+            unlink(pgone);
+            unlink(pkeep);
+            rmdir(base);
+        }
+        drain_epilog_ignores();
+        drain_epilog_files();
     }
 
     /* --- a target count larger than the packed array ------------------ */

--- a/test/unit/server_control.c
+++ b/test/unit/server_control.c
@@ -127,14 +127,20 @@
  *      registered so that it reports as a failure instead of taking the
  *      epilog below it down.
  *
- *   job control: the two cleanup modes, and what each one spares
+ *   job control: the two cleanup modes, and the epilog's identity
  *      PMIX_CLEANUP_RECURSIVE and PMIX_CLEANUP_EMPTY are mutually
  *      exclusive - the first removes every file and then the
  *      directories that held them, the second removes only the
  *      directories that are empty and leaves every file alone - so a
  *      request naming both is refused. Both are driven over a real tree
  *      on disk, because what each one spares is as much the point as
- *      what it removes.
+ *      what it removes. The last case is the privilege drop: the epilog
+ *      records the uid the host registered the peer with, and walks
+ *      under it rather than as whatever user the server happens to be.
+ *      We are unprivileged, so pointing the epilog at anyone else is a
+ *      drop we cannot make, and the file must survive - paired with the
+ *      same removal under our own identity, so the case cannot pass by
+ *      the epilog simply never working.
  */
 
 #include "src/include/pmix_config.h"
@@ -1151,6 +1157,7 @@ int main(int argc, char **argv)
         PMIX_INFO_DESTRUCT(&jc[0]);
         drain_epilog_ignores();
     }
+
     /* --- a conflicting request must apply none of itself --------------- */
     {
         pmix_info_t at[4];
@@ -1231,6 +1238,7 @@ int main(int argc, char **argv)
         drain_epilog_dirs();
         drain_epilog_ignores();
     }
+
     /* --- the epilog must honor an ignore, and a comma-delimited list --- */
     {
         char tdir[] = "/tmp/pmix-ctlut-XXXXXX";
@@ -1316,10 +1324,12 @@ int main(int argc, char **argv)
         drain_epilog_ignores();
         drain_epilog_files();
     }
+
     /* --- PMIX_CLEANUP_EMPTY, and its exclusion with RECURSIVE --------- */
     {
         char tdir[] = "/tmp/pmix-ctlut-e-XXXXXX";
         char tdir2[] = "/tmp/pmix-ctlut-r-XXXXXX";
+        char tdir3[] = "/tmp/pmix-ctlut-p-XXXXXX";
         char *base;
         char demptyp[300], dfullp[300], dnestp[300], fkeepp[300];
         pmix_info_t at[3];
@@ -1437,6 +1447,54 @@ int main(int argc, char **argv)
             rmdir(base);
         }
         drain_epilog_dirs();
+        drain_epilog_files();
+
+        /* The privilege drop. We are unprivileged, so naming any other
+         * uid is a drop we cannot make - and the right answer to that is
+         * to remove nothing at all, rather than to remove it as
+         * ourselves, which is the behavior pmix_execute_epilog exists to
+         * stop. Point the epilog at a uid that is not ours and check the
+         * file survives; then put the identity back and check the same
+         * file goes, so the case cannot pass by simply never working. */
+        base = mkdtemp(tdir3);
+        if (NULL == base) {
+            report("made a scratch file for the privilege case", false);
+        } else {
+            uid_t saveuid = pmix_globals.mypeer->nptr->epilog.uid;
+
+            snprintf(fkeepp, sizeof(fkeepp), "%s/owned", base);
+            fp = fopen(fkeepp, "w");
+            if (NULL != fp) {
+                fclose(fp);
+            }
+            PMIX_INFO_LOAD(&at[0], PMIX_REGISTER_CLEANUP, fkeepp, PMIX_STRING);
+            rc = do_job_ctrl(at, 1);
+            report("the privilege-case file registered", PMIX_OPERATION_SUCCEEDED == rc);
+            PMIX_INFO_DESTRUCT(&at[0]);
+
+            /* nobody's real uid, and certainly not ours */
+            pmix_globals.mypeer->nptr->epilog.uid = saveuid + 1;
+            pmix_execute_epilog(&pmix_globals.mypeer->nptr->epilog);
+            report("a cleanup we cannot drop for removes nothing",
+                   0 == access(fkeepp, F_OK));
+            pmix_globals.mypeer->nptr->epilog.uid = saveuid;
+
+            /* and the same request under our own identity does go through,
+             * so the case above is not passing on a broken epilog */
+            PMIX_INFO_LOAD(&at[0], PMIX_REGISTER_CLEANUP, fkeepp, PMIX_STRING);
+            rc = do_job_ctrl(at, 1);
+            report("the privilege-case file registered again",
+                   PMIX_OPERATION_SUCCEEDED == rc);
+            PMIX_INFO_DESTRUCT(&at[0]);
+            pmix_execute_epilog(&pmix_globals.mypeer->nptr->epilog);
+            report("a cleanup under our own identity does remove it",
+                   0 != access(fkeepp, F_OK));
+
+            unlink(fkeepp);
+            rmdir(base);
+        }
+        drain_epilog_dirs();
+        drain_epilog_ignores();
         drain_epilog_files();
     }
 


### PR DESCRIPTION
Started as an investigation of the `docs/todo.rst` entry "A conflicting
cleanup request is applied in part before it fails" and grew to cover the
rest of the cleanup path, which turned out to have several related
defects. Four commits, each independently buildable and green.

### 1. Apply a job-control cleanup request in full or not at all

The recorded reasoning for deferring this did not hold up. It said what
survived a refused request was "the conservative half" — but the
directories accepted ahead of the conflict are registered *for deletion*,
and the sharpest case was missed: a duplicate `PMIX_REGISTER_CLEANUP_DIR`
takes the flag-upgrade branch, so a refused request can turn an existing
non-recursive entry **recursive**, and a directory the client believes
untouched takes its whole subtree with it at termination.

It also said a validation pass would have to reproduce the
duplicate-detection logic exactly. It does not: the conflict verdict is a
pure function of the path, the epilog's pre-existing lists, and the
request's own ignores. The handler now stages every addition on
per-epilog lists and commits with `pmix_list_join` once nothing can fail,
which covers the `PMIX_ERR_NOMEM` arms too.

### 2. Compare cleanup paths against what the client actually named

All three path attributes are documented as comma-delimited, and the
expansion happened only in `pmix_execute_epilog` — so every comparison in
between ran against the unexpanded string. An ignore of `"/a,/b"`
protected neither, `PMIX_CLEANUP_LEAVE_TOPDIR` was silently dropped, and
conflict detection could not see inside a list. A value of `","` was
worse: `PMIx_Argv_split` returns `NULL` rather than an empty array and the
epilog indexed it, so a client could take the server down at job
termination with one directive.

The other half was in the epilog itself: `ignores` was read only by
`dirpath_destroy`, and the `cleanup_files` loop unlinked every path on its
list without asking — so an ignore naming an already-registered cleanup
path was recorded and had no effect, which is the case that list exists
for.

### 3. Implement `PMIX_CLEANUP_EMPTY`

Defined, documented, and advertised by `pmix_attributes.c` — and read
nowhere. Not inert either: it was not counted as a cleanup directive, so a
request carrying it plus a cleanup directive registered locally *and* went
up to the host to be registered a second time.

It removes all empty directories and leaves every file in place;
`PMIX_CLEANUP_RECURSIVE` removes all files and then the directories that
held them. The two are mutually exclusive and a request naming both is
refused with `PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES`.

### 4. Run the epilog as the client that asked for the cleanup

`pmix_epilog_t` carries a `uid` and `gid`, filled in by the connection
handler from the identity the host registered the peer with, and read
nowhere — so a privileged system-level PMIx server unlinked whatever path
a client named, as whatever user the server was. The walk now runs under
the recorded identity: in place when we already are that user (the
ordinary per-user server), otherwise `fork()` and drop in the child
(`setgroups`/`setgid`/`setuid`, checked and verified). A child rather than
`seteuid()` on the spot because credentials are per-process — dropping
here would run the whole server as the client for the length of the walk.

This surfaced a related defect: `PMIX_NEW` `malloc`s rather than
`calloc`s, and neither constructor assigned those two members, so they
were uninitialized heap. Both now default to `geteuid()`/`getegid()`,
which makes an epilog nobody vouched for behave exactly as it always has.

`config/pmix.m4` gains a `setgroups` probe; the tree was regenerated with
`autogen.pl` + `configure`.

### Testing

`test/unit/server_control.c` goes from 72 to 100 assertions, including
real on-disk trees for both cleanup modes and a fork-path case that pairs
"cannot drop, so remove nothing" with "own identity, so remove it" — so it
cannot pass by the epilog simply never working. Every case in commits 1
and 2 fails against the unfixed library (verified by reverting each).

Full `make check` green (172 tests, 2 skips), `simptest` passes, docs
build warning-free, build clean under `--enable-devel-check`.

`docs/todo.rst` loses one entry and gains none — everything it recorded
about this handler is now fixed rather than deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgGDLJAeM9rmUPWeozGivg