### PR TITLE
Pass on what the host gave us instead of failing the job

### DIFF
--- a/docs/review-notes.rst
+++ b/docs/review-notes.rst
@@ -242,6 +242,68 @@ was verified by re-breaking each half separately: without the sharing the
 "second job is given the first job's session segment" assertion fails,
 and without the ownership move the surviving-job read crashes.
 
+An absent app-level value fails a child's launch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Found in the ``src/mca/pmdl`` review (2026-08-19), closed 2026-09-02.
+``pmdl/ompi``'s ``setup_fork`` treated a missing ``PMIX_PROCDIR``,
+``PMIX_WDIR`` or ``PMIX_APP_ARGV`` as an error, and a ``setup_fork``
+error fails ``PMIx_server_setup_fork`` and with it the child's launch.
+The entry deferred it on the question of "which of them Open MPI
+genuinely requires".
+
+That question does not have to be answered here, and trying to answer it
+was what kept the entry open.  PMIx is not the component that knows what
+Open MPI needs: it is filling in an environment for a library that reads
+it, and a library that cannot start without ``OMPI_MCA_initial_wdir``
+will say so far more usefully than a failed ``setup_fork`` ever could.
+So the rule is now the one the sizes already followed — **pass on what we
+have** — and it is applied to every value the function fetches, not only
+to the three the entry named: ``PMIX_PROCDIR``, ``PMIX_WDIR``,
+``PMIX_APP_ARGV``, ``PMIX_APPNUM``, ``PMIX_LOCAL_RANK``,
+``PMIX_NODE_RANK``, and the per-app ``PMIX_APP_SIZE`` / ``PMIX_APPLDR``
+lists.  A value that cannot be fetched, or cannot be read as the type it
+needs, leaves its envar unset and the function keeps going.
+
+**The same defect was one function up, and worse.**  ``register_nspace``
+returned the fetch error for a missing ``PMIX_UNIV_SIZE``,
+``PMIX_JOB_SIZE`` or ``PMIX_JOB_NUM_APPS``, and that error fails
+``PMIx_server_register_nspace`` itself — the host cannot register the
+namespace at all, never mind fork a child into it.  It fires in the
+tree's own tests: ``PMIX_UNIV_SIZE`` is a *session*-realm key, so a host
+that registers a job without naming a session has no universe size to
+find, and ``test/simple``'s ``simptest --model`` was logging
+``PMIX_ERR_NOT_FOUND`` out of ``register_nspace`` and then hanging with
+``PMIX_ERR_UNREACH``.  It now runs to "Test finished OK!".  The sizes
+already had a "not known" state — ``UINT32_MAX``, which ``setup_fork``
+declines to pass on — so the fix was to leave the field in it.  An
+unknown app count now also stops before the per-app lists instead of
+looping ``UINT32_MAX`` times.
+
+Two details of the shape are worth keeping.  A **type mismatch is
+treated as an absence** rather than as an error: the host stored
+something under a key this module can only read one way, and the choice
+is between leaving the variable unset and setting it from whatever else
+was in the union — never between failing and not failing.  And the
+per-app lists are **all-or-nothing**: ``setenv_per_app`` joins one value
+per app into a single space-separated string, which means nothing if a
+value is missing from the middle of it, so a value it cannot get drops
+the whole variable rather than emitting a short list.
+
+What still comes back out of ``setup_fork`` is the module's own failure
+— out of memory, or an environment it could not write.  That is now all
+a non-``PMIX_SUCCESS`` return from ``setenv_string`` means, which is why
+the ``PMIX_ERROR_LOG`` at its call sites is still right.
+
+Covered by ``test/unit/pmdl_envars``, which registers a third namespace
+carrying the ompi personality and the job size and *nothing else*, then
+forks a rank out of it.  Verified by breaking each half separately: with
+the ``register_nspace`` change reverted the registration fails, and with
+only ``setenv_string``'s tolerance reverted the fork does.  The case is
+placed ahead of the MPMD one deliberately — a session-realm value
+registered by an earlier job in the same process is still there for a
+later one, so a job registered after it *does* find a universe size.
+
 Review log
 ----------
 

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -52,7 +52,7 @@ At a glance
 * :ref:`todo-mca-param-owner`
 * :ref:`todo-iof-pull-handle`
 
-**Deferred work — 10**
+**Deferred work — 9**
 
 * :ref:`todo-resolve-peers-wildcard`
 * :ref:`todo-get-pointer-values`
@@ -61,7 +61,6 @@ At a glance
 * :ref:`todo-global-syslog`
 * :ref:`todo-compress-length-prefix`
 * :ref:`todo-pcompress-init-fatal`
-* :ref:`todo-pmdl-app-values`
 * :ref:`todo-fabric-inventory`
 * :ref:`todo-server-genvars`
 
@@ -362,27 +361,6 @@ one of the five leaves the slot ``NULL``.  It is recorded because the
 first module that does implement it will inherit the inconsistency, and
 the fix — degrade to the base default rather than fail — should be made
 then, with a module to test it against.
-
-.. _todo-pmdl-app-values:
-
-An absent app-level value fails a child's launch
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Found in the ``src/mca/pmdl`` review (2026-08-19), and narrowed rather
-than closed.  ``pmdl/ompi``'s ``setup_fork`` treats a missing
-``PMIX_PROCDIR``, ``PMIX_WDIR`` or ``PMIX_APP_ARGV`` as an error, and a
-``setup_fork`` error fails ``PMIx_server_setup_fork`` and with it the
-child's launch — so a host that registers a namespace without one of them
-cannot start the job at all, however little the resulting envar matters
-(``OMPI_MCA_initial_wdir`` is informational).
-
-The review closed the case that was unambiguously wrong —
-``PMIX_REINCARNATION``, which nothing in PMIx sets and no host is obliged
-to provide, so its absence now means "zero restarts" rather than a failed
-launch.  The three above are ordinary registration data that every host
-in practice provides, so making them optional would be a behavior change
-with nothing to test it against; it needs a decision about which of them
-Open MPI genuinely requires.
 
 .. _todo-fabric-inventory:
 

--- a/src/mca/pmdl/ompi/AGENTS.md
+++ b/src/mca/pmdl/ompi/AGENTS.md
@@ -160,12 +160,24 @@ Two things about the match are load-bearing, and both were wrong:
 ### `register_nspace`
 
 For a tracked nspace, fetches `PMIX_UNIV_SIZE`, `PMIX_JOB_SIZE`,
-`PMIX_JOB_NUM_APPS`, and (best-effort) `PMIX_LOCAL_SIZE` from GDS into the
-tracker. If the job has more than one application, it also builds
-space-separated `OMPI_APP_SIZES` (per-app `PMIX_APP_SIZE`) and
-`OMPI_FIRST_RANKS` (per-app `PMIX_APPLDR`) strings and caches them back
-into GDS as job info via `PMIX_GDS_CACHE_JOB_INFO`. A single-app job
-returns early. An unknown nspace returns `PMIX_ERR_TAKE_NEXT_OPTION`.
+`PMIX_JOB_NUM_APPS` and `PMIX_LOCAL_SIZE` from GDS into the tracker. If
+the job has more than one application, it also builds space-separated
+`OMPI_APP_SIZES` (per-app `PMIX_APP_SIZE`) and `OMPI_FIRST_RANKS`
+(per-app `PMIX_APPLDR`) strings and caches them back into GDS as job info
+via `PMIX_GDS_CACHE_JOB_INFO`. A single-app job returns early. An unknown
+nspace returns `PMIX_ERR_TAKE_NEXT_OPTION`.
+
+**Every one of those fetches is best-effort**, the same rule `setup_fork`
+follows below. A size the host did not register leaves its field at
+`UINT32_MAX` — the tracker's "not known" — and `setup_fork` then does not
+pass it on. Returning the fetch error instead failed
+`PMIx_server_register_nspace` outright, so a host that registered a
+namespace without one of them could not register it at all. That was not
+theoretical: `PMIX_UNIV_SIZE` is a *session*-realm key
+(`pmix_check_session_info`), so a host that registers a job without
+naming a session has none to find, which is exactly what `test/simple`'s
+`simptest --model` does. An unknown app count is also a reason to stop
+before the per-app lists rather than to loop `UINT32_MAX` times.
 
 ### `setup_fork`
 
@@ -184,19 +196,31 @@ drawing sizes from the tracker and per-rank facts from GDS:
   `OMPI_COMM_WORLD_NODE_RANK` (`PMIX_NODE_RANK`);
 - multi-app only: `OMPI_APP_CTX_NUM_PROCS` (per-app sizes),
   `OMPI_FIRST_RANKS` (per-app leaders);
-- `OMPI_MCA_num_restarts` (`PMIX_REINCARNATION`), **if the host provided
-  one** — nothing in PMIx sets that key, and a host that has never
-  restarted the proc has nothing to say. Its absence is not a failure;
-  returning the fetch error from here fails `PMIx_server_setup_fork` and
-  with it the child's launch;
+- `OMPI_MCA_num_restarts` (`PMIX_REINCARNATION`) — nothing in PMIx sets
+  that key, and a host that has never restarted the proc has nothing to
+  say;
 - finally, every `myenvars` value collected by `parse_file_envars`.
 
-Three rules govern the whole function:
+Four rules govern the whole function:
 
+- **Every value it passes on is best-effort.** A host is not obliged to
+  have registered everything Open MPI would like, so a value the module
+  cannot fetch — or cannot read as the type it needs — leaves that envar
+  unset and the function keeps going. It does *not* return the fetch
+  error: a `setup_fork` error fails `PMIx_server_setup_fork` and with it
+  the child's launch, which is far too heavy a response to a missing
+  `PMIX_WDIR`. If Open MPI genuinely needs something that was not
+  supplied, the Open MPI library is the component that knows it and will
+  say so. The only statuses that come back out are the module's own
+  failures — out of memory, or an environment it could not write, which
+  is all a non-`SUCCESS` return from `setenv_string` means. The per-app
+  lists are all-or-nothing: `setenv_per_app` needs every app's value to
+  build a meaningful space-separated string, so one it cannot get drops
+  the whole variable.
 - **The per-app values belong to the child's app, not to ours.**
   `PMIX_WDIR` and `PMIX_APP_ARGV` are app-level, so they are fetched with
   the appnum of `proc` — read from the datastore, defaulting to 0 the way
-  `gds/hash` does when a host names none. `pmix_globals.appnum` is *my*
+  `gds/hash` does when a host names none or names one we cannot read. `pmix_globals.appnum` is *my*
   appnum, which in a server is the server's; using it handed every rank in
   an MPMD job the first app's command line and working directory.
 - **Only the per-app breakdown is multi-app-only.** Everything after it —

--- a/src/mca/pmdl/ompi/pmdl_ompi.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi.c
@@ -748,242 +748,6 @@ static pmix_status_t setup_nspace_kv(pmix_namespace_t *nptr, pmix_kval_t *kv)
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t register_nspace(pmix_namespace_t *nptr)
-{
-    pmdl_nspace_t *ns, *ns2;
-    char *ev1, **tmp;
-    pmix_proc_t wildcard, undef;
-    pmix_status_t rc;
-    pmix_kval_t *kv;
-    pmix_info_t info[2];
-    uint32_t n;
-    pmix_cb_t cb;
-
-    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
-                        "pmdl:ompi: register_nspace for %s", nptr->nspace);
-
-    /* see if we already have this nspace */
-    ns = NULL;
-    PMIX_LIST_FOREACH (ns2, &mynspaces, pmdl_nspace_t) {
-        if (PMIX_CHECK_NSPACE(ns2->nspace, nptr->nspace)) {
-            ns = ns2;
-            break;
-        }
-    }
-    if (NULL == ns) {
-        /* we don't know anything about this one or
-         * it doesn't have any ompi-based apps */
-        return PMIX_ERR_TAKE_NEXT_OPTION;
-    }
-
-    /* do we already have the data we need here? Servers are
-     * allowed to call register_nspace multiple times with
-     * different info, so we really need to recheck those
-     * values that haven't already been filled */
-    PMIX_LOAD_PROCID(&wildcard, nptr->nspace, PMIX_RANK_WILDCARD);
-
-    /* fetch the universe size */
-    if (UINT32_MAX == ns->univ_size) {
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        cb.proc = &wildcard;
-        cb.copy = true;
-        cb.key = PMIX_UNIV_SIZE;
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-        cb.key = NULL;
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DESTRUCT(&cb);
-            return rc;
-        }
-        /* the data is the first value on the cb.kvs list */
-        if (1 != pmix_list_get_size(&cb.kvs)) {
-            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-            PMIX_DESTRUCT(&cb);
-            return PMIX_ERR_BAD_PARAM;
-        }
-        kv = (pmix_kval_t *) pmix_list_get_first(&cb.kvs);
-        ns->univ_size = kv->value->data.uint32;
-        PMIX_DESTRUCT(&cb);
-    }
-
-    /* fetch the job size */
-    if (UINT32_MAX == ns->job_size) {
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        cb.proc = &wildcard;
-        cb.copy = true;
-        cb.key = PMIX_JOB_SIZE;
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-        cb.key = NULL;
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DESTRUCT(&cb);
-            return rc;
-        }
-        /* the data is the first value on the cb.kvs list */
-        if (1 != pmix_list_get_size(&cb.kvs)) {
-            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-            PMIX_DESTRUCT(&cb);
-            return PMIX_ERR_BAD_PARAM;
-        }
-        kv = (pmix_kval_t *) pmix_list_get_first(&cb.kvs);
-        ns->job_size = kv->value->data.uint32;
-        PMIX_DESTRUCT(&cb);
-    }
-
-    /* fetch the number of apps */
-    if (UINT32_MAX == ns->num_apps) {
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        cb.proc = &wildcard;
-        cb.copy = true;
-        cb.key = PMIX_JOB_NUM_APPS;
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-        cb.key = NULL;
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DESTRUCT(&cb);
-            return rc;
-        }
-        /* the data is the first value on the cb.kvs list */
-        if (1 != pmix_list_get_size(&cb.kvs)) {
-            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-            PMIX_DESTRUCT(&cb);
-            return PMIX_ERR_BAD_PARAM;
-        }
-        kv = (pmix_kval_t *) pmix_list_get_first(&cb.kvs);
-        ns->num_apps = kv->value->data.uint32;
-        PMIX_DESTRUCT(&cb);
-    }
-
-    /* fetch the number of local peers */
-    if (UINT32_MAX == ns->local_size) {
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        cb.proc = &wildcard;
-        cb.copy = true;
-        cb.key = PMIX_LOCAL_SIZE;
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-        cb.key = NULL;
-        /* it is okay if there are no local procs */
-        if (PMIX_SUCCESS == rc) {
-            /* the data is the first value on the cb.kvs list */
-            if (1 != pmix_list_get_size(&cb.kvs)) {
-                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-                PMIX_DESTRUCT(&cb);
-                return PMIX_ERR_BAD_PARAM;
-            }
-            kv = (pmix_kval_t *) pmix_list_get_first(&cb.kvs);
-            ns->local_size = kv->value->data.uint32;
-        }
-        /* the cb owns whatever the fetch put on its list either way */
-        PMIX_DESTRUCT(&cb);
-    }
-
-    if (1 == ns->num_apps) {
-        return PMIX_SUCCESS;
-    }
-
-    /* construct the list of app sizes */
-    PMIX_LOAD_PROCID(&undef, nptr->nspace, PMIX_RANK_UNDEF);
-    PMIX_INFO_LOAD(&info[0], PMIX_APP_INFO, NULL, PMIX_BOOL);
-    tmp = NULL;
-    for (n = 0; n < ns->num_apps; n++) {
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        cb.proc = &undef;
-        cb.copy = true;
-        cb.info = info;
-        cb.ninfo = 2;
-        cb.key = PMIX_APP_SIZE;
-        PMIX_INFO_LOAD(&info[1], PMIX_APPNUM, &n, PMIX_UINT32);
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-        PMIX_INFO_DESTRUCT(&info[1]);
-        cb.key = NULL;
-        cb.info = NULL;
-        cb.ninfo = 0;
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DESTRUCT(&cb);
-            return rc;
-        }
-        /* the data is the first value on the cb.kvs list */
-        if (1 != pmix_list_get_size(&cb.kvs)) {
-            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-            PMIX_DESTRUCT(&cb);
-            return PMIX_ERR_BAD_PARAM;
-        }
-        kv = (pmix_kval_t *) pmix_list_get_first(&cb.kvs);
-        pmix_asprintf(&ev1, "%u", kv->value->data.uint32);
-        PMIx_Argv_append_nosize(&tmp, ev1);
-        free(ev1);
-        PMIX_DESTRUCT(&cb);
-    }
-    PMIX_INFO_DESTRUCT(&info[0]);
-
-    if (NULL != tmp) {
-        ev1 = PMIx_Argv_join(tmp, ' ');
-        PMIx_Argv_free(tmp);
-        PMIX_INFO_LOAD(&info[0], "OMPI_APP_SIZES", ev1, PMIX_STRING);
-        free(ev1);
-        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr, info, 1);
-        PMIX_INFO_DESTRUCT(&info[0]);
-        if (PMIX_SUCCESS != rc) {
-            /* setup_fork hands this to the child from the datastore, so a
-             * silent failure here is a job that comes up without it */
-            PMIX_ERROR_LOG(rc);
-            return rc;
-        }
-    }
-
-    /* construct the list of app leaders */
-    PMIX_INFO_LOAD(&info[0], PMIX_APP_INFO, NULL, PMIX_BOOL);
-    tmp = NULL;
-    for (n = 0; n < ns->num_apps; n++) {
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        cb.proc = &undef;
-        cb.copy = true;
-        cb.info = info;
-        cb.ninfo = 2;
-        cb.key = PMIX_APPLDR;
-        PMIX_INFO_LOAD(&info[1], PMIX_APPNUM, &n, PMIX_UINT32);
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
-        PMIX_INFO_DESTRUCT(&info[1]);
-        cb.key = NULL;
-        cb.info = NULL;
-        cb.ninfo = 0;
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DESTRUCT(&cb);
-            return rc;
-        }
-        /* the data is the first value on the cb.kvs list */
-        if (1 != pmix_list_get_size(&cb.kvs)) {
-            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-            PMIX_DESTRUCT(&cb);
-            return PMIX_ERR_BAD_PARAM;
-        }
-        kv = (pmix_kval_t *) pmix_list_get_first(&cb.kvs);
-        pmix_asprintf(&ev1, "%u", kv->value->data.uint32);
-        PMIx_Argv_append_nosize(&tmp, ev1);
-        free(ev1);
-        PMIX_DESTRUCT(&cb);
-    }
-    PMIX_INFO_DESTRUCT(&info[0]);
-
-    if (NULL != tmp) {
-        ev1 = PMIx_Argv_join(tmp, ' ');
-        PMIx_Argv_free(tmp);
-        tmp = NULL;
-        PMIX_INFO_LOAD(&info[0], "OMPI_FIRST_RANKS", ev1, PMIX_STRING);
-        free(ev1);
-        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr, info, 1);
-        PMIX_INFO_DESTRUCT(&info[0]);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            return rc;
-        }
-    }
-
-    return PMIX_SUCCESS;
-}
-
 /* Fetch one value from our own datastore, copying it into "value" - which
  * the caller destructs.  "qual"/"nqual" carry the app-level qualifiers,
  * if any.  Every call site used to open-code this, and each copy had to
@@ -1019,7 +783,164 @@ static pmix_status_t fetch_value(const pmix_proc_t *proc, const char *key,
     return rc;
 }
 
-/* the same, for a value the caller wants as a string it does not own */
+/* the same, for a value this module keeps as a uint32.  A host is not
+ * obliged to have registered every one of them, so "value" is left as it
+ * was - UINT32_MAX, this module's "not known" - and false returned when
+ * there is nothing usable to read. */
+static bool fetch_u32(const pmix_proc_t *proc, const char *key,
+                      pmix_info_t *qual, size_t nqual, uint32_t *value)
+{
+    pmix_value_t val;
+    pmix_status_t rc;
+
+    PMIX_VALUE_CONSTRUCT(&val);
+    rc = fetch_value(proc, key, qual, nqual, &val);
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Value_get_number(&val, value, PMIX_UINT32);
+    }
+    PMIX_VALUE_DESTRUCT(&val);
+    if (PMIX_SUCCESS != rc) {
+        pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                            "pmdl:ompi: no %s available", key);
+        return false;
+    }
+    return true;
+}
+
+/* Build the list Open MPI expects for a per-app key: one value per app,
+ * in appnum order, for the caller to join into a single space-separated
+ * string.  That string only means anything if we have every app's value,
+ * so one we cannot get returns NULL and the caller leaves its variable
+ * unset rather than emitting a short list. */
+static char **collect_per_app(const pmix_proc_t *undef, uint32_t num_apps,
+                              const char *key)
+{
+    pmix_info_t info[2];
+    char *ev1, **tmp = NULL;
+    uint32_t n, u32 = 0;
+
+    PMIX_INFO_LOAD(&info[0], PMIX_APP_INFO, NULL, PMIX_BOOL);
+    for (n = 0; n < num_apps; n++) {
+        PMIX_INFO_LOAD(&info[1], PMIX_APPNUM, &n, PMIX_UINT32);
+        if (!fetch_u32(undef, key, info, 2, &u32)) {
+            PMIX_INFO_DESTRUCT(&info[1]);
+            PMIx_Argv_free(tmp);
+            tmp = NULL;
+            break;
+        }
+        PMIX_INFO_DESTRUCT(&info[1]);
+        if (0 > pmix_asprintf(&ev1, "%u", u32)) {
+            PMIx_Argv_free(tmp);
+            tmp = NULL;
+            break;
+        }
+        PMIx_Argv_append_nosize(&tmp, ev1);
+        free(ev1);
+    }
+    PMIX_INFO_DESTRUCT(&info[0]);
+    return tmp;
+}
+
+static pmix_status_t register_nspace(pmix_namespace_t *nptr)
+{
+    pmdl_nspace_t *ns, *ns2;
+    char *ev1, **tmp;
+    pmix_proc_t wildcard, undef;
+    pmix_status_t rc;
+    pmix_info_t info[1];
+
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:ompi: register_nspace for %s", nptr->nspace);
+
+    /* see if we already have this nspace */
+    ns = NULL;
+    PMIX_LIST_FOREACH (ns2, &mynspaces, pmdl_nspace_t) {
+        if (PMIX_CHECK_NSPACE(ns2->nspace, nptr->nspace)) {
+            ns = ns2;
+            break;
+        }
+    }
+    if (NULL == ns) {
+        /* we don't know anything about this one or
+         * it doesn't have any ompi-based apps */
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    /* do we already have the data we need here? Servers are
+     * allowed to call register_nspace multiple times with
+     * different info, so we really need to recheck those
+     * values that haven't already been filled.  None of them is
+     * required: a host that has not given us a size leaves the field at
+     * UINT32_MAX, which setup_fork reads as "not known" and simply does
+     * not pass on.  Returning the fetch error instead failed
+     * PMIx_server_register_nspace outright, so a host that registered a
+     * namespace without, say, PMIX_UNIV_SIZE could not register it at
+     * all */
+    PMIX_LOAD_PROCID(&wildcard, nptr->nspace, PMIX_RANK_WILDCARD);
+
+    if (UINT32_MAX == ns->univ_size) {
+        fetch_u32(&wildcard, PMIX_UNIV_SIZE, NULL, 0, &ns->univ_size);
+    }
+    if (UINT32_MAX == ns->job_size) {
+        fetch_u32(&wildcard, PMIX_JOB_SIZE, NULL, 0, &ns->job_size);
+    }
+    if (UINT32_MAX == ns->num_apps) {
+        fetch_u32(&wildcard, PMIX_JOB_NUM_APPS, NULL, 0, &ns->num_apps);
+    }
+    /* it is okay if there are no local procs */
+    if (UINT32_MAX == ns->local_size) {
+        fetch_u32(&wildcard, PMIX_LOCAL_SIZE, NULL, 0, &ns->local_size);
+    }
+
+    /* the per-app lists below only mean anything to an MPMD job, and we
+     * cannot count the apps if the host never said how many there are */
+    if (UINT32_MAX == ns->num_apps || 1 == ns->num_apps) {
+        return PMIX_SUCCESS;
+    }
+
+    /* construct the list of app sizes */
+    PMIX_LOAD_PROCID(&undef, nptr->nspace, PMIX_RANK_UNDEF);
+    tmp = collect_per_app(&undef, ns->num_apps, PMIX_APP_SIZE);
+
+    if (NULL != tmp) {
+        ev1 = PMIx_Argv_join(tmp, ' ');
+        PMIx_Argv_free(tmp);
+        PMIX_INFO_LOAD(&info[0], "OMPI_APP_SIZES", ev1, PMIX_STRING);
+        free(ev1);
+        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr, info, 1);
+        PMIX_INFO_DESTRUCT(&info[0]);
+        if (PMIX_SUCCESS != rc) {
+            /* setup_fork hands this to the child from the datastore, so a
+             * silent failure here is a job that comes up without it */
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+    }
+
+    /* construct the list of app leaders */
+    tmp = collect_per_app(&undef, ns->num_apps, PMIX_APPLDR);
+
+    if (NULL != tmp) {
+        ev1 = PMIx_Argv_join(tmp, ' ');
+        PMIx_Argv_free(tmp);
+        PMIX_INFO_LOAD(&info[0], "OMPI_FIRST_RANKS", ev1, PMIX_STRING);
+        free(ev1);
+        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr, info, 1);
+        PMIX_INFO_DESTRUCT(&info[0]);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* the same, for a value the caller wants as a string it does not own.
+ * A key the host never registered - or registered as something we cannot
+ * read as a string - leaves "var" unset and is not an error: we set what
+ * we can and leave it to Open MPI to complain about anything it actually
+ * needs.  Only a failure to write the environment is reported back. */
 static pmix_status_t setenv_string(const pmix_proc_t *proc, const char *key,
                                    pmix_info_t *qual, size_t nqual,
                                    const char *var, char ***env)
@@ -1030,15 +951,20 @@ static pmix_status_t setenv_string(const pmix_proc_t *proc, const char *key,
     PMIX_VALUE_CONSTRUCT(&val);
     rc = fetch_value(proc, key, qual, nqual, &val);
     if (PMIX_SUCCESS != rc) {
+        pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                            "pmdl:ompi: no %s - leaving %s unset", key, var);
         PMIX_VALUE_DESTRUCT(&val);
-        return rc;
+        return PMIX_SUCCESS;
     }
     if (PMIX_STRING != val.type || NULL == val.data.string) {
         /* the host stored something else under a key we can only use as
-         * a string - saying so beats setting the variable from whatever
-         * else was in the union */
+         * a string - leaving the variable unset beats setting it from
+         * whatever else was in the union */
+        pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                            "pmdl:ompi: %s is not a string - leaving %s unset",
+                            key, var);
         PMIX_VALUE_DESTRUCT(&val);
-        return PMIX_ERR_TYPE_MISMATCH;
+        return PMIX_SUCCESS;
     }
     rc = PMIx_Setenv(var, val.data.string, true, env);
     PMIX_VALUE_DESTRUCT(&val);
@@ -1065,40 +991,14 @@ static pmix_status_t setenv_per_app(const pmix_proc_t *proc, uint32_t num_apps,
                                     const char *key, const char *var, char ***env)
 {
     pmix_proc_t undef;
-    pmix_info_t info[2];
-    pmix_value_t val;
     pmix_status_t rc;
-    char *ev1, **tmp = NULL;
-    uint32_t n, u32;
+    char *ev1, **tmp;
 
     PMIX_LOAD_PROCID(&undef, proc->nspace, PMIX_RANK_UNDEF);
-    PMIX_INFO_LOAD(&info[0], PMIX_APP_INFO, NULL, PMIX_BOOL);
-    for (n = 0; n < num_apps; n++) {
-        PMIX_INFO_LOAD(&info[1], PMIX_APPNUM, &n, PMIX_UINT32);
-        PMIX_VALUE_CONSTRUCT(&val);
-        rc = fetch_value(&undef, key, info, 2, &val);
-        PMIX_INFO_DESTRUCT(&info[1]);
-        if (PMIX_SUCCESS == rc) {
-            rc = PMIx_Value_get_number(&val, &u32, PMIX_UINT32);
-        }
-        PMIX_VALUE_DESTRUCT(&val);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_INFO_DESTRUCT(&info[0]);
-            PMIx_Argv_free(tmp);
-            return rc;
-        }
-        if (0 > pmix_asprintf(&ev1, "%u", u32)) {
-            PMIX_INFO_DESTRUCT(&info[0]);
-            PMIx_Argv_free(tmp);
-            return PMIX_ERR_NOMEM;
-        }
-        PMIx_Argv_append_nosize(&tmp, ev1);
-        free(ev1);
-    }
-    PMIX_INFO_DESTRUCT(&info[0]);
-
+    tmp = collect_per_app(&undef, num_apps, key);
     if (NULL == tmp) {
+        pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                            "pmdl:ompi: incomplete %s - leaving %s unset", key, var);
         return PMIX_SUCCESS;
     }
     ev1 = PMIx_Argv_join(tmp, ' ');
@@ -1152,10 +1052,19 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
 
-    /* the sizes come from register_nspace, and a host is not obliged to
-     * have given us every one of them.  UINT32_MAX is this module's "not
-     * known", so pass on what we have rather than telling the child its
-     * universe holds four billion procs */
+    /* Everything below is best-effort.  A host is not obliged to have
+     * registered every value Open MPI would like, and a value we cannot
+     * get leaves its envar unset rather than failing this function -
+     * setup_fork's error fails PMIx_server_setup_fork and with it the
+     * child's launch, which is far too heavy a response to, say, a
+     * missing initial working directory.  If Open MPI genuinely needs
+     * something we could not supply, the Open MPI library is the one
+     * that knows it and will say so.  Only our own failures - out of
+     * memory, an environment we could not write - are returned.
+     *
+     * The sizes come from register_nspace.  UINT32_MAX is this module's
+     * "not known", so pass on what we have rather than telling the child
+     * its universe holds four billion procs */
 
     /* pass universe size */
     if (UINT32_MAX != ns->univ_size) {
@@ -1193,6 +1102,7 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
     /* pass an envar so the proc can find any files it had prepositioned */
     rc = setenv_string(proc, PMIX_PROCDIR, NULL, 0, "OMPI_FILE_LOCATION", env);
     if (PMIX_SUCCESS != rc) {
+        /* setenv_string only fails if it could not write the environment */
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -1206,12 +1116,8 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
     rc = fetch_value(proc, PMIX_APPNUM, NULL, 0, &val);
     if (PMIX_SUCCESS == rc) {
         rc = PMIx_Value_get_number(&val, &appnum, PMIX_UINT32);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_VALUE_DESTRUCT(&val);
-            return rc;
-        }
-    } else {
+    }
+    if (PMIX_SUCCESS != rc) {
         /* a host that never said is telling us there is only one app -
          * the same assumption gds/hash makes when registering a proc */
         appnum = 0;
@@ -1229,18 +1135,15 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env, char ***pr
         goto quals;
     }
 
-    /* pass its command. */
+    /* pass its command, if the host gave us one */
     PMIX_VALUE_CONSTRUCT(&val);
     rc = fetch_value(&undef, PMIX_APP_ARGV, qual, 2, &val);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    if (PMIX_SUCCESS != rc || PMIX_STRING != val.type || NULL == val.data.string) {
+        pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                            "pmdl:ompi: no usable %s - leaving OMPI_COMMAND and "
+                            "OMPI_ARGV unset", PMIX_APP_ARGV);
         PMIX_VALUE_DESTRUCT(&val);
-        goto quals;
-    }
-    if (PMIX_STRING != val.type || NULL == val.data.string) {
-        PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
-        PMIX_VALUE_DESTRUCT(&val);
-        rc = PMIX_ERR_TYPE_MISMATCH;
+        rc = PMIX_SUCCESS;
         goto quals;
     }
     /* an argv with nothing in it splits to no argv at all, so there is
@@ -1298,13 +1201,16 @@ quals:
         rc = PMIx_Value_get_number(&val, &u16, PMIX_UINT16);
     }
     PMIX_VALUE_DESTRUCT(&val);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        return rc;
-    }
-    rc = setenv_number("OMPI_COMM_WORLD_LOCAL_RANK", (unsigned long) u16, env);
-    if (PMIX_SUCCESS != rc) {
-        return rc;
+    if (PMIX_SUCCESS == rc) {
+        rc = setenv_number("OMPI_COMM_WORLD_LOCAL_RANK", (unsigned long) u16, env);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+    } else {
+        pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                            "pmdl:ompi: no local rank for %s - leaving "
+                            "OMPI_COMM_WORLD_LOCAL_RANK unset",
+                            PMIX_NAME_PRINT(proc));
     }
 
     /* get the proc's node rank */
@@ -1314,13 +1220,16 @@ quals:
         rc = PMIx_Value_get_number(&val, &u16, PMIX_UINT16);
     }
     PMIX_VALUE_DESTRUCT(&val);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        return rc;
-    }
-    rc = setenv_number("OMPI_COMM_WORLD_NODE_RANK", (unsigned long) u16, env);
-    if (PMIX_SUCCESS != rc) {
-        return rc;
+    if (PMIX_SUCCESS == rc) {
+        rc = setenv_number("OMPI_COMM_WORLD_NODE_RANK", (unsigned long) u16, env);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+    } else {
+        pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                            "pmdl:ompi: no node rank for %s - leaving "
+                            "OMPI_COMM_WORLD_NODE_RANK unset",
+                            PMIX_NAME_PRINT(proc));
     }
 
     /* the per-app breakdown only means anything to an MPMD job */
@@ -1344,18 +1253,13 @@ quals:
     rc = fetch_value(proc, PMIX_REINCARNATION, NULL, 0, &val);
     if (PMIX_SUCCESS == rc) {
         rc = PMIx_Value_get_number(&val, &n, PMIX_UINT32);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_VALUE_DESTRUCT(&val);
-            return rc;
-        }
-        PMIX_VALUE_DESTRUCT(&val);
+    }
+    PMIX_VALUE_DESTRUCT(&val);
+    if (PMIX_SUCCESS == rc) {
         rc = setenv_number("OMPI_MCA_num_restarts", n, env);
         if (PMIX_SUCCESS != rc) {
             return rc;
         }
-    } else {
-        PMIX_VALUE_DESTRUCT(&val);
     }
 
     /* add any envars we collected from param files.  This, and the

--- a/test/unit/pmdl_envars.c
+++ b/test/unit/pmdl_envars.c
@@ -50,6 +50,7 @@
 
 #define APP0NS "pmdl-mpmd"
 #define APP1NS "pmdl-single"
+#define APP2NS "pmdl-sparse"
 
 static int failures = 0;
 static int checks = 0;
@@ -172,6 +173,40 @@ static pmix_status_t register_job(const char *nspace, uint32_t napps)
     return (PMIX_OPERATION_SUCCEEDED == rc) ? PMIX_SUCCESS : rc;
 }
 
+/* register an ompi job the sparse way: the personality and the job size,
+ * and nothing else.  No universe size, no app count, no app array (so no
+ * working directory and no command line) and no proc array (so no
+ * procdir and no local or node rank).  A host is not obliged to provide
+ * any of them, and every one of them used to fail either the
+ * registration or the launch */
+static pmix_status_t register_sparse_job(const char *nspace, uint32_t jobsize)
+{
+    void *jinfo;
+    pmix_data_array_t darray;
+    pmix_nspace_t ns;
+    pmix_info_t *info;
+    pmix_status_t rc;
+    size_t ninfo;
+    uint32_t u32;
+
+    /* the API takes a pmix_nspace_t, so hand it one - a bare string
+     * literal is a smaller region than the parameter's type and the
+     * compiler says so once this function is inlined */
+    PMIX_LOAD_NSPACE(ns, nspace);
+
+    PMIX_INFO_LIST_START(jinfo);
+    PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_PERSONALITY, "ompi", PMIX_STRING);
+    u32 = jobsize;
+    PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_JOB_SIZE, &u32, PMIX_UINT32);
+    PMIX_INFO_LIST_CONVERT(rc, jinfo, &darray);
+    PMIX_INFO_LIST_RELEASE(jinfo);
+    info = (pmix_info_t *) darray.array;
+    ninfo = darray.size;
+    rc = PMIx_server_register_nspace(ns, jobsize, info, ninfo, NULL, NULL);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+    return (PMIX_OPERATION_SUCCEEDED == rc) ? PMIX_SUCCESS : rc;
+}
+
 int main(int argc, char **argv)
 {
     pmix_mca_base_var_file_value_t *fv, *fvnext;
@@ -280,6 +315,45 @@ int main(int argc, char **argv)
         }
     }
 
+    /* --- a host that registered almost nothing --- */
+
+    /* None of what this job leaves out is required.  register_nspace
+     * used to return the fetch error for a missing PMIX_UNIV_SIZE, which
+     * fails PMIx_server_register_nspace outright, and setup_fork used to
+     * do the same for a missing PMIX_PROCDIR, PMIX_WDIR or
+     * PMIX_APP_ARGV, which fails PMIx_server_setup_fork and with it the
+     * child's launch.  Both now pass on what they have: if Open MPI
+     * genuinely needs one of these, the Open MPI library is what says so */
+    rc = register_sparse_job(APP2NS, 2);
+    ok(PMIX_SUCCESS == rc, "a namespace registers without a universe size");
+    if (PMIX_SUCCESS == rc) {
+        PMIX_LOAD_PROCID(&proc, APP2NS, 1);
+        env = NULL;
+        rc = pmix_pmdl.setup_fork(&proc, &env);
+        ok(PMIX_SUCCESS == rc, "setup_fork succeeds with almost nothing registered");
+        /* what it could work out, it still passes on */
+        ok_env(env, "OMPI_COMM_WORLD_SIZE", "2");
+        ok_env(env, "OMPI_COMM_WORLD_RANK", "1");
+        /* and what it was never given, it leaves alone */
+        ok(NULL == envval(env, "OMPI_UNIVERSE_SIZE"),
+           "no universe size envar when the host named no session");
+        ok(NULL == envval(env, "OMPI_NUM_APP_CTX"),
+           "no app count envar when the host named no apps");
+        ok(NULL == envval(env, "OMPI_MCA_initial_wdir"),
+           "no working directory envar when the host named none");
+        ok(NULL == envval(env, "OMPI_COMMAND") && NULL == envval(env, "OMPI_ARGV"),
+           "no command envars when the host gave no argv");
+        ok(NULL == envval(env, "OMPI_FILE_LOCATION"),
+           "no file location envar when the host gave no procdir");
+        ok(NULL == envval(env, "OMPI_COMM_WORLD_LOCAL_RANK"),
+           "no local rank envar when the host registered no proc data");
+        /* the MCA-file values do not depend on any of that */
+        ev = envval(env, "OMPI_MCA_btl");
+        ok(NULL != ev && 0 == strcmp(ev, "self,tcp"),
+           "and the MCA param file values still reach the child");
+        PMIx_Argv_free(env);
+    }
+
     /* --- an MPMD job's per-app values --- */
 
     rc = register_job(APP0NS, 2);
@@ -346,6 +420,7 @@ int main(int argc, char **argv)
 
     pmix_pmdl.deregister_nspace(APP0NS);
     pmix_pmdl.deregister_nspace(APP1NS);
+    pmix_pmdl.deregister_nspace(APP2NS);
 
     PMIx_server_finalize();
 


### PR DESCRIPTION
`pmdl/ompi` treated a value it could not fetch as an error.

In `setup_fork` that meant a missing `PMIX_PROCDIR`, `PMIX_WDIR` or
`PMIX_APP_ARGV` failed `PMIx_server_setup_fork` and with it the child's
launch. In `register_nspace` a missing `PMIX_UNIV_SIZE`, `PMIX_JOB_SIZE`
or `PMIX_JOB_NUM_APPS` failed `PMIx_server_register_nspace` outright, so
the host could not register the namespace at all.

None of that is ours to decide. This module is filling in an environment
for a library that reads it, and PMIx is not the component that knows
what Open MPI requires. If Open MPI genuinely needs a value we could not
supply, the Open MPI library is the one that will say so — far more
usefully than a failed `setup_fork`. So the rule is now the one the sizes
already followed: **set what we can, and leave unset what we were not
given.**

That covers every value both functions fetch: `PMIX_PROCDIR`,
`PMIX_WDIR`, `PMIX_APP_ARGV`, `PMIX_APPNUM`, `PMIX_LOCAL_RANK`,
`PMIX_NODE_RANK`, the per-app `PMIX_APP_SIZE`/`PMIX_APPLDR` lists, and
the four sizes. A type mismatch counts as an absence — the host stored
something we can only read one way, and the choice there is between
leaving the variable unset and setting it from whatever else was in the
union, never between failing and not failing. The per-app lists stay
all-or-nothing, since a space-separated string with a value missing from
the middle of it means nothing. What still comes back out is our own
failure: out of memory, or an environment we could not write.

## The `register_nspace` half was not theoretical

`PMIX_UNIV_SIZE` is a session-realm key, so a host that registers a job
without naming a session has no universe size to find — which is exactly
what `test/simple`'s `simptest --model` does. It was logging
`PMIX_ERR_NOT_FOUND` out of `register_nspace` and then hanging with
`PMIX_ERR_UNREACH`. It now runs to `Test finished OK!`.

The sizes already had a "not known" state (`UINT32_MAX`, which
`setup_fork` declines to pass on), so the fix was to leave the field in
it. An unknown app count now also stops before the per-app lists instead
of looping `UINT32_MAX` times. Two open-coded fetch loops collapse into
`fetch_u32` / `collect_per_app`, which `setup_fork` now shares.

## Testing

`test/unit/pmdl_envars` gains a namespace registered with the ompi
personality and the job size and *nothing else*, then forks a rank out of
it. It is placed ahead of the MPMD case deliberately: a session-realm
value registered by an earlier job in the same process is still there for
a later one, so a job registered after it *does* find a universe size.

Verified by breaking each half separately — with the `register_nspace`
change reverted the registration fails, and with only `setenv_string`'s
tolerance reverted the fork does.

- macOS: clean build; `test/` 21/21; `test/unit/` 109 pass + 2 skip.
- Linux container, `PMIX_ENABLE_DEBUG 0` and default visibility: 0
  warnings, 179 tests, 0 failures.
- `sphinx-build -W` clean.

## Docs

Closes the `todo-pmdl-app-values` entry in `docs/todo.rst` and records the
reasoning in `docs/review-notes.rst`. `src/mca/pmdl/ompi/AGENTS.md` gains
the best-effort rule for both functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aUqWg9dofxcNxHUaJjVpp