### PR TITLE
Address a batch of Coverity reports

### DIFF
--- a/examples/iof_watcher.c
+++ b/examples/iof_watcher.c
@@ -59,8 +59,12 @@ static void regcb(pmix_status_t status, size_t refid, void *cbdata)
 {
     mylock_t *lock = (mylock_t *) cbdata;
 
+    /* the registration id is what a tool would keep in order to
+     * PMIx_IOF_deregister later; this one watches until it exits, so it
+     * has no use for the id and does not record it */
+    EXAMPLES_HIDE_UNUSED_PARAMS(refid);
+
     lock->status = status;
-    lock->count = (int) refid;
     DEBUG_WAKEUP_THREAD(lock);
 }
 

--- a/src/common/pmix_pfexec.c
+++ b/src/common/pmix_pfexec.c
@@ -165,19 +165,26 @@ void pmix_pfexec_check_complete(int sd, short args, void *cbdata)
     pmix_pfexec_child_t *child;
     bool stillalive = false;
     pmix_proc_t wildcard;
+    pmix_nspace_t nspace;
     PMIX_HIDE_UNUSED_PARAMS(sd, args);
 
+    /* Everything below asks about the completed child's NAMESPACE, not
+     * about the child, so take the name while the child is indisputably
+     * ours - before the delist drops the list's reference. The caddy's
+     * own reference does outlive that (see PMIX_PFEXEC_CHK_COMPLETE),
+     * but a copied name needs no such argument to be safe. */
+    PMIX_LOAD_NSPACE(nspace, cd->child->proc.nspace);
     child_delist(cd->child);
     /* see if any more children from this nspace are alive */
     PMIX_LIST_FOREACH (child, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
-        if (PMIX_CHECK_NSPACE(child->proc.nspace, cd->child->proc.nspace)) {
+        if (PMIX_CHECK_NSPACE(child->proc.nspace, nspace)) {
             stillalive = true;
         }
     }
     if (!stillalive) {
         /* generate a local event indicating job terminated */
         PMIX_INFO_LOAD(&cd->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-        PMIX_LOAD_NSPACE(wildcard.nspace, cd->child->proc.nspace);
+        PMIX_LOAD_NSPACE(wildcard.nspace, nspace);
         PMIX_INFO_LOAD(&cd->info[1], PMIX_EVENT_AFFECTED_PROC, &wildcard, PMIX_PROC);
         rc = PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pmix_globals.myid, PMIX_RANGE_PROC_LOCAL,
                                cd->info, 2, _ntfy_done, cd);
@@ -706,6 +713,7 @@ void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata)
      * caddy holds this child across two evtimers, and a completion posted
      * before we got here is still queued behind us with a reference of
      * its own; whichever of the two runs last is the one that frees it. */
+    const pid_t pid = child->pid;
     PMIX_RETAIN(child);
     scd->child = child;
     child_delist(child);
@@ -716,9 +724,10 @@ void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata)
        value. */
     pmix_output_verbose(5, pmix_client_globals.spawn_output, "%s SENDING SIGCONT",
                          PMIX_NAME_PRINT(&pmix_globals.myid));
-    /* through the caddy, which is the reference that keeps this alive
-     * now that the list's is gone */
-    sigproc(scd->child->pid, SIGCONT);
+    /* the pid read above, before the delist: this stage needs nothing
+     * else from the child, and a pid_t is not something a reference
+     * count has to keep alive for it */
+    sigproc(pid, SIGCONT);
 
     /* wait a little to give the proc a chance to wakeup, then continue
      * to the SIGTERM stage */

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1881,6 +1881,19 @@ static pmix_status_t _hash_store_modex(pmix_proc_t *proc,
     PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, &kv, &cnt, PMIX_KVAL);
 
     while (PMIX_SUCCESS == rc) {
+        /* Every path below reads through this value - the type test
+         * that follows, both stores, and pmix_hash_store() itself - so
+         * the check they all need is made here, once, rather than on
+         * whichever one happens to carry it. A successful unpack always
+         * leaves a value behind, allocating it before filling it in, so
+         * a NULL is not a contribution that named no value: it is an
+         * unpacker that answered success without producing one. */
+        if (NULL == kv.value) {
+            rc = PMIX_ERR_BAD_PARAM;
+            PMIX_ERROR_LOG(rc);
+            PMIX_DESTRUCT(&kv);
+            return rc;
+        }
         /* An entry whose value is PMIX_UNDEF is not data - it is the
          * contributing process saying the key is gone. The modex is
          * additive, so a contribution that merely stops carrying a key
@@ -1888,7 +1901,7 @@ static pmix_status_t _hash_store_modex(pmix_proc_t *proc,
          * is where it is acted on. We can take the key straight out,
          * unlike a datastore whose copy is in a segment it cannot
          * rewrite. */
-        if (NULL != kv.value && PMIX_UNDEF == kv.value->type) {
+        if (PMIX_UNDEF == kv.value->type) {
             pmix_rank_t drank = (PMIX_RANK_UNDEF == proc->rank) ? 0 : proc->rank;
             rc = pmix_hash_remove_data(&trk->remote, drank, kv.key, NULL);
             if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {

--- a/src/mca/gds/shmem3/gds_shmem3.c
+++ b/src/mca/gds/shmem3/gds_shmem3.c
@@ -625,27 +625,6 @@ job_construct(
     job->conni = NULL;
 }
 
-static pmix_tma_t *
-get_tma_by_shmem3_id(
-    pmix_gds_shmem3_job_t *job,
-    pmix_gds_shmem3_job_shmem3_id_t shmem3_id
-) {
-    switch (shmem3_id) {
-        case PMIX_GDS_SHMEM3_JOB_ID:
-            return &job->smdata->tma;
-        case PMIX_GDS_SHMEM3_MODEX_ID:
-            return &job->smmodex->tma;
-        case PMIX_GDS_SHMEM3_SESSION_ID:
-            return &job->session->smdata->tma;
-        case PMIX_GDS_SHMEM3_INVALID_ID:
-        default:
-            PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
-            // This is an internal error.
-            abort();
-            return NULL;
-    }
-}
-
 static const char *
 get_shmem3_id_name(
     pmix_gds_shmem3_job_shmem3_id_t shmem3_id
@@ -688,34 +667,10 @@ emit_segment_usage_stats(
 }
 
 static void
-emit_shmem3_usage_stats(
-    pmix_gds_shmem3_job_t *job,
-    pmix_gds_shmem3_job_shmem3_id_t shmem3_id
-) {
-    pmix_status_t rc = PMIX_SUCCESS;
-
-    pmix_shmem_t *shmem3;
-    rc = pmix_gds_shmem3_get_job_shmem3_by_id(
-        job, shmem3_id, &shmem3
-    );
-    if (PMIX_UNLIKELY(rc != PMIX_SUCCESS)) {
-        PMIX_ERROR_LOG(rc);
-        return;
-    }
-
-    emit_segment_usage_stats(
-        shmem3,
-        get_tma_by_shmem3_id(job, shmem3_id),
-        get_shmem3_id_name(shmem3_id)
-    );
-}
-
-static void
 job_destruct(
     pmix_gds_shmem3_job_t *job
 ) {
     PMIX_GDS_SHMEM3_VVOUT_HERE();
-    pmix_status_t rc = PMIX_SUCCESS;
 
     if (job->nspace_id) {
         free(job->nspace_id);
@@ -729,7 +684,7 @@ job_destruct(
     }
 
     /* Retired modex generations. Each holds its own segment handle, and
-     * the class destructor gives it back the same way the loop below
+     * the class destructor gives it back the same way the block below
      * does for the current one. */
     pmix_gds_shmem3_chain_destruct(&job->job_chain);
     pmix_gds_shmem3_chain_destruct(&job->modex_chain);
@@ -772,39 +727,27 @@ job_destruct(
     }
 
     /* Neither the job's nor the session's published segments are in the
-     * loop below: both are held by chains, which gave them back above.
+     * block below: both are held by chains, which gave them back above.
      * What is left is the modex BUILD slot - a generation that was being
      * assembled when this job went away and was never published. */
-    static const pmix_gds_shmem3_job_shmem3_id_t shmem3_ids[] = {
-        PMIX_GDS_SHMEM3_MODEX_ID,
-        PMIX_GDS_SHMEM3_INVALID_ID
-    };
-    for (int i = 0; shmem3_ids[i] != PMIX_GDS_SHMEM3_INVALID_ID; ++i) {
-        const pmix_gds_shmem3_job_shmem3_id_t sid = shmem3_ids[i];
-
-        pmix_shmem_t *shmem3;
-        rc = pmix_gds_shmem3_get_job_shmem3_by_id(job, sid, &shmem3);
-        if (PMIX_UNLIKELY(rc != PMIX_SUCCESS)) {
-            /* Neither of the two ids above can fail this lookup - both
-             * handles are allocated by job_construct(). Checked anyway,
-             * and skipped rather than returned on, because abandoning
-             * the loop would also abandon the arena reservation and the
-             * session reference given back below. */
-            PMIX_ERROR_LOG(rc);
-            continue;
-        }
-        if (pmix_gds_shmem3_has_status(job, sid, PMIX_GDS_SHMEM3_MINE)) {
+    if (NULL != job->modex_shmem3) {
+        if (NULL != job->smmodex &&
+            (job->modex_shmem3_status & PMIX_GDS_SHMEM3_MINE)) {
             // Emit usage status before we potentially destroy the segment.
-            emit_shmem3_usage_stats(job, sid);
+            emit_segment_usage_stats(
+                job->modex_shmem3, &job->smmodex->tma,
+                get_shmem3_id_name(PMIX_GDS_SHMEM3_MODEX_ID)
+            );
             // Points to a pmix_gds_shmem3_alloc_ctx_t.
-            PMIX_RELEASE(get_tma_by_shmem3_id(job, sid)->data_context);
+            PMIX_RELEASE(job->smmodex->tma.data_context);
         }
-        // Releases memory for the structures located in shared-memory. This
-        // will also unmap in case we need to later remap something in the
-        // address space covered by this.
-        PMIX_RELEASE(shmem3);
-        // Invalidate the shmem3 flags.
-        pmix_gds_shmem3_clearall_status(job, sid);
+        /* Releases memory for the structures located in shared-memory.
+         * This will also unmap in case we need to later remap something
+         * in the address space covered by this. */
+        PMIX_RELEASE(job->modex_shmem3);
+        job->modex_shmem3 = NULL;
+        job->smmodex = NULL;
+        job->modex_shmem3_status = 0;
     }
 
     /* The arena goes last: releasing it unmaps everything inside it, so
@@ -1774,10 +1717,9 @@ init_client_side_sm_data(
     if (PMIX_GDS_SHMEM3_SESSION_ID == shmem3_id) {
         return pmix_gds_shmem3_publish_session_segment(job->session);
     }
-    if (PMIX_GDS_SHMEM3_JOB_ID == shmem3_id) {
-        return pmix_gds_shmem3_publish_job_segment(job);
-    }
-    return PMIX_SUCCESS;
+    /* Only the job segment is left: the switch above abort()s on any
+     * other id, so there is no fourth case to fall through to. */
+    return pmix_gds_shmem3_publish_job_segment(job);
 }
 
 static pmix_status_t
@@ -2818,9 +2760,14 @@ pack_shmem3_connection_info(
          * tracker this segment belongs to, which a client cannot work out
          * from the segment because the answer decides whether to map it.
          * A job that named no session sends nothing, and its receiver
-         * keeps the private tracker it was constructed with. */
+         * keeps the private tracker it was constructed with.
+         *
+         * A session blob is never packed for a job without a session
+         * tracker: pack_shmem3_seg_blob() returns before describing one,
+         * and the by-id lookup above refuses the segment - so the id is
+         * safe to read here. */
         if (PMIX_GDS_SHMEM3_SESSION_ID != shmem3_id ||
-            NULL == job->session || UINT32_MAX == job->session->id) {
+            UINT32_MAX == job->session->id) {
             break;
         }
         PMIX_DESTRUCT(&kv);

--- a/src/util/pmix_net.c
+++ b/src/util/pmix_net.c
@@ -343,10 +343,12 @@ bool pmix_net_samenetwork(const struct sockaddr_storage *addr1,
         if (0 != nbytes && 0 != memcmp(a6_1, a6_2, nbytes)) {
             return false;
         }
-        if (0 != nbits) {
-            /* nbits is 1..7 here, so neither shift is undefined, and
-             * nbytes is at most 15 - a prefix that ends mid-byte cannot
-             * be 128 */
+        /* nbits is 1..7 here, so neither shift is undefined, and nbytes
+         * is at most 15 - a prefix that ends mid-byte cannot be 128.
+         * The index is bounded in the test rather than only in this
+         * comment: the two are correlated through prefixlen, which no
+         * reader of this line alone - human or analyzer - can see. */
+        if (0 != nbits && nbytes < sizeof(inaddr1.sin6_addr)) {
             uint8_t mask = (uint8_t) (0xFFU << (8 - nbits));
             if ((a6_1[nbytes] & mask) != (a6_2[nbytes] & mask)) {
                 return false;


### PR DESCRIPTION
Five Coverity reports, one commit each. Four are analyzer artifacts where
the code was already correct but its invariant lived only in a comment;
one is a dead store. No behavior changes.

| CID | Where | Commit |
|-----|-------|--------|
| 505757-61 | `gds/shmem3` `job_destruct()`, `init_client_side_sm_data()`, `pack_shmem3_connection_info()` | Describe the modex build slot directly instead of looping over one id |
| 505635 | `pmix_net_samenetwork()` | Bound the partial-byte index in samenetwork's own test |
| 505625-26 | `pmix_pfexec` completion and kill caddies | Read what the pfexec caddies need before dropping the list reference |
| 505480 | `gds/hash` `_hash_store_modex()` | Check the unpacked modex value once, where all of its readers are |
| 505464 | `examples/iof_watcher.c` | Stop recording an IOF registration id nobody reads |

**shmem3** — `job_destruct()` walked a static array of segment ids that has
held a single entry, the modex build slot, since the job and session slots
moved onto chains. Coverity cannot fold the array load, so it runs the loop
with the job id too, where the block just above has already NULLed
`job->shmem3`/`job->smdata`. Replaced with a direct release shaped like the
block above it, which also picks up the NULL-`smmodex` guard that block
already has - a job whose construction did not finish can carry the MINE
flag with no mapped data. Two genuinely unreachable statements went with
it: the trailing `return PMIX_SUCCESS` in `init_client_side_sm_data()` (the
switch above `abort()`s on any other id) and the `NULL == job->session`
test in `pack_shmem3_connection_info()` (both callers refuse a session blob
for a job without a session tracker).

**pmix_net** — the index into the 16-byte address and the leftover bit count
are correlated through `prefixlen`, so an index of 16 arrives only with zero
leftover bits. That was written in a comment and nowhere else; it is now in
the test. Existing unit cases (/128, /127, /24, /28, clamped /150) pin the
behavior.

**pfexec** — both sites retain the child, call `child_delist()` (which drops
the list's reference), then read a field back out. Safe, but resting on a
refcount invisible at the point of use. Neither read wants the child:
`check_complete()` wants the completed child's namespace, `kill_proc()` wants
a pid. Both are now taken before the delist. Lifetimes are unchanged.

**gds/hash** — the deletion test guarded one of four reads of the unpacked
value; the two `store_qualified()` calls and `pmix_hash_store()` read through
it unguarded. Moved the check to just after the unpack so it covers every
reader. A successful `PMIX_KVAL` unpack always allocates the value, so a NULL
is a bad buffer rather than a contribution that named no value - hence
`PMIX_ERR_BAD_PARAM` rather than a skip.

**iof_watcher** — the registration callback stored the refid in the lock's
`count` field, truncating a `size_t` into an `int`; nothing read it. The
write was not racy (the mutex `DEBUG_WAKEUP_THREAD` takes and
`DEBUG_WAIT_THREAD` reacquires orders it against the waiter), it was simply
dead.

CID 505465 in `pmix_cmd_line.c` is not here: it was fixed on master by
77502f4c5 (2026-08-25), which added the `NULL != shorts` guard the report
asks for. The scan predates it.

Tested on Linux (the tree's own configuration does not build `gds/shmem3`):
`--enable-devel-check --disable-python-bindings`, warning-free build, and
`make check` green - 0 FAIL / 0 ERROR across all five suites.
