### PR TITLE
Cover what the shmem3 update tests missed, and fix what that uncovered

### DIFF
--- a/docs/how-things-work/shmem3.rst
+++ b/docs/how-things-work/shmem3.rst
@@ -518,6 +518,15 @@ delivery completes with nothing refused. Declining turns the silent
 wrong answer back into the miss the paragraph above describes, and the
 server answers it correctly.
 
+One caller sees that as a failure rather than a round trip, and it is
+worth knowing which. ``PMIX_OPTIONAL`` says "do not ask the server", so
+a request carrying it against a realm that is declining has nowhere to
+be answered from and returns ``PMIX_ERR_NOT_FOUND``. That is the honest
+answer — the process genuinely cannot answer without asking — but a
+caller that uses ``PMIX_OPTIONAL`` as a cheap presence test will see a
+key it had before appear to vanish, until a delivery completes with
+nothing refused and the realm answers locally again.
+
 Clients are read-only, and the MMU enforces it
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -887,9 +887,22 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     pmix_kval_t *kv;
     pmix_get_logic_t *lg;
     pmix_proc_t rproc;
+    /* job-level values this reply carried that were handed back rather
+     * than stored - see the accept_kvs_resp contract */
+    pmix_list_t jobvals;
     PMIX_HIDE_UNUSED_PARAMS(pr, hdr);
 
     PMIX_ACQUIRE_OBJECT(cb);
+
+    /* Constructed before the first exit that reaches "done:", because
+     * the matching loop past that label walks it either way.
+     *
+     * Job-level values come back on this list rather than being stored,
+     * when this client reads its job data from some other module - see
+     * the note on the accept_kvs_resp contract. They answer the requests
+     * below and are then dropped, so nothing keeps a copy of job data
+     * that the module owning it would never refresh. */
+    PMIX_CONSTRUCT(&jobvals, pmix_list_t);
 
     pmix_output_verbose(2, pmix_client_globals.get_output,
                         "pmix: get_nb callback recvd");
@@ -897,6 +910,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     if (PMIX_UNLIKELY(NULL == cb || NULL == cb->lg)) {
         /* nothing we can do */
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        PMIX_LIST_DESTRUCT(&jobvals);
         return;
     }
     lg = cb->lg;
@@ -942,7 +956,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
      * the buffer will include a copy of the data. If
      * it is the shmem component, it will contain just
      * the memory address info */
-    PMIX_GDS_ACCEPT_KVS_RESP(rc, pmix_globals.mypeer, buf);
+    PMIX_GDS_ACCEPT_KVS_RESP(rc, pmix_globals.mypeer, buf, &jobvals);
     if (PMIX_UNLIKELY(PMIX_SUCCESS != rc)) {
         /* what the payload could not be stored as is precisely what every
          * waiter below is about to be answered from, so the store's
@@ -987,7 +1001,32 @@ done:
             pmix_output_verbose(2, pmix_client_globals.get_output,
                                 "pmix: get_nb searching for key %s for rank %s", cb->key,
                                 PMIX_RANK_PRINT(cb->proc->rank));
-            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
+            /* the job-level values this reply carried, which were handed
+             * back rather than stored */
+            rc = PMIX_ERR_NOT_FOUND;
+            if (NULL != cb->key) {
+                pmix_kval_t *jk;
+                PMIX_LIST_FOREACH (jk, &jobvals, pmix_kval_t) {
+                    if (PMIX_CHECK_KEY(jk, cb->key)) {
+                        pmix_kval_t *cp = PMIX_NEW(pmix_kval_t);
+                        if (NULL == cp) {
+                            rc = PMIX_ERR_NOMEM;
+                            break;
+                        }
+                        cp->key = strdup(jk->key);
+                        PMIX_VALUE_XFER(rc, cp->value, jk->value);
+                        if (PMIX_SUCCESS == rc) {
+                            pmix_list_append(&cb->kvs, &cp->super);
+                        } else {
+                            PMIX_RELEASE(cp);
+                        }
+                        break;
+                    }
+                }
+            }
+            if (PMIX_SUCCESS != rc) {
+                PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
+            }
             if (PMIX_OPERATION_SUCCEEDED == rc) {
                 rc = PMIX_SUCCESS;
             } else if (PMIX_SUCCESS != rc && PMIX_RANK_UNDEF == cb->proc->rank) {
@@ -1061,6 +1100,7 @@ done:
             }
         }
     }
+    PMIX_LIST_DESTRUCT(&jobvals);
 }
 
 static pmix_status_t process_values(pmix_cb_t *cb)

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -153,10 +153,23 @@ typedef pmix_status_t (*pmix_gds_base_module_assemb_kvs_req_fn_t)(const pmix_pro
     } while (0)
 
 /* CLIENT FN: unpack buffer and key processing */
-typedef pmix_status_t (*pmix_gds_base_module_accept_kvs_resp_fn_t)(pmix_buffer_t *buf);
+/* Take delivery of a server's reply to a data request.
+ *
+ * Rank-specific ("modex") values are stored: this client has no other
+ * copy of another proc's put data. JOB-LEVEL values are different - a
+ * client whose server module keeps them elsewhere (gds/shmem3 keeps
+ * them in shared segments the server republishes on every change)
+ * already has an authoritative copy, and a second one here would never
+ * be refreshed by that republication. Those are appended to "jobvals"
+ * for the caller to answer the request in flight from, and then
+ * discarded. When the module IS where this client reads job data from,
+ * they are stored as before.
+ */
+typedef pmix_status_t (*pmix_gds_base_module_accept_kvs_resp_fn_t)(pmix_buffer_t *buf,
+                                                                   pmix_list_t *jobvals);
 
 /* define a macro for client key processing from a server response based on peer */
-#define PMIX_GDS_ACCEPT_KVS_RESP(s, p, b)                                      \
+#define PMIX_GDS_ACCEPT_KVS_RESP(s, p, b, j)                                      \
     do {                                                                       \
         pmix_gds_base_module_t *_g = PMIX_GDS_PEER_MODULE(p);                  \
         (s) = PMIX_SUCCESS;                                                    \
@@ -171,7 +184,7 @@ typedef pmix_status_t (*pmix_gds_base_module_accept_kvs_resp_fn_t)(pmix_buffer_t
             pmix_output_verbose(1, pmix_gds_base_output,                       \
                                 "[%s:%d] GDS ACCEPT RESP WITH %s",             \
                                 __FILE__, __LINE__, _g->name);                 \
-            (s) = _g->accept_kvs_resp(b);                                      \
+            (s) = _g->accept_kvs_resp((b), (j));                                      \
         }                                                                      \
     } while (0)
 

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -503,7 +503,7 @@ static pmix_status_t nspace_del(const char *nspace);
 static pmix_status_t assemb_kvs_req(const pmix_proc_t *proc, pmix_list_t *kvs, pmix_buffer_t *bo,
                                     void *cbdata);
 
-static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf);
+static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf, pmix_list_t *jobvals);
 
 
 static pmix_status_t mark_modex_complete(struct pmix_peer_t *peer,
@@ -2167,7 +2167,7 @@ static pmix_status_t store_app_info(pmix_nspace_t nspace, pmix_kval_t *kv)
     return rc;
 }
 
-static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf)
+static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf, pmix_list_t *jobvals)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     int32_t cnt;
@@ -2175,6 +2175,8 @@ static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf)
     pmix_buffer_t pbkt;
     pmix_kval_t kv;
     pmix_proc_t proct;
+    pmix_rank_t wildrank;
+    bool keep_jobdata;
 
     /* the incoming payload is provided as a set of packed
      * byte objects, one for each rank. A pmix_proc_t is the first
@@ -2197,11 +2199,33 @@ static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf)
             PMIX_DESTRUCT(&pbkt);
             return rc;
         }
+        /* remembered before the normalization below, which turns UNDEF
+         * into our own rank and would hide what this object is */
+        wildrank = proct.rank;
         /* if the rank is UNDEF, then we store this on our own
          * rank tables */
         if (PMIX_RANK_UNDEF == proct.rank) {
             proct.rank = pmix_globals.myid.rank;
         }
+
+        /* Is this byte object JOB-LEVEL data, and does this client read
+         * its job data somewhere other than here?
+         *
+         * If so it must not be stored. gds/shmem3 keeps a client's job
+         * data in shared segments that the server republishes whenever
+         * it changes, and the notice that carries a republication goes
+         * to THAT module - so a copy kept here is never refreshed by it.
+         * It is not even a fast path: it is only ever consulted when the
+         * client's real store has nothing to say, which is exactly when
+         * a stale copy answers in place of a miss. One local fetch that
+         * missed would then be answered from this copy for the rest of
+         * the run, however many times the host revised the value.
+         *
+         * A client whose server module IS "hash" reads job data from
+         * these very tables, so for it this is not a second copy and the
+         * store below is right. */
+        keep_jobdata = (PMIX_RANK_WILDCARD == wildrank) &&
+                       !PMIX_GDS_CHECK_COMPONENT(pmix_client_globals.myserver, "hash");
 
         cnt = 1;
         PMIX_CONSTRUCT(&kv, pmix_kval_t);
@@ -2215,6 +2239,22 @@ static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf)
                 rc = store_node_info(proct.nspace, &kv);
             } else if (PMIX_CHECK_KEY(&kv, PMIX_APP_INFO_ARRAY)) {
                 rc = store_app_info(proct.nspace, &kv);
+            } else if (keep_jobdata) {
+                /* job-level, and this client reads its job data
+                 * elsewhere - hand it back for the request in flight
+                 * rather than keeping a copy nothing will refresh */
+                pmix_kval_t *jk = PMIX_NEW(pmix_kval_t);
+                if (NULL == jk) {
+                    rc = PMIX_ERR_NOMEM;
+                } else {
+                    jk->key = strdup(kv.key);
+                    PMIX_VALUE_XFER(rc, jk->value, kv.value);
+                    if (PMIX_SUCCESS == rc && NULL != jobvals) {
+                        pmix_list_append(jobvals, &jk->super);
+                    } else {
+                        PMIX_RELEASE(jk);
+                    }
+                }
             } else {
                 /* A LONE key, which is what a keyed PMIx_Get is answered
                  * with - no wrapper to route on. File it by what its name

--- a/test/unit/job_data_update.c
+++ b/test/unit/job_data_update.c
@@ -47,6 +47,11 @@
  * what is checked is that the value is still right afterwards, which is
  * what a caller would notice if a restatement had gone wrong.
  *
+ * Later phases cover what the earlier ones did not: a payload too big
+ * for an estimate made from the key count, a data array whose elements
+ * are copied recursively, and a key whose TYPE changes - all of which
+ * a host may legitimately send and none of which a scalar exercises.
+ *
  * The third phase covers the OTHER path a host might revise job data by.
  * PMIx_server_register_resources() carries job-level information that
  * governs every namespace on the server, and its fan-out reaches the
@@ -81,6 +86,17 @@ extern char **environ;
 #define SECOND  22
 #define THIRD   33
 #define FOURTH  44
+/* A payload big enough that an estimate built from the KEY COUNT alone
+ * cannot cover it. The segment estimate used to be all per-entry
+ * constants while the values are copied into it twice, so a single
+ * large value ran the bump allocator off the end - and the allocator
+ * aborts rather than returning an error, taking the server and every
+ * client on the node with it. Nothing caught that because every value
+ * this test used was four bytes. */
+#define BIGKEY  "sut.big.key"
+#define BIGLEN  65536
+#define ARRKEY  "sut.arr.key"
+#define ARRN    32
 
 static int npass = 0, nfail = 0;
 
@@ -244,6 +260,113 @@ static int run_client(int readyfd, int gofd)
                         "job-level value\n");
     }
 
+    /* phase 5: a payload no key-count estimate covers */
+    c = 'r';
+    if (1 != write(readyfd, &c, 1) || 1 != read(gofd, &c, 1)) {
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    {
+        pmix_proc_t p;
+        pmix_value_t *bv = NULL;
+        pmix_info_t opt;
+        int i;
+
+        PMIX_LOAD_PROCID(&p, NSPACE, PMIX_RANK_WILDCARD);
+        /* poll: the notice travels on a different channel from the pipe */
+        for (i = 0; i < 200; i++) {
+            PMIX_INFO_LOAD(&opt, PMIX_OPTIONAL, NULL, PMIX_BOOL);
+            if (PMIX_SUCCESS == PMIx_Get(&p, BIGKEY, &opt, 1, &bv) &&
+                NULL != bv) {
+                PMIX_INFO_DESTRUCT(&opt);
+                break;
+            }
+            PMIX_INFO_DESTRUCT(&opt);
+            bv = NULL;
+            usleep(25000);
+        }
+        if (NULL == bv) {
+            fprintf(stderr, "  client: never saw the large value\n");
+            PMIx_Finalize(NULL, 0);
+            return 6;
+        }
+        if (PMIX_STRING != bv->type || NULL == bv->data.string ||
+            BIGLEN != strlen(bv->data.string) ||
+            'a' != bv->data.string[0] ||
+            (char)('a' + ((BIGLEN - 1) % 26)) != bv->data.string[BIGLEN - 1]) {
+            fprintf(stderr, "  client: the large value came back wrong "
+                            "(len %zu, wanted %d)\n",
+                    (NULL == bv->data.string) ? (size_t)0
+                                              : strlen(bv->data.string),
+                    BIGLEN);
+            PMIX_VALUE_RELEASE(bv);
+            PMIx_Finalize(NULL, 0);
+            return 7;
+        }
+        PMIX_VALUE_RELEASE(bv);
+        fprintf(stdout, "  client: reads the %d-byte value intact\n", BIGLEN);
+
+        /* and the array that rode with it */
+        bv = NULL;
+        PMIX_INFO_LOAD(&opt, PMIX_OPTIONAL, NULL, PMIX_BOOL);
+        if (PMIX_SUCCESS != PMIx_Get(&p, ARRKEY, &opt, 1, &bv) ||
+            NULL == bv || PMIX_DATA_ARRAY != bv->type ||
+            NULL == bv->data.darray || ARRN != bv->data.darray->size) {
+            fprintf(stderr, "  client: the data array came back wrong\n");
+            PMIX_INFO_DESTRUCT(&opt);
+            if (NULL != bv) {
+                PMIX_VALUE_RELEASE(bv);
+            }
+            PMIx_Finalize(NULL, 0);
+            return 8;
+        }
+        PMIX_INFO_DESTRUCT(&opt);
+        PMIX_VALUE_RELEASE(bv);
+        fprintf(stdout, "  client: reads the %d-element array intact\n", ARRN);
+    }
+
+    /* phase 6: the same key, a different type */
+    c = 'r';
+    if (1 != write(readyfd, &c, 1) || 1 != read(gofd, &c, 1)) {
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    {
+        pmix_proc_t p;
+        pmix_value_t *tv = NULL;
+        pmix_info_t opt;
+        int i;
+
+        PMIX_LOAD_PROCID(&p, NSPACE, PMIX_RANK_WILDCARD);
+        for (i = 0; i < 200; i++) {
+            PMIX_INFO_LOAD(&opt, PMIX_OPTIONAL, NULL, PMIX_BOOL);
+            if (PMIX_SUCCESS == PMIx_Get(&p, LATEKEY, &opt, 1, &tv) &&
+                NULL != tv && PMIX_STRING == tv->type) {
+                PMIX_INFO_DESTRUCT(&opt);
+                break;
+            }
+            PMIX_INFO_DESTRUCT(&opt);
+            if (NULL != tv) {
+                PMIX_VALUE_RELEASE(tv);
+                tv = NULL;
+            }
+            usleep(25000);
+        }
+        if (NULL == tv || PMIX_STRING != tv->type ||
+            NULL == tv->data.string ||
+            0 != strcmp(tv->data.string, "now-a-string")) {
+            fprintf(stderr, "  client: the key did not change type - a "
+                            "changed type has to count as a change\n");
+            if (NULL != tv) {
+                PMIX_VALUE_RELEASE(tv);
+            }
+            PMIx_Finalize(NULL, 0);
+            return 9;
+        }
+        PMIX_VALUE_RELEASE(tv);
+        fprintf(stdout, "  client: sees the key change type\n");
+    }
+
     PMIx_Finalize(NULL, 0);
     return 0;
 }
@@ -393,6 +516,78 @@ static pmix_status_t revise_by_resources(uint32_t value)
     return rc;
 }
 
+/* A payload no key-count estimate can cover: a long string and a data
+ * array whose elements are copied one at a time. Both in ONE update, so
+ * the segment has to be sized for their sum rather than for two keys. */
+static pmix_status_t publish_big_values(void)
+{
+    pmix_info_t upd[2];
+    pmix_data_array_t *darray = NULL;
+    pmix_info_t *iptr;
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    char *big;
+    size_t n;
+
+    big = (char *) malloc(BIGLEN + 1);
+    if (NULL == big) {
+        return PMIX_ERR_NOMEM;
+    }
+    /* a pattern, not zeros, so a truncated copy is visible */
+    for (n = 0; n < BIGLEN; n++) {
+        big[n] = (char) ('a' + (n % 26));
+    }
+    big[BIGLEN] = '\0';
+
+    PMIX_DATA_ARRAY_CREATE(darray, ARRN, PMIX_INFO);
+    if (NULL == darray) {
+        free(big);
+        return PMIX_ERR_NOMEM;
+    }
+    iptr = (pmix_info_t *) darray->array;
+    for (n = 0; n < ARRN; n++) {
+        char key[PMIX_MAX_KEYLEN + 1];
+        uint32_t v = (uint32_t) n;
+        snprintf(key, sizeof(key), "sut.arr.%zu", n);
+        PMIX_INFO_LOAD(&iptr[n], key, &v, PMIX_UINT32);
+    }
+
+    PMIX_INFO_LOAD(&upd[0], BIGKEY, big, PMIX_STRING);
+    PMIX_LOAD_KEY(upd[1].key, ARRKEY);
+    upd[1].flags = 0;
+    upd[1].value.type = PMIX_DATA_ARRAY;
+    upd[1].value.data.darray = darray;
+
+    PMIX_LOAD_NSPACE(ns, NSPACE);
+    rc = PMIx_server_register_nspace(ns, -1, upd, 2, NULL, NULL);
+    PMIX_INFO_DESTRUCT(&upd[0]);
+    PMIX_INFO_DESTRUCT(&upd[1]);
+    free(big);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+    return rc;
+}
+
+/* The same key, a different TYPE. A host may do this, and "has this
+ * changed?" has to say yes - PMIx_Value_compare() reports a type
+ * mismatch as not-equal, which is what makes it so. */
+static pmix_status_t retype_late_key(void)
+{
+    pmix_info_t upd;
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+
+    PMIX_LOAD_NSPACE(ns, NSPACE);
+    PMIX_INFO_LOAD(&upd, LATEKEY, "now-a-string", PMIX_STRING);
+    rc = PMIx_server_register_nspace(ns, -1, &upd, 1, NULL, NULL);
+    PMIX_INFO_DESTRUCT(&upd);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+    return rc;
+}
+
 int main(int argc, char **argv)
 {
     pmix_info_t sinfo;
@@ -518,6 +713,31 @@ int main(int argc, char **argv)
     rc = revise_whole_description(FOURTH);
     report("the host restates the whole description with one value changed",
            PMIX_SUCCESS == rc);
+    c = 'g';
+    if (1 != write(gopipe[1], &c, 1)) {
+        goto done;
+    }
+
+    /* phase 5: a payload no key-count estimate covers */
+    if (1 != read(readypipe[0], &c, 1)) {
+        fprintf(stderr, "the client never reported its fifth read\n");
+        goto done;
+    }
+    rc = publish_big_values();
+    report("the host publishes a large value and a data array",
+           PMIX_SUCCESS == rc);
+    c = 'g';
+    if (1 != write(gopipe[1], &c, 1)) {
+        goto done;
+    }
+
+    /* phase 6: the same key with a different type */
+    if (1 != read(readypipe[0], &c, 1)) {
+        fprintf(stderr, "the client never reported its sixth read\n");
+        goto done;
+    }
+    rc = retype_late_key();
+    report("the host changes an existing key's type", PMIX_SUCCESS == rc);
     c = 'g';
     if (1 != write(gopipe[1], &c, 1)) {
         goto done;

--- a/test/unit/update_attach_fail.c
+++ b/test/unit/update_attach_fail.c
@@ -81,6 +81,12 @@ extern char **environ;
 #define SESSION  8765
 #define FIRST    8
 #define UNIV_GROWN   64
+/* A job-level key revised by a JOB-segment update, which is the other
+ * delivery force_update_attach_failure reaches and the one this branch
+ * of the library was built for. The test covered only the session. */
+#define JOBKEY   "sut.jobupd.key"
+#define JOB_WAS  1
+#define JOB_NOW  7
 
 static int npass = 0, nfail = 0;
 
@@ -222,6 +228,92 @@ static int run_client(int readyfd, int gofd)
                 (unsigned) got);
     }
 
+    /* THE JOB-SEGMENT HALF. Everything above rigged a SESSION segment.
+     * force_update_attach_failure fails a job segment too, and that is
+     * the delivery server_add_job_data() produces - so fail one and
+     * require the same two things of it: the client still holds its own
+     * job data, and an ordinary get returns the revised value rather
+     * than the one the segment it could not map was published to
+     * replace. */
+    c = 'r';
+    if (1 != write(readyfd, &c, 1) || 1 != read(gofd, &c, 1)) {
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    {
+        pmix_proc_t jp;
+        pmix_value_t *jv = NULL;
+        uint32_t got = 0;
+        pmix_status_t r;
+        int i;
+
+        PMIX_LOAD_PROCID(&jp, myproc.nspace, PMIX_RANK_WILDCARD);
+        /* the notice and the pipe are different channels */
+        for (i = 0; i < 200; i++) {
+            jv = NULL;
+            r = PMIx_Get(&jp, JOBKEY, NULL, 0, &jv);
+            if (PMIX_SUCCESS == r && NULL != jv) {
+                if (PMIX_SUCCESS == PMIx_Value_get_number(jv, &got,
+                                                          PMIX_UINT32) &&
+                    JOB_NOW == got) {
+                    PMIX_VALUE_RELEASE(jv);
+                    break;
+                }
+                PMIX_VALUE_RELEASE(jv);
+                jv = NULL;
+            }
+            usleep(25000);
+        }
+        if (JOB_NOW != got) {
+            fprintf(stderr, "  client: job value read back as %u, expected "
+                            "the revised %u - the client answered from the "
+                            "segment the update replaced\n",
+                    (unsigned) got, (unsigned) JOB_NOW);
+            PMIx_Finalize(NULL, 0);
+            return 6;
+        }
+        fprintf(stdout, "  client: reads the revised job value %u after a "
+                        "failed JOB segment attach\n", (unsigned) got);
+
+        /* And the tracker survived - which is asked differently here
+         * than in the session half above.
+         *
+         * There, PMIX_OPTIONAL is the right question: a session failure
+         * leaves the JOB realm untouched, so the client must still
+         * answer job-level reads out of its own store. Here the failure
+         * IS the job realm, so that realm is declining locally on
+         * purpose, and PMIX_OPTIONAL - which forbids asking the server -
+         * has no way to be answered. Requiring it to succeed would be
+         * requiring the client to answer from data it has just been
+         * told may be superseded.
+         *
+         * So ask without it. What distinguishes "the tracker went with
+         * the segment" from "this realm is declining" is that the first
+         * takes the namespace with it: pmix_gds_shmem3_fetch() answers
+         * PMIX_ERR_INVALID_NAMESPACE and the server round trip cannot
+         * repair it. A plain get returning the registered job size says
+         * the tracker is there. */
+        {
+            pmix_value_t *sv = NULL;
+            uint32_t jobsz = 0;
+
+            if (PMIX_SUCCESS != PMIx_Get(&jp, PMIX_JOB_SIZE, NULL, 0, &sv) ||
+                NULL == sv ||
+                PMIX_SUCCESS != PMIx_Value_get_number(sv, &jobsz, PMIX_UINT32) ||
+                1 != jobsz) {
+                fprintf(stderr, "  client: own job data lost after the "
+                                "failed job-segment attach\n");
+                if (NULL != sv) {
+                    PMIX_VALUE_RELEASE(sv);
+                }
+                PMIx_Finalize(NULL, 0);
+                return 7;
+            }
+            PMIX_VALUE_RELEASE(sv);
+        }
+        fprintf(stdout, "  client: its namespace and job data survived it\n");
+    }
+
     PMIx_Finalize(NULL, 0);
     return 0;
 }
@@ -242,13 +334,13 @@ static pmix_server_module_t mymodule = {0};
 
 static pmix_status_t register_job(void)
 {
-    pmix_info_t info[5], *sptr;
+    pmix_info_t info[6], *sptr;
     pmix_data_array_t *array;
     pmix_proc_t proc;
     pmix_nspace_t ns;
     pmix_status_t rc;
     char *noderegex = NULL, *ppnregex = NULL;
-    uint32_t nprocs = 1, univ = FIRST, sid = SESSION;
+    uint32_t nprocs = 1, univ = FIRST, sid = SESSION, jv = JOB_WAS;
     int i;
 
     PMIx_generate_regex(pmix_globals.hostname, &noderegex);
@@ -270,9 +362,12 @@ static pmix_status_t register_job(void)
     info[4].value.type = PMIX_DATA_ARRAY;
     info[4].value.data.darray = array;
 
+    /* a job-level value for the job-segment half to revise */
+    PMIX_INFO_LOAD(&info[5], JOBKEY, &jv, PMIX_UINT32);
+
     PMIX_LOAD_NSPACE(ns, NSPACE);
-    rc = PMIx_server_register_nspace(ns, 1, info, 5, NULL, NULL);
-    for (i = 0; i < 5; i++) {
+    rc = PMIx_server_register_nspace(ns, 1, info, 6, NULL, NULL);
+    for (i = 0; i < 6; i++) {
         PMIX_INFO_DESTRUCT(&info[i]);
     }
     free(noderegex);
@@ -297,6 +392,25 @@ static pmix_status_t register_job(void)
         usleep(50000);
     }
     return PMIX_SUCCESS;
+}
+
+/* Revise a JOB-level value, which publishes a job segment - the other
+ * delivery the forced attach failure reaches. */
+static pmix_status_t revise_job_value(void)
+{
+    pmix_info_t upd;
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    uint32_t v = JOB_NOW;
+
+    PMIX_LOAD_NSPACE(ns, NSPACE);
+    PMIX_INFO_LOAD(&upd, JOBKEY, &v, PMIX_UINT32);
+    rc = PMIx_server_register_nspace(ns, -1, &upd, 1, NULL, NULL);
+    PMIX_INFO_DESTRUCT(&upd);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+    return rc;
 }
 
 int main(int argc, char **argv)
@@ -408,6 +522,19 @@ int main(int argc, char **argv)
     c = 'g';
     if (1 != write(gopipe[1], &c, 1)) {
         fprintf(stderr, "could not release the client\n");
+        goto done;
+    }
+
+    /* the job-segment half */
+    if (1 != read(readypipe[0], &c, 1)) {
+        fprintf(stderr, "the client never reported its job-segment read\n");
+        goto done;
+    }
+    rc = revise_job_value();
+    report("the host revises a job value, which the client cannot map",
+           PMIX_SUCCESS == rc);
+    c = 'g';
+    if (1 != write(gopipe[1], &c, 1)) {
         goto done;
     }
 

--- a/test/unit/update_attach_fail.c
+++ b/test/unit/update_attach_fail.c
@@ -87,6 +87,15 @@ extern char **environ;
 #define JOBKEY   "sut.jobupd.key"
 #define JOB_WAS  1
 #define JOB_NOW  7
+#define JOB_NOW2 9
+/* TWO local ranks, and only one of them rigged to fail.
+ *
+ * One rank cannot show what this defect costs. The harm is not that a
+ * client is slower - it is that two processes on the same node, in the
+ * same job, answer the same question differently, because one of them
+ * kept reading a value the other had already seen replaced. Both ranks
+ * read the same keys here and both must get the same answers. */
+#define NPROCS   2
 
 static int npass = 0, nfail = 0;
 
@@ -146,7 +155,7 @@ static int run_client(int readyfd, int gofd)
     }
 
     /* before the update: the client obviously holds its own job data */
-    if (0 != read_local_job_size(&sz) || 1 != sz) {
+    if (0 != read_local_job_size(&sz) || NPROCS != sz) {
         fprintf(stderr, "  client: job data unreadable BEFORE the update\n");
         PMIx_Finalize(NULL, 0);
         return 1;
@@ -184,9 +193,9 @@ static int run_client(int readyfd, int gofd)
         PMIx_Finalize(NULL, 0);
         return 2;
     }
-    if (1 != sz) {
-        fprintf(stderr, "  client: job size read back as %u, expected 1\n",
-                (unsigned) sz);
+    if (NPROCS != sz) {
+        fprintf(stderr, "  client: job size read back as %u, expected %u\n",
+                (unsigned) sz, (unsigned) NPROCS);
         PMIx_Finalize(NULL, 0);
         return 3;
     }
@@ -300,7 +309,7 @@ static int run_client(int readyfd, int gofd)
             if (PMIX_SUCCESS != PMIx_Get(&jp, PMIX_JOB_SIZE, NULL, 0, &sv) ||
                 NULL == sv ||
                 PMIX_SUCCESS != PMIx_Value_get_number(sv, &jobsz, PMIX_UINT32) ||
-                1 != jobsz) {
+                NPROCS != jobsz) {
                 fprintf(stderr, "  client: own job data lost after the "
                                 "failed job-segment attach\n");
                 if (NULL != sv) {
@@ -312,6 +321,46 @@ static int run_client(int readyfd, int gofd)
             PMIX_VALUE_RELEASE(sv);
         }
         fprintf(stdout, "  client: its namespace and job data survived it\n");
+    }
+
+    /* the repeat: a second update over the one that was refused */
+    c = 'r';
+    if (1 != write(readyfd, &c, 1) || 1 != read(gofd, &c, 1)) {
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    {
+        pmix_proc_t jp;
+        pmix_value_t *jv;
+        uint32_t got = 0;
+        int i;
+
+        PMIX_LOAD_PROCID(&jp, myproc.nspace, PMIX_RANK_WILDCARD);
+        for (i = 0; i < 200; i++) {
+            jv = NULL;
+            if (PMIX_SUCCESS == PMIx_Get(&jp, JOBKEY, NULL, 0, &jv) &&
+                NULL != jv) {
+                if (PMIX_SUCCESS == PMIx_Value_get_number(jv, &got,
+                                                          PMIX_UINT32) &&
+                    JOB_NOW2 == got) {
+                    PMIX_VALUE_RELEASE(jv);
+                    break;
+                }
+                PMIX_VALUE_RELEASE(jv);
+            }
+            usleep(25000);
+        }
+        if (JOB_NOW2 != got) {
+            fprintf(stderr, "  client: after a second update the value is "
+                            "%u, expected the newest %u - a re-offered "
+                            "older segment must not answer in front of a "
+                            "newer one\n",
+                    (unsigned) got, (unsigned) JOB_NOW2);
+            PMIx_Finalize(NULL, 0);
+            return 8;
+        }
+        fprintf(stdout, "  client: reads the newest value %u after a repeat "
+                        "notice\n", (unsigned) got);
     }
 
     PMIx_Finalize(NULL, 0);
@@ -340,11 +389,11 @@ static pmix_status_t register_job(void)
     pmix_nspace_t ns;
     pmix_status_t rc;
     char *noderegex = NULL, *ppnregex = NULL;
-    uint32_t nprocs = 1, univ = FIRST, sid = SESSION, jv = JOB_WAS;
+    uint32_t nprocs = NPROCS, univ = FIRST, sid = SESSION, jv = JOB_WAS;
     int i;
 
     PMIx_generate_regex(pmix_globals.hostname, &noderegex);
-    PMIx_generate_ppn("0", &ppnregex);
+    PMIx_generate_ppn("0,1", &ppnregex);
     PMIX_INFO_LOAD(&info[0], PMIX_NODE_MAP, noderegex, PMIX_REGEX);
     PMIX_INFO_LOAD(&info[1], PMIX_PROC_MAP, ppnregex, PMIX_REGEX);
     PMIX_INFO_LOAD(&info[2], PMIX_JOB_SIZE, &nprocs, PMIX_UINT32);
@@ -379,17 +428,20 @@ static pmix_status_t register_job(void)
         return rc;
     }
 
-    PMIX_LOAD_PROCID(&proc, NSPACE, 0);
-    rc = PMIx_server_register_client(&proc, geteuid(), getegid(), NULL,
-                                     regcbfunc, NULL);
-    if (PMIX_OPERATION_SUCCEEDED == rc) {
-        return PMIX_SUCCESS;
-    }
-    if (PMIX_SUCCESS != rc) {
-        return rc;
-    }
-    for (i = 0; i < 400 && !regdone; i++) {
-        usleep(50000);
+    for (i = 0; i < NPROCS; i++) {
+        PMIX_LOAD_PROCID(&proc, NSPACE, (pmix_rank_t) i);
+        regdone = false;
+        rc = PMIx_server_register_client(&proc, geteuid(), getegid(), NULL,
+                                         regcbfunc, NULL);
+        if (PMIX_OPERATION_SUCCEEDED != rc && PMIX_SUCCESS != rc) {
+            return rc;
+        }
+        if (PMIX_SUCCESS == rc) {
+            int w;
+            for (w = 0; w < 400 && !regdone; w++) {
+                usleep(50000);
+            }
+        }
     }
     return PMIX_SUCCESS;
 }
@@ -413,6 +465,24 @@ static pmix_status_t revise_job_value(void)
     return rc;
 }
 
+/* A second revision, published after the first was refused. */
+static pmix_status_t revise_job_value_again(void)
+{
+    pmix_info_t upd;
+    pmix_nspace_t ns;
+    pmix_status_t rc;
+    uint32_t v = JOB_NOW2;
+
+    PMIX_LOAD_NSPACE(ns, NSPACE);
+    PMIX_INFO_LOAD(&upd, JOBKEY, &v, PMIX_UINT32);
+    rc = PMIx_server_register_nspace(ns, -1, &upd, 1, NULL, NULL);
+    PMIX_INFO_DESTRUCT(&upd);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+    return rc;
+}
+
 int main(int argc, char **argv)
 {
     pmix_info_t sinfo, upd;
@@ -421,8 +491,9 @@ int main(int argc, char **argv)
     char **client_env = NULL;
     char *client_argv[5];
     char fdbuf[32];
-    int readypipe[2], gopipe[2], status = 0;
-    pid_t child;
+    int readypipe[NPROCS][2], gopipe[NPROCS][2], status = 0;
+    pid_t child[NPROCS];
+    int k;
     bool flag = true;
     uint32_t grown = UNIV_GROWN;
     char c;
@@ -436,9 +507,11 @@ int main(int argc, char **argv)
 
     fprintf(stdout, "=== a failed update attach costs only that segment ===\n");
 
-    if (0 != pipe(readypipe) || 0 != pipe(gopipe)) {
-        fprintf(stderr, "pipe() failed\n");
-        return 1;
+    for (k = 0; k < NPROCS; k++) {
+        if (0 != pipe(readypipe[k]) || 0 != pipe(gopipe[k])) {
+            fprintf(stderr, "pipe() failed\n");
+            return 1;
+        }
     }
 
     PMIX_INFO_LOAD(&sinfo, PMIX_SERVER_TOOL_SUPPORT, &flag, PMIX_BOOL);
@@ -455,17 +528,10 @@ int main(int argc, char **argv)
         goto done;
     }
 
-    PMIX_LOAD_PROCID(&proc, NSPACE, 0);
     /* Seed the child's environment with our own first - see the note in
      * event_forward.c: without it the child runs against the INSTALLED
      * PMIx rather than the one under test. */
     client_env = PMIx_Argv_copy(environ);
-    rc = PMIx_server_setup_fork(&proc, &client_env);
-    if (PMIX_SUCCESS != rc) {
-        fprintf(stderr, "PMIx_server_setup_fork failed: %s\n",
-                PMIx_Error_string(rc));
-        goto done;
-    }
     /* Force the client's attach of the update to fail.
      *
      * This is the only way to reach the case from a test: whether a
@@ -477,38 +543,61 @@ int main(int argc, char **argv)
      *
      * It is set only in the CHILD's environment; this server has to go
      * on mapping its own segments. */
-    PMIx_Argv_append_nosize(
-        &client_env, "PMIX_MCA_gds_shmem3_force_update_attach_failure=1"
-    );
+    for (k = 0; k < NPROCS; k++) {
+        char **kenv;
 
-    child = fork();
-    if (0 > child) {
-        fprintf(stderr, "fork() failed\n");
-        goto done;
+        PMIX_LOAD_PROCID(&proc, NSPACE, (pmix_rank_t) k);
+        kenv = PMIx_Argv_copy(client_env);
+        rc = PMIx_server_setup_fork(&proc, &kenv);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "PMIx_server_setup_fork failed: %s\n",
+                    PMIx_Error_string(rc));
+            PMIx_Argv_free(kenv);
+            goto done;
+        }
+        /* ONLY RANK 0 is rigged. Rank 1 maps everything and is the
+         * control: what it reads is what the host set, so if rank 0
+         * answers differently the two have diverged - which is the harm,
+         * and what a single-client test cannot show. */
+        if (0 == k) {
+            PMIx_Argv_append_nosize(
+                &kenv, "PMIX_MCA_gds_shmem3_force_update_attach_failure=1"
+            );
+        }
+
+        child[k] = fork();
+        if (0 > child[k]) {
+            fprintf(stderr, "fork() failed\n");
+            PMIx_Argv_free(kenv);
+            goto done;
+        }
+        if (0 == child[k]) {
+            /* exec rather than run in the fork: this process has an
+             * initialized PMIx server in it */
+            close(readypipe[k][0]);
+            close(gopipe[k][1]);
+            client_argv[0] = argv[0];
+            client_argv[1] = (char *) "client";
+            snprintf(fdbuf, sizeof(fdbuf), "%d", readypipe[k][1]);
+            client_argv[2] = strdup(fdbuf);
+            snprintf(fdbuf, sizeof(fdbuf), "%d", gopipe[k][0]);
+            client_argv[3] = strdup(fdbuf);
+            client_argv[4] = NULL;
+            execve(argv[0], client_argv, kenv);
+            fprintf(stderr, "exec of %s failed\n", argv[0]);
+            _exit(127);
+        }
+        close(readypipe[k][1]);
+        close(gopipe[k][0]);
+        PMIx_Argv_free(kenv);
     }
-    if (0 == child) {
-        /* exec rather than run in the fork: this process has an
-         * initialized PMIx server in it */
-        close(readypipe[0]);
-        close(gopipe[1]);
-        client_argv[0] = argv[0];
-        client_argv[1] = (char *) "client";
-        snprintf(fdbuf, sizeof(fdbuf), "%d", readypipe[1]);
-        client_argv[2] = strdup(fdbuf);
-        snprintf(fdbuf, sizeof(fdbuf), "%d", gopipe[0]);
-        client_argv[3] = strdup(fdbuf);
-        client_argv[4] = NULL;
-        execve(argv[0], client_argv, client_env);
-        fprintf(stderr, "exec of %s failed\n", argv[0]);
-        _exit(127);
-    }
-    close(readypipe[1]);
-    close(gopipe[0]);
 
     /* wait until the client is up and reading its own job data */
-    if (1 != read(readypipe[0], &c, 1)) {
-        fprintf(stderr, "the client never reported that it was up\n");
-        goto done;
+    for (k = 0; k < NPROCS; k++) {
+        if (1 != read(readypipe[k][0], &c, 1)) {
+            fprintf(stderr, "the client never reported that it was up\n");
+            goto done;
+        }
     }
     report("a running client reads its own job data", true);
 
@@ -518,36 +607,74 @@ int main(int argc, char **argv)
     PMIX_INFO_DESTRUCT(&upd);
     report("the host publishes a session update", PMIX_SUCCESS == rc);
 
-    /* release the client to read again */
+    /* release both ranks to read again */
     c = 'g';
-    if (1 != write(gopipe[1], &c, 1)) {
-        fprintf(stderr, "could not release the client\n");
-        goto done;
+    for (k = 0; k < NPROCS; k++) {
+        if (1 != write(gopipe[k][1], &c, 1)) {
+            fprintf(stderr, "could not release the clients\n");
+            goto done;
+        }
     }
 
     /* the job-segment half */
-    if (1 != read(readypipe[0], &c, 1)) {
-        fprintf(stderr, "the client never reported its job-segment read\n");
-        goto done;
+    for (k = 0; k < NPROCS; k++) {
+        if (1 != read(readypipe[k][0], &c, 1)) {
+            fprintf(stderr, "the client never reported its job-segment read\n");
+            goto done;
+        }
     }
     rc = revise_job_value();
     report("the host revises a job value, which the client cannot map",
            PMIX_SUCCESS == rc);
     c = 'g';
-    if (1 != write(gopipe[1], &c, 1)) {
-        goto done;
+    for (k = 0; k < NPROCS; k++) {
+        if (1 != write(gopipe[k][1], &c, 1)) {
+            goto done;
+        }
     }
 
-    waitpid(child, &status, 0);
-    if (WIFEXITED(status)) {
-        report("the client still holds its own job data afterwards",
-               0 == WEXITSTATUS(status));
-        if (0 != WEXITSTATUS(status)) {
-            fprintf(stdout, "        (client exited %d)\n", WEXITSTATUS(status));
+    /* A SECOND update, after one has already been refused.
+     *
+     * The server re-sends the whole chain on every notice, so this
+     * delivery offers the segment that failed before as well as the new
+     * one. That is the retry the recovery depends on - and it is also
+     * how a chain can end up out of order, since the older segment
+     * would be published in front of the newer one if a client took it
+     * on its second offer. Both ranks must end up reading the NEWEST
+     * value either way. */
+    for (k = 0; k < NPROCS; k++) {
+        if (1 != read(readypipe[k][0], &c, 1)) {
+            fprintf(stderr, "a client never reported its repeat read\n");
+            goto done;
         }
-    } else {
-        report("the client still holds its own job data afterwards", false);
-        fprintf(stdout, "        (client died on a signal)\n");
+    }
+    rc = revise_job_value_again();
+    report("the host publishes a second update over the refused one",
+           PMIX_SUCCESS == rc);
+    c = 'g';
+    for (k = 0; k < NPROCS; k++) {
+        if (1 != write(gopipe[k][1], &c, 1)) {
+            goto done;
+        }
+    }
+
+    {
+        bool allok = true;
+        for (k = 0; k < NPROCS; k++) {
+            waitpid(child[k], &status, 0);
+            if (WIFEXITED(status)) {
+                if (0 != WEXITSTATUS(status)) {
+                    allok = false;
+                    fprintf(stdout, "        (rank %d exited %d)\n", k,
+                            WEXITSTATUS(status));
+                }
+            } else {
+                allok = false;
+                fprintf(stdout, "        (rank %d died on a signal)\n", k);
+            }
+        }
+        report("both ranks agree, and each still holds its own job data",
+               allok);
     }
 
     completed = true;


### PR DESCRIPTION
The test coverage the shmem3 review asked for — and one defect the new
coverage found.

## A payload worth sizing for

Every value `job_data_update` sent was four bytes, which is why the
segment-sizing defect it should have caught was invisible to it. It now
sends a 64 KiB string and a 32-element data array in **one** update, so
the segment has to be sized for their sum rather than for two keys. The
array is there for its own reason: its elements are copied one at a
time, by a different path from a flat value.

Verified by reverting the payload term: the run reaches that phase and
dies with **SIGABRT** and shmem3's out-of-memory notice, which is the
failure mode as reported — the bump allocator aborts rather than
returning an error. A sixth phase changes an existing key's *type*,
which nothing exercised.

## Failing a job segment, not only a session one

`update_attach_fail` rigged a session segment and stopped there, so the
delivery this component grew a whole mechanism for —
`server_add_job_data()` publishing a job segment — was never failed.
`force_update_attach_failure` reaches it; nothing asked it to.

The tracker-survived assertion has to be posed differently for the job
half, and the difference is worth reading: in the session half
`PMIX_OPTIONAL` is right, because a session failure leaves the job
realm untouched. In the job half that realm is declining *on purpose*,
and `PMIX_OPTIONAL` forbids asking the server — so requiring it to
succeed would require the client to answer from data it has just been
told may be superseded. It asks without it, and distinguishes "the
tracker went with the segment" by what only that does: take the
namespace with it. `docs/how-things-work/shmem3.rst` now states the
`PMIX_OPTIONAL` consequence, since a caller can meet it.

## Two ranks, and the defect that found

One client cannot show what a stale read costs. The harm is not that a
client is slower — it is that two processes in one job on one node
answer the same question differently. The test now runs two ranks and
rigs only one; rank 1 maps everything and is the control.

That immediately failed, and not because of the test. A client's reply
from the server goes into `pmix_globals.mypeer`, hard-set to `"hash"`,
and `accept_kvs_resp()` takes both kinds of payload — its own comment
says a `PMIX_RANK_WILDCARD` byte object is job-level info and a
rank-specific one is that proc's put data. So a `gds/shmem3` client kept
**two** stores for its job data: the segments it reads, and a hash copy
of whatever it once fetched.

Nothing refreshes the second. The server republishes changed job data by
publishing a segment and sending a notice, and that notice goes to the
client's *assigned* module — shmem3 — not to `mypeer`'s hash. And the
hash copy is never a fast path: it is consulted only when the real store
had nothing to say, which is exactly when a stale copy answers in place
of a miss. **Any** shmem3 client that missed locally once, for any
reason, answered from that copy for the rest of the run however many
times the host revised the value.

Split by what the data is. Rank-specific values are still stored — this
client has no other copy of another proc's put data, and the reply
carries all of that rank's, which is what makes caching it worth doing.
Job-level values are handed back on a list, answer the request in
flight, and are dropped — unless the client's server module *is* hash,
in which case `mypeer`'s tables are where it reads job data from and the
store is right rather than a shadow. That condition is the one already
used a few lines further on to skip a duplicate lookup, for the same
reason: when both peers are hash they point at the same tables.

Verified in both directions: with the job reply cached back into the
client's hash, rank 0 reads the previous update's value while rank 1
reads the current one — the divergence, reproduced. With the fix, both
read the same value.

## Testing

- Linux, `--enable-devel-check`: warning-free.
- `make check`: 0 failures three ways — default (`shmem3`),
  `PMIX_MCA_gds=hash`, and `PMIX_GET_ON_PROGRESS_THREAD=1`.
- `job_data_update` 8/0 and `update_attach_fail` 5/0 under both gds
  components.
- Rebased onto current master and re-verified there, rather than
  trusting a clean rebase.

`gds/shmem3` does not compile on macOS, so all of the above was run on
Linux. No multi-node run — the dockerswarm is released for another
user.

## Not included

A **modex** attach-failure case in `make check`. It is already covered
where it can be covered properly: `contrib/dockerswarm/run-gds-tests.sh`
drives `force_modex_attach_failure` at 2/4/8 servers and asserts the
fence still succeeds and job data survives. A single-node version would
need a full two-client fence harness to test less than that.

## Deferred, deliberately

The reply path is inefficient: a `dmodex` result is fetched and cached
per process, where the server could publish it into shmem3 once and let
every local client share it — one copy per node instead of per process.
Worth doing, but it is an exception path rather than the norm, it needs
the inline reply retained as a fallback (a published segment can fail to
map, which an inline reply cannot), and it needs batching so segments do
not accumulate. Its job-level counterpart is the *cumulative* segment
already noted in the chain-ordering commit. Both are their own effort.
