### PR TITLE
Stop tools paying seconds of dead time on a clean departure

### DIFF
--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -362,7 +362,23 @@ PMIX_EXPORT void pmix_internal_reg_event_hdlr(int sd, short args, void *cbdata);
  * after invoking cbfunc.opcbfn, so the poster must not. */
 PMIX_EXPORT void pmix_internal_dereg_event_hdlr(int sd, short args, void *cbdata);
 
-#define PMIX_REPORT_EVENT(e, p, r, f)                                                          \
+/* Cache an event for aggregation, then report it.
+ *
+ * The window (w) is how long the chain stays open for other sources of the
+ * same status to join it, and it is the whole reason this caching exists: a
+ * job that dies takes its peers with it, and one event naming all of them
+ * beats a cascade of identical events naming one each.  Pass
+ * &pmix_globals.event_window for that - PMIX_REPORT_EVENT below is the
+ * shorthand, and is what almost every report wants.
+ *
+ * Pass a zero window where the report has nothing it could ever aggregate
+ * with, because there the wait is pure latency bought with nothing.  Note
+ * that a zero window handed to an already-open chain flushes that chain
+ * now, carrying whatever had joined it out early; nothing is lost, it is
+ * merely reported sooner, and a report urgent enough to skip the window is
+ * urgent enough to take the others with it.
+ */
+#define PMIX_REPORT_EVENT_WINDOW(e, p, r, f, w)                                                \
     do {                                                                                       \
         pmix_event_chain_t *ch, *cp;                                                           \
         size_t _n;                                                                             \
@@ -403,7 +419,7 @@ PMIX_EXPORT void pmix_internal_dereg_event_hdlr(int sd, short args, void *cbdata
             ch->timer_active = true;                                                           \
             pmix_event_assign(&ch->ev, pmix_globals.evbase, -1, 0, pmix_event_timeout_cb, ch); \
             PMIX_POST_OBJECT(ch);                                                              \
-            pmix_event_add(&ch->ev, &pmix_globals.event_window);                               \
+            pmix_event_add(&ch->ev, (w));                                                      \
         } else {                                                                               \
             /* add this peer to the array of sources */                                        \
             pmix_proc_t proc_tmp;                                                              \
@@ -428,9 +444,13 @@ PMIX_EXPORT void pmix_internal_dereg_event_hdlr(int sd, short args, void *cbdata
             }                                                                                  \
             PMIX_POST_OBJECT(ch);                                                              \
             ch->timer_active = true;                                                           \
-            pmix_event_add(&ch->ev, &pmix_globals.event_window);                               \
+            pmix_event_add(&ch->ev, (w));                                                      \
         }                                                                                      \
     } while (0)
+
+/* Report an event over the standard aggregation window. */
+#define PMIX_REPORT_EVENT(e, p, r, f) \
+    PMIX_REPORT_EVENT_WINDOW((e), (p), (r), (f), &pmix_globals.event_window)
 
 END_C_DECLS
 

--- a/src/mca/ptl/base/base.h
+++ b/src/mca/ptl/base/base.h
@@ -140,6 +140,11 @@ PMIX_EXPORT void pmix_ptl_base_stop_listening(void);
 /* base support functions */
 PMIX_EXPORT pmix_status_t pmix_ptl_base_setup_fork(const pmix_proc_t *proc, char ***env);
 PMIX_EXPORT void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata);
+
+/* Drain everything already queued for this peer onto its socket before that
+ * socket is closed in an orderly teardown.  Bounded and best-effort - see
+ * the definition. */
+PMIX_EXPORT void pmix_ptl_base_flush_sends(pmix_peer_t *peer);
 PMIX_EXPORT void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata);
 PMIX_EXPORT void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata);
 PMIX_EXPORT pmix_status_t pmix_ptl_base_set_nonblocking(int sd);

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -58,6 +58,10 @@
 #define PMIX_PTL_FLUSH_MAX_RETRIES 10
 #define PMIX_PTL_FLUSH_RETRY_USEC  1000
 
+/* The aggregation window to use for a report that cannot aggregate: deliver
+ * on the next pass of the event loop rather than a second from now. */
+static struct timeval report_now = {0, 0};
+
 static void _notify_complete(pmix_status_t status, void *cbdata)
 {
     (void) status;
@@ -182,9 +186,20 @@ static void lost_connection(pmix_peer_t *peer)
             /* if this peer already called finalize, then
              * we are just seeing their connection go away
              * when they terminate - so do not generate
-             * an event. If an abnormal termination, then we do */
-            PMIX_REPORT_EVENT(PMIX_ERR_LOST_CONNECTION, peer,
-                              PMIX_RANGE_PROC_LOCAL, _notify_complete);
+             * an event. If an abnormal termination, then we do.
+             *
+             * Which peer it was decides whether the aggregation window is
+             * worth waiting out.  Losing a client is precisely the cascade
+             * the window exists for: a job that dies drops all of its
+             * peers at once, and one event naming them all is the point.
+             * Losing my own server is not - I have exactly one, so that
+             * chain can never gain a second source and the window is a
+             * second of delay in exchange for nothing. */
+            PMIX_REPORT_EVENT_WINDOW(PMIX_ERR_LOST_CONNECTION, peer,
+                                     PMIX_RANGE_PROC_LOCAL, _notify_complete,
+                                     (peer == pmix_client_globals.myserver)
+                                         ? &report_now
+                                         : &pmix_globals.event_window);
         }
 
         /* if a local peer finalized cleanly and its socket has now dropped,
@@ -212,11 +227,19 @@ static void lost_connection(pmix_peer_t *peer)
          * then we need to exit */
         pmix_atomic_unset_bool(&pmix_globals.connected);
         lost_my_server();
-        /* if I called finalize, then don't generate an event */
+        /* if I called finalize, then don't generate an event.
+         *
+         * No aggregation window here: this report names my one and only
+         * server, so nothing can ever join it.  Waiting the window out is
+         * what made a tool whose whole job is to watch for this - pterm,
+         * which orders a DVM down and then waits for the connection to
+         * drop as proof it went - spend a full second of its ~1.02 s
+         * runtime waiting for an event that was ready immediately. */
         if (!pmix_globals.mypeer->finalized) {
-            PMIX_REPORT_EVENT(PMIX_ERR_LOST_CONNECTION,
-                              pmix_client_globals.myserver,
-                              PMIX_RANGE_PROC_LOCAL, _notify_complete);
+            PMIX_REPORT_EVENT_WINDOW(PMIX_ERR_LOST_CONNECTION,
+                                     pmix_client_globals.myserver,
+                                     PMIX_RANGE_PROC_LOCAL, _notify_complete,
+                                     &report_now);
         }
     }
 }

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -50,6 +50,14 @@
 
 #include "src/mca/ptl/base/base.h"
 
+/* How long pmix_ptl_base_flush_sends() is willing to wait on a peer that is
+ * not draining its socket: at most MAX_RETRIES waits of RETRY_USEC each.
+ * Small on purpose - the messages this path exists for are a few tens of
+ * bytes on a socket the peer is about to read to EOF, so a full kernel
+ * buffer here means the peer is wedged, not busy. */
+#define PMIX_PTL_FLUSH_MAX_RETRIES 10
+#define PMIX_PTL_FLUSH_RETRY_USEC  1000
+
 static void _notify_complete(pmix_status_t status, void *cbdata)
 {
     (void) status;
@@ -260,6 +268,89 @@ retry:
             msg->sdbytes = ntohl(msg->hdr.nbytes) - rc;
         }
         return PMIX_ERR_RESOURCE_BUSY;
+    }
+}
+
+/* Write out everything already queued for this peer, right now.
+ *
+ * A peer's queued sends normally drain from its send_event, which cannot
+ * fire until the event base next polls. That is fine while the peer is
+ * alive, and wrong at the moment we are about to close its socket in an
+ * orderly teardown: the bytes sitting on send_msg are a reply we owe that
+ * peer, and closing the socket under them discards the reply with no notice
+ * to either side. The peer is then left waiting for an answer that was
+ * packed, queued and thrown away - which for the finalize reply means
+ * waiting out the client's or tool's finalize guard timer, seconds spent
+ * for nothing on every clean departure.
+ *
+ * Bounded and best-effort by design: the socket is non-blocking, so a peer
+ * that has stopped reading gets a short grace period and then loses the
+ * remainder. Truncating a message to a peer that is not draining it is much
+ * cheaper than letting that peer stall the progress thread, which is what
+ * an unbounded wait here would do.
+ */
+void pmix_ptl_base_flush_sends(pmix_peer_t *peer)
+{
+    pmix_ptl_send_t *msg;
+    pmix_status_t rc;
+    int retries;
+    fd_set wfds;
+    struct timeval tv;
+
+    if (NULL == peer || peer->sd < 0) {
+        return;
+    }
+
+    /* stop the send event: we are draining by hand, and leaving it armed
+     * would let it fire against a socket that is about to be closed */
+    if (peer->send_ev_active) {
+        pmix_event_del(&peer->send_event);
+        peer->send_ev_active = false;
+    }
+
+    while (1) {
+        if (NULL == peer->send_msg) {
+            peer->send_msg = (pmix_ptl_send_t *) pmix_list_remove_first(&peer->send_queue);
+            if (NULL == peer->send_msg) {
+                break;
+            }
+        }
+        msg = peer->send_msg;
+        retries = 0;
+        while (PMIX_SUCCESS != (rc = send_msg(peer->sd, msg))) {
+            if ((PMIX_ERR_RESOURCE_BUSY != rc && PMIX_ERR_WOULD_BLOCK != rc) ||
+                PMIX_PTL_FLUSH_MAX_RETRIES <= retries) {
+                /* the peer is unreachable, or is not reading fast enough to
+                 * be worth waiting on - drop this message and everything
+                 * queued behind it */
+                pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                                    "%s ptl:base:flush_sends giving up on sd %d: %s",
+                                    PMIX_NAME_PRINT(&pmix_globals.myid), peer->sd,
+                                    PMIx_Error_string(rc));
+                PMIX_RELEASE(msg);
+                peer->send_msg = NULL;
+                while (NULL != (msg = (pmix_ptl_send_t *)
+                                pmix_list_remove_first(&peer->send_queue))) {
+                    PMIX_RELEASE(msg);
+                }
+                return;
+            }
+            /* the kernel buffer is full - give it a moment to drain. select
+             * is used rather than poll because sys/select.h is what PMIx
+             * already requires of the platform */
+            ++retries;
+            FD_ZERO(&wfds);
+            FD_SET(peer->sd, &wfds);
+            tv.tv_sec = 0;
+            tv.tv_usec = PMIX_PTL_FLUSH_RETRY_USEC;
+            select(peer->sd + 1, NULL, &wfds, NULL, &tv);
+        }
+        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                            "%s ptl:base:flush_sends MSG SENT on sd %d tag %u",
+                            PMIX_NAME_PRINT(&pmix_globals.myid), peer->sd,
+                            ntohl(msg->hdr.tag));
+        PMIX_RELEASE(msg);
+        peer->send_msg = NULL;
     }
 }
 

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -65,12 +65,47 @@ static void _notify_complete(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(chain);
 }
 
-static void lost_connection(pmix_peer_t *peer)
+/* My connection to the server I am a client of has dropped.
+ *
+ * It is possible that we have sendrecv's in progress where we are waiting
+ * for a response to arrive. Since we have lost connection to the server,
+ * that will never happen. Thus, to preclude any chance of hanging, cycle
+ * thru the list of posted recvs and complete any that are the return call
+ * from a sendrecv - i.e., any that are waiting on dynamic tags.
+ */
+static void lost_my_server(void)
 {
     pmix_ptl_posted_recv_t *rcv;
     pmix_buffer_t buf;
     pmix_ptl_hdr_t hdr;
 
+    if (NULL == pmix_client_globals.myserver ||
+        NULL == pmix_client_globals.myserver->nptr) {
+        return;
+    }
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    /* must set the buffer type so it doesn't fail in unpack */
+    buf.type = pmix_client_globals.myserver->nptr->compat.type;
+    hdr.nbytes = 0; // initialize the hdr to something safe
+    PMIX_LIST_FOREACH (rcv, &pmix_ptl_base.posted_recvs, pmix_ptl_posted_recv_t) {
+        /* only the dynamic tags carry a sendrecv reply that somebody
+         * is blocked on. The reserved tags below PMIX_PTL_TAG_DYNAMIC
+         * hold persistent recvs - the notification, IOF and IOF flow
+         * control handlers - and nobody is waiting on those. Handing
+         * one of them this empty buffer would only make it fail to
+         * unpack a message that was never sent. */
+        if (PMIX_PTL_TAG_DYNAMIC <= rcv->tag && UINT_MAX != rcv->tag &&
+            NULL != rcv->cbfunc) {
+            /* construct and load the buffer */
+            hdr.tag = rcv->tag;
+            rcv->cbfunc(pmix_globals.mypeer, &hdr, &buf, rcv->cbdata);
+        }
+    }
+    PMIX_DESTRUCT(&buf);
+}
+
+static void lost_connection(pmix_peer_t *peer)
+{
     /* stop all events */
     if (peer->recv_ev_active) {
         pmix_event_del(&peer->recv_event);
@@ -124,9 +159,21 @@ static void lost_connection(pmix_peer_t *peer)
          * this peer's data is told. */
         pmix_server_purge_events(peer, NULL, PMIX_ERR_LOST_CONNECTION);
 
-        if (PMIX_PEER_IS_LAUNCHER(pmix_globals.mypeer)) {
-            /* only connection I can lose is to my server, so mark it */
+        /* Ask which peer went away, not what I am. A launcher - prun, and
+         * anything else that passes PMIX_LAUNCHER to PMIx_tool_init - is a
+         * tool with an upstream server AND a server with downstream peers of
+         * its own, because PMIX_PROC_LAUNCHER carries PMIX_PROC_SERVER. So
+         * "am I a server" cannot distinguish the two directions, and testing
+         * it here got both of them wrong: losing a tool of my own would
+         * declare me disconnected from my server, while losing my server
+         * would leave every sendrecv I had outstanding on it unanswered -
+         * the finalize sync among them, so a launcher paid its full
+         * finalize guard timer on every departure whose reply went astray.
+         * That recovery lives in the client arm below, which a launcher
+         * never reaches. */
+        if (peer == pmix_client_globals.myserver) {
             pmix_atomic_unset_bool(&pmix_globals.connected);
+            lost_my_server();
         } else if (!PMIX_PEER_IS_TOOL(peer)) {
             /* cleanup any sensors that are monitoring them */
             pmix_psensor.stop(peer, NULL);
@@ -164,32 +211,7 @@ static void lost_connection(pmix_peer_t *peer)
         /* if this was the server to which I am connected,
          * then we need to exit */
         pmix_atomic_unset_bool(&pmix_globals.connected);
-        /* it is possible that we have sendrecv's in progress where
-         * we are waiting for a response to arrive. Since we have
-         * lost connection to the server, that will never happen.
-         * Thus, to preclude any chance of hanging, cycle thru
-         * the list of posted recvs and complete any that are
-         * the return call from a sendrecv - i.e., any that are
-         * waiting on dynamic tags */
-        PMIX_CONSTRUCT(&buf, pmix_buffer_t);
-        /* must set the buffer type so it doesn't fail in unpack */
-        buf.type = pmix_client_globals.myserver->nptr->compat.type;
-        hdr.nbytes = 0; // initialize the hdr to something safe
-        PMIX_LIST_FOREACH (rcv, &pmix_ptl_base.posted_recvs, pmix_ptl_posted_recv_t) {
-            /* only the dynamic tags carry a sendrecv reply that somebody
-             * is blocked on. The reserved tags below PMIX_PTL_TAG_DYNAMIC
-             * hold persistent recvs - the notification, IOF and IOF flow
-             * control handlers - and nobody is waiting on those. Handing
-             * one of them this empty buffer would only make it fail to
-             * unpack a message that was never sent. */
-            if (PMIX_PTL_TAG_DYNAMIC <= rcv->tag && UINT_MAX != rcv->tag &&
-                NULL != rcv->cbfunc) {
-                /* construct and load the buffer */
-                hdr.tag = rcv->tag;
-                rcv->cbfunc(pmix_globals.mypeer, &hdr, &buf, rcv->cbdata);
-            }
-        }
-        PMIX_DESTRUCT(&buf);
+        lost_my_server();
         /* if I called finalize, then don't generate an event */
         if (!pmix_globals.mypeer->finalized) {
             PMIX_REPORT_EVENT(PMIX_ERR_LOST_CONNECTION,

--- a/src/mca/ptl/ptl.h
+++ b/src/mca/ptl/ptl.h
@@ -160,6 +160,41 @@ typedef struct pmix_ptl_module_t pmix_ptl_module_t;
         }                                            \
     } while (0)
 
+/* (ONE-WAY, NO THREAD-SHIFT) send a message to the peer from a caller that
+ * is already running on the PMIx progress thread. The buffer will be free'd
+ * at the completion of the send, exactly as with PMIX_PTL_SEND_ONEWAY.
+ *
+ * The difference is not an optimization, it is ordering. PMIX_PTL_SEND_ONEWAY
+ * activates an event to do the queuing, so the message lands on the peer
+ * *behind* everything already sitting in the progress thread's active queue.
+ * That is fatal whenever the host answers a command and then retires the
+ * peer: on PMIX_FINALIZE_CMD the host's client_finalized callback and its
+ * following PMIx_server_deregister_nspace are both activated on this base
+ * from this thread, so a reply that takes the extra hop queues behind the
+ * deregistration, which closes the peer's socket - and the reply is then
+ * discarded with "no connection" while the client sits out its finalize
+ * guard timer. Queuing the reply inline puts the bytes on the peer before
+ * the deregistration can run.
+ *
+ * Only use this where the caller is known to be on the progress thread.
+ */
+#define PMIX_PTL_SEND_ONEWAY_INLINE(r, p, b, t)      \
+    do {                                             \
+        pmix_ptl_queue_t *q;                         \
+        pmix_peer_t *pr = (pmix_peer_t *) (p);       \
+        if ((p)->finalized) {                        \
+            (r) = PMIX_ERR_UNREACH;                  \
+        } else {                                     \
+            q = PMIX_NEW(pmix_ptl_queue_t);          \
+            PMIX_RETAIN(pr);                         \
+            q->peer = pr;                            \
+            q->buf = (b);                            \
+            q->tag = (t);                            \
+            pmix_ptl_base_send(-1, 0, q);            \
+            (r) = PMIX_SUCCESS;                      \
+        }                                            \
+    } while (0)
+
 /* expose functions used by the macros */
 PMIX_EXPORT extern void pmix_ptl_base_send(int sd, short args, void *cbdata);
 PMIX_EXPORT extern void pmix_ptl_base_send_recv(int sd, short args, void *cbdata);

--- a/src/server/pmix_server_registration.c
+++ b/src/server/pmix_server_registration.c
@@ -44,6 +44,7 @@
 #include "src/mca/pgpu/base/base.h"
 #include "src/mca/pnet/base/base.h"
 #include "src/mca/psensor/base/base.h"
+#include "src/mca/ptl/base/base.h"
 #include "src/runtime/pmix_progress_threads.h"
 #include "src/util/pmix_error.h"
 #include "src/util/pmix_output.h"
@@ -934,6 +935,18 @@ static void remove_client(pmix_namespace_t *nptr, pmix_proc_t *p)
                 }
                 /* honor any registered epilogs */
                 pmix_execute_epilog(&peer->epilog);
+                /* Push out anything still queued for this peer before its
+                 * socket goes away.  We are retiring a peer the host has
+                 * told us about, not reacting to one that vanished, so a
+                 * message sitting on its send queue is one we accepted the
+                 * obligation to deliver - typically the reply to the very
+                 * finalize that brought the host here, which reaches the
+                 * peer only when its send event next fires and so is still
+                 * unwritten at this point.  Dropping it leaves the peer
+                 * waiting on an answer that was packed and discarded, and
+                 * on the finalize path that wait is the full guard timer in
+                 * PMIx_Finalize/PMIx_tool_finalize. */
+                pmix_ptl_base_flush_sends(peer);
                 /* ensure we close the socket to this peer so we don't
                  * generate "connection lost" events should it be
                  * subsequently "killed" by the host */

--- a/src/server/pmix_server_switchyard.c
+++ b/src/server/pmix_server_switchyard.c
@@ -83,10 +83,18 @@ static void _opcbfunc(int sd, short args, void *cbdata)
         goto cleanup;
     }
 
-    /* the function that created the server_caddy did a
-     * retain on the peer, so we don't have to worry about
-     * it still being present - send a copy to the originator */
-    PMIX_PTL_SEND_ONEWAY(rc, cd->peer, reply, cd->hdr.tag);
+    /* The function that created the server_caddy did a retain on the peer,
+     * so we don't have to worry about it still being present - send a copy
+     * to the originator.
+     *
+     * Queue it inline rather than through PMIX_PTL_SEND_ONEWAY. We are
+     * already on the progress thread, and taking that macro's extra hop
+     * would put this reply behind whatever the host activated on this same
+     * base while handling the command. For PMIX_FINALIZE_CMD that is the
+     * host's own PMIx_server_deregister_nspace of the departing peer, which
+     * closes its socket - and the reply we owe it is then dropped with "no
+     * connection" while the client waits out its finalize guard timer. */
+    PMIX_PTL_SEND_ONEWAY_INLINE(rc, cd->peer, reply, cd->hdr.tag);
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(reply);
     }


### PR DESCRIPTION
Reported as [openpmix/prrte#2749](https://github.com/openpmix/prrte/issues/2749).

## The problem

A `prun` into a persistent DVM returned about 5.05 s after the application it launched had already exited, on essentially every launch. Three separate defects sit behind that number and behind the second `pterm` spends on top of it; each is fixed in its own commit.

Reproduced on macOS 26.6 against PRRTE master, 10 of 10 launches slow, matching the reporter's Rocky Linux 8.10 traces line for line.

## What was wrong

**The finalize reply was packed and then thrown away.** The host answers `PMIX_FINALIZE_CMD` and then deregisters the departing peer's namespace. Both are activated on the progress thread from the host's own thread, so they run back to back in one dispatch pass, and `PMIX_PTL_SEND_ONEWAY` takes an event of its own to do the queuing — so the reply lands *behind* the deregistration, which closes the peer's socket. Removing that hop is not enough on its own: `pmix_ptl_base_send()` does not write, it arms an fd event that cannot fire until the base next polls, so the deregistration still closes the socket over bytes that are queued and unwritten. Both halves are fixed — the reply is queued inline from `_opcbfunc`, and an orderly teardown flushes what a peer has queued before closing its socket.

**The recovery for a lost server was unreachable for launchers.** `lost_connection()` completes every outstanding dynamic-tag recv when the answer can no longer arrive, but it asked what I am rather than which peer went away. `PMIX_PROC_LAUNCHER` carries `PMIX_PROC_SERVER`, so `prun` took the server arm and never reached it — and, in the other direction, losing one of its own tools declared it disconnected from its server. It now asks which peer was lost.

**An event that cannot aggregate was held for a second anyway.** `PMIX_REPORT_EVENT` caches a chain for `pmix_globals.event_window` so other sources of the same status can join it. That is exactly right for a server losing clients — a dying job drops them all at once and one event naming all of them beats a cascade. A process has exactly one server, so the report that it went away can never gain a second source. The window is now an argument, and the two reports naming my own server ask for delivery on the next pass of the loop.

## Effect

| | before | after |
|---|---|---|
| `prun` into a warm DVM | 5.17 s | 0.13 s |
| — of which, after the app exited | 5.05 s | 0.02 s |
| `pterm` on a live DVM | 1.02 s | 0.03 s |

Any workflow that relaunches into a persistent DVM paid the first row per launch, in series. The reporter measured it as ~88% of an elastic-run reconfiguration interval, and observed that standing a whole DVM up and demolishing it again was faster than relaunching one application inside a warm one.

## Verification

- Each of the three commits builds clean on its own tree, `--enable-debug --enable-devel-check`, zero warnings.
- `make check`: 107 pass / 2 skip / 0 fail, plus 21/21.
- PRRTE built against this and `make check` passes; 25-launch `prun` soak with none over 4 s; `prterun`, multi-proc launch, stdout/stderr forwarding, exit-status propagation (`exit 3` → 3, `kill -9` → 137), `--display map`, and DVM health after a failed job all behave.
- The second defect was confirmed in isolation by backing the first fix out and rebuilding: the server still logs `no connection` for the reply, and `prun` still exits in 0.020 s — so the safety net is genuinely reachable now, which is what protects the case the guard timer actually exists for, a server that is wedged or gone.