### PR TITLE
Degrade to the base default when a pcompress module cannot start

### DIFF
--- a/docs/review-notes.rst
+++ b/docs/review-notes.rst
@@ -304,6 +304,42 @@ placed ahead of the MPMD one deliberately — a session-realm value
 registered by an earlier job in the same process is still there for a
 later one, so a job registered after it *does* find a universe size.
 
+A pcompress module's ``init()`` failure is fatal to library init
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Found in the ``src/mca/pcompress`` review (2026-08-20), closed
+2026-09-02.  The framework's stance is that having no compressor is not
+an error — ``pmix_compress_base_select()`` returns ``PMIX_SUCCESS`` when
+it selects nothing and the base's no-op stubs stay in place — but if the
+winning module's ``init()`` failed, that status was returned, and
+``pmix_rte_init()`` treats a non-``SUCCESS`` return from the select as
+fatal to ``PMIx_Init``.  A compression library that loaded but could not
+start took the whole library down, where an absent one was shrugged off.
+
+The entry deferred it for want of a module to test against: no component
+implements ``init``, and all five leave the slot ``NULL``.  That
+condition does not need a test to resolve, because it is not a question
+about behavior under load — the two states are already indistinguishable
+to everything downstream.  A module that cannot start and a module that
+was never installed leave ``pmix_compress`` holding exactly the same six
+stubs, so they get the same answer: ``select()`` now returns
+``PMIX_SUCCESS`` in every case.
+
+Three details make the degradation complete rather than merely
+non-fatal.  The assignment to ``pmix_compress`` was already *after* the
+``init()`` call, so a failed module never becomes the active one — which
+also means ``pcompress_base_close()`` never calls its ``finalize``, the
+right outcome for something that never started.  The user is still told:
+the base stubs emit the ``help-pcompress.txt`` "unavailable" message the
+first time anything tries to compress, so the only thing lost is the
+crash.  And the failure is not swallowed for a developer either — it is
+reported at verbose level 2 with the component's name and the status it
+returned.
+
+The code is still unreachable, and that is the point: it is written for
+the first module that implements ``init``, so that module inherits the
+framework's documented stance instead of a contradiction of it.
+
 Review log
 ----------
 

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -52,7 +52,7 @@ At a glance
 * :ref:`todo-mca-param-owner`
 * :ref:`todo-iof-pull-handle`
 
-**Deferred work — 9**
+**Deferred work — 8**
 
 * :ref:`todo-resolve-peers-wildcard`
 * :ref:`todo-get-pointer-values`
@@ -60,22 +60,22 @@ At a glance
 * :ref:`todo-tool-delete-notice`
 * :ref:`todo-global-syslog`
 * :ref:`todo-compress-length-prefix`
-* :ref:`todo-pcompress-init-fatal`
 * :ref:`todo-fabric-inventory`
 * :ref:`todo-server-genvars`
 
-**Coverage gaps — 20.**  No CI race detector; the switchyard's
+**Coverage gaps — 21.**  No CI race detector; the switchyard's
 out-of-memory and finalize-race arms; a multi-namespace
 ``PMIx_Disconnect``; a spawn hosted by ``simptest``; the
 ``PMIx_Compute_distances`` reply path; two ``src/tool`` fixes (SIGCONT
 stdin, late finalize reply); the ``PMIx_Init`` debugger-wait teardown;
-leak validation of the process-set and resolve examples; ``pps``
-against a live process table; the compressed half of ``preg``;
-``psensor/file`` drop counts; a blocking ``psec`` handshake; ``psec/munge``'s
-failed encode; ``plog/smtp`` (never run at all); the ``pnet`` fabric
-calls; ``pnet/simptest``'s end-to-end launch; the TSD finalize ordering;
-``gds/shmem3`` on macOS; the client-side tombstone generation; and three
-``src/hwloc`` findings.  Each is listed in full under `Coverage gaps`_.
+leak validation of the process-set and resolve examples; ``pps`` against
+a live process table; the compressed half of ``preg``; ``psensor/file``
+drop counts; a ``pcompress`` module that fails to start; a blocking
+``psec`` handshake; ``psec/munge``'s failed encode; ``plog/smtp`` (never
+run at all); the ``pnet`` fabric calls; ``pnet/simptest``'s end-to-end
+launch; the TSD finalize ordering; ``gds/shmem3`` on macOS; the
+client-side tombstone generation; and three ``src/hwloc`` findings.
+Each is listed in full under `Coverage gaps`_.
 
 **Review coverage — 3 directories unread**, plus ``src/common`` and four
 lower-priority directories whose code has moved since their review.
@@ -341,27 +341,6 @@ Note also that the caller has already read the whole blob into memory by
 the time it gets here, so the amplification is bounded by what the PTL
 was willing to accept.
 
-.. _todo-pcompress-init-fatal:
-
-A pcompress module's ``init()`` failure is fatal to library init
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Also from the ``src/mca/pcompress`` review, and dead code today.
-
-The framework's documented stance is that having no compressor is not an
-error: ``pmix_compress_base_select()`` returns ``PMIX_SUCCESS`` when it
-selects nothing, and the base default no-op stubs stay in place.  But if
-the winning module's ``init()`` fails, that error is returned, and
-``pmix_init.c`` treats a non-``SUCCESS`` return from the select as fatal
-to ``PMIx_Init``.  So a compression library that loads but cannot start
-would take the whole library down, where an absent one is shrugged off.
-
-Unreachable: no module in the framework implements ``init``, and every
-one of the five leaves the slot ``NULL``.  It is recorded because the
-first module that does implement it will inherit the inconsistency, and
-the fix — degrade to the base default rather than fail — should be made
-then, with a module to test it against.
-
 .. _todo-fabric-inventory:
 
 Fabric inventory collection is a stub
@@ -488,6 +467,14 @@ Coverage gaps
 * ``pps`` **has never been validated against a live process-table
   server.**  Its no-connect paths are covered by the tools smoke test;
   the proc-table rendering is not.
+* **A** ``pcompress`` **module that fails to start has nothing to fail
+  it with.**  ``pmix_compress_base_select()`` now degrades to the base's
+  no-op stubs when the winning module's ``init()`` returns an error,
+  rather than failing ``PMIx_Init``.  No component implements ``init``
+  — all five leave the slot ``NULL`` — so reaching that branch needs a
+  component written to fail on purpose.  The behavior it replaced was
+  equally unreachable; the branch is written for the first module that
+  does implement ``init``.
 * **The compressed half of** ``preg`` **is invisible to a build with no
   compression library.**  ``preg/compress`` disables itself when
   ``pcompress`` has no module, so on such a build — a stock macOS

--- a/src/mca/pcompress/AGENTS.md
+++ b/src/mca/pcompress/AGENTS.md
@@ -104,7 +104,7 @@ implements; the rest stay `NULL`.
 
 | Field | Signature | Purpose |
 |-------|-----------|---------|
-| `init` | `(void) -> int` | one-time setup; **unset by every module today** |
+| `init` | `(void) -> int` | one-time setup; **unset by every module today**. A non-`PMIX_SUCCESS` return means "I cannot run" — the base defaults stay in place and the library carries on without compression |
 | `finalize` | `(void) -> int` | teardown; called by base close only if non-`NULL` |
 | `compress` | `(const uint8_t *in, size_t size, uint8_t **out, size_t *nbytes) -> bool` | compress a byte block; `true` if it did |
 | `decompress` | `(uint8_t **out, size_t *outlen, const uint8_t *in, size_t len) -> bool` | inflate a block produced by `compress` |
@@ -124,7 +124,10 @@ caller ships the data uncompressed.
 `init` and `finalize` are declared in the struct but set by **neither**
 the base default module **nor** any of the four components — they are always
 `NULL` in practice. `finalize` is safely guarded (`pcompress_base_close`
-calls it only when non-`NULL`).
+calls it only when non-`NULL`), and a failing `init` is too: it degrades
+to the base default rather than failing `PMIx_Init` (see `select` above).
+Both behaviors are written for the first module that does implement them;
+neither can be reached today.
 
 `get_decompressed_size` and `get_decompressed_strlen`, by contrast, **are**
 implemented by every module (the base default, `zlib`, `zlibng`, `zstd`
@@ -395,6 +398,15 @@ rule: a new format means a new scheme, not a silent change to this one).
   copies it into `pmix_compress`. Selecting nothing is **not** an error —
   the base default stubs simply remain in place. (Contrast `ptl`/`preg`,
   which treat "no component" as fatal; `pcompress` degrades to a no-op.)
+  **It returns `PMIX_SUCCESS` in every case**, including a winning
+  module whose `init` fails: `pmix_rte_init()` treats any other status as
+  fatal to `PMIx_Init`, and a compression library that loads but cannot
+  start is the same situation as one that was never installed — the
+  stubs are what the library will call either way. A failed `init`
+  leaves `pmix_compress` untouched, so the module never becomes the
+  active one and `pcompress_base_close` never calls its `finalize`
+  either. The degradation is not silent: the first attempt to compress
+  anything emits the "unavailable" help message.
 
 The framework is opened and selected during library init in
 [`src/runtime/pmix_init.c`](../../runtime/pmix_init.c) for **all** process

--- a/src/mca/pcompress/base/pcompress_base_select.c
+++ b/src/mca/pcompress/base/pcompress_base_select.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,9 +28,24 @@
 #include "src/mca/pcompress/base/base.h"
 #include "src/util/pmix_output.h"
 
+/* Having no compressor is not an error - this framework's whole stance is
+ * that compression is an optimization, so a tree built without any of the
+ * libraries, or a run that selects nothing, leaves the base's no-op stubs
+ * in place and carries on. `pmix_compress` starts out as those stubs and
+ * is only overwritten once a module is ready to take over.
+ *
+ * That is why this function returns PMIX_SUCCESS even when it selects
+ * nothing at all: the one caller, `pmix_rte_init()`, treats any other
+ * status as fatal to PMIx_Init. A module that loads and then fails to
+ * start is the same situation as one that was never there - the stubs
+ * are still what the library will call - so it gets the same answer,
+ * and the user still hears about it: the first attempt to compress
+ * anything shows the "unavailable" help message. Returning the init
+ * error instead would take the whole library down over a compression
+ * library that could not start, where an absent one is shrugged off. */
 int pmix_compress_base_select(void)
 {
-    int ret = PMIX_SUCCESS;
+    int ret;
     pmix_mca_base_component_t *best_component = NULL;
     pmix_compress_base_module_t *best_module = NULL;
 
@@ -49,19 +64,28 @@ int pmix_compress_base_select(void)
                                 (pmix_mca_base_component_t **) &best_component, NULL)) {
         /* This will only happen if no component was selected,
          * in which case we use the default one */
-        goto cleanup;
+        return PMIX_SUCCESS;
     }
 
     /* Initialize the winner */
     if (NULL != best_module) {
         if (NULL != best_module->init) {
-            if (PMIX_SUCCESS != (ret = best_module->init())) {
-                goto cleanup;
+            ret = best_module->init();
+            if (PMIX_SUCCESS != ret) {
+                /* leave the base defaults in place - and leave them in
+                 * place completely: the module never becomes
+                 * `pmix_compress`, so nothing calls its finalize either */
+                pmix_output_verbose(2, pmix_pcompress_base_framework.framework_output,
+                                    "pcompress: %s failed to initialize (%d) - "
+                                    "continuing without compression",
+                                    (NULL == best_component) ? "selected component"
+                                                             : best_component->pmix_mca_component_name,
+                                    ret);
+                return PMIX_SUCCESS;
             }
         }
         pmix_compress = *best_module;
     }
 
-cleanup:
-    return ret;
+    return PMIX_SUCCESS;
 }


### PR DESCRIPTION
Closes the `todo-pcompress-init-fatal` entry.

This framework's stance is that having no compressor is not an error:
`pmix_compress_base_select()` returns `PMIX_SUCCESS` when it selects
nothing, and the base's no-op stubs stay in place. But if the winning
module's `init()` failed, that status was returned, and `pmix_rte_init()`
treats a non-`SUCCESS` return from the select as fatal to `PMIx_Init`. A
compression library that loaded but could not start took the whole library
down, where an absent one is shrugged off.

Select now returns `PMIX_SUCCESS` in every case. The two states it was
distinguishing are already indistinguishable to everything downstream: a
module that cannot start and a module that was never installed leave
`pmix_compress` holding exactly the same six stubs, so they get the same
answer.

Three details make the degradation complete rather than merely non-fatal:

- The assignment to `pmix_compress` was already *after* the `init()` call,
  so a failed module never becomes the active one — which also means
  `pcompress_base_close()` never calls its `finalize`, the right outcome
  for something that never started.
- The user is still told: the base stubs emit the `help-pcompress.txt`
  "unavailable" message the first time anything tries to compress. The
  only thing lost is the crash.
- The failure is not swallowed for a developer either — it is reported at
  verbose level 2 with the component's name and the status it returned.

The branch is unreachable today (no component implements `init`; all five
leave the slot `NULL`), and that is the point: it is written so the first
module that does implement `init` inherits the framework's stated stance
rather than a contradiction of it. Recorded as a coverage gap in
`docs/todo.rst` for the same reason.

## Testing

Behavior change is by inspection — there is no module to reach it with.

- macOS: clean build; `test/` 21/21; `test/unit/` 109 pass + 2 skip.
- Linux container, `PMIX_ENABLE_DEBUG 0` and default visibility: 0
  warnings, 179 tests, 0 failures.
- `sphinx-build -W` clean.

## Docs

Retires the entry from `docs/todo.rst` (with the reasoning moved to
`docs/review-notes.rst`) and updates `src/mca/pcompress/AGENTS.md`, which
had documented the old behavior in three places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aUqWg9dofxcNxHUaJjVpp