### PR TITLE
Create the caller's own directory prefix for composed output paths

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1084,10 +1084,17 @@ static ssize_t pattern_literal_head(const char *pattern)
 }
 
 /* Create the directories a composed output name needs, then open it.
- * Everything below the caller's own prefix is walked a component at a
- * time; see pattern_literal_head() for where that prefix ends. `name` is
- * modified in place while the directory part is taken off it, and is put
- * back before returning. */
+ *
+ * The caller's own prefix is created as one path, exactly as it was
+ * before any of this was composed a component at a time: it is text the
+ * caller wrote, and a caller naming a directory tree that does not exist
+ * yet expects it to be made.  Only what PMIx composes BELOW that prefix
+ * is walked a component at a time - see pattern_literal_head() for where
+ * the prefix ends, and pmix_os_dirpath_create_under() for why the rest
+ * cannot be handed to the kernel as one string.
+ *
+ * `name` is modified in place while the directory part is taken off it,
+ * and is put back before returning. */
 static int open_composed_output(const char *pattern, char *name, mode_t dmode)
 {
     ssize_t head = pattern_literal_head(pattern);
@@ -1111,6 +1118,19 @@ static int open_composed_output(const char *pattern, char *name, mode_t dmode)
     if (NULL == root) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         return -1;
+    }
+
+    /* The caller's own prefix has to exist before anything can be walked
+     * under it, and nothing else will create it.  Leaving this out made
+     * every pattern naming a directory that did not already exist fail to
+     * open, with mkdir reporting ENOENT for the prefix itself. */
+    if (0 < head) {
+        rc = pmix_os_dirpath_create(root, dmode);
+        if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
+            PMIX_ERROR_LOG(rc);
+            free(root);
+            return -1;
+        }
     }
 
     /* any directory levels inside the composed part have to exist first */
@@ -1171,7 +1191,19 @@ static pmix_iof_write_event_t* pmix_iof_setup(pmix_namespace_t *nptr,
         }
         /* ensure the directory exists. An existing directory is fine:
          * the job may legitimately be writing into one that is already
-         * there (a rerun, or another rank that got here first) */
+         * there (a rerun, or another rank that got here first).
+         *
+         * The caller's own directory is created as one path - it is theirs
+         * to name, and naming one that does not exist yet is the ordinary
+         * case - and only the namespace and rank levels below it are walked
+         * a component at a time. */
+        rc = pmix_os_dirpath_create(nptr->iof_flags.directory,
+                                    S_IRWXU | S_IRGRP | S_IXGRP);
+        if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
+            PMIX_ERROR_LOG(rc);
+            free(outdir);
+            return NULL;
+        }
         rc = pmix_os_dirpath_create_under(nptr->iof_flags.directory, outdir,
                                           S_IRWXU | S_IRGRP | S_IXGRP);
         if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -1164,6 +1164,16 @@ who composed which part of the name:
   component" walk therefore declines the platform; it was tried, and
   that is what it did — while also declining the legitimate reclaim of a
   stale segment file, which is how the mistake surfaced.
+- **"Taken as given" is not "assumed to exist".** These helpers *open* the
+  prefix; nothing in them creates it, and one of the three kinds of prefix
+  above is routinely named into thin air — a user-supplied output
+  directory. `$TMPDIR` and `PMIX_NSDIR` are there by the time anything
+  composes under them, so the omission is invisible from those call sites;
+  `--output file=/tmp/out/%h/rank-%R:pattern` with no `/tmp/out` yet is a
+  job that silently produces no output at all. A caller whose prefix may
+  not exist has to create it first, with `pmix_os_dirpath_create()` — the
+  whole-path entry point, which is right for it precisely because that
+  path came from outside.
 - **What PMIx composes below the prefix gets walked.** Those names are
   the library's own, so nothing else should have put anything at them.
   Each is created with `mkdirat()` and opened with `O_NOFOLLOW` against


### PR DESCRIPTION
## What breaks

A job writing its output under a directory that does not exist yet produces no
output at all:

```
$ prterun --host node2:1,node3:1 -np 2 --map-by node \
      --output "file=/tmp/szpat/%h/rank-%R:pattern" bash -c 'echo PAT-$PMIX_RANK'
PMIx detected a call to mkdir was unable to create the desired directory:

  Directory: /tmp/szpat
  Error:     No such file or directory
```

`--output dir=<a directory that does not exist>` has the same shape.

## Why

`6cee08940` split path handling between the prefix PMIx is handed and what PMIx
composes below it, so that a symlink partway down cannot redirect the result.
That split is right, and the walk below the prefix is right. What went with the
rework is the creation of the prefix itself: `pmix_dirname()` +
`pmix_os_dirpath_create()` used to make the whole directory path, and the
`_under()` helpers only ever *open* the prefix.

For two of the three kinds of prefix that commit names the omission is
invisible — `$TMPDIR` and `PMIX_NSDIR` are already there by the time anything
composes under them. The third, a user-named output directory, is the one
prefix routinely named into thin air, and it is the only one that breaks. The
two call sites that take one are both in `pmix_iof.c`; the other adopters of
the new API (`pmix_shmem.c`, `pmix_hwloc.c`) use the leaf-only
`pmix_os_dirpath_open_file()`, which creates no directories and whose prefix is
a session directory PMIx made itself.

## The change

Create the caller's prefix as one path with `pmix_os_dirpath_create()` — the
whole-path entry point, which is right for it precisely because that path came
from outside — and keep the component-at-a-time walk for what PMIx composes
below it. The distinction is what the walk is for: a name the caller supplied
is theirs to resolve; a name this library invents is not.

`src/util/AGENTS.md` gains the rule beside the three-entry-point table, since
that is where the next caller chooses: *"taken as given" is not "assumed to
exist"*.

## Testing

Found by the PRRTE dockerswarm suite, where it was six failures with one cause
(`--output file=...:pattern` and the `copy:raw` qualifier cases). With this
change the reproducer above writes `/tmp/szpat/node2/rank-0.out` as it did
before `6cee08940`, and the suite is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nQdmQr9wSWDyq5EMiw4LC