### PR TITLE
Add namespace and procID comparisons that do not wildcard

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -339,6 +339,7 @@ PMIX_MAN3 = \
 	PMIx_Check_nspace.3 \
 	PMIx_Check_nspace_strict.3 \
 	PMIx_Check_procid.3 \
+	PMIx_Check_procid_strict.3 \
 	PMIx_Check_rank.3 \
 	PMIx_Xfer_procid.3 \
 	PMIx_Nspace_invalid.3 \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -337,6 +337,7 @@ PMIX_MAN3 = \
 	PMIx_Check_reserved_key.3 \
 	PMIx_Check_key.3 \
 	PMIx_Check_nspace.3 \
+	PMIx_Check_nspace_strict.3 \
 	PMIx_Check_procid.3 \
 	PMIx_Check_rank.3 \
 	PMIx_Xfer_procid.3 \

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -124,6 +124,14 @@ Utility APIs
      bool PMIx_Check_procid(const pmix_proc_t *a,
                             const pmix_proc_t *b);
 
+* Check two process ID structs for equality, wildcarding on neither the
+  namespace nor the rank:
+
+  .. code-block:: c
+
+     bool PMIx_Check_procid_strict(const pmix_proc_t *a,
+                                   const pmix_proc_t *b);
+
 * Check two ranks for equality:
 
   .. code-block:: c

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -82,11 +82,19 @@ Utility APIs
 
      void PMIx_Load_nspace(pmix_nspace_t nspace, const char *str);
 
-* Check two ``nspace`` structs for equality:
+* Check two ``nspace`` structs for equality, an invalid namespace on
+  either side matching anything:
 
   .. code-block:: c
 
      bool PMIx_Check_nspace(const char *key1, const char *key2);
+
+* Check two ``nspace`` structs for equality, an invalid namespace on
+  either side matching nothing:
+
+  .. code-block:: c
+
+     bool PMIx_Check_nspace_strict(const char *key1, const char *key2);
 
 * Check if a namespace is invalid:
 

--- a/docs/man/man3/PMIx_Check_nspace.3.rst
+++ b/docs/man/man3/PMIx_Check_nspace.3.rst
@@ -63,8 +63,18 @@ implementation of the ``PMIX_CHECK_NSPACE`` macro. Because an invalid
 namespace is treated as a wildcard, this routine is intended for matching
 semantics rather than a strict byte-for-byte equality test.
 
+That wildcard is easy to inherit by accident. Structures commonly carry
+namespace fields that are legitimately empty |mdash| a parent or launcher
+that was never recorded, a requestor nobody is waiting on, an object named
+only later in its lifetime |mdash| and comparing one of those here answers
+``true`` against every namespace in the system. Where the question being
+asked is "do these two belong to the same namespace" rather than "does this
+pass the filter", use
+:ref:`PMIx_Check_nspace_strict(3) <man3-PMIx_Check_nspace_strict>`.
+
 
 .. seealso::
+   :ref:`PMIx_Check_nspace_strict(3) <man3-PMIx_Check_nspace_strict>`,
    :ref:`PMIx_Load_nspace(3) <man3-PMIx_Load_nspace>`,
    :ref:`PMIx_Nspace_invalid(3) <man3-PMIx_Nspace_invalid>`,
    :ref:`pmix_nspace_t(5) <man5-pmix_nspace_t>`

--- a/docs/man/man3/PMIx_Check_nspace_strict.3.rst
+++ b/docs/man/man3/PMIx_Check_nspace_strict.3.rst
@@ -1,0 +1,87 @@
+.. _man3-PMIx_Check_nspace_strict:
+
+PMIx_Check_nspace_strict
+========================
+
+.. include_body
+
+``PMIx_Check_nspace_strict`` |mdash| Compare two
+:ref:`pmix_nspace_t(5) <man5-pmix_nspace_t>` values for equality, without
+treating an invalid namespace as a wildcard
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   bool PMIx_Check_nspace_strict(const char *key1, const char *key2);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+No Python equivalent
+
+
+INPUT PARAMETERS
+----------------
+
+* ``key1``: Pointer to the first namespace (typically a
+  :ref:`pmix_nspace_t(5) <man5-pmix_nspace_t>`) to be compared.
+* ``key2``: Pointer to the second namespace to be compared.
+
+
+DESCRIPTION
+-----------
+
+Compare two namespaces for equality. The comparison examines at most
+``PMIX_MAX_NSLEN`` characters, which is the maximum length a
+:ref:`pmix_nspace_t <man5-pmix_nspace_t>` can hold.
+
+An invalid namespace (``NULL`` or zero-length, as determined by
+:ref:`PMIx_Nspace_invalid(3) <man3-PMIx_Nspace_invalid>`) matches
+**nothing** |mdash| not even another invalid namespace. "Unset" is not a
+value two namespaces can agree on.
+
+This is the difference between this routine and
+:ref:`PMIx_Check_nspace(3) <man3-PMIx_Check_nspace>`, which treats an
+invalid namespace on either side as a *wildcard* that matches anything.
+
+
+RETURN VALUE
+------------
+
+Returns ``true`` only when both namespaces are valid and their first
+``PMIX_MAX_NSLEN`` characters match. Returns ``false`` otherwise |mdash|
+including when either namespace, or both, is invalid.
+
+
+NOTES
+-----
+
+``PMIx_Check_nspace_strict`` is an OpenPMIx convenience routine and is the
+backing implementation of the ``PMIX_CHECK_NSPACE_STRICT`` macro.
+
+Choosing between the two routines is a question of what is being asked:
+
+* Use :ref:`PMIx_Check_nspace(3) <man3-PMIx_Check_nspace>` to match a
+  request against a **filter**, where an unset namespace means "any" |mdash|
+  for example, deciding whether a query restricted to one namespace should
+  see a given entry.
+
+* Use ``PMIx_Check_nspace_strict`` to ask whether two things belong to the
+  **same namespace**. Structures frequently carry namespace fields that are
+  legitimately empty (a launcher or parent that was never recorded, a
+  request nobody is waiting on), and comparing one of those with
+  ``PMIx_Check_nspace`` silently answers ``true`` against every namespace in
+  the system.
+
+
+.. seealso::
+   :ref:`PMIx_Check_nspace(3) <man3-PMIx_Check_nspace>`,
+   :ref:`PMIx_Load_nspace(3) <man3-PMIx_Load_nspace>`,
+   :ref:`PMIx_Nspace_invalid(3) <man3-PMIx_Nspace_invalid>`,
+   :ref:`pmix_nspace_t(5) <man5-pmix_nspace_t>`

--- a/docs/man/man3/PMIx_Check_procid.3.rst
+++ b/docs/man/man3/PMIx_Check_procid.3.rst
@@ -46,7 +46,14 @@ when *both* their namespaces match (as determined by
 Because the underlying namespace and rank comparisons both apply wildcard
 semantics, this is a matching test rather than a strict byte-for-byte
 comparison: an invalid namespace matches any namespace, and
-``PMIX_RANK_WILDCARD`` matches any rank.
+``PMIX_RANK_WILDCARD`` matches any rank. Both wildcards are easy to inherit
+by accident from data that is legitimately unset. Where the question being
+asked is "do these two name the same process" rather than "does this match
+the specification", use
+:ref:`PMIx_Check_procid_strict(3) <man3-PMIx_Check_procid_strict>`.
+
+A ``NULL`` argument is accepted: two absent procIDs are reported as equal,
+and an absent one is not equal to a present one.
 
 
 RETURN VALUE
@@ -60,11 +67,11 @@ NOTES
 -----
 
 ``PMIx_Check_procid`` is an OpenPMIx convenience routine and is the backing
-implementation of the ``PMIX_CHECK_PROCID`` macro. Both arguments must point
-to valid structures; the routine performs no ``NULL`` checking.
+implementation of the ``PMIX_CHECK_PROCID`` macro.
 
 
 .. seealso::
+   :ref:`PMIx_Check_procid_strict(3) <man3-PMIx_Check_procid_strict>`,
    :ref:`PMIx_Load_procid(3) <man3-PMIx_Load_procid>`,
    :ref:`PMIx_Check_nspace(3) <man3-PMIx_Check_nspace>`,
    :ref:`PMIx_Check_rank(3) <man3-PMIx_Check_rank>`,

--- a/docs/man/man3/PMIx_Check_procid_strict.3.rst
+++ b/docs/man/man3/PMIx_Check_procid_strict.3.rst
@@ -1,0 +1,101 @@
+.. _man3-PMIx_Check_procid_strict:
+
+PMIx_Check_procid_strict
+========================
+
+.. include_body
+
+``PMIx_Check_procid_strict`` |mdash| Compare two
+:ref:`pmix_proc_t(5) <man5-pmix_proc_t>` values for equality, without
+wildcard semantics on either the namespace or the rank
+
+
+SYNOPSIS
+--------
+
+.. code-block:: c
+
+   #include <pmix.h>
+
+   bool PMIx_Check_procid_strict(const pmix_proc_t *a,
+                                 const pmix_proc_t *b);
+
+
+Python Syntax
+^^^^^^^^^^^^^
+
+No Python equivalent
+
+
+INPUT PARAMETERS
+----------------
+
+* ``a``: Pointer to the first :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` to be
+  compared.
+* ``b``: Pointer to the second :ref:`pmix_proc_t(5) <man5-pmix_proc_t>` to be
+  compared.
+
+
+DESCRIPTION
+-----------
+
+Compare two process identifiers for equality, treating neither an invalid
+namespace nor ``PMIX_RANK_WILDCARD`` as matching anything other than itself.
+The two are equal when their namespaces match as determined by
+:ref:`PMIx_Check_nspace_strict(3) <man3-PMIx_Check_nspace_strict>`, *and*
+their ranks are literally equal.
+
+The two halves are strict in different ways, because the two fields differ:
+
+* An invalid namespace (``NULL`` or zero-length) matches **nothing**, not
+  even another invalid namespace, exactly as in
+  :ref:`PMIx_Check_nspace_strict(3) <man3-PMIx_Check_nspace_strict>`.
+
+* The rank is compared **literally**, and is not tested for validity.
+  ``PMIX_RANK_WILDCARD`` is a value a caller may legitimately be holding
+  |mdash| "every rank of this namespace" is how most connect requests name
+  their participants |mdash| so it names the same thing as another
+  ``PMIX_RANK_WILDCARD`` and a different thing from rank 0. This routine
+  declines to treat one rank as standing for the others; it does not refuse
+  any particular rank.
+
+This is the difference between this routine and
+:ref:`PMIx_Check_procid(3) <man3-PMIx_Check_procid>`, which wildcards twice
+over: an invalid namespace there matches any namespace, and
+``PMIX_RANK_WILDCARD`` matches any rank.
+
+A ``NULL`` argument names no process, and so matches none |mdash| including
+another ``NULL``. Note that this too is the opposite of
+:ref:`PMIx_Check_procid(3) <man3-PMIx_Check_procid>`, which reports two
+absent procIDs as equal.
+
+
+RETURN VALUE
+------------
+
+Returns ``true`` only when both arguments are non-``NULL``, both namespaces
+are valid and equal, and both ranks are equal. Returns ``false`` otherwise.
+
+
+NOTES
+-----
+
+``PMIx_Check_procid_strict`` is an OpenPMIx convenience routine and is the
+backing implementation of the ``PMIX_CHECK_PROCID_STRICT`` macro.
+
+Choosing between the two routines is a question of what is being asked. Use
+:ref:`PMIx_Check_procid(3) <man3-PMIx_Check_procid>` to match a procID
+against a **specification**, where an unset namespace means "any namespace"
+and ``PMIX_RANK_WILDCARD`` means "any rank". Use
+``PMIx_Check_procid_strict`` to ask whether two procIDs **name the same
+thing** |mdash| deciding whether a participant list matches one recorded
+earlier, for instance, where ``ns/0`` and ``ns/WILDCARD`` are different
+participant lists and must not be confused for one another.
+
+
+.. seealso::
+   :ref:`PMIx_Check_procid(3) <man3-PMIx_Check_procid>`,
+   :ref:`PMIx_Check_nspace_strict(3) <man3-PMIx_Check_nspace_strict>`,
+   :ref:`PMIx_Load_procid(3) <man3-PMIx_Load_procid>`,
+   :ref:`PMIx_Check_rank(3) <man3-PMIx_Check_rank>`,
+   :ref:`pmix_proc_t(5) <man5-pmix_proc_t>`

--- a/docs/man/man3/index.rst
+++ b/docs/man/man3/index.rst
@@ -246,6 +246,7 @@ APIs (section 3)
    PMIx_Check_nspace.3.rst
    PMIx_Check_nspace_strict.3.rst
    PMIx_Check_procid.3.rst
+   PMIx_Check_procid_strict.3.rst
    PMIx_Check_rank.3.rst
    PMIx_Xfer_procid.3.rst
    PMIx_Nspace_invalid.3.rst

--- a/docs/man/man3/index.rst
+++ b/docs/man/man3/index.rst
@@ -244,6 +244,7 @@ APIs (section 3)
    PMIx_Check_reserved_key.3.rst
    PMIx_Check_key.3.rst
    PMIx_Check_nspace.3.rst
+   PMIx_Check_nspace_strict.3.rst
    PMIx_Check_procid.3.rst
    PMIx_Check_rank.3.rst
    PMIx_Xfer_procid.3.rst

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1699,6 +1699,11 @@ PMIX_EXPORT void PMIx_Xfer_procid(pmix_proc_t *dst,
 PMIX_EXPORT bool PMIx_Check_procid(const pmix_proc_t *a,
                                    const pmix_proc_t *b);
 
+/* check two procIDs for equality, without treating an invalid
+ * namespace or PMIX_RANK_WILDCARD as matching anything */
+PMIX_EXPORT bool PMIx_Check_procid_strict(const pmix_proc_t *a,
+                                          const pmix_proc_t *b);
+
 /* check two ranks for equality */
 PMIX_EXPORT bool PMIx_Check_rank(pmix_rank_t a,
                                  pmix_rank_t b);

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1679,6 +1679,10 @@ PMIX_EXPORT void PMIx_Load_nspace(pmix_nspace_t nspace, const char *str);
 /* check two nspace structs for equality */
 PMIX_EXPORT bool PMIx_Check_nspace(const char *key1, const char *key2);
 
+/* check two nspace structs for equality, treating an invalid
+ * namespace as matching nothing rather than as a wildcard */
+PMIX_EXPORT bool PMIx_Check_nspace_strict(const char *key1, const char *key2);
+
 /* check if a namespace is invalid */
 PMIX_EXPORT bool PMIx_Nspace_invalid(const char *nspace);
 

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -272,6 +272,10 @@ PMIX_EXPORT void PMIx_Load_nspace(pmix_nspace_t nspace, const char *str);
 /* check two nspace structs for equality */
 PMIX_EXPORT bool PMIx_Check_nspace(const char *key1, const char *key2);
 
+/* check two nspace structs for equality, treating an invalid
+ * namespace as matching nothing rather than as a wildcard */
+PMIX_EXPORT bool PMIx_Check_nspace_strict(const char *key1, const char *key2);
+
 /* check if a namespace is invalid */
 PMIX_EXPORT bool PMIx_Nspace_invalid(const char *nspace);
 
@@ -901,6 +905,12 @@ PMIX_EXPORT void PMIx_Fabric_construct(pmix_fabric_t *p);
 /* define a convenience macro for checking nspaces */
 #define PMIX_CHECK_NSPACE(a, b) \
     PMIx_Check_nspace(a, b)
+
+/* ...and one that does NOT treat an invalid namespace as a wildcard.
+ * Use this one to ask "are these the same namespace"; PMIX_CHECK_NSPACE
+ * answers that question "yes" whenever either side is unset. */
+#define PMIX_CHECK_NSPACE_STRICT(a, b) \
+    PMIx_Check_nspace_strict(a, b)
 
 #define PMIX_NSPACE_INVALID(a) \
     PMIx_Nspace_invalid(a)

--- a/include/pmix_deprecated.h
+++ b/include/pmix_deprecated.h
@@ -292,6 +292,11 @@ PMIX_EXPORT void PMIx_Xfer_procid(pmix_proc_t *dst,
 PMIX_EXPORT bool PMIx_Check_procid(const pmix_proc_t *a,
                                    const pmix_proc_t *b);
 
+/* check two procIDs for equality, without treating an invalid
+ * namespace or PMIX_RANK_WILDCARD as matching anything */
+PMIX_EXPORT bool PMIx_Check_procid_strict(const pmix_proc_t *a,
+                                          const pmix_proc_t *b);
+
 /* check two ranks for equality */
 PMIX_EXPORT bool PMIx_Check_rank(pmix_rank_t a,
                                  pmix_rank_t b);
@@ -925,6 +930,12 @@ PMIX_EXPORT void PMIx_Fabric_construct(pmix_fabric_t *p);
 
 #define PMIX_CHECK_PROCID(a, b) \
     PMIx_Check_procid(a, b)
+
+/* ...and one that wildcards on neither half.  Use this one to ask "are
+ * these the same process"; PMIX_CHECK_PROCID answers that "yes" whenever
+ * either namespace is unset or either rank is PMIX_RANK_WILDCARD. */
+#define PMIX_CHECK_PROCID_STRICT(a, b) \
+    PMIx_Check_procid_strict(a, b)
 
 #define PMIX_CHECK_RANK(a, b) \
     PMIx_Check_rank(a, b)

--- a/src/mca/bfrops/base/bfrop_base_macro_backers.c
+++ b/src/mca/bfrops/base/bfrop_base_macro_backers.c
@@ -70,6 +70,12 @@ bool PMIx_Check_procid(const pmix_proc_t *a,
     return pmix_bfrops_base_tma_check_procid(a, b, NULL);
 }
 
+bool PMIx_Check_procid_strict(const pmix_proc_t *a,
+                              const pmix_proc_t *b)
+{
+    return pmix_bfrops_base_tma_check_procid_strict(a, b, NULL);
+}
+
 bool PMIx_Check_rank(pmix_rank_t a,
                      pmix_rank_t b)
 {

--- a/src/mca/bfrops/base/bfrop_base_macro_backers.c
+++ b/src/mca/bfrops/base/bfrop_base_macro_backers.c
@@ -36,6 +36,11 @@ bool PMIx_Check_nspace(const char *nspace1, const char *nspace2)
     return pmix_bfrops_base_tma_check_nspace(nspace1, nspace2, NULL);
 }
 
+bool PMIx_Check_nspace_strict(const char *nspace1, const char *nspace2)
+{
+    return pmix_bfrops_base_tma_check_nspace_strict(nspace1, nspace2, NULL);
+}
+
 bool PMIx_Nspace_invalid(const char *nspace)
 {
     return pmix_bfrops_base_tma_nspace_invalid(nspace, NULL);

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -353,6 +353,40 @@ bool pmix_bfrops_base_tma_check_procid(const pmix_proc_t *a,
     return pmix_bfrops_base_tma_check_rank(a->rank, b->rank, tma);
 }
 
+/* The strict counterpart of the above: no wildcard on either half.
+ *
+ * pmix_bfrops_base_tma_check_procid() wildcards twice over - once through
+ * check_nspace(), where an unset namespace matches anything, and once
+ * through check_rank(), where PMIX_RANK_WILDCARD does.  Both are right for
+ * matching a proc against a specification and wrong for asking whether two
+ * procIDs name the same process.
+ *
+ * The two halves are strict in different ways, because the two fields
+ * differ.  An unset namespace matches nothing at all, not even another
+ * unset namespace, for the reason given above check_nspace_strict().  The
+ * rank is simply compared literally: PMIX_RANK_WILDCARD is a real value a
+ * caller may legitimately be carrying - "every rank of this namespace" is
+ * how most connect requests name their participants - and it names the same
+ * thing as another PMIX_RANK_WILDCARD and a different thing from rank 0.
+ * So this routine does not test the rank for validity; it only declines to
+ * treat one value as standing for the others. */
+static inline
+bool pmix_bfrops_base_tma_check_procid_strict(const pmix_proc_t *a,
+                                              const pmix_proc_t *b,
+                                              pmix_tma_t *tma)
+{
+    /* an absent procID names no process, so it matches none - including
+     * another absent one.  Note this is the opposite of check_procid(),
+     * which calls two NULLs the same proc */
+    if (NULL == a || NULL == b) {
+        return false;
+    }
+    if (!pmix_bfrops_base_tma_check_nspace_strict(a->nspace, b->nspace, tma)) {
+        return false;
+    }
+    return (a->rank == b->rank);
+}
+
 static inline
 bool pmix_bfrops_base_tma_procid_invalid(const pmix_proc_t *p,
                                          pmix_tma_t *tma)

--- a/src/mca/bfrops/base/bfrop_base_tma.h
+++ b/src/mca/bfrops/base/bfrop_base_tma.h
@@ -249,6 +249,36 @@ bool pmix_bfrops_base_tma_check_nspace(const char *nspace1,
     return false;
 }
 
+/* The strict counterpart of the above.
+ *
+ * pmix_bfrops_base_tma_check_nspace() treats an invalid namespace as a
+ * WILDCARD, which is right for matching a request against a filter and
+ * wrong for asking "are these the same job".  Callers of the second kind
+ * want a namespace that has never been set to match nothing at all, and
+ * writing that out by hand - guard with nspace_invalid(), then compare -
+ * is easy to forget and easy to get subtly wrong.  So it is spelled once,
+ * here.
+ *
+ * Note the asymmetry that makes this worth its own routine: an invalid
+ * namespace does not even match another invalid one.  "Unset" is not a
+ * value two things can agree on. */
+static inline
+bool pmix_bfrops_base_tma_check_nspace_strict(const char *nspace1,
+                                              const char *nspace2,
+                                              pmix_tma_t *tma)
+{
+    if (pmix_bfrops_base_tma_nspace_invalid(nspace1, tma)) {
+        return false;
+    }
+    if (pmix_bfrops_base_tma_nspace_invalid(nspace2, tma)) {
+        return false;
+    }
+    if (0 == strncmp(nspace1, nspace2, PMIX_MAX_NSLEN)) {
+        return true;
+    }
+    return false;
+}
+
 static inline
 bool pmix_bfrops_base_tma_check_reserved_key(const char *key,
                                              pmix_tma_t *tma)

--- a/src/mca/ptl/base/ptl_base_connection_hdlr.c
+++ b/src/mca/ptl/base/ptl_base_connection_hdlr.c
@@ -740,18 +740,18 @@ static pmix_namespace_t *consolidate_nspace(pmix_pending_connection_t *pnd,
         return nptr;
     }
 
-    /* Compare names EXACTLY. Do not reach for PMIx_Check_nspace() here:
-     * it reports a match whenever *either* name is absent, which is the
-     * right answer for the wildcard matching its callers do and a
-     * catastrophic one for us. The server's list legitimately carries
-     * namespaces whose name is not set yet, and treating the first of
-     * those as "the same namespace" hands this tool an object belonging
-     * to something else - after which the job data the server packs for
-     * it is somebody else's, and the tool fails to unpack its own
-     * identity out of the reply. */
+    /* Compare names EXACTLY, which is what PMIx_Check_nspace_strict() is
+     * for. Do NOT reach for PMIx_Check_nspace() here: it reports a match
+     * whenever *either* name is absent, which is the right answer for the
+     * wildcard matching its callers do and a catastrophic one for us. The
+     * server's list legitimately carries namespaces whose name is not set
+     * yet, and treating the first of those as "the same namespace" hands
+     * this tool an object belonging to something else - after which the
+     * job data the server packs for it is somebody else's, and the tool
+     * fails to unpack its own identity out of the reply. */
     PMIX_LIST_FOREACH (ns, &pmix_globals.nspaces, pmix_namespace_t) {
-        if (ns != nptr && NULL != ns->nspace &&
-            0 == strncmp(nptr->nspace, ns->nspace, PMIX_MAX_NSLEN)) {
+        if (ns != nptr &&
+            PMIx_Check_nspace_strict(nptr->nspace, ns->nspace)) {
             existing = ns;
             break;
         }

--- a/test/unit/bfrops_helpers.c
+++ b/test/unit/bfrops_helpers.c
@@ -131,6 +131,7 @@ static void test_procid_degenerate(void)
 
     PMIx_Load_procid(NULL, "ns", 0);
     (void) PMIx_Check_procid(NULL, NULL);
+    (void) PMIx_Check_procid_strict(NULL, NULL);
     (void) PMIx_Procid_invalid(NULL);
     PMIx_Xfer_procid(NULL, NULL);
 
@@ -177,6 +178,63 @@ static void test_nspace_comparison(void)
 
     report("an unset namespace is a wildcard to one comparison and to "
            "neither side of the other", ok);
+}
+
+/* Same question one level up: PMIX_CHECK_PROCID wildcards twice over,
+ * through the namespace and again through PMIX_RANK_WILDCARD, and the
+ * strict form does neither.  Note the rank half is strict in a different
+ * way from the namespace half - it compares literally rather than
+ * refusing any particular value - because PMIX_RANK_WILDCARD is a real
+ * participant designation, not an unset field. */
+static void test_procid_comparison(void)
+{
+    pmix_proc_t a, b;
+    int ok = 1;
+
+    PMIx_Load_procid(&a, "jobA", 0);
+    PMIx_Load_procid(&b, "jobA", 0);
+    ok = ok && PMIx_Check_procid(&a, &b);
+    ok = ok && PMIx_Check_procid_strict(&a, &b);
+
+    /* a different rank of the same job is a different proc to both */
+    PMIx_Load_procid(&b, "jobA", 1);
+    ok = ok && !PMIx_Check_procid(&a, &b);
+    ok = ok && !PMIx_Check_procid_strict(&a, &b);
+
+    /* the same rank of a different job, likewise */
+    PMIx_Load_procid(&b, "jobB", 0);
+    ok = ok && !PMIx_Check_procid(&a, &b);
+    ok = ok && !PMIx_Check_procid_strict(&a, &b);
+
+    /* a wildcard rank stands for every rank to the ordinary form, and
+     * for itself alone to the strict one - "jobA/0" and "jobA/WILDCARD"
+     * are different participant lists */
+    PMIx_Load_procid(&b, "jobA", PMIX_RANK_WILDCARD);
+    ok = ok && PMIx_Check_procid(&a, &b);
+    ok = ok && !PMIx_Check_procid_strict(&a, &b);
+
+    /* ...but it does name the same thing as another wildcard: the strict
+     * form declines to treat one rank as standing for the others, it does
+     * not refuse any particular rank */
+    PMIx_Load_procid(&a, "jobA", PMIX_RANK_WILDCARD);
+    ok = ok && PMIx_Check_procid_strict(&a, &b);
+
+    /* an unset namespace is a wildcard to one and matches nothing in the
+     * other, exactly as for the bare namespace comparison */
+    PMIx_Load_procid(&a, NULL, 0);
+    PMIx_Load_procid(&b, "jobA", 0);
+    ok = ok && PMIx_Check_procid(&a, &b);
+    ok = ok && !PMIx_Check_procid_strict(&a, &b);
+
+    /* two absent procIDs are the same proc to one and neither to the
+     * other: an absent procID names no process, so it matches none */
+    ok = ok && PMIx_Check_procid(NULL, NULL);
+    ok = ok && !PMIx_Check_procid_strict(NULL, NULL);
+    ok = ok && !PMIx_Check_procid(NULL, &b);
+    ok = ok && !PMIx_Check_procid_strict(NULL, &b);
+
+    report("neither an unset namespace nor a wildcard rank stands for "
+           "anything in the strict procID comparison", ok);
 }
 
 /* The two halves of a multi-cluster nspace are written element by
@@ -373,6 +431,7 @@ int main(int argc, char **argv)
     test_argv_still_works();
     test_procid_degenerate();
     test_nspace_comparison();
+    test_procid_comparison();
     test_multicluster_parse();
     test_zero_and_null_lifecycle();
     test_load_helpers_with_no_data();

--- a/test/unit/bfrops_helpers.c
+++ b/test/unit/bfrops_helpers.c
@@ -137,12 +137,46 @@ static void test_procid_degenerate(void)
     PMIx_Load_key(k, NULL);
     (void) PMIx_Check_key(NULL, NULL);
     (void) PMIx_Check_nspace(NULL, NULL);
+    (void) PMIx_Check_nspace_strict(NULL, NULL);
     PMIx_Load_nspace(n, NULL);
 
     PMIx_Multicluster_nspace_parse(NULL, cluster, nspace);
     PMIx_Load_procid(&p, NULL, 0);
 
     report("the proc and key helpers survive NULL arguments", 1);
+}
+
+/* The two namespace comparisons answer opposite questions, and the whole
+ * point of having both is that they disagree about an unset namespace.
+ * This is one of the few things in this file that asserts behaviour
+ * rather than survival, because a caller can tell the difference and the
+ * difference is the reason the strict form exists. */
+static void test_nspace_comparison(void)
+{
+    int ok = 1;
+
+    /* two real namespaces: both routines agree, both ways */
+    ok = ok && PMIx_Check_nspace("jobA", "jobA");
+    ok = ok && PMIx_Check_nspace_strict("jobA", "jobA");
+    ok = ok && !PMIx_Check_nspace("jobA", "jobB");
+    ok = ok && !PMIx_Check_nspace_strict("jobA", "jobB");
+
+    /* an unset namespace is a WILDCARD to the ordinary form... */
+    ok = ok && PMIx_Check_nspace("", "jobA");
+    ok = ok && PMIx_Check_nspace("jobA", "");
+    ok = ok && PMIx_Check_nspace(NULL, "jobA");
+
+    /* ...and matches NOTHING in the strict form, including another
+     * unset namespace: "unset" is not a value two things can agree on */
+    ok = ok && !PMIx_Check_nspace_strict("", "jobA");
+    ok = ok && !PMIx_Check_nspace_strict("jobA", "");
+    ok = ok && !PMIx_Check_nspace_strict(NULL, "jobA");
+    ok = ok && !PMIx_Check_nspace_strict("jobA", NULL);
+    ok = ok && !PMIx_Check_nspace_strict("", "");
+    ok = ok && !PMIx_Check_nspace_strict(NULL, NULL);
+
+    report("an unset namespace is a wildcard to one comparison and to "
+           "neither side of the other", ok);
 }
 
 /* The two halves of a multi-cluster nspace are written element by
@@ -338,6 +372,7 @@ int main(int argc, char **argv)
     test_argv_degenerate();
     test_argv_still_works();
     test_procid_degenerate();
+    test_nspace_comparison();
     test_multicluster_parse();
     test_zero_and_null_lifecycle();
     test_load_helpers_with_no_data();


### PR DESCRIPTION
`PMIx_Check_nspace()` treats an invalid namespace as a **wildcard**: it returns true if either side is `NULL` or zero-length. `PMIx_Check_procid()` inherits that and adds a second wildcard of its own, since `PMIx_Check_rank()` matches `PMIX_RANK_WILDCARD` against anything.

That is the right answer for what these were written for — matching a request against a specification, where an unset namespace means "any" — and the wrong answer for the other question callers ask them, which is *"do these two things name the same job/process?"*

The second question gets asked constantly, and it gets asked of fields that are legitimately empty: a parent or launcher that was never recorded, a requestor nobody is waiting on, an object that is not named until later in its lifetime. Comparing one of those does not fail loudly — it quietly answers "yes" against every namespace in the system, and whatever set was being computed silently acquires everything.

Callers who noticed have been writing the strict form out by hand, each differently: a bare `strncmp`, or an `nspace_invalid()` guard in front of `PMIx_Check_nspace()`, each with a comment explaining why the obvious macro could not be used. **This library has such a site itself**, in `ptl_base_connection_hdlr.c`, where taking one namespace for another hands a connecting tool an object belonging to something else — after which the job data the server packs for it is somebody else's, and the tool fails to unpack its own identity out of the reply. Spelling the same thing several ways in several places is how the next caller comes to write the version with the guard left off.

## What this adds

- **`PMIx_Check_nspace_strict()`** / `PMIX_CHECK_NSPACE_STRICT` — matches only when both namespaces are valid and equal.
- **`PMIx_Check_procid_strict()`** / `PMIX_CHECK_PROCID_STRICT` — the same one level up, composed out of it.

Two asymmetries are deliberate and are what earn these their own routines rather than a flag argument:

- **An invalid namespace matches nothing, not even another invalid one.** "Unset" is not a value two things can agree on. A `NULL` procID likewise matches none, including another `NULL` — note that this is the *opposite* of `PMIx_Check_procid()`, which reports two absent procIDs as equal.
- **The rank half is strict in a different way from the namespace half.** It compares literally and does *not* test the rank for validity, because `PMIX_RANK_WILDCARD` is not an unset field — it is a real participant designation ("every rank of this namespace"), which is how most connect requests name their members. So it names the same thing as another `PMIX_RANK_WILDCARD` and a different thing from rank 0. The routine's whole job on that half is to stop one rank standing in for the others.

The PTL site is converted to the new routine. Both pairs of man pages cross-reference each other, so a reader arriving at either one learns the distinction and which question it answers.

Also corrects an existing inaccuracy: `PMIx_Check_procid.3` said the routine does no `NULL` checking. It has done since the guard returning `(a == b)` was added, and a caller told otherwise will either write a check the routine already performs or avoid a call that would have been safe.

No capability flag: these are plain new entry points, not behavior a consumer has to branch on.

## Testing

`test/unit/bfrops_helpers.c` gains two cases that assert *behavior* rather than survival, because the whole point is that the strict and non-strict forms disagree, and exactly where. 10/0 locally. Warning-free build; docs render warning-free and both new man pages are generated.

Also built PRRTE against this and ran its suite (25/0) plus a live DVM — see openpmix/prrte#2767, which converts nine such hand-rolled sites onto these.