### PR TITLE
Build psec/munge only when MUNGE is explicitly requested

### DIFF
--- a/docs/installing-pmix/configure-cli-options/optional-support-libraries.rst
+++ b/docs/installing-pmix/configure-cli-options/optional-support-libraries.rst
@@ -6,7 +6,9 @@ CLI Options for optional support libraries
 The following ``configure`` command line options are for PMIx's
 :ref:`optional support libraries
 <label-install-optional-support-libraries>` |mdash| libraries PMIx will
-use if it finds them, and build without if it does not.
+use if it finds them, and build without if it does not. The one
+exception is ``--with-munge``, which is opt-in only: nothing looks for
+MUNGE unless that option is given.
 
 Compression
 -----------
@@ -46,6 +48,14 @@ Other capabilities
   builds the ``psec/munge`` component, which authenticates PMIx
   connections using MUNGE credentials.
 
+  Unlike the other options on this page, MUNGE is **opt-in only**:
+  ``configure`` does not go looking for it, so a host that has MUNGE
+  installed builds no ``psec/munge`` component unless this option is
+  given. That is deliberate |mdash| ``psec/munge`` outranks the default
+  ``psec/native`` mechanism, so building it changes how every PMIx
+  connection on that installation is authenticated. Ask for it
+  explicitly, or do not get it.
+
 * ``--with-smtp[=VALUE]``:
 
   Specifies where to find `libesmtp
@@ -73,8 +83,10 @@ Permitted values, and one important behavior
    that you want it |mdash| so if it cannot find a usable copy it will
    **abort** rather than quietly build without it. Omit the option
    entirely to get a best-effort search that silently continues on
-   failure. This is why a build that "should have had compression" and
-   does not is almost always one where the option was left off.
+   failure |mdash| except for ``--with-munge``, which is opt-in only and
+   searches for nothing when it is omitted. This is why a build that
+   "should have had compression" and does not is almost always one where
+   the option was left off.
 
 * ``--with-zstd-libdir=LIBDIR``:
 * ``--with-zlibng-libdir=LIBDIR``:

--- a/docs/installing-pmix/optional-support-libraries.rst
+++ b/docs/installing-pmix/optional-support-libraries.rst
@@ -6,7 +6,8 @@ Optional support libraries
 Beyond the :ref:`required support libraries
 <label-install-required-support-libraries>`, PMIx will use a number of
 further libraries **if it finds them at configure time**, and will build
-without them otherwise.
+without them otherwise. MUNGE is the one exception: it is searched for
+only when ``--with-munge`` asks for it (see below).
 
 None of these is needed to produce a working PMIx. Each one either
 enables a capability that some sites want and others do not, or makes
@@ -111,8 +112,10 @@ costs you that capability and nothing else.
    * - `MUNGE <https://dun.github.io/munge/>`_
      - ``--with-munge``
      - Builds the ``psec/munge`` component, which authenticates PMIx
-       connections using MUNGE credentials. Without it, the other
-       ``psec`` components (``native``, ``none``) remain available.
+       connections using MUNGE credentials. **Opt-in only:** unlike the
+       rest of this table, an installed MUNGE is not detected on its own
+       |mdash| the option must be given. Without it, the other ``psec``
+       components (``native``, ``none``) remain available.
    * - `libesmtp <https://libesmtp.github.io/>`_
      - ``--with-smtp``
      - Builds the ``plog/smtp`` component, which can emit log messages by

--- a/src/mca/psec/AGENTS.md
+++ b/src/mca/psec/AGENTS.md
@@ -337,7 +337,7 @@ Default priorities come from each component's `component_query`:
 | Component | Priority | Model | Active when |
 |-----------|----------|-------|-------------|
 | `dummy_handshake` | 100 | handshake | built only with `--enable-dummy-handshake`; always active when built |
-| `munge` | 80 | single-shot | built only if libmunge is found; `init` succeeds only if the `munged` daemon issues a credential |
+| `munge` | 80 | single-shot | built only if `--with-munge` was given and libmunge is found; `init` succeeds only if the `munged` daemon issues a credential |
 | `native` | 10 | single-shot | always (no `configure.m4`, no gate) |
 | `none` | 0 | single-shot (no-op) | **only** if the `psec` MCA value explicitly names `none` (its `component_open` checks) |
 
@@ -420,10 +420,12 @@ src/mca/psec/
 (which in a stock build lists exactly `native` and `none`). The other two
 are conditional:
 
-- **`munge`** ships a [`configure.m4`](munge/configure.m4) that runs
-  `OAC_CHECK_PACKAGE` for `munge.h` / `libmunge`. It is built only if
-  MUNGE is present (or errors out if `--with-munge` was requested and not
-  found). Its source can be *compile-tested* without the real library via
+- **`munge`** ships a [`configure.m4`](munge/configure.m4) that is
+  **opt-in**: it runs `OAC_CHECK_PACKAGE` for `munge.h` / `libmunge`
+  only when `--with-munge[=DIR]` (or `--with-munge-libdir=DIR`) was
+  given, and errors out if that check then fails. A host with libmunge
+  installed but no `--with-munge` builds no `munge` component. Its source
+  can be *compile-tested* without the real library via
   the `#if PMIX_TESTBUILD` stub block at the top of `psec_munge.c`
   (activated by `--enable-test-build`) — that block is not used in real
   builds.

--- a/src/mca/psec/munge/AGENTS.md
+++ b/src/mca/psec/munge/AGENTS.md
@@ -22,7 +22,7 @@ specific to `munge`. It uses the **single-shot credential** model
 
 | File | Contents |
 |------|----------|
-| `configure.m4` | `OAC_CHECK_PACKAGE` gate — builds the component only if `munge.h` / `libmunge` are found. |
+| `configure.m4` | opt-in gate — builds the component only when `--with-munge` was given *and* `munge.h` / `libmunge` are found. |
 | `psec_munge.h` | Declares the component and module symbols. |
 | `psec_munge_component.c` | Component struct + `component_query` (priority **80**). |
 | `psec_munge.c` | The module: `init`/`finalize` + `create_cred` / `validate_cred`, wrapping `libmunge`. |
@@ -31,12 +31,17 @@ specific to `munge`. It uses the **single-shot credential** model
 
 Two gates must both pass:
 
-1. **Build-time.** [`configure.m4`](configure.m4) runs
-   `OAC_CHECK_PACKAGE([munge], …, [munge.h], [munge], [munge_encode], …)`.
-   The component is compiled only if MUNGE is present; if `--with-munge`
-   was given and MUNGE is *not* found, configure errors out rather than
-   silently skipping. So on a host without MUNGE, `munge` is simply not in
-   the tree's `static-components.h`.
+1. **Build-time.** MUNGE is **opt-in**: [`configure.m4`](configure.m4)
+   runs `OAC_CHECK_PACKAGE([munge], …, [munge.h], [munge],
+   [munge_encode], …)` **only** when `--with-munge[=DIR]` (or
+   `--with-munge-libdir=DIR`) was given, and if the check then fails,
+   configure errors out rather than silently skipping. Merely having
+   MUNGE installed is not enough — `OAC_CHECK_PACKAGE` ends its search in
+   pkg-config and the default compiler paths, so calling it
+   unconditionally would build this component on every host that happens
+   to have libmunge, which is exactly the bug that guard prevents. So
+   unless MUNGE was asked for, `munge` is simply not in the tree's
+   `static-components.h`.
 2. **Run-time.** Even when built, `munge_init` calls `munge_encode` to
    obtain a credential as a liveness check on the local `munged` daemon.
    If that fails it returns `PMIX_ERR_SERVER_NOT_AVAIL`, and

--- a/src/mca/psec/munge/configure.m4
+++ b/src/mca/psec/munge/configure.m4
@@ -6,6 +6,7 @@
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,20 +21,36 @@ AC_DEFUN([MCA_pmix_psec_munge_CONFIG],[
 
     AC_ARG_WITH([munge],
                 [AS_HELP_STRING([--with-munge=DIR],
-                                [Search for munge headers and libraries in DIR ])])
+                                [Build MUNGE support (not built unless requested), searching DIR for headers and libraries])])
     AC_ARG_WITH([munge-libdir],
                 [AS_HELP_STRING([--with-munge-libdir=DIR],
                                 [Search for munge libraries in DIR ])])
 
-    OAC_CHECK_PACKAGE([munge],
-                      [psec_munge],
-                      [munge.h],
-                      [munge],
-                      [munge_encode],
-                      [psec_munge_support=1],
-                      [psec_munge_support=0])
+    # MUNGE support is opt-in: it is built only when the user asks for
+    # it. OAC_CHECK_PACKAGE ends its search by looking in pkg-config
+    # and the default compiler paths, so running it unconditionally
+    # would enable this component on any host that merely happens to
+    # have MUNGE installed - and would ignore --without-munge.
+    psec_munge_support=0
 
-    if test -n "$with_munge" && test "$with_munge" != "no" && test "$psec_munge_support" != "1"; then
+    AS_IF([test "$with_munge" = "no"],
+          [pmix_munge_requested=no
+           psec_munge_SUMMARY="no (explicitly disabled)"],
+          [test -n "$with_munge" || test -n "$with_munge_libdir"],
+          [pmix_munge_requested=yes],
+          [pmix_munge_requested=no
+           psec_munge_SUMMARY="no (not requested)"])
+
+    AS_IF([test "$pmix_munge_requested" = "yes"],
+          [OAC_CHECK_PACKAGE([munge],
+                             [psec_munge],
+                             [munge.h],
+                             [munge],
+                             [munge_encode],
+                             [psec_munge_support=1],
+                             [psec_munge_support=0])])
+
+    if test "$pmix_munge_requested" = "yes" && test "$psec_munge_support" != "1"; then
         AC_MSG_WARN([MUNGE SUPPORT REQUESTED AND NOT FOUND.])
         AC_MSG_ERROR([CANNOT CONTINUE])
     fi
@@ -41,9 +58,12 @@ AC_DEFUN([MCA_pmix_psec_munge_CONFIG],[
     # --enable-test-build force-builds this component (against the
     # non-functional in-source shim in psec_munge.c if libmunge is
     # absent) so it can be compile-checked.
+    AC_MSG_CHECKING([will munge support be built])
     AS_IF([test "$psec_munge_support" = "1" || test "$pmix_testbuild" = "1"],
-          [$1],
-          [$2])
+          [$1
+           AC_MSG_RESULT([yes])],
+          [$2
+           AC_MSG_RESULT([no])])
 
     PMIX_SUMMARY_ADD([External Packages], [munge], [], [${psec_munge_SUMMARY}])
 


### PR DESCRIPTION
`psec/munge` is meant to be opt-in — MUNGE support should be built only
when `--with-munge` asks for it. It is currently auto-enabled on any host
that merely happens to have libmunge installed.

### The mechanism

`src/mca/psec/munge/configure.m4` calls `OAC_CHECK_PACKAGE`
unconditionally. That macro's search ends in pkg-config and then in the
plain default compiler paths, so on a host with `munge.h` and `libmunge`
installed normally the check succeeds, `psec_munge_support=1`, and the
component is built with nobody having asked for it.

`with_munge` is consulted in exactly one place — the "requested and not
found" error check — and never in the decision to run the probe. So
`--without-munge` is ignored for the same reason.

This is not a harmless extra component: `psec/munge` queries at priority
80 against `psec/native`'s 10, so building it changes the mechanism every
PMIx connection on that installation authenticates with.

### Where the guard went

Commit 0098f8cff (2016, *"Only build munge support when specifically
requested"*) wrapped the probe in
`test ! -z "$with_munge" && test "$with_munge" != "no"`. The migration to
OAC in 385308035 replaced the hand-rolled `PMIX_CHECK_PACKAGE` block with
`OAC_CHECK_PACKAGE` and dropped that wrapper along with it.

### The fix

`OAC_CHECK_PACKAGE` now runs only when `--with-munge[=DIR]` or
`--with-munge-libdir=DIR` was given. Preserved: the abort when MUNGE was
requested and not found, and `--enable-test-build` force-building the
component for compile coverage. The configure summary now distinguishes
`no (not requested)` from `no (explicitly disabled)`, and the
`checking will munge support be built...` line the migration dropped is
restored, matching the sibling `pcompress` and `plog/smtp` components.

### Verification

A fake `munge.h` + `libmunge` planted on the default search paths,
configured both ways:

* **no option** → `checking will munge support be built... no`,
  `munge: no (not requested)`, absent from `static-components.h`
* **`--with-munge`** → `Searching for munge in default search paths` →
  `munge.h yes`, `munge_encode yes`, built, present in
  `static-components.h`

The second run is the proof of the bug: the probe finds MUNGE *in the
default paths*, which is exactly what the unguarded call was doing on
every configure.

Full clean cycle after the change (`autogen.pl` → `configure` → `make` →
`make check`): warning-free build, 179 tests, 0 failures, 2 skips. Docs
rebuilt warning-free.

### Docs

Both installation pages framed these libraries as ones PMIx uses "if it
finds them", so MUNGE is now called out as the one opt-in-only exception.
`src/mca/psec/AGENTS.md` and `src/mca/psec/munge/AGENTS.md` both
described the auto-detect behavior as intended and are corrected.
