### PR TITLE
Close out the shmem3 review: update-stream compatibility and the smaller findings

### DIFF
--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -149,6 +149,13 @@ static pmix_status_t session_del(uint32_t sessionID)
  * Nothing is packed for a job with no session, which is the ordinary
  * case for a host that never described one.
  */
+/* File a lone realm key where its realm keeps values - see the note on
+ * the definition. Used by every path that takes one: the registration
+ * that first stores a job description, the reply to a keyed get, and
+ * the job-level values an update carries. */
+static pmix_status_t store_lone_realm_key(pmix_job_t *trk, uint32_t sid,
+                                          const char *key, pmix_value_t *value);
+
 static pmix_status_t hash_pack_update(struct pmix_peer_t *pr,
                                       pmix_buffer_t *buff)
 {
@@ -166,13 +173,55 @@ static pmix_status_t hash_pack_update(struct pmix_peer_t *pr,
         return PMIX_SUCCESS;
     }
 
-    /* Job-level values added since this namespace was registered.
+    /* Job-level values added since this namespace was registered,
+     * wrapped in a PMIX_JOB_INFO_ARRAY.
+     *
+     * The wrapper is what makes this stream SELF-DESCRIBING, and that is
+     * the point of it rather than tidiness. Sent bare, a job-level value
+     * is indistinguishable from any other kval, so the receiver had to
+     * treat "not a session array" as "a job-level value" - and would
+     * therefore misfile, as job data, the first new kind of entry any
+     * future release adds here. Named, each kind can be recognized and
+     * an unrecognized one skipped, which is what the project's wire
+     * rules ask of a reader.
      *
      * These go first and unconditionally - a job need not be in a
      * session at all, and the session walk below returns early when it
      * is not, which would have dropped these with it. */
-    PMIX_LIST_FOREACH (kvptr, &trk->updates, pmix_kval_t) {
-        PMIX_BFROPS_PACK(rc, peer, buff, kvptr, 1, PMIX_KVAL);
+    if (0 < pmix_list_get_size(&trk->updates)) {
+        pmix_data_array_t *darray = NULL;
+        pmix_info_t *iptr;
+        pmix_kval_t wrap;
+        size_t n = 0;
+
+        PMIX_DATA_ARRAY_CREATE(darray, pmix_list_get_size(&trk->updates),
+                               PMIX_INFO);
+        if (NULL == darray) {
+            return PMIX_ERR_NOMEM;
+        }
+        iptr = (pmix_info_t *) darray->array;
+        PMIX_LIST_FOREACH (kvptr, &trk->updates, pmix_kval_t) {
+            PMIX_LOAD_KEY(iptr[n].key, kvptr->key);
+            rc = PMIx_Value_xfer(&iptr[n].value, kvptr->value);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_DATA_ARRAY_FREE(darray);
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+            n++;
+        }
+        PMIX_CONSTRUCT(&wrap, pmix_kval_t);
+        wrap.key = strdup(PMIX_JOB_INFO_ARRAY);
+        wrap.value = (pmix_value_t *) calloc(1, sizeof(pmix_value_t));
+        if (NULL == wrap.key || NULL == wrap.value) {
+            PMIX_DATA_ARRAY_FREE(darray);
+            PMIX_DESTRUCT(&wrap);
+            return PMIX_ERR_NOMEM;
+        }
+        wrap.value->type = PMIX_DATA_ARRAY;
+        wrap.value->data.darray = darray;
+        PMIX_BFROPS_PACK(rc, peer, buff, &wrap, 1, PMIX_KVAL);
+        PMIX_DESTRUCT(&wrap);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             return rc;
@@ -231,19 +280,53 @@ static pmix_status_t hash_accept_update(pmix_buffer_t *buff)
                 return rc;
             }
         }
-        else {
-            /* a job-level value the host added after we attached. It
+        else if (PMIX_CHECK_KEY(&kv, PMIX_JOB_INFO_ARRAY)) {
+            /* Job-level values the host added after we attached. Each
              * goes where hash_cache_job_info() would have put it had it
-             * been there at the time, and pmix_hash_store() replaces by
-             * key - so a notice that arrives twice, or one that restates
-             * what we already hold, lands on the same state. */
-            rc = pmix_hash_store(&trk->internal, PMIX_RANK_WILDCARD, &kv,
-                                 NULL, 0, NULL);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
+             * been there at the time - which for a key naming a realm is
+             * that realm, not the job's own table - and the stores
+             * replace by key, so a notice that arrives twice, or one
+             * that restates what we already hold, lands on the same
+             * state. */
+            pmix_info_t *uptr;
+            size_t nu, u;
+
+            if (PMIX_DATA_ARRAY != kv.value->type ||
+                NULL == kv.value->data.darray ||
+                NULL == kv.value->data.darray->array) {
                 PMIX_DESTRUCT(&kv);
-                return rc;
+                return PMIX_ERR_TYPE_MISMATCH;
             }
+            uptr = (pmix_info_t *) kv.value->data.darray->array;
+            nu = kv.value->data.darray->size;
+            for (u = 0; u < nu; u++) {
+                pmix_kval_t ukv;
+
+                rc = store_lone_realm_key(trk, UINT32_MAX, uptr[u].key,
+                                          &uptr[u].value);
+                if (PMIX_ERR_TAKE_NEXT_OPTION == rc) {
+                    /* no realm of its own - the job's own table */
+                    ukv.key = uptr[u].key;
+                    ukv.value = &uptr[u].value;
+                    rc = pmix_hash_store(&trk->internal, PMIX_RANK_WILDCARD,
+                                         &ukv, NULL, 0, NULL);
+                }
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DESTRUCT(&kv);
+                    return rc;
+                }
+            }
+        }
+        else {
+            /* A kind of entry this build has not been taught to read.
+             * Skip it: a reader tolerates what it does not recognize, so
+             * that a server which has learned to send one more thing can
+             * still talk to a client that has not learned to read it.
+             * Storing it as job data instead - which is what "not a
+             * session array" used to mean here - would misfile it under
+             * its own key, where nothing looks for it. */
+            ;
         }
         PMIX_DESTRUCT(&kv);
         cnt = 1;
@@ -422,11 +505,6 @@ static pmix_status_t assemb_kvs_req(const pmix_proc_t *proc, pmix_list_t *kvs, p
 
 static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf);
 
-/* File a lone realm key where its realm keeps values - see the note on
- * the definition. Used by both paths that take one: the registration
- * that first stores a job description, and the reply to a keyed get. */
-static pmix_status_t store_lone_realm_key(pmix_job_t *trk, uint32_t sid,
-                                          const char *key, pmix_value_t *value);
 
 static pmix_status_t mark_modex_complete(struct pmix_peer_t *peer,
                                          pmix_list_t *nslist,

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -2090,7 +2090,8 @@ shmem3_segment_create_and_attach(
     pmix_gds_shmem3_job_t *job,
     pmix_gds_shmem3_job_shmem3_id_t shmem3_id,
     const char *segment_name,
-    size_t segment_size
+    size_t segment_size,
+    pmix_gds_shmem3_attach_ctx_t ctx
 ) {
     pmix_status_t rc = PMIX_SUCCESS;
     // Pad given size to fill remaining space on the last page.
@@ -2264,17 +2265,34 @@ out:
     }
     return rc;
 out_release:
-    /* Mirror shmem3_attach()'s failure handling: detach and drop the job
-     * tracker entry.
-     *
-     * Take the backing file with it. pmix_shmem_segment_create() made it
-     * and shmem_destruct() only unlinks a segment it managed to ATTACH,
-     * so a failure between the two left the file in the session tmpdir
-     * for the life of the node - and the path is built from a pid, which
-     * gets reused. */
+    /* Take the backing file with the failed segment.
+     * pmix_shmem_segment_create() made it and shmem_destruct() only
+     * unlinks a segment it managed to ATTACH, so a failure between the
+     * two left the file in the session tmpdir for the life of the node -
+     * and the path is built from a pid, which gets reused. */
     (void)pmix_shmem_segment_unlink(shmem3);
     (void)pmix_shmem_segment_detach(shmem3);
-    drop_job_tracker(job);
+
+    /* WHETHER THE TRACKER GOES depends on which case this is, and the
+     * caller is the only one that knows - the same distinction, for the
+     * same reason, that shmem3_attach() was given.
+     *
+     * During registration nothing has read this job yet, so a tracker
+     * whose first segment could not be built has nothing to keep and
+     * dropping it is the cleanup.
+     *
+     * Afterwards it is the opposite. A modex generation, a session
+     * update and an addition to a registered job all build a segment on
+     * a job whose clients are attached and reading - so dropping the
+     * tracker would take away the job and session segments they have
+     * held since PMIx_Init, and pmix_gds_shmem3_fetch() would answer
+     * every lookup for their own namespace with
+     * PMIX_ERR_INVALID_NAMESPACE. That is openpmix#4156 again, from the
+     * server side and by way of a transient failure - no VM hole found,
+     * a full tmpdir - rather than a client that could not map. */
+    if (PMIX_GDS_SHMEM3_ATTACH_INIT == ctx) {
+        drop_job_tracker(job);
+    }
     return rc;
 }
 
@@ -2431,7 +2449,9 @@ prepare_shmem3_stores_for_local_job_data(
     // This will be the backing store for data associated with static, read-only
     // data shared between the server and its clients.
     rc = shmem3_segment_create_and_attach(
-        job, PMIX_GDS_SHMEM3_JOB_ID, "jobdata", seg_size
+        job, PMIX_GDS_SHMEM3_JOB_ID, "jobdata", seg_size,
+        /* registering: nothing has read this job yet */
+        PMIX_GDS_SHMEM3_ATTACH_INIT
     );
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
@@ -2472,7 +2492,9 @@ prepare_shmem3_stores_for_local_job_data(
     }
 
     rc = shmem3_segment_create_and_attach(
-        job, PMIX_GDS_SHMEM3_SESSION_ID, session_name, seg_size
+        job, PMIX_GDS_SHMEM3_SESSION_ID, session_name, seg_size,
+        /* registering: nothing has read this job yet */
+        PMIX_GDS_SHMEM3_ATTACH_INIT
     );
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
@@ -4097,7 +4119,10 @@ server_store_modex_cb(pmix_proc_t *proc,
         // Create and attach to the shared-memory
         // segment that will back these data.
         rc = shmem3_segment_create_and_attach(
-            job, PMIX_GDS_SHMEM3_MODEX_ID, segname, minfo.size
+            job, PMIX_GDS_SHMEM3_MODEX_ID, segname, minfo.size,
+            /* a live job - its clients are reading the segments this
+             * tracker owns */
+            PMIX_GDS_SHMEM3_ATTACH_UPDATE
         );
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -4529,7 +4554,10 @@ publish_session_update(
         goto out;
     }
     rc = shmem3_segment_create_and_attach(
-        job, PMIX_GDS_SHMEM3_SESSION_ID, name, seg_size
+        job, PMIX_GDS_SHMEM3_SESSION_ID, name, seg_size,
+        /* a live job - its clients are reading the segments this
+         * tracker owns */
+        PMIX_GDS_SHMEM3_ATTACH_UPDATE
     );
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);
@@ -5074,7 +5102,10 @@ server_add_job_data(
     snprintf(segname, sizeof(segname), "jobdata.%u",
              (unsigned) job->job_generation);
     rc = shmem3_segment_create_and_attach(
-        job, PMIX_GDS_SHMEM3_JOB_ID, segname, seg_size
+        job, PMIX_GDS_SHMEM3_JOB_ID, segname, seg_size,
+        /* a live job - its clients are reading the segments this
+         * tracker owns */
+        PMIX_GDS_SHMEM3_ATTACH_UPDATE
     );
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         PMIX_ERROR_LOG(rc);

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -3505,10 +3505,11 @@ unpack_shmem3_seg_blob_and_attach_if_necessary(
          * pmix_gds_shmem3_get_job_shmem3_by_id(), which abort()s, and a
          * missing nspace reaches strcmp() with NULL.
          *
-         * Skip such a blob rather than failing - it is the same forward
-         * compatibility the unrecognized-key arm of the unpacker keeps,
-         * one level up. A segment kind we have never heard of is one we
-         * have no use for by construction. */
+         * Skip such a blob rather than failing - the same forward
+         * compatibility the unrecognized-key arm one level up keeps, and
+         * the one the fields of this blob get in
+         * unpack_shmem3_connection_info(). A segment kind we have never
+         * heard of is one we have no use for by construction. */
         if (PMIX_GDS_SHMEM3_JOB_ID != usb.smid &&
             PMIX_GDS_SHMEM3_SESSION_ID != usb.smid &&
             PMIX_GDS_SHMEM3_MODEX_ID != usb.smid) {
@@ -3844,13 +3845,20 @@ client_connect_to_shmem3_from_buffi(
             }
         }
         else {
+            /* A key this build has not been taught to read. Skip it.
+             *
+             * Refusing the whole delivery instead makes every future
+             * addition a flag day - and, at PMIx_Init, fails the init
+             * outright rather than degrading. It is the same rule the
+             * inner unpacker keeps for the fields of a seg blob, which
+             * the note in unpack_shmem3_connection_info() spells out;
+             * the two ends of one stream disagreed about it, and the
+             * comment in this file claiming they agreed was reading the
+             * inner one. */
             PMIX_GDS_SHMEM3_VOUT(
-                "%s:ERROR unexpected key=%s", __func__,
+                "%s: ignoring unrecognized key=%s", __func__,
                 (NULL == kval.key) ? "(null)" : kval.key
             );
-            rc = PMIX_ERR_BAD_PARAM;
-            PMIX_ERROR_LOG(rc);
-            break;
         }
         PMIX_DESTRUCT(&kval);
     };

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -1810,6 +1810,14 @@ shmem3_segment_attach_and_init(
     // Now we can safely initialize our shared data structures.
     rc = init_client_side_sm_data(job, seginfo->smid);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
+        /* Undo the attach. Leaving it mapped and marked ready leaves
+         * this handle claiming a segment nothing finished setting up -
+         * and pmix_shmem_segment_attach() refuses a handle that is
+         * already attached, so the NEXT delivery of this segment kind
+         * could never map either. One failed allocation would cost the
+         * rest of the run's deliveries rather than this one. */
+        (void)pmix_shmem_segment_detach(shmem3);
+        pmix_gds_shmem3_clearall_status(job, seginfo->smid);
         return rc;
     }
     /* We are a reader of this segment, so take write access away and let

--- a/src/mca/gds/shmem3/gds_shmem3_fetch.c
+++ b/src/mca/gds/shmem3/gds_shmem3_fetch.c
@@ -1049,7 +1049,15 @@ shmem3_fetch_from_job(
             return rc;
         }
         // Finally, we need the job-level info for each rank in the job.
-        for (pmix_rank_t rank = 0; rank < job->nspace->nprocs; rank++) {
+        /* Read the bound ONCE. It lives on the shared namespace object
+         * and gds/hash assigns it from PMIX_JOB_SIZE on the progress
+         * thread, while this walk can be running on the application's -
+         * so re-reading it per iteration lets the range move underneath
+         * the loop. One read gives the loop a bound that does not change
+         * while it runs; which of the two values it gets is the ordinary
+         * "answered just before the update" question every reader has. */
+        const pmix_rank_t nranks = job->nspace->nprocs;
+        for (pmix_rank_t rank = 0; rank < nranks; rank++) {
             pmix_list_t rkvs;
             PMIX_CONSTRUCT(&rkvs, pmix_list_t);
             rc = job_fetch(job, rank, NULL, NULL, 0, &rkvs);
@@ -1142,7 +1150,9 @@ doover:
     // known ranks for this nspace as any one of them could
     // be the source.
     if (PMIX_RANK_UNDEF == proc->rank && (useremote ? have_modex : have_job)) {
-        for (pmix_rank_t rnk = 0; rnk < job->nspace->nprocs; rnk++) {
+        /* read once - see the note on the other sweep below */
+        const pmix_rank_t nranks = job->nspace->nprocs;
+        for (pmix_rank_t rnk = 0; rnk < nranks; rnk++) {
             rc = useremote
                      ? modex_fetch(job, rnk, key, qualifiers, nqual, kvs)
                      : job_fetch(job, rnk, key, qualifiers, nqual, kvs);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -647,4 +647,17 @@ PMIX_EXPORT void pmix_server_grp_member_left(const char *grpid, const pmix_proc_
  * of pmix_pending_nspace_requests, called from the same two sites. */
 PMIX_EXPORT void pmix_server_grp_check_pending(void);
 
+/* Does this entry belong somewhere other than a job's own job-level
+ * table - a map, a realm array, a programming-model key, or a lone key
+ * naming the session, node or app realm?
+ *
+ * Both paths by which a host revises a running job ask this, because
+ * both hand what they collect to PMIX_GDS_ADD_JOB_DATA, which files
+ * job-level VALUES. An entry that belongs to another realm cannot be
+ * filed there: it would be stored under its own key where no reader of
+ * its realm looks, and - since the "has this changed?" test also asks
+ * the job-level table - would count as changed on every restatement.
+ * See the note on the definition. */
+PMIX_EXPORT bool pmix_server_job_update_is_elsewhere(const pmix_info_t *entry);
+
 #endif // PMIX_SERVER_OPS_H

--- a/src/server/pmix_server_registration.c
+++ b/src/server/pmix_server_registration.c
@@ -86,7 +86,7 @@
  * a restated description exactly as it found it - which is what this
  * API did with all of it before it could update anything.
  */
-static bool job_update_is_elsewhere(const pmix_info_t *entry)
+bool pmix_server_job_update_is_elsewhere(const pmix_info_t *entry)
 {
     if (PMIX_CHECK_KEY(entry, PMIX_NSPACE) ||
         PMIX_CHECK_KEY(entry, PMIX_SESSION_ID) ||
@@ -121,7 +121,7 @@ static bool add_job_update(pmix_info_t **array, size_t *n,
     if (0 == strlen(entry->key)) {
         return true;
     }
-    if (job_update_is_elsewhere(entry)) {
+    if (pmix_server_job_update_is_elsewhere(entry)) {
         return true;
     }
     for (i = 0; i < *n; i++) {

--- a/src/server/pmix_server_registration.c
+++ b/src/server/pmix_server_registration.c
@@ -203,7 +203,17 @@ static void _register_nspace(int sd, short args, void *cbdata)
          * in our hash datastore until someone
          * requests it */
         gds = pmix_globals.mypeer->nptr->compat.gds;
-        if (NULL != gds && NULL != gds->store) {
+        /* Deliberately NOT gated on gds->store.
+         *
+         * Only two of the arms below call it; the rest collect job-level
+         * values for the fan-out afterwards, which does not use gds at
+         * all. Gating the whole walk on that slot meant a module that
+         * leaves it NULL - and gds/shmem3 does - collected nothing,
+         * fanned out nothing and returned PMIX_SUCCESS, so the host's
+         * update silently did nothing. That we are assigned "hash"
+         * today, and hash has a store, is a coincidence the neighbouring
+         * file already warns about relying on. */
+        {
             /* default the target to the job level. A PMIX_PROC_INFO_ARRAY
              * narrows it to the rank that array describes, but the other
              * arms below are job-level updates that carry no rank of their
@@ -213,6 +223,13 @@ static void _register_nspace(int sd, short args, void *cbdata)
             PMIX_LOAD_PROCID(&proc, cd->proc.nspace, PMIX_RANK_WILDCARD);
             for (i=0; i < cd->ninfo; i++) {
                 if (PMIX_CHECK_KEY(&cd->info[i], PMIX_PROC_INFO_ARRAY)) {
+                    /* this arm stores through the module - say so rather
+                     * than quietly dropping what the host sent */
+                    if (NULL == gds || NULL == gds->store) {
+                        rc = PMIX_ERR_NOT_SUPPORTED;
+                        PMIX_ERROR_LOG(rc);
+                        goto release;
+                    }
                     /* the type has to be checked before the darray member
                      * of the union is read: an entry carrying this key with
                      * any other type hands us whatever that member happens
@@ -270,6 +287,11 @@ static void _register_nspace(int sd, short args, void *cbdata)
                         }
                     }
                 } else if (PMIX_CHECK_KEY(&cd->info[i], PMIX_GROUP_CONTEXT_ID)) {
+                    if (NULL == gds || NULL == gds->store) {
+                        rc = PMIX_ERR_NOT_SUPPORTED;
+                        PMIX_ERROR_LOG(rc);
+                        goto release;
+                    }
                     PMIX_KVAL_NEW(kv, cd->info[i].key);
                     if (PMIX_UNLIKELY(NULL == kv)) {
                         rc = PMIX_ERR_NOMEM;

--- a/src/server/pmix_server_registration.c
+++ b/src/server/pmix_server_registration.c
@@ -199,6 +199,22 @@ static void _register_nspace(int sd, short args, void *cbdata)
         pmix_list_append(&pmix_globals.nspaces, &nptr->super);
     }
     if (0 > cd->nlocalprocs) {
+        /* An update revises what we already hold. If we hold nothing
+         * for this namespace, there is nothing to revise, and the
+         * nptr created above is a namespace this server was never told
+         * about - left on pmix_globals.nspaces for the life of the
+         * process, describing nothing, while the host is told its
+         * update succeeded. A typo'd namespace is then indistinguishable
+         * from a namespace that was actually updated.
+         *
+         * Take it back off the list and say what is true. Not registered
+         * is exactly what PMIX_ERR_NOT_FOUND says. */
+        if (!nptr->job_info_recvd && SIZE_MAX == nptr->nlocalprocs) {
+            pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);
+            PMIX_RELEASE(nptr);
+            rc = PMIX_ERR_NOT_FOUND;
+            goto release;
+        }
         /* this is just an update, so we store it
          * in our hash datastore until someone
          * requests it */

--- a/src/server/pmix_server_setup.c
+++ b/src/server/pmix_server_setup.c
@@ -162,7 +162,29 @@ static void _register_resources(int sd, short args, void *cbdata)
              * the two populations answer differently for one host call
              * - forever. Borrowed views of cd->info, which outlives the
              * call. */
-            pmix_info_t *ftmp = (pmix_info_t *)
+            pmix_info_t *ftmp;
+
+            /* ...but only what a job-level fan-out can actually file.
+             * The arms above sort out the group keys; they do not sort
+             * out a map, a realm array, or a lone key naming the
+             * session, node or app realm, and this else arm sweeps all
+             * of those in. PMIX_GDS_ADD_JOB_DATA files job-level
+             * VALUES, so handing it one of those stores it under its own
+             * key where no reader of its realm looks - and counts it as
+             * changed on every call, which in gds/shmem3 publishes a
+             * segment that is never reclaimed.
+             *
+             * The same classification PMIx_server_register_nspace()'s
+             * update path applies, asked of the same function, so the
+             * two ways a host may revise a running job agree about what
+             * a job-level value is. Such entries still reach the cache
+             * below, which is copied into a namespace by the
+             * registration path - and that one does know how to decode
+             * them. */
+            if (pmix_server_job_update_is_elsewhere(&cd->info[n])) {
+                goto cache_it;
+            }
+            ftmp = (pmix_info_t *)
                 realloc(fanout, (nfanout + 1) * sizeof(pmix_info_t));
             if (NULL == ftmp) {
                 ret = PMIX_ERR_NOMEM;
@@ -172,6 +194,7 @@ static void _register_resources(int sd, short args, void *cbdata)
             memcpy(&fanout[nfanout], &cd->info[n], sizeof(pmix_info_t));
             nfanout++;
 
+cache_it:
             /* add any provided data to our global cache for all nspaces */
             kv = PMIX_NEW(pmix_kval_t);
             if (NULL == kv) {

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -381,9 +381,16 @@ static void job_data(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
         return;
     }
 
-    /* decode it */
+    /* decode it - leave cb->status set to the store result so the caller
+     * sees a storage failure rather than having it masked as success.
+     * The client and server callbacks that do the same job say the same
+     * thing; this one overwrote the status unconditionally, so a tool
+     * completed PMIx_tool_init() believing it held job data it had
+     * failed to store. */
     PMIX_GDS_STORE_JOB_INFO(cb->status, pmix_client_globals.myserver, nspace, buf);
-    cb->status = PMIX_SUCCESS;
+
+    /* the unpack above allocated it, as it does for the other two */
+    free(nspace);
     PMIX_POST_OBJECT(cb);
     PMIX_WAKEUP_THREAD(&cb->lock);
 }

--- a/test/unit/.gitignore.bak
+++ b/test/unit/.gitignore.bak
@@ -1,1 +1,0 @@
-/gds_plain_request


### PR DESCRIPTION
The remainder of the adversarial review of `gds/shmem3` and the update
path — everything #4216 left behind, plus two defects found while
fixing them and one stray file that #4216 shipped by mistake.

## The update stream had no way to be extended

Its two ends broke the same forward-compatibility rule in opposite
directions, and a comment claimed they agreed.

`gds/shmem3`'s **outer** unpacker *refused* an unrecognized key —
`PMIX_ERR_BAD_PARAM`, which the caller turns into
`PMIX_ERR_UNPACK_FAILURE`, and on the job-info delivery that is a failed
`PMIx_Init` rather than a degraded client. The note above the seg-blob
arm said skipping was "the same forward compatibility the
unrecognized-key arm of the unpacker keeps, one level up"; one level up
did the opposite. The claim was true of the **inner** unpacker, which
does skip unknown fields and explains why.

`gds/hash`'s `accept_update` failed it the other way, and could not
simply be fixed at the reader: the stream carried job-level values
*bare*, so "not a session array" had to mean "a job-level value". A
future release's new kind of entry would be silently stored under its
own key as job data. Sent bare, an entry cannot be recognized, so the
receiver could not be written to skip anything.

So the job-level values now travel in a `PMIX_JOB_INFO_ARRAY`, which
makes the stream self-describing — session array, job array, and
anything else, which a reader skips. Both ends change together, and
`pmix_server_notify_gds_update()` skips peers earlier than 7.0.0 while
`VERSION` is `7.0.0a1`, so no released peer has ever seen this tag.
There is nothing to stay compatible with yet, which is exactly when to
fix the shape.

Unwrapping there also routes those values through
`store_lone_realm_key()`, so a session-, node- or app-realm key a host
adds to a running job is filed in its realm — the same routing the
registration and the keyed-get reply already use.

## A cleanup that inferred what its caller wanted

`shmem3_segment_create_and_attach()` ended its failure path by dropping
the job tracker. That was right for the one caller it had — registration,
where a tracker whose first segment could not be built has nothing to
keep. It now has five, and **three are on a live job**: a modex
generation, a session update, and an addition to a registered job. There
the tracker owns the job and session segments clients have been reading
since `PMIx_Init`; dropping it takes their mappings away and
`pmix_gds_shmem3_fetch()` then answers every lookup for their own
namespace with `PMIX_ERR_INVALID_NAMESPACE` — openpmix#4156 from the
server side, by way of a transient failure rather than a client that
could not map. It now takes the same `ATTACH_INIT`/`ATTACH_UPDATE` the
attach path was given, for the same reason.

## The two update paths disagreed about what a job-level value is

`register_nspace`'s update path classifies what a host sends before
handing it to `PMIX_GDS_ADD_JOB_DATA`; `register_resources` did not.
Its arms sort out the five group keys and the `else` swept in
everything else — a `PMIX_NODE_INFO_ARRAY`, a `PMIX_NODE_MAP`, a lone
`PMIX_UNIV_SIZE` — and fanned it at every live namespace as job-level
data. Same misfiling #4216 fixed on the other path, by the other door;
and a host-supplied `PMIX_JOB_INFO_ARRAY` reaching it would have been
double-wrapped by the framing above. The classification is now exported
and asked in both places.

Also here: the update collector was gated on `gds->store`, though only
two of its arms use that slot and the fan-out uses none of it. A module
leaving it NULL — `gds/shmem3` does — collected nothing, fanned out
nothing, and returned `PMIX_SUCCESS`, so a host's update silently did
nothing.

## Four smaller ones

- A **tool** completed `PMIx_tool_init()` believing it held job data it
  had failed to store: its `job_data` callback overwrote the store's
  status with `PMIX_SUCCESS`, where the client and server callbacks
  deliberately keep it. The same callback never freed the nspace string
  it unpacked, which the other two do.
- An **attach that succeeded and was then abandoned stayed mapped**, and
  since `pmix_shmem_segment_attach()` refuses an already-attached
  handle, the *next* delivery of that segment kind could never map
  either.
- An **update naming an unknown namespace left a phantom** on
  `pmix_globals.nspaces` and returned success, making a typo
  indistinguishable from a real update. Now `PMIX_ERR_NOT_FOUND`.
- The two **per-rank sweeps re-read `job->nspace->nprocs`** as their
  loop bound every iteration, while `gds/hash` assigns it on the
  progress thread. Read once.

## And a stray file

`test/unit/.gitignore.bak`, the output of a `sed -i.bak` during a
rename, went in with #4216 — `rm -f test/unit/*.bak` does not match a
leading dot. Removed.

## Testing

- Linux, `--enable-devel-check`: warning-free.
- `make check`: 0 failures under both `shmem3` and `PMIX_MCA_gds=hash`.
- The three update-stream tests on the new framing: `job_data_update`
  6/0, `update_attach_fail` 3/0, `session_update` 3/0.

`gds/shmem3` does not compile on macOS, so all of the above was run on
Linux. **This branch has not had a multi-node run** — the dockerswarm
was released for another user — so CI, and the `xversion` jobs in
particular, are the first cross-version and cross-node look at the
`PMIX_JOB_INFO_ARRAY` framing.

## Still open, deliberately

Test coverage the review asked for and this does not add:
`update_attach_fail` has no modex-failure, multi-rank or
repeat-notification case, and `job_data_update` exercises only scalar
values — which is precisely why the segment-sizing bug #4216 fixed was
invisible to it.

And one design item recorded rather than built: a client that declines
an out-of-order segment reads from its server for the rest of the run,
because nothing it is later offered is newer than what it holds. The
way out is a *cumulative* segment that supersedes everything before it,
the way a full modex contribution collapses the generations behind it.
That changes what a host's update means, not how it is delivered.
