### PR TITLE
Give every constructor an initial value for the members it skipped

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -309,6 +309,8 @@ typedef struct {
 } pmix_held_delete_t;
 static void hdcon(pmix_held_delete_t *p)
 {
+    PMIX_LOAD_PROCID(&p->proc, NULL, PMIX_RANK_UNDEF);
+    p->scope = PMIX_SCOPE_UNDEF;
     p->key = NULL;
 }
 static void hddes(pmix_held_delete_t *p)

--- a/src/client/pmix_client_resolve.c
+++ b/src/client/pmix_client_resolve.c
@@ -77,6 +77,7 @@ typedef struct {
 static void rcon(pmix_resolve_caddy_t *p)
 {
     PMIX_CONSTRUCT_LOCK(&p->lock);
+    p->status = PMIX_SUCCESS;
     p->nodename = NULL;
     PMIX_LOAD_NSPACE(p->nspace, NULL);
     p->procs = NULL;

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -3519,6 +3519,8 @@ reactivate:
 /* class instances */
 static void iof_sink_construct(pmix_iof_sink_t *ptr)
 {
+    PMIX_LOAD_PROCID(&ptr->name, NULL, PMIX_RANK_UNDEF);
+    ptr->tag = PMIX_FWD_NO_CHANNELS;
     PMIX_CONSTRUCT(&ptr->wev, pmix_iof_write_event_t);
     ptr->xoff = false;
     ptr->exclusive = false;
@@ -3555,6 +3557,7 @@ static void iof_read_event_construct(pmix_iof_read_event_t *rev)
     rev->tv.tv_sec = 0;
     rev->tv.tv_usec = 0;
     rev->fd = -1;
+    PMIX_LOAD_PROCID(&rev->name, NULL, PMIX_RANK_UNDEF);
     rev->channel = PMIX_FWD_NO_CHANNELS;
     rev->active = false;
     rev->childproc = NULL;
@@ -3636,6 +3639,14 @@ PMIX_CLASS_INSTANCE(pmix_iof_write_output_t,
 
 static void iofrescon(pmix_iof_residual_t *p)
 {
+    PMIX_LOAD_PROCID(&p->name, NULL, PMIX_RANK_UNDEF);
+    p->channel = NULL;
+    /* every field of the flags is overwritten wholesale when the
+     * residual is filled in - see pmix_iof_write_output */
+    memset(&p->flags, 0, sizeof(p->flags));
+    p->stream = PMIX_FWD_NO_CHANNELS;
+    p->copystdout = false;
+    p->copystderr = false;
     PMIX_BYTE_OBJECT_CONSTRUCT(&p->bo);
 }
 static void iofresdes(pmix_iof_residual_t *p)

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -1874,6 +1874,7 @@ static void sevcon(pmix_event_hdlr_t *p)
     p->precedence = PMIX_EVENT_ORDER_NONE;
     p->oneshot = false;
     p->locator = NULL;
+    PMIX_LOAD_PROCID(&p->source, NULL, PMIX_RANK_UNDEF);
     p->rng.range = PMIX_RANGE_UNDEF;
     p->rng.procs = NULL;
     p->rng.nprocs = 0;
@@ -1915,6 +1916,7 @@ PMIX_CLASS_INSTANCE(pmix_event_hdlr_t, pmix_list_item_t, sevcon, sevdes);
 
 static void accon(pmix_active_code_t *p)
 {
+    p->code = PMIX_SUCCESS;
     p->nregs = 0;
     p->peer = NULL;
 }
@@ -1951,6 +1953,7 @@ PMIX_CLASS_INSTANCE(pmix_events_t,
 
 static void chcon(pmix_event_chain_t *p)
 {
+    p->status = PMIX_SUCCESS;
     p->timer_active = false;
     memset(p->source.nspace, 0, PMIX_MAX_NSLEN + 1);
     p->source.rank = PMIX_RANK_UNDEF;

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -31,6 +31,9 @@
 static void rscon(pmix_rshift_caddy_t *p)
 {
     PMIX_CONSTRUCT_LOCK(&p->lock);
+    p->active = false;
+    p->status = PMIX_SUCCESS;
+    p->index = SIZE_MAX;
     p->firstoverall = false;
     p->enviro = false;
     p->list = NULL;

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -388,7 +388,12 @@ static void pcon(pmix_peer_t *p)
     p->proc_cnt = 0;
     p->index = 0;
     p->sd = -1;
+    /* the send/recv events are assigned to this peer's socket when the
+     * connection is established - until then they are simply unarmed,
+     * which is what a zeroed event is */
+    memset(&p->send_event, 0, sizeof(p->send_event));
     p->send_ev_active = false;
+    memset(&p->recv_event, 0, sizeof(p->recv_event));
     p->recv_ev_active = false;
     PMIX_CONSTRUCT(&p->send_queue, pmix_list_t);
     p->send_msg = NULL;
@@ -590,9 +595,11 @@ static void cbcon(pmix_cb_t *p)
 {
     PMIX_CONSTRUCT_LOCK(&p->lock);
     p->status = PMIX_SUCCESS;
+    p->pstatus = PMIX_SUCCESS;
     p->checked = false;
     PMIX_CONSTRUCT(&p->data, pmix_buffer_t);
     p->cbfunc.ptlfn = NULL;
+    p->errhandler_ref = SIZE_MAX; // no handler
     p->cbdata = NULL;
     p->pname.nspace = NULL;
     p->pname.rank = PMIX_RANK_UNDEF;
@@ -738,6 +745,7 @@ static void ncon(pmix_notify_caddy_t *p)
     p->ts = tv.tv_sec;
 #endif
     p->room = -1;
+    p->status = PMIX_SUCCESS;
     memset(p->source.nspace, 0, PMIX_MAX_NSLEN + 1);
     p->source.rank = PMIX_RANK_UNDEF;
     p->range = PMIX_RANGE_UNDEF;
@@ -752,6 +760,9 @@ static void ncon(pmix_notify_caddy_t *p)
     p->nondefault = false;
     p->info = NULL;
     p->ninfo = 0;
+    p->buf = NULL;
+    p->cbfunc = NULL;
+    p->cbdata = NULL;
 }
 static void ndes(pmix_notify_caddy_t *p)
 {
@@ -1186,6 +1197,8 @@ int pmix_event_del_checked(struct event *ev)
 
 static void tcon(pmix_timer_t *p)
 {
+    p->tv.tv_sec = 0;
+    p->tv.tv_usec = 0;
     p->active = false;
     p->payload = NULL;
 }

--- a/src/mca/base/pmix_mca_base_components_open.c
+++ b/src/mca/base/pmix_mca_base_components_open.c
@@ -50,7 +50,7 @@ struct pmix_mca_base_dummy_framework_list_item_t {
 };
 
 typedef struct fc_pair {
-    pmix_list_item_t li;
+    pmix_list_item_t super;
     char *framework_name;
     char *component_name;
 } fc_pair_t;
@@ -220,7 +220,7 @@ int pmix_mca_base_show_load_errors_init(void)
                 }
                 free(split);
 
-                pmix_list_append(list, &fcp->li);
+                pmix_list_append(list, &fcp->super);
             }
 
         done:

--- a/src/mca/bfrops/base/bfrop_base_frame.c
+++ b/src/mca/bfrops/base/bfrop_base_frame.c
@@ -168,6 +168,7 @@ PMIX_CLASS_INSTANCE(pmix_buffer_t, pmix_object_t, pmix_buffer_construct, pmix_bu
 
 static void pmix_bfrop_type_info_construct(pmix_bfrop_type_info_t *obj)
 {
+    obj->odti_type = PMIX_UNDEF;
     obj->odti_name = NULL;
     obj->odti_pack_fn = NULL;
     obj->odti_unpack_fn = NULL;

--- a/src/mca/bfrops/bfrops_types.h
+++ b/src/mca/bfrops/bfrops_types.h
@@ -109,7 +109,7 @@ pmix_bfrop_tma_kval_new(
  * Structure for holding a buffer */
 typedef struct {
     /** First member must be the object's parent */
-    pmix_object_t parent;
+    pmix_object_t super;
     /** type of buffer */
     pmix_bfrop_buffer_type_t type;
     /** Start of my memory */

--- a/src/mca/plog/stdfd/plog_stdfd.c
+++ b/src/mca/plog/stdfd/plog_stdfd.c
@@ -72,6 +72,7 @@ typedef struct{
 } pmix_iof_deliver_t;
 static void pdcon(pmix_iof_deliver_t *p)
 {
+    PMIX_LOAD_PROCID(&p->source, NULL, PMIX_RANK_UNDEF);
     p->bo.bytes = NULL;
     p->bo.size = 0;
 }

--- a/src/mca/pmdl/ompi/pmdl_ompi.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi.c
@@ -80,6 +80,7 @@ typedef struct {
 } pmdl_nspace_t;
 static void nscon(pmdl_nspace_t *p)
 {
+    PMIX_LOAD_NSPACE(p->nspace, NULL);
     p->univ_size = UINT32_MAX;
     p->job_size = UINT32_MAX;
     p->local_size = UINT32_MAX;

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -79,6 +79,9 @@ static void ft_constructor(file_tracker_t *ft)
     ft->requestor = NULL;
     ft->id = NULL;
     ft->event_active = false;
+    /* the tracker's add event is assigned when the tracker is handed to
+     * the sensor thread - until then it is simply unarmed */
+    memset(&ft->cdev, 0, sizeof(ft->cdev));
     ft->tv.tv_sec = 0;
     ft->tv.tv_usec = 0;
     ft->file = NULL;

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -64,6 +64,9 @@ static void ft_constructor(pmix_heartbeat_trkr_t *ft)
     ft->requestor = NULL;
     ft->id = NULL;
     ft->event_active = false;
+    /* the tracker's add event is assigned when the tracker is handed to
+     * the sensor thread - until then it is simply unarmed */
+    memset(&ft->cdev, 0, sizeof(ft->cdev));
     ft->tv.tv_sec = 0;
     ft->tv.tv_usec = 0;
     ft->nbeats = 0;

--- a/src/mca/pstat/base/pstat_base_frame.c
+++ b/src/mca/pstat/base/pstat_base_frame.c
@@ -198,19 +198,21 @@ static pmix_status_t pmix_pstat_base_unsupported_finalize(void)
 
 static void opcon(pmix_pstat_op_t *p)
 {
-    /* PMIX_NEW does not zero the object, so every member a consumer might
-     * read has to be set here. requestor and eventcode are the two that
-     * matter: a periodic op notifies with PMIx_Notify_event(eventcode)
-     * scoped to requestor, so leaving them holding heap garbage means
-     * raising an arbitrary status at an arbitrary process. Both real
-     * components assign them immediately after PMIX_NEW, which is what
-     * keeps this latent rather than live - but nothing enforces that.
-     * ev and tv are deliberately not initialized: tv is set by
-     * PMIX_PSTAT_OP_START before the timer is armed, and ev is only ever
-     * touched under the active flag, which starts false. */
+    /* every member a consumer might read is set here. requestor and
+     * eventcode are the two that matter: a periodic op notifies with
+     * PMIx_Notify_event(eventcode) scoped to requestor, so an op that
+     * reached that point without them would raise a status nobody meant
+     * at a process nobody named. Both real components assign them
+     * immediately after PMIX_NEW, which is what keeps this latent rather
+     * than live - but nothing enforces that. ev is the one member left
+     * alone: libevent arms it, and it is only ever touched under the
+     * active flag, which starts false. */
     PMIX_PROC_CONSTRUCT(&p->requestor);
     p->eventcode = PMIX_SUCCESS;
     p->id = NULL;
+    /* overwritten by PMIX_PSTAT_OP_START before the timer is armed */
+    p->tv.tv_sec = 0;
+    p->tv.tv_usec = 0;
     p->active = false;
     p->rate = 0;
     PMIX_CONSTRUCT(&p->peers, pmix_list_t);

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -68,6 +68,8 @@ typedef struct {
 static void chcon(cnct_hdlr_t *p)
 {
     memset(&p->ev, 0, sizeof(pmix_event_t));
+    p->status = PMIX_SUCCESS;
+    p->reply = PMIX_SUCCESS;
     p->pnd = NULL;
     p->peer = NULL;
     p->info = NULL;

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -584,6 +584,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_send_t,
 static void rcon(pmix_ptl_recv_t *p)
 {
     p->peer = NULL;
+    p->sd = -1;
     memset(&p->hdr, 0, sizeof(pmix_ptl_hdr_t));
     p->hdr.tag = UINT32_MAX;
     p->hdr.nbytes = 0;
@@ -615,7 +616,9 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_posted_recv_t,
 
 static void srcon(pmix_ptl_sr_t *p)
 {
+    p->active = false;
     p->peer = NULL;
+    p->status = PMIX_SUCCESS;
     p->bfr = NULL;
     p->cbfunc = NULL;
     p->cbdata = NULL;
@@ -720,6 +723,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_listener_t,
 
 static void qcon(pmix_ptl_queue_t *p)
 {
+    p->active = false;
     p->peer = NULL;
     p->buf = NULL;
     p->tag = UINT32_MAX;

--- a/src/runtime/pmix_info_support.c
+++ b/src/runtime/pmix_info_support.c
@@ -104,6 +104,11 @@ static void component_map_construct(pmix_info_component_map_t *map)
 {
     map->project = NULL;
     map->type = NULL;
+    /* the framework's own lists, borrowed when the map is filled in -
+     * see info_register_framework(), which is why the destructor below
+     * leaves them alone */
+    map->components = NULL;
+    map->failed_components = NULL;
 }
 static void component_map_destruct(pmix_info_component_map_t *map)
 {

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -65,16 +65,22 @@ static void tracker_constructor(pmix_progress_tracker_t *p)
     p->name = NULL;
     p->ev_base = NULL;
     p->ev_active = false;
+    /* both of these are filled in later - 'block' by pmix_event_assign
+     * once the event base exists, 'engine' by PMIX_CONSTRUCT when the
+     * thread is about to be started - and the flags beside them say
+     * whether that has happened yet */
+    memset(&p->block, 0, sizeof(p->block));
     p->block_assigned = false;
+    memset(&p->engine, 0, sizeof(p->engine));
     p->engine_constructed = false;
 }
 
 static void tracker_destructor(pmix_progress_tracker_t *p)
 {
-    /* PMIX_NEW does not zero the object, so 'block' holds garbage until
-     * pmix_event_assign has run. A tracker released before that point -
-     * an allocation failure in pmix_progress_thread_init - must not hand
-     * that garbage to libevent */
+    /* 'block' is not a libevent event until pmix_event_assign has run.
+     * A tracker released before that point - an allocation failure in
+     * pmix_progress_thread_init - must not hand the zeroed struct to
+     * libevent */
     if (p->block_assigned) {
         pmix_event_del(&p->block);
     }

--- a/src/server/pmix_server_classes.c
+++ b/src/server/pmix_server_classes.c
@@ -76,6 +76,9 @@ static void tcon(pmix_server_trkr_t *t)
     t->completion_fired = false;
     t->local = true;
     t->id = NULL;
+    /* no command matches this, so a tracker whose type was never set
+     * cannot be mistaken for a PMIX_REQ_CMD collective */
+    t->type = UINT8_MAX;
     PMIX_LOAD_PROCID(&t->pname, NULL, PMIX_RANK_UNDEF);
     t->pcs = NULL;
     t->npcs = 0;
@@ -189,6 +192,7 @@ static void scadcon(pmix_setup_caddy_t *p)
     p->napps = 0;
     p->server_object = NULL;
     p->nlocalprocs = 0;
+    p->sessionid = UINT32_MAX; // no session, as everywhere else
     p->info = NULL;
     p->ninfo = 0;
     p->units = NULL;

--- a/src/util/pmix_show_help.c
+++ b/src/util/pmix_show_help.c
@@ -109,6 +109,7 @@ typedef struct {
 static void tacon(tuple_array_item_t *p)
 {
     p->project = NULL;
+    p->array = NULL;
 }
 static void tades(tuple_array_item_t *p)
 {

--- a/test/unit/ctor_coverage_baseline.txt
+++ b/test/unit/ctor_coverage_baseline.txt
@@ -1,60 +1,20 @@
 # Constructors that do not account for every member of their own class.
 #
-# This is a record of what was already here when the check was written, not a
-# list of things that are fine.  Each line is a member whose constructor never
-# mentions it: harmless where zero is the intended default, a latent bug where
-# it is not, and impossible to tell apart without reading each one.
+# The list is empty, and the check is what keeps it that way: every member
+# of every class is now named by its constructor, so anything the check
+# reports is a member somebody forgot rather than one of a backlog nobody
+# had gotten to.
 #
-# The check fails on anything NOT listed here, so new omissions are caught
-# immediately.  It also fails on a line that no longer occurs, so that fixing
-# one obliges you to delete its line and the list can only shrink.
+# It began as a record of what was already here when the check was written -
+# harmless where zero was the intended default, a latent bug where it was
+# not, and impossible to tell apart without reading each one. Each of those
+# was read and given an explicit initial value, and the line recording it
+# deleted.
+#
+# The check fails on anything NOT listed here, so a new omission is caught
+# immediately. It also fails on a line that no longer occurs, so nothing can
+# be listed that has since been fixed - which is how this list emptied and
+# why it should stay empty. Add a line only for an omission you have read
+# and deliberately decided to leave, and say why.
 #
 # Format: <path> <type>.<member>
-src/client/pmix_client.c pmix_held_delete_t.proc
-src/client/pmix_client.c pmix_held_delete_t.scope
-src/client/pmix_client_resolve.c pmix_resolve_caddy_t.status
-src/common/pmix_iof.c pmix_iof_read_event_t.name
-src/common/pmix_iof.c pmix_iof_residual_t.channel
-src/common/pmix_iof.c pmix_iof_residual_t.copystderr
-src/common/pmix_iof.c pmix_iof_residual_t.copystdout
-src/common/pmix_iof.c pmix_iof_residual_t.flags
-src/common/pmix_iof.c pmix_iof_residual_t.name
-src/common/pmix_iof.c pmix_iof_residual_t.stream
-src/common/pmix_iof.c pmix_iof_sink_t.name
-src/common/pmix_iof.c pmix_iof_sink_t.tag
-src/event/pmix_event_notification.c pmix_active_code_t.code
-src/event/pmix_event_notification.c pmix_event_chain_t.status
-src/event/pmix_event_notification.c pmix_event_hdlr_t.source
-src/event/pmix_event_registration.c pmix_rshift_caddy_t.active
-src/event/pmix_event_registration.c pmix_rshift_caddy_t.index
-src/event/pmix_event_registration.c pmix_rshift_caddy_t.status
-src/include/pmix_globals.c pmix_cb_t.errhandler_ref
-src/include/pmix_globals.c pmix_cb_t.pstatus
-src/include/pmix_globals.c pmix_notify_caddy_t.buf
-src/include/pmix_globals.c pmix_notify_caddy_t.cbdata
-src/include/pmix_globals.c pmix_notify_caddy_t.cbfunc
-src/include/pmix_globals.c pmix_notify_caddy_t.status
-src/include/pmix_globals.c pmix_peer_t.recv_event
-src/include/pmix_globals.c pmix_peer_t.send_event
-src/include/pmix_globals.c pmix_timer_t.tv
-src/mca/base/pmix_mca_base_components_open.c fc_pair_t.li
-src/mca/bfrops/base/bfrop_base_frame.c pmix_bfrop_type_info_t.odti_type
-src/mca/bfrops/base/bfrop_base_frame.c pmix_buffer_t.parent
-src/mca/plog/stdfd/plog_stdfd.c pmix_iof_deliver_t.source
-src/mca/pmdl/ompi/pmdl_ompi.c pmdl_nspace_t.nspace
-src/mca/psensor/file/psensor_file.c file_tracker_t.cdev
-src/mca/psensor/heartbeat/psensor_heartbeat.c pmix_heartbeat_trkr_t.cdev
-src/mca/pstat/base/pstat_base_frame.c pmix_pstat_op_t.tv
-src/mca/ptl/base/ptl_base_connection_hdlr.c cnct_hdlr_t.reply
-src/mca/ptl/base/ptl_base_connection_hdlr.c cnct_hdlr_t.status
-src/mca/ptl/base/ptl_base_frame.c pmix_ptl_queue_t.active
-src/mca/ptl/base/ptl_base_frame.c pmix_ptl_recv_t.sd
-src/mca/ptl/base/ptl_base_frame.c pmix_ptl_sr_t.active
-src/mca/ptl/base/ptl_base_frame.c pmix_ptl_sr_t.status
-src/runtime/pmix_info_support.c pmix_info_component_map_t.components
-src/runtime/pmix_info_support.c pmix_info_component_map_t.failed_components
-src/runtime/pmix_progress_threads.c pmix_progress_tracker_t.block
-src/runtime/pmix_progress_threads.c pmix_progress_tracker_t.engine
-src/server/pmix_server_classes.c pmix_server_trkr_t.type
-src/server/pmix_server_classes.c pmix_setup_caddy_t.sessionid
-src/util/pmix_show_help.c tuple_array_item_t.array


### PR DESCRIPTION
The constructor-coverage check (`test/unit/check_ctor_coverage.py`) shipped
with a baseline of 48 members that no constructor mentioned — a record of
what was already there when the check was written, harmless where zero was
the intended default and a latent bug where it was not, with no way to tell
the two apart without reading each one. They have now been read, and each
one is set explicitly, so the baseline is empty and the check is what keeps
it that way.

### What changed

Most members got the value that means "not set yet": `PMIX_RANK_UNDEF` for a
proc, `PMIX_SCOPE_UNDEF`, `PMIX_FWD_NO_CHANNELS`, `PMIX_UNDEF` for a data
type, `-1` for a socket, `UINT32_MAX` for a session id — as those members are
spelled everywhere else in the tree.

**Two would have been wrong at zero:**

* `pmix_server_trkr_t.type` is a `pmix_cmd_t`, and zero is `PMIX_REQ_CMD`, so
  a tracker whose type was never assigned compares equal to a real command.
  It now starts at `UINT8_MAX`, which matches none.
* `pmix_cb_t.errhandler_ref` now starts at `SIZE_MAX` — the same "no handler"
  value the handler objects use for their index — rather than at the index of
  the first handler.

**The libevent members** (a peer's `send_event`/`recv_event`, the psensor
trackers' `cdev`, the progress tracker's `block` and `engine`) are memset with
a note saying who arms or constructs them later, the same shape the connection
handler's caddy already used for its `ev`. A zeroed event is an unarmed one
either way; saying so keeps the member from reading as forgotten.

Two comments claiming "PMIX_NEW does not zero the object" came out with them.
That stopped being true when the object system started zeroing an object
before running its constructors.

### The separate first commit

`pmix_buffer_t` called its object header `parent` and `fc_pair_t` called its
list-item header `li`. Both are the member the object system fills in, the one
a constructor must never touch, and every other class in the tree spells it
`super` — which is what lets a reader, or a check over the constructors, tell
the header apart from a member somebody forgot. Renamed, no behavior change;
the only reference to either name outside its own declaration was one list
append.

### Testing

* `make check` — 108 pass / 2 skip (pnet components not built locally) in
  `test/unit`, and 30 / 10 / 7 / 21 in the other suites, zero failures.
* Warning-free build with `--enable-devel-check`.
* `contrib/dockerswarm`: ten-container swarm, `run-tests.sh linux` — 12
  passed, 0 failed. That covers the paths this touches: the cross-daemon
  launch smoke exercises the peer send/recv events and the ptl recv/sr/queue
  constructors over real sockets between hosts; the six group-construction
  methods and the two loss-accounting cases exercise `pmix_server_trkr_t`
  with its new `type` start, including collectives that complete after a
  participant dies; the voluntary-leave case exercises the event chain and
  the notify caddy.