### PR TITLE
Fix credential ownership on both sides of pmix_credential_cbfunc_t

### DIFF
--- a/docs/man/man3/PMIx_Get_credential.3.rst
+++ b/docs/man/man3/PMIx_Get_credential.3.rst
@@ -73,7 +73,11 @@ The non-blocking form replaces ``credential`` with a callback:
 
 * ``cbfunc``: Callback function of type :ref:`pmix_credential_cbfunc_t <man5-pmix_credential_cbfunc_t>` invoked with
   the final status, the returned credential, and any accompanying information once
-  the request completes.
+  the request completes. On success the callback takes ownership of the
+  credential itself |mdash| the payload the byte object points at, which it
+  releases when done |mdash| but not of the byte object carrying it, which
+  remains the library's and may be transient. A failing status carries no
+  credential, so there is nothing to release in that case.
 * ``cbdata``: Opaque pointer that is passed, unmodified, to ``cbfunc``.
 
 

--- a/docs/man/man5/pmix_callback_functions.5.rst
+++ b/docs/man/man5/pmix_callback_functions.5.rst
@@ -192,12 +192,28 @@ pmix_credential_cbfunc_t
 
 Returns a requested security credential obtained via
 :ref:`PMIx_Get_credential(3) <man3-PMIx_Get_credential>`. On success,
-``credential`` points to an allocated ``pmix_byte_object_t`` holding the opaque
-credential blob; ownership of the credential is transferred to the recipient,
-which is responsible for releasing that memory. The ``info`` array (``ninfo``
-elements) conveys any additional system-provided metadata about the credential,
-such as the identity of the issuing agent; that array is owned by the library
-and must not be altered or released by the recipient.
+``credential`` points to a ``pmix_byte_object_t`` holding the opaque credential
+blob; ownership of the credential is transferred to the recipient, which is
+responsible for releasing that memory.
+
+What transfers is the credential itself |mdash| the payload the byte object
+points at, which the recipient releases (with ``free``) when done with it. The
+byte object carrying it does **not** transfer: it belongs to the caller of the
+callback and may be transient, so the recipient must take the payload pointer
+and size out of it rather than retain the object, and must not destruct or free
+the object itself. The ``info`` array (``ninfo`` elements) conveys any
+additional system-provided metadata about the credential, such as the identity
+of the issuing agent; that array is owned by the library and must not be altered
+or released by the recipient.
+
+The transfer describes the direction in which the library returns a credential
+to its caller. The same signature is used in the opposite direction, where a
+PMIx server passes a ``get_credential`` request up to its host environment (see
+:ref:`pmix_server_module_t(5) <man5-pmix_server_module_t>`), and there the
+ownership runs the other way: the host retains the credential it provides and
+may release it as soon as the callback returns. The library therefore copies
+nothing and keeps nothing |mdash| it packs the reply to the requesting client
+before returning from the up-call.
 
 
 .. _man5-pmix_validation_cbfunc_t:

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -256,6 +256,17 @@ each time somebody asks.
           not survive being checked, and the repair was a
           stage-then-commit split of the one handler.
 
+          The credential entry closed the same day, and for a related
+          reason: what had been put to the Standard is answered by the
+          call's own shape — the host gets no callback saying the library
+          is done, and the library cannot tell a stack frame from a
+          ``malloc``, so the host keeps its data and the library must be
+          finished with it by the time it returns.  Being finished never
+          required copying it; the server now packs the reply before it
+          returns.  Reading the question that way also exposed the
+          client-side half, where the library *does* transfer the
+          credential and was freeing it anyway.
+
           One entry was opened and closed within the same day —
           the ordering of a registration's acknowledgement against the
           cached events replayed behind it — because the push-back that
@@ -432,22 +443,66 @@ Who owns a credential the host hands up
 ``pmix_credential_cbfunc_t`` is documented in ``include/pmix_common.h.in``
 as transferring ownership of the credential to the receiving function —
 "responsibility for releasing the memory lies outside the PMIx library."
-That text is written for the *client* side, where the receiving function
-is the application's callback.  Read literally it also governs the
-server-side up-call, where the receiving function is
-``pmix_server_cred_cbfunc``: the host's ``pmix_byte_object_t`` would then
-be ours to free.  It does not free it — it makes a copy and leaves the
-original alone — so under that reading every ``PMIx_Get_credential``
-leaks the host's credential, and under the opposite reading freeing it
-would be a double free in the host.
+This entry used to read that sentence as also governing the server-side
+up-call, where the receiving function is ``pmix_server_cred_cbfunc``, and
+asked whether the host's ``pmix_byte_object_t`` was therefore ours to
+free.  **That is closed**, and it closed on the shape of the call rather
+than on the Standard's word.
 
-Deciding this needs the Standard's word rather than this file's, and the
-wrong guess is much more expensive in one direction than the other, so
-the copy stays.  If the transfer reading is confirmed, the fix is to take
-the host's object rather than copy it (``psec`` mechanisms allocate a
-fresh one per request), not to add a ``free`` beside the copy.  The same
-question applies to the info array on the same callback, which the same
-paragraph describes as owned by the PMIx library.
+The host hands its data down and is given no callback telling it when the
+library is finished; the library, for its part, cannot tell whether what
+it was handed was ever ``malloc``'d.  Ownership stays with the host, and
+the only contract binding the library is the narrower one: be done with
+the data by the time the up-call returns, so the host may dispose of it
+on the next line.  That is what
+:ref:`pmix_server_module_t(5) <man5-pmix_server_module_t>` already told
+hosts — data returned through a completion callback is the host's to
+release once the callback returns — read from the library's side.
+
+Being *done with it* never required copying it.  Both
+``pmix_server_cred_cbfunc`` and ``pmix_server_validate_cbfunc`` now pack
+the whole reply where they stand, on whatever thread the host called
+them from, and thread-shift only the finished buffer; packing writes into
+a buffer of our own and reads the peer's ``bfrops`` module, neither of
+which is progress-thread state.  ``_queue_sec_reply`` does the queueing,
+which is the part that genuinely has to be on the progress thread, since
+``PMIX_SERVER_QUEUE_REPLY`` writes ``peer->send_msg``, the peer's send
+queue, and the send event.  The credential copy, the info-array copy, and
+the ``infocopy`` bookkeeping that went with them are gone.  The
+regression case in ``test/unit/server_control.c`` is unchanged and still
+passes: its host stub destructs and overwrites both the credential and
+the info array the instant the callback returns, which a reply packed
+after the return cannot survive.
+
+The client side is closed too, and it is where the sentence in the header
+was aimed all along — but it says less than it appears to.  What
+transfers is the *credential*: the payload the byte object points at, and
+its size.  The byte object carrying it does not transfer; it stays the
+library's, and may be a stack frame.  So the receiver takes the pointer
+out of it and releases that when done, and the library's obligation is
+the negative one — do not destruct the object once the callback has been
+given it, because the payload is no longer ours.  ``getcbfunc()`` in
+``src/common/pmix_security.c`` destructed exactly there, freeing the
+payload out from under the application: a receiver that kept it read
+freed memory, and one that released it, as the header requires, double
+freed.  The two arms that answer from a local ``psec`` mechanism did the
+same to the payload the mechanism had just allocated.  Each of them now
+destructs only on the arm where there was no ``cbfunc`` to hand the
+payload to.
+
+One asymmetry had to be dealt with rather than documented away.  The same
+signature runs in both directions, so a server whose host implements
+``get_credential`` used to have the host's borrowed payload passed
+straight through to the caller of ``PMIx_Get_credential_nb``, who is told
+it owns what it receives.  ``cred_relay()`` now interposes on that path
+and copies, so the caller answers to one contract rather than two.  With
+the transfer uniform, ``mycdcb()`` takes the payload instead of copying
+it and ``PMIx_Get_credential`` hands that same allocation to its caller,
+retiring both of the copies the blocking form used to make.
+
+Covered by ``test/unit/common_api.c``, which reads the credential after
+the callback that delivered it has returned and then releases it — a
+use-after-free and a double free, respectively, against the old code.
 
 A pruned deregistration is not propagated
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -2903,11 +2903,33 @@ typedef void (*pmix_info_cbfunc_t)(pmix_status_t status,
  * status - PMIX_SUCCESS if a credential could be assigned as requested, or
  *          else an appropriate error code indicating the problem
  *
- * credential - pointer to an allocated pmix_byte_object_t containing the
- *              credential (as a opaque blob) and its size. Ownership of
- *              the credential is transferred to the receiving function - thus,
+ * credential - pointer to a pmix_byte_object_t containing the credential
+ *              (as a opaque blob) and its size. Ownership of the credential
+ *              is transferred to the receiving function - thus,
  *              responsibility for releasing the memory lies outside the
  *              PMIx library.
+ *
+ *              What transfers is the credential itself - the payload the
+ *              byte object points at, which the receiver releases when it
+ *              is done with it. The byte object carrying it does not: it
+ *              belongs to the caller of this function and may be transient,
+ *              so the receiver must read the payload pointer and size out
+ *              of it rather than retain the object, and must not destruct
+ *              or free the object itself.
+ *
+ *              The transfer describes the direction in which the library
+ *              returns a credential to its caller - e.g., the callback
+ *              passed to PMIx_Get_credential_nb. The same signature is used
+ *              in the opposite direction when a PMIx server passes a
+ *              request up to its host, and there the ownership runs the
+ *              other way: the host retains the credential it provides and
+ *              may release it as soon as the callback returns, exactly as
+ *              it may with any other data it returns through a completion
+ *              callback. The library cannot release it in that direction -
+ *              the signature carries no release function to report
+ *              completion with, and nothing tells the library whether the
+ *              payload was ever allocated - so it is instead required to be
+ *              finished with the data before it returns.
  *
  * info - an array of pmix_info_t structures provided by the system to pass
  *        any additional information about the credential - e.g., the identity

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -444,6 +444,27 @@ the mandatory `pmix_event_t ev` and a `pmix_lock_t`.
   of the caller's cbfunc leak it whenever `cbfunc == NULL` (or when the
   substituted blocking cbfunc ignores the release-fn). Handle the NULL
   case explicitly.
+- **A credential goes *out* of `pmix_security.c` owned and comes *in*
+  borrowed — and what is owned is the payload, not the box.**
+  `pmix_credential_cbfunc_t` transfers the credential itself: the bytes
+  the `pmix_byte_object_t` points at, and their size. The object carrying
+  them stays the library's and may be a stack frame, so the receiver
+  reads the pointer out of it and never destructs it. That makes the rule
+  here a negative one: where the library hands a credential to its caller
+  — the callback given to `PMIx_Get_credential_nb` — the frame that holds
+  the object must **not** `PMIX_BYTE_OBJECT_DESTRUCT` it afterwards,
+  because the payload is no longer ours. `getcbfunc()` did exactly that
+  and left the caller reading freed memory, or double-freeing if it
+  followed the documented contract. The destruct belongs only on the arm
+  where there was no `cbfunc` to hand the payload to, which is why every
+  such site here is an if/else rather than an unconditional cleanup.
+  Where a *host* hands a credential up to a server through the same
+  signature it is only borrowed — the host may reclaim it as soon as the
+  call returns — so `cred_relay()` interposes on that path and copies the
+  payload before the caller sees it, rather than passing the host's
+  memory through and making the caller answer to two contracts at once.
+  The accompanying info array is owned by the library in *both*
+  directions and is released here once the callback returns.
 
 ## Recurring pitfalls specific to this directory
 

--- a/src/common/pmix_security.c
+++ b/src/common/pmix_security.c
@@ -35,6 +35,23 @@
 #include "src/include/pmix_globals.h"
 #include "src/server/pmix_server_ops.h"
 
+/* carries the caller's callback across a request the host answers */
+typedef struct {
+    pmix_credential_cbfunc_t cbfunc;
+    void *cbdata;
+} pmix_cred_relay_t;
+
+/* Return a credential to the caller of PMIx_Get_credential_nb.
+ *
+ * What pmix_credential_cbfunc_t transfers is the credential itself - the
+ * payload inside the byte object, and its size - not the object that
+ * carries it. That object remains the library's, and may therefore be
+ * the frame below; what it must not do is destruct, since that would
+ * release the payload the receiver now owns. Nothing is transferred
+ * alongside a failure - the object handed over carries no payload there,
+ * so the receiver has nothing to release. The info array is ours in either case - the same
+ * contract says that array remains owned by the library - and is
+ * released once the callback returns. */
 static void getcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
                       pmix_buffer_t *buf, void *cbdata)
 {
@@ -66,17 +83,23 @@ static void getcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     PMIX_BFROPS_UNPACK(rc, peer, buf, &status, &cnt, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        status = rc;
         goto complete;
     }
     if (PMIX_SUCCESS != status) {
         goto complete;
     }
 
-    /* unpack the credential */
+    /* unpack the credential - the payload allocated here is what is
+     * handed on to the caller */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &cred, &cnt, PMIX_BYTE_OBJECT);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        /* a status of success alongside nothing to point at would have
+         * the caller reading a payload we never unpacked */
+        PMIX_BYTE_OBJECT_DESTRUCT(&cred);
+        status = rc;
         goto complete;
     }
 
@@ -85,6 +108,7 @@ static void getcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        status = rc;
         goto complete;
     }
     if (0 < ninfo) {
@@ -93,6 +117,7 @@ static void getcbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
         PMIX_BFROPS_UNPACK(rc, peer, buf, info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            status = rc;
             goto complete;
         }
     }
@@ -101,13 +126,59 @@ complete:
     pmix_output_verbose(2, pmix_globals.debug_output, "pmix:security cback from server releasing");
     /* release the caller */
     if (NULL != cd->credcbfunc) {
+        /* the payload goes with it - the object must NOT be destructed */
         cd->credcbfunc(status, &cred, info, ninfo, cd->cbdata);
+    } else {
+        /* nobody took the payload, so it is still ours to release */
+        PMIX_BYTE_OBJECT_DESTRUCT(&cred);
     }
-    PMIX_BYTE_OBJECT_DESTRUCT(&cred);
     if (NULL != info) {
         PMIX_INFO_FREE(info, ninfo);
     }
     PMIX_RELEASE(cd);
+}
+
+/* Relay a credential the host produced to the caller of
+ * PMIx_Get_credential_nb.
+ *
+ * The two directions of pmix_credential_cbfunc_t do not carry the same
+ * ownership, and this is where they meet. Coming down from the library
+ * to its caller, the credential is transferred: the caller keeps the
+ * payload and releases it when done. Coming up from the host it is only
+ * borrowed - the signature has no release function, so the host may
+ * reclaim the payload the instant the up-call returns, and nothing tells
+ * us whether it was ever malloc'd. Passing the host's payload straight
+ * through would hold the caller to both contracts at once, so what goes
+ * out is a copy that is genuinely the caller's. The info array is passed
+ * along as it stands; it belongs to neither of them to release. */
+static void cred_relay(pmix_status_t status, pmix_byte_object_t *credential,
+                       pmix_info_t info[], size_t ninfo, void *cbdata)
+{
+    pmix_cred_relay_t *relay = (pmix_cred_relay_t *) cbdata;
+    pmix_byte_object_t cred;
+
+    if (NULL == relay->cbfunc) {
+        /* nobody asked to be told - the host's data is still the host's,
+         * so there is nothing here to release but ourselves */
+        free(relay);
+        return;
+    }
+    PMIX_BYTE_OBJECT_CONSTRUCT(&cred);
+
+    if (PMIX_SUCCESS == status && NULL != credential && NULL != credential->bytes) {
+        cred.bytes = malloc(credential->size);
+        if (NULL == cred.bytes) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            status = PMIX_ERR_NOMEM;
+        } else {
+            memcpy(cred.bytes, credential->bytes, credential->size);
+            cred.size = credential->size;
+        }
+    }
+
+    /* the copy goes to the caller, who releases it - not us */
+    relay->cbfunc(status, &cred, info, ninfo, relay->cbdata);
+    free(relay);
 }
 
 static void mycdcb(pmix_status_t status, pmix_byte_object_t *credential,
@@ -119,15 +190,53 @@ static void mycdcb(pmix_status_t status, pmix_byte_object_t *credential,
     PMIX_ACQUIRE_OBJECT(cb);
     cb->status = status;
     if (PMIX_SUCCESS == status && NULL != credential) {
-        cb->bo.bytes = malloc(credential->size);
-        if (NULL == cb->bo.bytes) {
-            cb->status = PMIX_ERR_NOMEM;
-        } else {
-            memcpy(cb->bo.bytes, credential->bytes, credential->size);
-            cb->bo.size = credential->size;
-        }
+        /* the payload is ours now - take it rather than copy it, and
+         * empty the object we were handed so that nothing frees it twice
+         * if a path above us ever grows a destruct */
+        cb->bo.bytes = credential->bytes;
+        cb->bo.size = credential->size;
+        credential->bytes = NULL;
+        credential->size = 0;
     }
     PMIX_WAKEUP_THREAD(&cb->lock);
+}
+
+/* Meet a credential request from a local psec mechanism: for a server
+ * whose host offers no credential support, and for a client or tool with
+ * no server to ask. The mechanism allocates the credential's payload
+ * into the byte object we hand it, and that payload goes on to the
+ * caller, who owns it from there - so this frame's object is never
+ * destructed once the callback has been given it. The results array is
+ * a different matter: the info array on this callback stays owned by the
+ * library, so it is released as soon as the callback has read it. */
+static pmix_status_t local_credential(const pmix_info_t info[], size_t ninfo,
+                                      pmix_credential_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_byte_object_t cred;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    pmix_status_t rc;
+
+    PMIX_BYTE_OBJECT_CONSTRUCT(&cred);
+    PMIX_PSEC_CREATE_CRED(rc, pmix_globals.mypeer, info, ninfo, &results, &nresults, &cred);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_BYTE_OBJECT_DESTRUCT(&cred);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+        }
+        return rc;
+    }
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, &cred, results, nresults, cbdata);
+    } else {
+        /* nobody took the payload, so it is still ours to release */
+        PMIX_BYTE_OBJECT_DESTRUCT(&cred);
+    }
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+    return PMIX_SUCCESS;
 }
 
 PMIX_EXPORT pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t ninfo,
@@ -162,13 +271,12 @@ PMIX_EXPORT pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t n
         PMIX_WAIT_THREAD(&cb.lock);
         rc = cb.status;
         if (NULL != cb.bo.bytes) {
-            credential->bytes = malloc(cb.bo.size);
-            if (NULL == credential->bytes) {
-                rc = PMIX_ERR_NOMEM;
-            } else {
-                memcpy(credential->bytes, cb.bo.bytes, cb.bo.size);
-                credential->size = cb.bo.size;
-            }
+            /* the credential mycdcb took is handed on to our caller,
+             * who releases it - the caddy must not destruct it here */
+            credential->bytes = cb.bo.bytes;
+            credential->size = cb.bo.size;
+            cb.bo.bytes = NULL;
+            cb.bo.size = 0;
         }
     }
     PMIX_DESTRUCT(&cb);
@@ -182,9 +290,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_credential_nb(const pmix_info_t info[], size_
     pmix_cmd_t cmd = PMIX_GET_CREDENTIAL_CMD;
     pmix_status_t rc;
     pmix_query_caddy_t *cb;
-    pmix_byte_object_t cred;
-    pmix_info_t *results = NULL;
-    size_t nresults = 0;
+    pmix_cred_relay_t *relay;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: Get_credential called with %d info",
@@ -204,48 +310,32 @@ PMIX_EXPORT pmix_status_t PMIx_Get_credential_nb(const pmix_info_t info[], size_
         /* if the host doesn't support this operation,
          * see if we can generate it ourselves */
         if (NULL == pmix_host_server.get_credential) {
-            PMIX_BYTE_OBJECT_CONSTRUCT(&cred);
-            PMIX_PSEC_CREATE_CRED(rc, pmix_globals.mypeer, info, ninfo, &results, &nresults, &cred);
-            if (PMIX_SUCCESS == rc) {
-                /* pass it back in the callback function - the cbfunc has no
-                 * release function, so we retain ownership of the credential
-                 * and results and must free them regardless of whether a
-                 * cbfunc was provided */
-                if (NULL != cbfunc) {
-                    cbfunc(PMIX_SUCCESS, &cred, results, nresults, cbdata);
-                }
-                if (NULL != results) {
-                    PMIX_INFO_FREE(results, nresults);
-                }
-                PMIX_BYTE_OBJECT_DESTRUCT(&cred);
-            }
-            return rc;
+            return local_credential(info, ninfo, cbfunc, cbdata);
         }
-        /* the host is available, so let them try to create it */
+        /* the host is available, so let them try to create it. What the
+         * host hands back stays the host's, so the answer goes out
+         * through a relay that gives our caller an object of its own */
         pmix_output_verbose(2, pmix_globals.debug_output, "pmix:get_credential handed to RM");
-        rc = pmix_host_server.get_credential(&pmix_globals.myid, info, ninfo, cbfunc, cbdata);
+        relay = (pmix_cred_relay_t *) malloc(sizeof(pmix_cred_relay_t));
+        if (NULL == relay) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            return PMIX_ERR_NOMEM;
+        }
+        relay->cbfunc = cbfunc;
+        relay->cbdata = cbdata;
+        rc = pmix_host_server.get_credential(&pmix_globals.myid, info, ninfo,
+                                             cred_relay, relay);
+        if (PMIX_SUCCESS != rc) {
+            /* the host will not be calling back */
+            free(relay);
+        }
         return rc;
     }
 
     /* if we are a client or tool and we aren't connected, see
      * if one of our internal plugins is capable of meeting the request */
     if (!pmix_atomic_check_bool(&pmix_globals.connected)) {
-        PMIX_BYTE_OBJECT_CONSTRUCT(&cred);
-        PMIX_PSEC_CREATE_CRED(rc, pmix_globals.mypeer, info, ninfo, &results, &nresults, &cred);
-        if (PMIX_SUCCESS == rc) {
-            /* pass it back in the callback function - the cbfunc has no
-             * release function, so we retain ownership of the credential
-             * and results and must free them regardless of whether a
-             * cbfunc was provided */
-            if (NULL != cbfunc) {
-                cbfunc(PMIX_SUCCESS, &cred, results, nresults, cbdata);
-            }
-            if (NULL != results) {
-                PMIX_INFO_FREE(results, nresults);
-            }
-            PMIX_BYTE_OBJECT_DESTRUCT(&cred);
-        }
-        return rc;
+        return local_credential(info, ninfo, cbfunc, cbdata);
     }
 
     /* if we are a client, then relay this request to the server */

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -464,6 +464,7 @@ static void scon(pmix_shift_caddy_t *p)
     p->npdata = 0;
     p->range = PMIX_RANGE_UNDEF;
     p->bo = NULL;
+    p->buf = NULL;
     p->dist = NULL;
     p->ndist = 0;
     p->evhdlr = NULL;
@@ -498,6 +499,9 @@ static void scdes(pmix_shift_caddy_t *p)
     }
     if (NULL != p->kv) {
         PMIX_RELEASE(p->kv);
+    }
+    if (NULL != p->buf) {
+        PMIX_RELEASE(p->buf);
     }
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_shift_caddy_t,

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -729,6 +729,10 @@ typedef struct {
     pmix_pdata_t *pdata;
     size_t npdata;
     pmix_byte_object_t *bo;
+    /* a reply packed before the shift, for the callbacks whose data is
+     * only theirs to read until they return - released here if it was
+     * never queued */
+    pmix_buffer_t *buf;
     pmix_device_distance_t *dist;
     size_t ndist;
     pmix_data_range_t range;

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -301,13 +301,14 @@ will synthesize nothing. `pmix_server_cred_cbfunc` copied the host's
 credential unconditionally — and the copy screens a NULL source and
 reports `PMIX_ERR_BAD_PARAM`, while a host that cannot issue one answers
 with an error status and *no* credential, which is exactly what
-`pmix_credential_cbfunc_t`'s contract says and exactly what
-`_cred_cbfunc` is written for (it packs the credential only under a
-success status). So the ordinary refusal took an error return that
-released the caddies and queued nothing, and the client sat in
-`PMIx_Get_credential` for good. Record the failure in `scd->status` and
-fall through to the shift; `pmix_server_validate_cbfunc`'s two info-copy
-arms had the same shape. Covered by `test/unit/server_control.c`.
+`pmix_credential_cbfunc_t`'s contract says. So the ordinary refusal took
+an error return that released the caddies and queued nothing, and the
+client sat in `PMIx_Get_credential` for good. Record the failure in
+`scd->status` and fall through to the shift; the packing that replaced
+that copy keeps the same discipline, and every arm of it — a buffer that
+could not be allocated, a payload that would not pack — still reaches
+`PMIX_THREADSHIFT`. `pmix_server_validate_cbfunc` had the same shape.
+Covered by `test/unit/server_control.c`.
 
 **And when it genuinely cannot shift, it still owes the caddies.** The
 `PMIX_NEW(pmix_shift_caddy_t)` failure arm is the twin of the
@@ -372,20 +373,27 @@ pull that was never granted, which is the same defect the synchronous
 refusal had. Do the removal first, and clear the array slot before
 releasing the request so the array never holds a stale pointer.
 
-**A callback signature with no release function has to *copy* what it
-parks.** `pmix_credential_cbfunc_t` and `pmix_validation_cbfunc_t` -
-`pmix_server_cred_cbfunc` and `pmix_server_validate_cbfunc` - carry no
-`(relfn, relcbdata)` pair, so nothing the host passes survives the return
-of the call. Both of them only thread-shift, and pack the reply later on
-the progress thread. Validate always copied its info array and said why;
-cred copied the credential (`PMIX_BFROPS_COPY`) and then parked the info
-array *by pointer* beside it, so a host that answered from a stack frame
-- the natural thing for a one-element reply - had the server pack that
-frame after it was gone. Copy into the caddy and set `infocopy`, rather
-than freeing explicitly at the end: the flag also covers the early
-returns above the completion, which is where validate leaked its copy.
-The regression case is in `test/unit/server_control.c`, whose host stub
-destructs and overwrites its array the instant the callback returns.
+**A callback signature with no release function must be *finished* with
+what the host handed it before it returns.** `pmix_credential_cbfunc_t`
+and `pmix_validation_cbfunc_t` - `pmix_server_cred_cbfunc` and
+`pmix_server_validate_cbfunc` - carry no `(relfn, relcbdata)` pair, so
+nothing the host passes survives the return of the call. It is not ours
+to release either: there is no way to tell a host stack frame from
+something malloc'd, so the host keeps ownership and reclaims it on the
+next line. Both callbacks used to park the data and pack the reply later
+on the progress thread, which meant copying it - and cred copied the
+credential (`PMIX_BFROPS_COPY`) but parked the info array *by pointer*
+beside it, so a host that answered from a stack frame, the natural thing
+for a one-element reply, had the server pack that frame after it was
+gone. Both now pack the whole reply where they stand, on the host's own
+thread, and shift only the finished buffer (`scd->buf`, released by the
+caddy's destructor if it was never queued); `_queue_sec_reply` does the
+queueing, which is the only part that has to be on the progress thread,
+since it writes `peer->send_msg`, the peer's send queue, and the send
+event. Prefer that shape to a copy wherever a callback's data feeds
+nothing but a reply. The regression case is in
+`test/unit/server_control.c`, whose host stub destructs and overwrites
+its array the instant the callback returns.
 
 **An internal completion path must hand the callback the object that
 callback casts.** `_fabric_response` exists to answer a fabric request the

--- a/src/server/pmix_server_info_replies.c
+++ b/src/server/pmix_server_info_replies.c
@@ -623,77 +623,92 @@ void pmix_server_monitor_cbfunc(pmix_status_t status, pmix_info_t *info, size_t 
     PMIX_THREADSHIFT(scd, _mon_cbfunc);
 }
 
-static void _cred_cbfunc(int sd, short args, void *cbdata)
+/* Pack a reply that carries nothing but its status.
+ *
+ * This is the whole of the answer to a request that failed, and it is
+ * also the fallback when the payload of a successful one cannot be
+ * packed: a body that was only half written is not something the client
+ * can unpack, so the buffer is discarded and rebuilt to carry just the
+ * failing status. */
+static pmix_buffer_t *pack_status_reply(pmix_peer_t *peer, pmix_status_t status)
 {
-    pmix_shift_caddy_t *scd = (pmix_shift_caddy_t*)cbdata;
-    pmix_query_caddy_t *qcd = (pmix_query_caddy_t *) scd->cbdata;
-    pmix_server_caddy_t *cd = (pmix_server_caddy_t *) qcd->cbdata;
     pmix_buffer_t *reply;
     pmix_status_t rc;
-    PMIX_HIDE_UNUSED_PARAMS(sd, args);
-
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
-        PMIX_RELEASE(cd);
-        PMIX_RELEASE(qcd);
-        PMIX_RELEASE(scd);
-        return;
-    }
-
-    pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "pmix:get credential callback with status %s",
-                        PMIx_Error_string(scd->status));
 
     reply = PMIX_NEW(pmix_buffer_t);
     if (NULL == reply) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        goto cleanup;
+        return NULL;
     }
-
-    /* pack the status */
-    PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
+    PMIX_BFROPS_PACK(rc, peer, reply, &status, 1, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        goto complete;
-    }
-
-    if (PMIX_SUCCESS == scd->status) {
-        /* pack the returned credential */
-        PMIX_BFROPS_PACK(rc, cd->peer, reply, scd->bo, 1, PMIX_BYTE_OBJECT);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            goto complete;
-        }
-
-        /* pack any returned data */
-        PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->ninfo, 1, PMIX_SIZE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            goto complete;
-        }
-        if (0 < scd->ninfo) {
-            PMIX_BFROPS_PACK(rc, cd->peer, reply, scd->info, scd->ninfo, PMIX_INFO);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-            }
-        }
-    }
-
-complete:
-    // send reply
-    PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
-    if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(reply);
+        return NULL;
+    }
+    return reply;
+}
+
+/* Add an info array to a reply that already carries its status */
+static pmix_status_t pack_reply_info(pmix_peer_t *peer, pmix_buffer_t *reply,
+                                     pmix_info_t info[], size_t ninfo)
+{
+    pmix_status_t rc;
+
+    PMIX_BFROPS_PACK(rc, peer, reply, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    if (0 < ninfo) {
+        PMIX_BFROPS_PACK(rc, peer, reply, info, ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+    }
+    return rc;
+}
+
+/* Send the reply the credential and validation callbacks packed.
+ *
+ * pmix_credential_cbfunc_t and pmix_validation_cbfunc_t carry no
+ * (release_fn, release_cbdata) pair, so nothing the host hands up
+ * survives the return of the up-call - and the library cannot dispose of
+ * that data itself, having no way to tell a host stack frame from
+ * something malloc'd. The host therefore keeps ownership, and all the
+ * library owes it is to be finished by the time the call returns. That
+ * does not require a copy: both callbacks pack the reply on the host's
+ * own thread, while its data is still valid, and shift only the finished
+ * buffer. Packing is safe there - it writes into a buffer of our own and
+ * reads the peer's bfrops module. Queueing is not, because it touches
+ * the peer's send queue and the send event, so it is left here. */
+static void _queue_sec_reply(int sd, short args, void *cbdata)
+{
+    pmix_shift_caddy_t *scd = (pmix_shift_caddy_t *) cbdata;
+    pmix_query_caddy_t *qcd = (pmix_query_caddy_t *) scd->cbdata;
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t *) qcd->cbdata;
+    pmix_status_t rc;
+    PMIX_HIDE_UNUSED_PARAMS(sd, args);
+
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "pmix:security callback with status %s",
+                        PMIx_Error_string(scd->status));
+
+    if (!pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped) &&
+        NULL != scd->buf) {
+        PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, scd->buf);
+        if (PMIX_SUCCESS == rc) {
+            /* the send owns the buffer now */
+            scd->buf = NULL;
+        }
     }
 
-cleanup:
     if (NULL != qcd->info) {
         PMIX_INFO_FREE(qcd->info, qcd->ninfo);
     }
-    if (NULL != scd->bo) {
-        PMIX_BYTE_OBJECT_FREE(scd->bo, 1);
-    }
     PMIX_RELEASE(qcd);
     PMIX_RELEASE(cd);
+    /* a buffer that was never queued goes back in the destructor */
     PMIX_RELEASE(scd);
 }
 
@@ -704,7 +719,6 @@ void pmix_server_cred_cbfunc(pmix_status_t status, pmix_byte_object_t *credentia
     pmix_query_caddy_t *qcd = (pmix_query_caddy_t *) cbdata;
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *) qcd->cbdata;
     pmix_status_t rc;
-    size_t n;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         PMIX_RELEASE(cd);
@@ -715,7 +729,7 @@ void pmix_server_cred_cbfunc(pmix_status_t status, pmix_byte_object_t *credentia
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "server:cred_cbfunc called");
 
-    /* need to thread-shift this callback as it accesses global data */
+    /* need to thread-shift the send as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
         /* we cannot answer the requestor, but we can at least let go of
@@ -726,9 +740,13 @@ void pmix_server_cred_cbfunc(pmix_status_t status, pmix_byte_object_t *credentia
         return;
     }
     scd->status = status;
-    /* this signature carries no release function, so nothing here is
-     * ours past the return - both the credential and the info array
-     * have to be copied before we hand them to another thread.
+
+    /* A host that could not issue a credential answers with an error
+     * status and no credential - the contract on
+     * pmix_credential_cbfunc_t says exactly that, and the credential is
+     * packed only under a success status. The reverse, a success with
+     * nothing to point at, would leave the client's unpack reading past
+     * the end of the reply, so it is refused here.
      *
      * Every failure below records itself in scd->status and falls
      * through to the thread-shift rather than returning. This callback
@@ -736,112 +754,30 @@ void pmix_server_cred_cbfunc(pmix_status_t status, pmix_byte_object_t *credentia
      * up-called the host and returned PMIX_SUCCESS, so the switchyard
      * has let go of the request and will synthesize nothing. Returning
      * here left the client blocked in PMIx_Get_credential for good. */
-    if (NULL != info && 0 < ninfo) {
-        PMIX_INFO_CREATE(scd->info, ninfo);
-        if (NULL == scd->info) {
-            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-            scd->status = PMIX_ERR_NOMEM;
-        } else {
-            scd->ninfo = ninfo;
-            /* the caddy owns the copy - flagging it here covers the early
-             * returns that never reach _cred_cbfunc's cleanup */
-            scd->infocopy = true;
-            for (n=0; n < scd->ninfo; n++) {
-                rc = PMIx_Info_xfer(&scd->info[n], &info[n]);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    scd->status = rc;
-                    /* discard the half-built array rather than putting
-                     * default-constructed elements on the wire */
-                    PMIX_INFO_FREE(scd->info, scd->ninfo);
-                    scd->ninfo = 0;
-                    scd->infocopy = false;
-                    break;
-                }
-            }
-        }
-    }
-    /* A host that could not issue a credential answers with an error
-     * status and no credential - the contract on
-     * pmix_credential_cbfunc_t says exactly that, and _cred_cbfunc packs
-     * the credential only under a success status. But the copy screens a
-     * NULL source and reports PMIX_ERR_BAD_PARAM, so the ordinary
-     * refusal used to take the error return above and the client was
-     * never told anything at all. Only copy what is there. */
-    if (NULL != credential) {
-        PMIX_BFROPS_COPY(rc, cd->peer, (void**)&scd->bo, credential, PMIX_BYTE_OBJECT);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            scd->status = rc;
-        }
-    } else if (PMIX_SUCCESS == scd->status) {
-        /* the host claimed success and handed us nothing. The client
-         * unpacks a credential after a success status, so answering that
-         * way would leave its unpack reading past the end of the reply */
+    if (PMIX_SUCCESS == scd->status && NULL == credential) {
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         scd->status = PMIX_ERR_BAD_PARAM;
     }
-    scd->cbdata = cbdata;
-    PMIX_THREADSHIFT(scd, _cred_cbfunc);
-}
 
-static void _valcbfunc(int sd, short args, void *cbdata)
-{
-    pmix_shift_caddy_t *scd = (pmix_shift_caddy_t*)cbdata;
-    pmix_query_caddy_t *qcd = (pmix_query_caddy_t *) scd->cbdata;
-    pmix_server_caddy_t *cd = (pmix_server_caddy_t *) qcd->cbdata;
-    pmix_buffer_t *reply;
-    pmix_status_t rc;
-    PMIX_HIDE_UNUSED_PARAMS(sd, args);
-
-    if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
-        PMIX_RELEASE(cd);
-        PMIX_RELEASE(qcd);
-        PMIX_RELEASE(scd);
-        return;
-    }
-
-    pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "pmix:validate credential callback with status %s",
-                        PMIx_Error_string(scd->status));
-
-    reply = PMIX_NEW(pmix_buffer_t);
-    if (NULL == reply) {
-        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        goto cleanup;
-    }
-    PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto complete;
-    }
-    /* pack any returned data */
-    PMIX_BFROPS_PACK(rc, cd->peer, reply, &scd->ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto complete;
-    }
-    if (0 < scd->ninfo) {
-        PMIX_BFROPS_PACK(rc, cd->peer, reply, scd->info, scd->ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
+    scd->buf = pack_status_reply(cd->peer, scd->status);
+    if (NULL != scd->buf && PMIX_SUCCESS == scd->status) {
+        /* pack the credential the host gave us, and whatever it told us
+         * about it - all of it read here, none of it kept */
+        PMIX_BFROPS_PACK(rc, cd->peer, scd->buf, credential, 1, PMIX_BYTE_OBJECT);
+        if (PMIX_SUCCESS == rc) {
+            rc = pack_reply_info(cd->peer, scd->buf, info, ninfo);
+        } else {
             PMIX_ERROR_LOG(rc);
+        }
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(scd->buf);
+            scd->status = rc;
+            scd->buf = pack_status_reply(cd->peer, scd->status);
         }
     }
 
-complete:
-    // send reply
-    PMIX_SERVER_QUEUE_REPLY(rc, cd->peer, cd->hdr.tag, reply);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_RELEASE(reply);
-    }
-
-cleanup:
-    if (NULL != qcd->info) {
-        PMIX_INFO_FREE(qcd->info, qcd->ninfo);
-    }
-    PMIX_RELEASE(qcd);
-    PMIX_RELEASE(cd);
-    PMIX_RELEASE(scd);
+    scd->cbdata = cbdata;
+    PMIX_THREADSHIFT(scd, _queue_sec_reply);
 }
 
 void pmix_server_validate_cbfunc(pmix_status_t status, pmix_info_t info[], size_t ninfo,
@@ -851,7 +787,6 @@ void pmix_server_validate_cbfunc(pmix_status_t status, pmix_info_t info[], size_
     pmix_query_caddy_t *qcd = (pmix_query_caddy_t *) cbdata;
     pmix_server_caddy_t *cd = (pmix_server_caddy_t *) qcd->cbdata;
     pmix_status_t rc;
-    size_t n;
 
     if (pmix_atomic_check_bool(&pmix_globals.progress_thread_stopped)) {
         PMIX_RELEASE(cd);
@@ -862,7 +797,7 @@ void pmix_server_validate_cbfunc(pmix_status_t status, pmix_info_t info[], size_
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "server:validate_cbfunc called");
 
-    /* need to thread-shift this callback as it accesses global data */
+    /* need to thread-shift the send as it accesses global data */
     scd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == scd) {
         /* we cannot answer the requestor, but we can at least let go of
@@ -873,38 +808,25 @@ void pmix_server_validate_cbfunc(pmix_status_t status, pmix_info_t info[], size_
         return;
     }
     scd->status = status;
-    /* need to copy the info as they may not hold it for us. As in
-     * pmix_server_cred_cbfunc, a failure records itself in scd->status
-     * and falls through to the thread-shift: this callback is the only
-     * thing that will ever answer the client, so returning here left it
-     * blocked in PMIx_Validate_credential for good. */
-    if (NULL != info && 0 < ninfo) {
-        PMIX_INFO_CREATE(scd->info, ninfo);
-        if (NULL == scd->info) {
-            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-            scd->status = PMIX_ERR_NOMEM;
-        } else {
-            scd->ninfo = ninfo;
-            /* the caddy owns the copy - flagging it here covers the early
-             * returns that never reach _valcbfunc's cleanup */
-            scd->infocopy = true;
-            for (n=0; n < scd->ninfo; n++) {
-                rc = PMIx_Info_xfer(&scd->info[n], &info[n]);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    scd->status = rc;
-                    /* discard the half-built array rather than putting
-                     * default-constructed elements on the wire */
-                    PMIX_INFO_FREE(scd->info, scd->ninfo);
-                    scd->ninfo = 0;
-                    scd->infocopy = false;
-                    break;
-                }
+
+    /* as in pmix_server_cred_cbfunc, the host's array is packed here
+     * rather than copied: it is ours only until we return, and a failure
+     * records itself in scd->status and falls through to the shift so
+     * that the client is answered either way */
+    scd->buf = pack_status_reply(cd->peer, scd->status);
+    if (NULL != scd->buf) {
+        rc = pack_reply_info(cd->peer, scd->buf, info, ninfo);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(scd->buf);
+            if (PMIX_SUCCESS == scd->status) {
+                scd->status = rc;
             }
+            scd->buf = pack_status_reply(cd->peer, scd->status);
         }
     }
+
     scd->cbdata = cbdata;
-    PMIX_THREADSHIFT(scd, _valcbfunc);
+    PMIX_THREADSHIFT(scd, _queue_sec_reply);
 }
 
 static void _fabcbfunc(int sd, short args, void *cbdata)

--- a/test/unit/common_api.c
+++ b/test/unit/common_api.c
@@ -498,6 +498,109 @@ static void test_out_parameters(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* PMIx_Get_credential: the payload is the caller's, the object is not */
+/* ------------------------------------------------------------------ */
+/* A singleton has no server, so both forms are answered by a local psec
+ * mechanism - which is the same code path a client or tool takes when it
+ * is not connected, and the one that hands the credential back through
+ * pmix_credential_cbfunc_t.
+ *
+ * What that callback transfers is the credential itself: the payload the
+ * byte object points at. The object carrying it belongs to the library
+ * and may be a stack frame, so a receiver reads the pointer out of it
+ * and releases the payload when it is done. The library used to destruct
+ * the object the moment the callback returned, which freed the payload
+ * out from under the receiver: reading it afterwards is a use-after-free
+ * and releasing it, as the contract requires, is a double free. Both are
+ * what this case does deliberately, so a re-broken library trips ASan
+ * here rather than in somebody's application. */
+static char *credpayload = NULL;
+static size_t credsize = 0;
+static pmix_status_t credstatus = PMIX_ERR_NOT_SUPPORTED;
+static volatile int credfired = 0;
+
+static void credcb(pmix_status_t status, pmix_byte_object_t *cred,
+                   pmix_info_t info[], size_t ninfo, void *cbdata)
+{
+    (void) info;
+    (void) ninfo;
+    (void) cbdata;
+
+    credstatus = status;
+    if (PMIX_SUCCESS == status && NULL != cred && NULL != cred->bytes) {
+        /* take the payload out of the object - the object itself is the
+         * library's and must not be retained or released here */
+        credpayload = cred->bytes;
+        credsize = cred->size;
+    }
+    credfired++;
+}
+
+static void test_credential_ownership(void)
+{
+    pmix_status_t rc;
+    pmix_byte_object_t cred;
+    pmix_listener_protocol_t proto;
+    size_t n;
+    int nonzero;
+
+    fprintf(stdout, "\n-- PMIx_Get_credential ownership --\n");
+
+    /* psec/native builds its credential out of the connection it is
+     * speaking over, and a singleton has none - its peer's protocol is
+     * PMIX_PROTOCOL_UNDEF, which the module declines. Claim the tcp
+     * protocol for the length of the case so the mechanism produces a
+     * credential and the ownership of it can be examined. */
+    proto = pmix_globals.mypeer->protocol;
+    pmix_globals.mypeer->protocol = PMIX_PROTOCOL_V2;
+
+    /* the blocking form fills the caller's own object */
+    PMIX_BYTE_OBJECT_CONSTRUCT(&cred);
+    rc = PMIx_Get_credential(NULL, 0, &cred);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stdout, "  skip  : no local credential mechanism (%s)\n",
+                PMIx_Error_string(rc));
+        pmix_globals.mypeer->protocol = proto;
+        return;
+    }
+    check(NULL != cred.bytes && 0 < cred.size, "blocking form returns a credential");
+    /* the caller owns the payload and releases it */
+    PMIX_BYTE_OBJECT_DESTRUCT(&cred);
+
+    /* and the non-blocking form transfers it to the callback */
+    credpayload = NULL;
+    credsize = 0;
+    credfired = 0;
+    rc = PMIx_Get_credential_nb(NULL, 0, credcb, NULL);
+    pmix_globals.mypeer->protocol = proto;
+    check(PMIX_SUCCESS == rc, "non-blocking request accepted");
+    if (PMIX_SUCCESS != rc) {
+        return;
+    }
+    check(1 == credfired, "the local mechanism answered before returning");
+    check(PMIX_SUCCESS == credstatus, "the callback was given a success");
+    check(NULL != credpayload && 0 < credsize, "the callback was given a credential");
+    if (NULL == credpayload) {
+        return;
+    }
+
+    /* the payload is ours now: it has to still be readable here, after
+     * the library has returned from the callback that handed it over */
+    nonzero = 0;
+    for (n = 0; n < credsize; n++) {
+        if (0 != credpayload[n]) {
+            nonzero = 1;
+            break;
+        }
+    }
+    check(1 == nonzero, "the credential survives the callback's return");
+
+    /* and it is ours to release - the library must not have done so */
+    free(credpayload);
+    credpayload = NULL;
+}
+
+/* ------------------------------------------------------------------ */
 /* PMIx_Register_attributes: a function name that is not there         */
 /* ------------------------------------------------------------------ */
 static void test_register_attributes(void)
@@ -586,6 +689,7 @@ int main(int argc, char **argv)
     test_iof_flags();
     test_iof_xml_escaping();
     test_out_parameters();
+    test_credential_ownership();
     test_register_attributes();
 
     rc = PMIx_Finalize(NULL, 0);

--- a/test/unit/common_api.c
+++ b/test/unit/common_api.c
@@ -516,6 +516,7 @@ static void test_out_parameters(void)
  * here rather than in somebody's application. */
 static char *credpayload = NULL;
 static size_t credsize = 0;
+static char *credcopy = NULL;
 static pmix_status_t credstatus = PMIX_ERR_NOT_SUPPORTED;
 static volatile int credfired = 0;
 
@@ -529,9 +530,15 @@ static void credcb(pmix_status_t status, pmix_byte_object_t *cred,
     credstatus = status;
     if (PMIX_SUCCESS == status && NULL != cred && NULL != cred->bytes) {
         /* take the payload out of the object - the object itself is the
-         * library's and must not be retained or released here */
+         * library's and must not be retained or released here - and keep
+         * a copy of what it holds while we are certainly still allowed
+         * to read it, so that the caller can compare */
         credpayload = cred->bytes;
         credsize = cred->size;
+        credcopy = malloc(cred->size);
+        if (NULL != credcopy) {
+            memcpy(credcopy, cred->bytes, cred->size);
+        }
     }
     credfired++;
 }
@@ -541,8 +548,6 @@ static void test_credential_ownership(void)
     pmix_status_t rc;
     pmix_byte_object_t cred;
     pmix_listener_protocol_t proto;
-    size_t n;
-    int nonzero;
 
     fprintf(stdout, "\n-- PMIx_Get_credential ownership --\n");
 
@@ -584,16 +589,17 @@ static void test_credential_ownership(void)
         return;
     }
 
-    /* the payload is ours now: it has to still be readable here, after
-     * the library has returned from the callback that handed it over */
-    nonzero = 0;
-    for (n = 0; n < credsize; n++) {
-        if (0 != credpayload[n]) {
-            nonzero = 1;
-            break;
-        }
-    }
-    check(1 == nonzero, "the credential survives the callback's return");
+    /* the payload is ours now: it has to read back here, after the
+     * library has returned from the callback that handed it over, as
+     * whatever the callback saw. Comparing against that copy rather than
+     * against any particular content keeps this independent of what the
+     * mechanism puts in a credential - psec/native builds one out of the
+     * effective uid and gid, which are all-zero bytes when the test runs
+     * as root. */
+    check(NULL != credcopy && 0 == memcmp(credpayload, credcopy, credsize),
+          "the credential survives the callback's return");
+    free(credcopy);
+    credcopy = NULL;
 
     /* and it is ours to release - the library must not have done so */
     free(credpayload);

--- a/test/unit/server_control.c
+++ b/test/unit/server_control.c
@@ -39,21 +39,26 @@
  *
  *   get_credential: a host that refuses must still be answered
  *      pmix_credential_cbfunc_t's contract is an error status and no
- *      credential. The copy of that credential screens a NULL source, so
- *      the ordinary refusal used to take an error return that queued
- *      nothing and the client's PMIx_Get_credential never came back.
+ *      credential. The copy the server used to make of that credential
+ *      screens a NULL source, so the ordinary refusal used to take an
+ *      error return that queued nothing and the client's
+ *      PMIx_Get_credential never came back.
  *
- *   get_credential: the host's reply info is copied, not borrowed
+ *   get_credential: the reply is packed before the up-call returns
  *      pmix_credential_cbfunc_t carries no (release_fn, release_cbdata)
  *      pair, so nothing the host passes to it survives the return of the
- *      call - and pmix_server_cred_cbfunc only thread-shifts, packing the
- *      reply later on the progress thread. The credential itself was
- *      always copied; the info array beside it was parked by pointer, so
- *      a host that built it on its stack (the natural thing to do for a
- *      one-element answer) had the server pack that frame after it had
+ *      call - and it is not the library's to release either, having no
+ *      way to tell a host stack frame from something malloc'd. The
+ *      answer is to be finished with it by the time the callback
+ *      returns: pmix_server_cred_cbfunc packs the whole reply where it
+ *      stands and thread-shifts only the finished buffer. It used to
+ *      park the data instead and pack on the progress thread - copying
+ *      the credential, but taking the info array by pointer, so a host
+ *      that built that array on its stack (the natural thing to do for a
+ *      one-element answer) had the server pack the frame after it had
  *      been reused. The stub below deliberately destructs and overwrites
- *      its array the instant the callback returns, so the queued reply
- *      carries a recognizable key only if the copy really happened.
+ *      both the instant the callback returns, so the queued reply
+ *      carries recognizable contents only if it was packed in time.
  *      Read back from the peer's send queue, which is where a reply to a
  *      socketless peer comes to rest.
  *
@@ -274,7 +279,7 @@ static void op_stub(pmix_status_t status, void *cbdata)
 /* Answer the credential request from data this frame owns, then take it
  * all back. pmix_credential_cbfunc_t hands down no release function, so
  * this is exactly what the contract permits - and it is what a server
- * that parked the array rather than copying it cannot survive. */
+ * that parked the data rather than packing it cannot survive. */
 static bool cred_fired = false;
 
 /* Overwrite through a volatile pointer: a plain memset over a local the
@@ -1033,7 +1038,8 @@ int main(int argc, char **argv)
                 report("credential reply carries one info", PMIX_SUCCESS == rc
                            && 1 == rninfo && NULL != rinfo);
                 /* the host destructed and overwrote its array before it
-                 * returned, so this only survives a real copy */
+                 * returned, so this survives only if the reply was
+                 * packed while the callback was still running */
                 report("credential reply kept the host's key",
                        NULL != rinfo && PMIX_CHECK_KEY(&rinfo[0], CTLUT_CREDKEY));
                 report("credential reply kept the host's value",
@@ -1051,12 +1057,12 @@ int main(int argc, char **argv)
 
     /* --- a host that cannot issue a credential must still answer ------ */
     /* The contract on pmix_credential_cbfunc_t is an error status and no
-     * credential, and _cred_cbfunc packs a credential only under a
-     * success status - so the reply path was written for this. But the
-     * outer callback copied the credential unconditionally, and the copy
-     * screens a NULL source and reports PMIX_ERR_BAD_PARAM, so the
-     * ordinary refusal took an error return that released everything and
-     * queued nothing. The client's PMIx_Get_credential never came back.
+     * credential, and the credential is packed only under a success
+     * status - so the reply path was written for this. But the callback
+     * used to copy the credential unconditionally, and the copy screens
+     * a NULL source and reports PMIX_ERR_BAD_PARAM, so the ordinary
+     * refusal took an error return that released everything and queued
+     * nothing. The client's PMIx_Get_credential never came back.
      * Against an unfixed library the first assertion below reports no
      * reply at all. */
     {


### PR DESCRIPTION
`pmix_credential_cbfunc_t` is used in both directions, and the two
directions do not carry the same ownership. Sorting out which is which
turned up a defect on each side.

**Coming up from the host.** The signature carries no
`(release_fn, release_cbdata)` pair, so nothing the host hands up
survives the return of the call — and it is not the library's to
release either, there being no way to tell a host stack frame from
something `malloc`'d. The host keeps ownership; all the library owes it
is to be finished by the time the call returns. Being finished never
required copying, so `pmix_server_cred_cbfunc` and
`pmix_server_validate_cbfunc` now pack the whole reply where they
stand, on whatever thread the host called them from, and thread-shift
only the finished buffer. Packing is safe there (a buffer of our own,
plus a read of the peer's `bfrops` module); queueing is not, so
`_queue_sec_reply` keeps that part. The credential copy, the info-array
copy and the `infocopy` bookkeeping are gone, and a payload that fails
to pack part way through now rebuilds the reply as status-only rather
than queueing a body the client cannot unpack.

**Going down to the application.** What transfers is the credential
itself — the payload the byte object points at — not the object
carrying it, which stays the library's and may be a stack frame. So the
library's obligation is a negative one, and `getcbfunc()` violated it:
it destructed the object the moment the callback returned, freeing the
payload out from under the application. A receiver that kept the
pointer read freed memory; one that released it, as the header
requires, freed it twice. The local `psec` arms did the same. Each now
destructs only where there was no `cbfunc` to hand the payload to.

The host pass-through was the case where the two directions met: a
server whose host implements `get_credential` used to hand that
borrowed payload straight to the caller of `PMIx_Get_credential_nb`,
who is told it owns what it receives. `cred_relay()` interposes and
copies. With the transfer uniform, `mycdcb()` takes the payload rather
than copying it, and `PMIx_Get_credential` hands that same allocation
to its caller — retiring both copies the blocking form used to make.

Smaller repairs alongside: `getcbfunc()` left `status` at
`PMIX_SUCCESS` when an unpack failed after the status had been read;
the `psec` arms leaked their results array on failure.

The header and man page text now says which half of the credential
transfers, and that the up-call runs the other way; the `docs/todo.rst`
entry that had this recorded as an open question is closed.

**Behavior note for the release:** an application that never released
the credential was not leaking before, because the library freed it. It
now owns the payload, as the documentation has always said, and leaks
until it adds the release. The alternative was to go on freeing memory
applications were told they owned.

**Testing:** `test/unit/common_api.c` gains a case that reads the
credential after the delivering callback has returned and then releases
it — a use-after-free and a double free respectively against the old
code (verified: re-adding the old destruct aborts the test).
`test/unit/server_control.c` needed no new assertions; its host stub
already destructs and scribbles over both the credential and the info
array the instant the callback returns, which a reply packed after the
return cannot survive. Full unit suite: 105 tests, 103 pass, 2 skip
(`pnet_tcp_ports`, `pnet_simptest_map`, not built here), 0 failures.
Library and docs build warning-free with `--enable-devel-check`.