### PR TITLE
Answer a cross-namespace get from the store that holds the modex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ examples/dmdx_departed
 examples/modex_attach_fail
 examples/dmodex
 examples/dynamic
+examples/xnspace_modex
 examples/modex_twice
 examples/fault
 examples/jctrl

--- a/contrib/dockerswarm/run-server-tests.sh
+++ b/contrib/dockerswarm/run-server-tests.sh
@@ -33,6 +33,13 @@
 # server.  A run with two ranks per node can be green with the whole remote
 # path broken.  Keep the geometry.
 #
+# ONE stage departs from it deliberately, and says why where it is defined:
+# xnspace_modex needs two namespaces resident on the same node, which is
+# only reachable with two slots per node.  It still asks for a peer on the
+# far node, so it does not lose the remote arm -- it adds a second
+# condition to it.  A new stage that wants two ranks per node for any other
+# reason is almost certainly wrong.
+#
 # What the stages reach that `make check` cannot:
 #
 #   * dmodex / modex_twice / group_dmodex -- a rank fetches a peer's data
@@ -46,6 +53,23 @@
 #     _satisfy_request(), which packs job-level data before the per-rank
 #     data and is the arm whose not-found path used to strand the packed
 #     buffer.
+#   * xnspace_modex -- the same cross-namespace get, but with the child
+#     job mapped BACK ONTO the nodes its parents already occupy.  THE ONLY
+#     STAGE HERE THAT WANTS TWO RANKS PER NODE, and it wants them for the
+#     opposite of the usual reason: co-residency is what gives the daemon
+#     a local client of the target namespace, and so a gds module for that
+#     namespace which is not the daemon's own -- gds/shmem3 keeps a job's
+#     modex in a shared segment the daemon's "hash" module cannot read.
+#     _satisfy_request() then has to consult that module, and it did not:
+#     a non-reserved key is fetched as "everything this proc has", our own
+#     store always holds the rank's job-level keys, and the resulting
+#     success was read as "we have what was asked for".  The reply went
+#     back with pmix.grank and friends and no modex, and -- being a
+#     success -- stopped pmix_server_get() from ever issuing the direct
+#     modex that would have found it.  It still needs a REMOTE target: the
+#     cross-namespace peer that is local here is answered out of the
+#     daemon's own store, because a local client's commit is filed in
+#     both.  See issue #4225.
 #   * multi_nspace_group -- a group whose members span namespaces and
 #     nodes, which drives the two-level group block/tracker engine through
 #     a real host rather than through simptest.
@@ -90,7 +114,7 @@ root="$(cd "$here/../.." && pwd)"
 
 # The examples this runner drives.  Each one puts the server library on a
 # path a single-node run cannot take; see the header.
-SERVER_EXAMPLES="${SERVER_EXAMPLES:-dmodex dmdx_departed modex_twice group_dmodex dynamic multi_nspace_group resolve simple_resolve pub}"
+SERVER_EXAMPLES="${SERVER_EXAMPLES:-dmodex dmdx_departed modex_twice group_dmodex dynamic xnspace_modex multi_nspace_group resolve simple_resolve pub}"
 
 # See run-client-tests.sh: these are COMPILED in a throwaway builder
 # container and RUN in the long-lived node containers, so they must link the
@@ -121,6 +145,14 @@ sv_geom() {
             # cross-namespace get cross a server boundary rather than being
             # answered out of the parent's own datastore.
             HOSTS="node1:1,node2:1,node3:1,node4:1"; NP=2 ;;
+        xnspace_modex)
+            # The one stage that deliberately breaks the one-rank-per-node
+            # rule: it needs the spawned children to land on nodes their
+            # parents already hold, which is what --map-by node over two
+            # two-slot nodes gives it, and it needs the peer it then asks
+            # for to be on the OTHER node. Both conditions at once, or the
+            # case passes whether the bug is there or not.
+            HOSTS="node1:2,node2:2"; NP=2 ;;
     esac
     case "$1" in
         # Not every example announces itself the same way. Match what each
@@ -133,6 +165,9 @@ sv_geom() {
         group_dmodex)   WANT='COMPLETE' ;;
         resolve)        WANT='Bye\.' ;;
         pub|simple_resolve) WANT='' ;;
+        # every rank grades itself and says so; a FAIL line is caught by
+        # judge() through the exit status the program returns with it
+        xnspace_modex)  WANT=': PASS' ;;
     esac
 }
 
@@ -257,6 +292,8 @@ test_linux() {
             modex_twice) judge "$ex" "repeated modex: second request joins an existing tracker" ;;
             group_dmodex) judge "$ex" "modex within a group spanning servers" ;;
             dynamic)     judge "$ex" "spawn + connect: a get across namespaces and servers" ;;
+            xnspace_modex)
+                         judge "$ex" "cross-namespace get for a remote peer where a node holds both namespaces" ;;
             multi_nspace_group)
                          judge "$ex" "group block/tracker engine across namespaces and nodes" ;;
             resolve)     judge "$ex" "resolve_peers/resolve_node answered by the host" ;;

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -91,7 +91,8 @@ noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi \
                   group_invite_abort group_invite_others group_invite_suppress group_invite_nb \
                   group_invite_endpts topology \
                   spawn_reuse spawn_iof iof_watcher group_badinfo datatypes toolswitch \
-                  modex_twice delete_key modex_attach_fail dmdx_departed
+                  modex_twice delete_key modex_attach_fail dmdx_departed \
+                  xnspace_modex
 
 if !WANT_HIDDEN
 # these examples use internal symbols
@@ -138,6 +139,10 @@ dmodex_LDADD =  $(top_builddir)/src/libpmix.la
 dynamic_SOURCES = dynamic.c examples.h
 dynamic_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 dynamic_LDADD = $(top_builddir)/src/libpmix.la
+
+xnspace_modex_SOURCES = xnspace_modex.c examples.h
+xnspace_modex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+xnspace_modex_LDADD = $(top_builddir)/src/libpmix.la
 
 fault_SOURCES = fault.c examples.h
 fault_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -364,4 +369,5 @@ distclean-local:
         spawn_group resolve multi_nspace_group pub2 toolqry \
         simple_resolve pubstress monitor monitor_remote \
         simple simple_server abort datatypes toolswitch \
-        modex_twice delete_key modex_attach_fail dmdx_departed
+        modex_twice delete_key modex_attach_fail dmdx_departed \
+        xnspace_modex

--- a/examples/xnspace_modex.c
+++ b/examples/xnspace_modex.c
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/*
+ * Cross-namespace modex: every proc reads a key every proc of the OTHER
+ * namespace posted, including the ones that are not on this node.
+ *
+ * This is the PMIx-level shape of what an MPI_Comm_spawn followed by
+ * MPI_Intercomm_merge and a collective does, and it is a regression test
+ * for a get that came back PMIX_ERR_NOT_FOUND for a key that was sitting
+ * in the server's own memory (issue #4225). Two things have to be true at
+ * once for that to happen, which is why the geometry below matters:
+ *
+ *   1. A NODE HOSTS BOTH NAMESPACES. That is what gives the daemon a
+ *      local client of the target namespace, and so a gds module for it
+ *      that is not the daemon's own - the modex of a job whose clients
+ *      negotiated gds/shmem3 goes into a shared segment the daemon's
+ *      "hash" module cannot see. Run this with the children mapped by
+ *      node onto the nodes their parents already occupy, i.e. at least
+ *      two slots per node.
+ *
+ *   2. THE TARGET RANK IS ON ANOTHER NODE. A rank of the other namespace
+ *      that is local here is answered out of the daemon's own store,
+ *      because a local client's commit is filed in both. So at least two
+ *      nodes.
+ *
+ * Either condition alone passes whether the bug is present or not. The
+ * failing geometry is therefore >= 2 nodes with >= 2 slots each:
+ *
+ *      prterun --host n1:2,n2:2 --map-by node -n 2 ./xnspace_modex
+ *
+ * Each proc prints one "xnspace_modex: <nspace>:<rank>: PASS|FAIL" line
+ * and a non-zero exit status accompanies any FAIL.
+ */
+
+#include <stdbool.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <libgen.h>
+
+#include "examples.h"
+#include <pmix.h>
+
+/* deliberately NOT a "pmix."-prefixed key: a reserved key is fetched by
+ * name, and it is the non-reserved path - fetch everything this proc has,
+ * then hope the wanted key is in there - that #4225 lived in */
+#define XNS_KEY "xnspace.probe"
+
+/* marks a child in its own environment, exactly as examples/dynamic.c does */
+#define XNS_CHILD_ENV "PMIX_XNSPACE_CHILD"
+
+static pmix_proc_t myproc;
+
+/* what rank "rank" of namespace "nspace" is expected to have posted */
+static void expected_value(char *buf, size_t sz, const char *nspace, pmix_rank_t rank)
+{
+    snprintf(buf, sz, "%s:%u", nspace, (unsigned) rank);
+}
+
+/* returns the number of failures, so a caller can just add them up */
+static int check_peer(const char *nspace, pmix_rank_t rank)
+{
+    pmix_proc_t proc;
+    pmix_value_t *val = NULL;
+    char expect[2 * PMIX_MAX_NSLEN + 32];
+    pmix_status_t rc;
+
+    PMIX_LOAD_PROCID(&proc, nspace, rank);
+    rc = PMIx_Get(&proc, XNS_KEY, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr,
+                "xnspace_modex: %s:%u: PMIx_Get(%s:%u, %s) failed: %s\n",
+                myproc.nspace, myproc.rank, nspace, (unsigned) rank,
+                XNS_KEY, PMIx_Error_string(rc));
+        return 1;
+    }
+    if (NULL == val || PMIX_STRING != val->type || NULL == val->data.string) {
+        fprintf(stderr,
+                "xnspace_modex: %s:%u: PMIx_Get(%s:%u, %s) returned the wrong type\n",
+                myproc.nspace, myproc.rank, nspace, (unsigned) rank, XNS_KEY);
+        if (NULL != val) {
+            PMIX_VALUE_RELEASE(val);
+        }
+        return 1;
+    }
+    expected_value(expect, sizeof(expect), nspace, rank);
+    if (0 != strcmp(expect, val->data.string)) {
+        fprintf(stderr,
+                "xnspace_modex: %s:%u: PMIx_Get(%s:%u, %s) gave \"%s\", expected \"%s\"\n",
+                myproc.nspace, myproc.rank, nspace, (unsigned) rank, XNS_KEY,
+                val->data.string, expect);
+        PMIX_VALUE_RELEASE(val);
+        return 1;
+    }
+    PMIX_VALUE_RELEASE(val);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL, value;
+    pmix_proc_t proc, *parray = NULL;
+    uint32_t nprocs;
+    size_t nall = 0, n, nother;
+    char nsp2[PMIX_MAX_NSLEN + 1];
+    char other[PMIX_MAX_NSLEN + 1];
+    char mine[2 * PMIX_MAX_NSLEN + 32];
+    char hostname[1024];
+    pmix_app_t *app;
+    pmix_info_t info[2];
+    bool ischild;
+    int failures = 0;
+
+    if (0 > gethostname(hostname, sizeof(hostname))) {
+        exit(1);
+    }
+    ischild = (NULL != getenv(XNS_CHILD_ENV));
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "xnspace_modex: PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+    fprintf(stderr, "xnspace_modex: %s:%u (%s) on host %s\n", myproc.nspace, myproc.rank,
+            ischild ? "child" : "parent", hostname);
+
+    /* how big is my own job */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Get job size failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+
+    /* post the value our peers in the other namespace will come looking
+     * for, and exchange it across my own job - this is the fence that
+     * puts a job's whole modex into the datastore of every daemon that
+     * hosts one of its procs, which is where #4225 could not find it */
+    expected_value(mine, sizeof(mine), myproc.nspace, myproc.rank);
+    value.type = PMIX_STRING;
+    value.data.string = mine;
+    rc = PMIx_Put(PMIX_GLOBAL, XNS_KEY, &value);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Put failed: %s\n", myproc.nspace, myproc.rank,
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    rc = PMIx_Commit();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Commit failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, NULL, PMIX_BOOL);
+    rc = PMIx_Fence(&proc, 1, info, 1);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Fence failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (ischild) {
+        /* the parent told us who it is on our command line */
+        if (3 > argc) {
+            fprintf(stderr, "xnspace_modex: %s:%u: child started without its parent's identity\n",
+                    myproc.nspace, myproc.rank);
+            goto done;
+        }
+        PMIX_LOAD_NSPACE(other, argv[1]);
+        nother = (size_t) atoi(argv[2]);
+    } else if (0 == myproc.rank) {
+        /* map the children by node so they land back on the nodes their
+         * parents already occupy - that co-residency is what gives each
+         * daemon a local client of both namespaces */
+        PMIX_APP_CREATE(app, 1);
+        app->cmd = strdup(argv[0]);
+        app->maxprocs = nprocs;
+        app->argv = (char **) malloc(4 * sizeof(char *));
+        app->argv[0] = strdup(basename(argv[0]));
+        app->argv[1] = strdup(myproc.nspace);
+        if (0 > asprintf(&app->argv[2], "%u", nprocs)) {
+            goto done;
+        }
+        app->argv[3] = NULL;
+        app->env = (char **) malloc(2 * sizeof(char *));
+        app->env[0] = strdup(XNS_CHILD_ENV "=1");
+        app->env[1] = NULL;
+
+        PMIX_INFO_LOAD(&info[0], PMIX_MAPBY, "node", PMIX_STRING);
+        rc = PMIx_Spawn(info, 1, app, 1, nsp2);
+        PMIX_INFO_DESTRUCT(&info[0]);
+        PMIX_APP_FREE(app, 1);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Spawn failed: %s\n", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        /* tell our own peers which namespace the children got */
+        value.type = PMIX_STRING;
+        value.data.string = nsp2;
+        rc = PMIx_Put(PMIX_GLOBAL, "xnspace.child", &value);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Put child nspace failed: %s\n",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        PMIx_Commit();
+        PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+        rc = PMIx_Fence(&proc, 1, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Fence failed: %s\n", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        PMIX_LOAD_NSPACE(other, nsp2);
+        nother = nprocs;
+    } else {
+        PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+        rc = PMIx_Fence(&proc, 1, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Fence failed: %s\n", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        proc.rank = 0;
+        rc = PMIx_Get(&proc, "xnspace.child", NULL, 0, &val);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Get child nspace failed: %s\n",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        PMIX_LOAD_NSPACE(other, val->data.string);
+        PMIX_VALUE_RELEASE(val);
+        nother = nprocs;
+    }
+
+    /* connect the two namespaces - the parents cannot look at the children
+     * until the children exist, and this is what makes both sides wait */
+    nall = nprocs + nother;
+    PMIX_PROC_CREATE(parray, nall);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_LOAD_PROCID(&parray[n], myproc.nspace, n);
+    }
+    for (n = 0; n < nother; n++) {
+        PMIX_LOAD_PROCID(&parray[n + nprocs], other, n);
+    }
+    rc = PMIx_Connect(parray, nall, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Connect failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* the point of the exercise: read what every proc of the other
+     * namespace posted. No fence spanning the two jobs, deliberately -
+     * each namespace exchanged its own data above, and answering this
+     * from what the daemons already hold (or fetching it from the daemon
+     * that does) is what PMIx is being asked to do */
+    for (n = 0; n < nother; n++) {
+        failures += check_peer(other, (pmix_rank_t) n);
+    }
+
+    fprintf(stderr, "xnspace_modex: %s:%u: %s\n", myproc.nspace, myproc.rank,
+            (0 == failures) ? "PASS" : "FAIL");
+
+    rc = PMIx_Disconnect(parray, nall, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Disconnect failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+
+done:
+    if (NULL != parray) {
+        PMIX_PROC_FREE(parray, nall);
+    }
+    rc = PMIx_Finalize(NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "xnspace_modex: %s:%u: PMIx_Finalize failed: %s\n", myproc.nspace,
+                myproc.rank, PMIx_Error_string(rc));
+    }
+    fflush(stderr);
+    return (0 == failures) ? 0 : 1;
+}

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -102,6 +102,7 @@ static pmix_status_t get_job_data(char *nspace, pmix_server_caddy_t *cd,
                                   char *key, pmix_buffer_t *pbkt);
 static void get_timeout(int sd, short args, void *cbdata);
 static pmix_peer_t *local_peer_of_nspace(pmix_namespace_t *nptr);
+static bool list_has_key(pmix_list_t *kvs, const char *key);
 
 /* The release function we hand to the reply path along with a payload we
  * unloaded from a buffer: the reply copies the bytes, then calls this to
@@ -1170,12 +1171,32 @@ static pmix_peer_t *local_peer_of_nspace(pmix_namespace_t *nptr)
     return NULL;
 }
 
+/* Does this fetch result already carry the given key? A fetch made with
+ * a NULL key answers "everything this proc has", so its status cannot
+ * say whether the key the caller actually wants is among what came
+ * back - only a walk of the result can. */
+static bool list_has_key(pmix_list_t *kvs, const char *key)
+{
+    pmix_kval_t *kv;
+
+    if (NULL == key) {
+        return false;
+    }
+    PMIX_LIST_FOREACH (kv, kvs, pmix_kval_t) {
+        if (NULL != kv->key && PMIX_CHECK_KEY(kv, key)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank, char *key,
                                       pmix_server_caddy_t *cd, bool diffnspace, pmix_scope_t scope,
                                       pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t rc;
     bool found = false;
+    bool answered;
     pmix_buffer_t pbkt, pkt;
     pmix_proc_t proc;
     pmix_cb_t cb;
@@ -1227,7 +1248,20 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank, 
     cb.info = cd->info;
     cb.ninfo = cd->ninfo;
     PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-    if (PMIX_SUCCESS != rc) {
+    /* Did that answer the question? Only a fetch that named the key can
+     * say so from its status alone. The optimization above asks for a
+     * non-reserved key as cb.key == NULL - "give me everything this proc
+     * has" - and for a rank of a namespace we have registered, our own
+     * store always holds that rank's job-level keys. So success there
+     * means "we hold something for this rank", not "we hold what was
+     * asked for", and taking it for the latter is what left a
+     * cross-namespace get answered with pmix.grank and friends and no
+     * modex at all. */
+    answered = (PMIX_SUCCESS == rc);
+    if (answered && NULL == cb.key && NULL != key) {
+        answered = list_has_key(&cb.kvs, key);
+    }
+    if (!answered) {
         /* Not in our own store - but that does not mean it is not here.
          * The target nspace's clients may be on a different gds module
          * than we are: gds/shmem3 keeps their modex in a shared-memory
@@ -1238,11 +1272,50 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank, 
         pmix_peer_t *nspeer = local_peer_of_nspace(nptr);
         if (NULL != nspeer && !PMIX_GDS_CHECK_PEER_COMPONENT(nspeer, pmix_globals.mypeer)) {
             pmix_kval_t *kvtmp;
-            /* a failed fetch may still have appended something */
-            while (NULL != (kvtmp = (pmix_kval_t *) pmix_list_remove_first(&cb.kvs))) {
-                PMIX_RELEASE(kvtmp);
+            pmix_status_t rc2;
+            pmix_cb_t cb2;
+
+            if (PMIX_SUCCESS != rc) {
+                /* a failed fetch may still have appended something */
+                while (NULL != (kvtmp = (pmix_kval_t *) pmix_list_remove_first(&cb.kvs))) {
+                    PMIX_RELEASE(kvtmp);
+                }
             }
-            PMIX_GDS_FETCH_KV(rc, nspeer, &cb);
+            /* Fetch into a list of its own and merge, rather than
+             * discarding what we already have and asking again. Neither
+             * store contains the other: the nspace's module holds the
+             * modex its own clients contributed, while ours holds what a
+             * cross-namespace direct modex put there - dmdx_cbfunc()
+             * stores a reply against mypeer whenever the requester's
+             * namespace differs from the target's. Where the two name
+             * the same key - each keeps its own copy of the job-level
+             * data - the copy we already have wins, because a key that
+             * appears twice reaches the client's process_values() as an
+             * aggregate and hands the application a PMIX_DATA_ARRAY
+             * where it asked for a scalar. */
+            PMIX_CONSTRUCT(&cb2, pmix_cb_t);
+            cb2.key = cb.key;
+            cb2.proc = &proc;
+            cb2.scope = scope;
+            cb2.copy = cb.copy;
+            cb2.info = cd->info;
+            cb2.ninfo = cd->ninfo;
+            PMIX_GDS_FETCH_KV(rc2, nspeer, &cb2);
+            if (PMIX_SUCCESS == rc2) {
+                while (NULL != (kvtmp = (pmix_kval_t *) pmix_list_remove_first(&cb2.kvs))) {
+                    if (list_has_key(&cb.kvs, kvtmp->key)) {
+                        PMIX_RELEASE(kvtmp);
+                    } else {
+                        pmix_list_append(&cb.kvs, &kvtmp->super);
+                    }
+                }
+                rc = PMIX_SUCCESS;
+            }
+            /* the info array is the caller's and the key is ours */
+            cb2.info = NULL;
+            cb2.ninfo = 0;
+            cb2.key = NULL;
+            PMIX_DESTRUCT(&cb2);
         }
     }
     if (PMIX_SUCCESS != rc) {


### PR DESCRIPTION
Fixes #4225.

## The defect

`_satisfy_request()` decided "our own store does not have this" from the
*status* of a fetch that never named the key.

A non-reserved key is deliberately fetched with `cb.key = NULL` — "return
everything this proc has", an optimization on the guess that one value will
be followed by others. For a rank of a namespace we have registered, our
store always holds that rank's job-level keys. So the fetch reported
success on the strength of `pmix.grank`, `pmix.appnum` and `pmix.hname`;
the fallback to the target namespace's own gds module never ran; and the
reply went back with nine job-level keys and no modex.

Being a *success*, that reply also stopped `pmix_server_get()` from
reaching its `request:` label, so the direct modex that would have found
the value was never issued either. The client stored what came back,
missed, and returned not-found for a key one node away.

The two trigger conditions in the issue are the two halves of that:

* **co-residency** is what gives the daemon a local client of the target
  namespace, and so a gds module for it that is not the daemon's own —
  `gds/shmem3` keeps a job's modex in a shared segment the daemon's `hash`
  module cannot read. Without it there is no second module and the request
  goes up to the host as it always did.
* **a remote target** is what stops the client reading that segment itself.

## The fix

Decide it on the result rather than the status: when the fetch named the
key its status still settles the question, and when it did not, look for
the key in what came back.

The fallback then has to **merge** rather than replace. Neither store
contains the other on this path — the namespace's module holds the modex
its own clients contributed, while ours holds what a cross-namespace direct
modex put there, because `dmdx_cbfunc()` stores a reply against `mypeer`
whenever the requester's namespace differs from the target's. Where both
name a key (each keeps its own copy of the job-level data) the copy we
already have wins: a key that appears twice reaches the client's
`process_values()` as an aggregate and hands the application a
`PMIX_DATA_ARRAY` where it asked for a scalar.

## The test

Neither suite we run today puts both conditions on the table at once.
`examples/dynamic` spawns and connects, so it reaches the cross-namespace
arm, but the swarm runs it one rank per node and the child lands where no
parent is — the daemon never holds two namespaces. Nothing in `test/unit`
can reach it at all: it needs a rank that is genuinely somewhere else,
served by a different PMIx server.

`examples/xnspace_modex.c` puts both up. Each namespace posts one
non-reserved key per rank and fences its own job — which is what files a
job's whole modex in every daemon hosting one of its procs. The parent then
spawns with `map_by=node`, so the children land back on the nodes the
parents already occupy; the two sides connect; and every proc reads the key
from every proc of the other namespace. The peer on this node is answered
locally and always worked. The peer on the far node is the one that did not.

The key is deliberately not `pmix.`-prefixed: a reserved key is fetched by
name, and it was the non-reserved path that the defect lived in.

It is wired into `contrib/dockerswarm/run-server-tests.sh`. That suite's
header is emphatic about one rank per node, for good reason, so both the
header and the geometry case say why this is the one stage that needs two.

## Verification

| Configuration | Result |
| --- | --- |
| 2 nodes x 2 slots, `gds/shmem3`, **without** the fix | **3 of 4 ranks FAIL**, each on exactly the cross-namespace peer on the *other* node; job exits non-zero |
| same, **with** the fix | 4/4 PASS |
| same, `--pmixmca gds hash` | 4/4 PASS |
| `make check`, macOS and Linux (clean trees) | 0 FAIL across all five suites, warning-free |

The failing run:

```
xnspace_modex: ...@2:0: PMIx_Get(...@1:1, xnspace.probe) failed: PMIX_ERR_INVALID_NAMESPACE
xnspace_modex: ...@1:0: PMIx_Get(...@2:1, xnspace.probe) failed: PMIX_ERR_INVALID_NAMESPACE
xnspace_modex: ...@1:1: PMIx_Get(...@2:0, xnspace.probe) failed: PMIX_ERR_INVALID_NAMESPACE
```

One difference from the issue as filed: the client-side status reproduced
here is `PMIX_ERR_INVALID_NAMESPACE` rather than `PMIX_ERR_NOT_FOUND`. The
server-side mechanism is the same one; this client has no prior tracker for
the other namespace where Open MPI's does, so the miss surfaces under a
different code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FS2Q1N6A2MVS58KZZNV6JU
