### PR TITLE
Stop a peer being freed while its own teardown is still using it

### DIFF
--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -110,6 +110,8 @@ static void lost_my_server(void)
 
 static void lost_connection(pmix_peer_t *peer)
 {
+    pmix_ptl_recv_t *msg;
+
     /* stop all events */
     if (peer->recv_ev_active) {
         pmix_event_del(&peer->recv_event);
@@ -119,10 +121,27 @@ static void lost_connection(pmix_peer_t *peer)
         pmix_event_del(&peer->send_event);
         peer->send_ev_active = false;
     }
-    if (NULL != peer->recv_msg) {
-        PMIX_RELEASE(peer->recv_msg);
-        peer->recv_msg = NULL;
-    }
+    /* Detach the message this peer was part-way through reading, but do
+     * NOT release it here.
+     *
+     * That message holds a reference on this peer, taken in
+     * pmix_ptl_base_recv_handler when the message was created, and it can
+     * be the last one - a peer whose only remaining holder is the partial
+     * message it was reading is exactly the peer that turns up in a
+     * teardown.  Releasing it at this point would run rdes, drop that
+     * reference, and free the peer; the assignment that used to follow was
+     * then a write into freed memory, and so was every use of peer in the
+     * rest of this function.
+     *
+     * Holding a reference of our own instead does not work, because the
+     * tail of this function hands the peer to pmix_server_peer_finalized(),
+     * which is an ownership transfer and not a balanced release - the
+     * comment there says the call must be the last use of the object.  So
+     * let the message's reference do exactly what a reference is for: keep
+     * the peer alive until we are finished with it, and release it at the
+     * very end. */
+    msg = peer->recv_msg;
+    peer->recv_msg = NULL;
     CLOSE_THE_SOCKET(peer->sd);
     if (PMIX_PEER_IS_SERVER(pmix_globals.mypeer)) {
 
@@ -241,6 +260,14 @@ static void lost_connection(pmix_peer_t *peer)
                                      PMIX_RANGE_PROC_LOCAL, _notify_complete,
                                      &report_now);
         }
+    }
+
+    /* Now let the in-flight message go.  This is the last statement that can
+     * touch the peer: the release runs rdes, which drops the message's
+     * reference, and where that was the last one the peer is freed right
+     * here - which is why nothing below may use it. */
+    if (NULL != msg) {
+        PMIX_RELEASE(msg);
     }
 }
 
@@ -683,22 +710,17 @@ void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata)
     return;
 
 err_close:
-    /* stop all events */
-    if (peer->recv_ev_active) {
-        pmix_event_del(&peer->recv_event);
-        peer->recv_ev_active = false;
-    }
-    if (peer->send_ev_active) {
-        pmix_event_del(&peer->send_event);
-        peer->send_ev_active = false;
-    }
-    if (NULL != peer->recv_msg) {
-        PMIX_RELEASE(peer->recv_msg);
-        peer->recv_msg = NULL;
-    }
+    /* Everything this used to do before calling lost_connection - stop the
+     * two events, release peer->recv_msg - lost_connection does itself, on
+     * exactly the same object, as its first three statements.  Doing it
+     * here as well was not merely redundant: releasing peer->recv_msg drops
+     * the reference it holds on this peer (taken above, when the message
+     * was created), so this teardown could free the peer and then hand the
+     * dangling pointer to lost_connection.  Just call it. */
     lost_connection(peer);
     /* ensure we post the modified peer object before another thread
-     * picks it back up */
+     * picks it back up.  lost_connection may have freed the peer, which is
+     * why this is a write barrier and not a dereference. */
     PMIX_POST_OBJECT(peer);
 }
 

--- a/src/server/pmix_server_registration.c
+++ b/src/server/pmix_server_registration.c
@@ -831,6 +831,32 @@ void pmix_server_peer_finalized(pmix_peer_t *peer)
         --info->proc_cnt;
     }
 
+    /* Is this object still the occupant of its own clients slot?
+     *
+     * If it is not, it has already been retired - the tombstone reclaim in
+     * process_tool_request/the connection handler nulls the slot, drops the
+     * finalized count and releases a finalized peer whose socket-close has
+     * not been processed yet - and the reference the array held is already
+     * gone.  Everything below would then be done a second time, on state
+     * that now belongs to somebody else: pmix_pointer_array_add hands a
+     * freed slot straight to the next connection, so peer->index can name
+     * the very peer that replaced this one.  Repeating the work would null
+     * that live peer out of the array, set the rank's peerid to -1 while it
+     * is still connected, decrement nfinalized twice, and release a
+     * reference this object no longer owns - which destroys it while its
+     * in-flight recv_msg still holds one, and the message's destructor then
+     * releases freed memory.
+     *
+     * Comparing the slot's OCCUPANT is what tells the two cases apart.  The
+     * index cannot: peers are constructed with index 0, a freed slot is
+     * reused, and info->peerid is compared against that same index just
+     * below - so an index test aliases a different object exactly when it
+     * matters most. */
+    if (peer != (pmix_peer_t *) pmix_pointer_array_get_item(&pmix_server_globals.clients,
+                                                            peer->index)) {
+        return;
+    }
+
     if (NULL != info && info->peerid == peer->index) {
         /* This peer is still the rank's referenced peer. How we retire it
          * depends on whether it is an application client or a tool. */
@@ -878,9 +904,10 @@ void pmix_server_peer_finalized(pmix_peer_t *peer)
      * over - a fork/exec'd clone still running, or a fast re-init that
      * reconnected before this socket-close was processed. In the stranded
      * case info->peerid no longer names this object, so nothing references
-     * it as the rank's peer. Either way it is safe to free it now: we null
-     * only its OWN clients slot (never the live referenced one), drop the
-     * finalized count it was still holding, and release it. */
+     * it as the rank's peer. Either way this object still occupies its own
+     * slot (the check above established that) and so still holds the
+     * reference the array took, which is the one dropped here: we null that
+     * slot, drop the finalized count it was still holding, and release it. */
     if (NULL != nptr && 0 < nptr->nfinalized) {
         --nptr->nfinalized;
     }


### PR DESCRIPTION
Two use-after-frees of a `pmix_peer_t` during connection teardown. Both end the process with a corrupted malloc arena, arbitrarily far from the fault — the first symptom is usually `malloc(): unsorted double linked list corrupted` in a server that has been running happily for minutes.

## 1. A peer freed by the message it was still reading

`peer->recv_msg` holds a reference on its peer: `pmix_ptl_base_recv_handler()` takes one with `PMIX_RETAIN(peer)` when it creates the message, and `rdes()` drops it when the message is released.

`lost_connection()` released that message as its third statement and then used the peer for its entire body — writing the handle back to `NULL`, closing the socket, accounting the loss to every collective, reporting the event, and finally retiring the object. Where the message held the *last* reference, all of that ran on freed memory, starting with the `peer->recv_msg = NULL` immediately after the release. A peer whose only remaining holder is the partial message it was reading is exactly the peer a teardown finds.

The fix is to let that reference do what a reference is for. The message is detached from the peer at the top of the function and released as the very last statement, once nothing will touch the peer again.

A reference of our own does **not** work here, and this is worth recording because it is the obvious first attempt: the tail of `lost_connection()` hands the peer to `pmix_server_peer_finalized()`, which is an ownership transfer rather than a balanced release — its own comment says the call must be the last use of the object — so a trailing `PMIX_RELEASE()` of our own is itself a use-after-free. Verified the hard way, in a debug build.

`pmix_ptl_base_recv_handler()`'s `err_close` now simply calls `lost_connection()`. Its event-stopping and message-releasing block was a verbatim copy of that function's first three statements, which is how it came to run the dangerous release a second time, outside any protection, and hand the dangling pointer on.

## 2. A peer retired twice

`pmix_server_peer_finalized()` ended by nulling `peer->index`'s clients slot, decrementing `nptr->nfinalized`, and releasing the peer — on the reasoning that a peer reaching it either is the rank's referenced peer or has been stranded by a newer connection, and that either way it still owns what is being dropped.

A finalized peer can reach it owning none of that. The tombstone reclaim in the connection handler — both the client path and the tool path in `process_tool_request()` — retires a finalized peer whose socket-close has not been processed yet, so a reconnecting rank can have a fresh peer: it nulls that slot, drops the finalized count, and releases the array's reference. When the deferred socket-close finally arrives, `lost_connection()` calls this function and all three steps run again. Since `pmix_pointer_array_add()` hands a freed slot straight to the next connection, `peer->index` by then can name the peer that *replaced* this one.

So the second pass nulls a live peer out of the clients array, sets a still-connected rank's `peerid` to `-1`, decrements `nfinalized` twice, and releases a reference this object no longer holds. That last one destroys a peer whose only remaining reference is its in-flight message, and the message's destructor then releases freed memory.

The premise is now established before it is acted on: compare the clients slot's **occupant** with this peer and return when they differ. The index cannot answer the question — peers are constructed with `index = 0`, freed slots are reused, and `info->peerid` is compared against that same index a few lines below, so an index test aliases a different object exactly when it matters.

## How this was found, and what it fixes

Under a PRRTE DVM whose daemons hold their connections open for the DVM's lifetime rather than a second (openpmix/prrte#2758), the last-reference case stops being rare and becomes reliable. A tool that reconnects across an init/finalize cycle — `prun` on the elastic and `--activate` paths — took the HNP down every time.

Verified against a ten-node cluster running a real SLURM (`contrib/slurmswarm`):

- Before: the HNP dies 3/3 with `malloc(): unsorted double linked list corrupted`, and valgrind reports a cascade of ~18 invalid reads and writes through the freed peer.
- With fix 1 only: the corruption and the whole valgrind cascade are gone; a debug build then trips `rdes: Assertion 'PMIX_OBJ_MAGIC_ID == _obj->obj_magic_id'`, which is fix 2's bug caught cleanly instead of silently.
- With both: 3/3 clean, no valgrind errors on that path.

Across that project's SLURM suite the two together take it from 95 passed / 21 failed to 127 / 4, with every elastic phase — extend, in-place resize, release-by-id, counted NEW, expander trimming, node reuse — passing. The four that remain are a PRRTE-side issue unrelated to this change.
